### PR TITLE
ci: publish all under build

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -28,12 +28,17 @@ jobs:
           exit 1
         fi
 
-    - name: Deploy build/ to prod branch
+    - name: Prepare publish directory with nested build/
+      run: |
+        mkdir public
+        cp -r /build public/build
+
+    - name: Publish to prod branch under /build
       uses: peaceiris/actions-gh-pages@v3
       with:
         # this token lets the Action push to prod
         github_token: ${{ secrets.GITHUB_TOKEN }}
         # point to your generated site
-        publish_dir: ./build
+        publish_dir: ./public
         # target branch (will be created if it doesn’t exist, or force‐updated if it does)
         publish_branch: prod


### PR DESCRIPTION
We'll adjust the publish workflow to retain the `/build` path to make it more obvious if folks end up comparing preview vs. public branches