### PR TITLE
better document what the first argument to a RemoteGraph can be

### DIFF
--- a/src/langgraph-platform/use-remote-graph.mdx
+++ b/src/langgraph-platform/use-remote-graph.mdx
@@ -14,7 +14,7 @@ sidebarTitle: Interact with the deployment using RemoteGraph
 
 When initializing a `RemoteGraph`, you must always specify:
 
-* `name`: the name of the graph you want to interact with. This is the same graph name you use in `langgraph.json` configuration file for your deployment. 
+* `name`: the name of the graph you want to interact with OR an assistant ID. If you specify a graph name, the default assistant will be used. If you specify an assistant ID, that specific assistant will be used. The graph name is the same name you use in `langgraph.json` configuration file for your deployment. 
 * `api_key`: a valid LangSmith API key. Can be set as an environment variable (`LANGSMITH_API_KEY`) or passed directly via the `api_key` argument. The API key could also be provided via the `client` / `sync_client` arguments, if `LangGraphClient` / `SyncLangGraphClient` were initialized with `api_key` argument.
 
 Additionally, you have to provide one of the following:
@@ -35,8 +35,14 @@ Additionally, you have to provide one of the following:
     from langgraph.pregel.remote import RemoteGraph
     
     url = <DEPLOYMENT_URL>
+    
+    # Using graph name (uses default assistant)
     graph_name = "agent"
     remote-graph = RemoteGraph(graph_name, url=url)
+    
+    # Using assistant ID (uses specific assistant)
+    assistant_id = "assistant-123"
+    remote-graph = RemoteGraph(assistant_id, url=url)
     ```
   </Tab>
   <Tab title="JavaScript">
@@ -44,8 +50,14 @@ Additionally, you have to provide one of the following:
     import { RemoteGraph } from "@langchain/langgraph/remote";
     
     const url = `<DEPLOYMENT_URL>`;
+    
+    // Using graph name (uses default assistant)
     const graphName = "agent";
     const remoteGraph = new RemoteGraph({ graphId: graphName, url });
+    
+    // Using assistant ID (uses specific assistant)
+    const assistantId = "assistant-123";
+    const remoteGraph = new RemoteGraph({ graphId: assistantId, url });
     ```
   </Tab>
 </Tabs>
@@ -59,10 +71,16 @@ Additionally, you have to provide one of the following:
     from langgraph.pregel.remote import RemoteGraph
     
     url = <DEPLOYMENT_URL>
-    graph_name = "agent"
     client = get_client(url=url)
     sync_client = get_sync_client(url=url)
+    
+    # Using graph name (uses default assistant)
+    graph_name = "agent"
     remote-graph = RemoteGraph(graph_name, client=client, sync_client=sync_client)
+    
+    # Using assistant ID (uses specific assistant)
+    assistant_id = "assistant-123"
+    remote-graph = RemoteGraph(assistant_id, client=client, sync_client=sync_client)
     ```
   </Tab>
   <Tab title="JavaScript">
@@ -71,8 +89,14 @@ Additionally, you have to provide one of the following:
     import { RemoteGraph } from "@langchain/langgraph/remote";
     
     const client = new Client({ apiUrl: `<DEPLOYMENT_URL>` });
+    
+    // Using graph name (uses default assistant)
     const graphName = "agent";
     const remoteGraph = new RemoteGraph({ graphId: graphName, client });
+    
+    // Using assistant ID (uses specific assistant)
+    const assistantId = "assistant-123";
+    const remoteGraph = new RemoteGraph({ graphId: assistantId, client });
     ```
   </Tab>
 </Tabs>

--- a/src/langgraph-platform/use-remote-graph.mdx
+++ b/src/langgraph-platform/use-remote-graph.mdx
@@ -95,7 +95,7 @@ Additionally, you have to provide one of the following:
     const remoteGraph = new RemoteGraph({ graphId: graphName, client });
     
     // Using assistant ID
-    const assistantId = <ASSISTANT_ID>;
+    const assistantId = `<ASSISTANT_ID>`;
     const remoteGraph = new RemoteGraph({ graphId: assistantId, client });
     ```
   </Tab>

--- a/src/langgraph-platform/use-remote-graph.mdx
+++ b/src/langgraph-platform/use-remote-graph.mdx
@@ -40,8 +40,8 @@ Additionally, you have to provide one of the following:
     graph_name = "agent"
     remote-graph = RemoteGraph(graph_name, url=url)
     
-    # Using assistant ID (uses specific assistant)
-    assistant_id = "assistant-123"
+    # Using assistant ID
+    assistant_id = <ASSISTANT_ID>
     remote-graph = RemoteGraph(assistant_id, url=url)
     ```
   </Tab>
@@ -55,8 +55,8 @@ Additionally, you have to provide one of the following:
     const graphName = "agent";
     const remoteGraph = new RemoteGraph({ graphId: graphName, url });
     
-    // Using assistant ID (uses specific assistant)
-    const assistantId = "assistant-123";
+    // Using assistant ID
+    const assistantId = `<ASSISTANT_ID>`;
     const remoteGraph = new RemoteGraph({ graphId: assistantId, url });
     ```
   </Tab>
@@ -78,8 +78,8 @@ Additionally, you have to provide one of the following:
     graph_name = "agent"
     remote-graph = RemoteGraph(graph_name, client=client, sync_client=sync_client)
     
-    # Using assistant ID (uses specific assistant)
-    assistant_id = "assistant-123"
+    # Using assistant ID
+    assistant_id = <ASSISTANT_ID>
     remote-graph = RemoteGraph(assistant_id, client=client, sync_client=sync_client)
     ```
   </Tab>
@@ -94,8 +94,8 @@ Additionally, you have to provide one of the following:
     const graphName = "agent";
     const remoteGraph = new RemoteGraph({ graphId: graphName, client });
     
-    // Using assistant ID (uses specific assistant)
-    const assistantId = "assistant-123";
+    // Using assistant ID
+    const assistantId = <ASSISTANT_ID>;
     const remoteGraph = new RemoteGraph({ graphId: assistantId, client });
     ```
   </Tab>

--- a/src/langgraph-platform/use-remote-graph.mdx
+++ b/src/langgraph-platform/use-remote-graph.mdx
@@ -14,7 +14,7 @@ sidebarTitle: Interact with the deployment using RemoteGraph
 
 When initializing a `RemoteGraph`, you must always specify:
 
-* `name`: the name of the graph you want to interact with OR an assistant ID. If you specify a graph name, the default assistant will be used. If you specify an assistant ID, that specific assistant will be used. The graph name is the same name you use in `langgraph.json` configuration file for your deployment. 
+* `name`: the name of the graph you want to interact with **or** an assistant ID. If you specify a graph name, the default assistant will be used. If you specify an assistant ID, that specific assistant will be used. The graph name is the same name you use in `langgraph.json` configuration file for your deployment. 
 * `api_key`: a valid LangSmith API key. Can be set as an environment variable (`LANGSMITH_API_KEY`) or passed directly via the `api_key` argument. The API key could also be provided via the `client` / `sync_client` arguments, if `LangGraphClient` / `SyncLangGraphClient` were initialized with `api_key` argument.
 
 Additionally, you have to provide one of the following:


### PR DESCRIPTION
when using RemoteGraph for a couple weeks, I noticed unexpected behavior that I could give either an assistant ID or a graph name as the first argument when instantiating a RemoteGraph.

Turns out this is by design, but it was not documented.