### PR TITLE
add note about how you dont need custom checkpointer

### DIFF
--- a/src/langgraph-platform/langgraph-basics/3-add-memory.mdx
+++ b/src/langgraph-platform/langgraph-basics/3-add-memory.mdx
@@ -15,6 +15,10 @@ LangGraph solves this problem through **persistent checkpointing**. If you provi
 
 We will see later that **checkpointing** is _much_ more powerful than simple chat memory - it lets you save and resume complex state at any time for error recovery, human-in-the-loop workflows, time travel interactions, and more. But first, let's add checkpointing to enable multi-turn conversations.
 
+<Note>
+  **For LangGraph Platform deployments**: When you deploy your graph to LangGraph Platform, checkpointing and memory are provided automatically - you don't need to configure a checkpointer. This tutorial shows local development setup; when deploying, you can remove the checkpointer configuration.
+</Note>
+
 ## 1. Create a `MemorySaver` checkpointer
 
 Create a `MemorySaver` checkpointer:

--- a/src/langgraph-platform/langgraph-basics/3-add-memory.mdx
+++ b/src/langgraph-platform/langgraph-basics/3-add-memory.mdx
@@ -16,7 +16,7 @@ LangGraph solves this problem through **persistent checkpointing**. If you provi
 We will see later that **checkpointing** is _much_ more powerful than simple chat memory - it lets you save and resume complex state at any time for error recovery, human-in-the-loop workflows, time travel interactions, and more. But first, let's add checkpointing to enable multi-turn conversations.
 
 <Note>
-If you're [deploying your graph to LangGraph Platform](/langgraph-platform/deployment-options), you do not need to set up a checkpointer manually—checkpointing and memory are handled for you automatically.
+If you're [deploying your graph to LangGraph Platform](/langgraph-platform/deployment-options), you do not need to set up a checkpointer manually — checkpointing and memory are handled for you automatically.
 
 This tutorial focuses on local development, where you do need to configure a checkpointer. When you're ready to deploy, remove this checkpointer configuration.
 </Note>

--- a/src/langgraph-platform/langgraph-basics/3-add-memory.mdx
+++ b/src/langgraph-platform/langgraph-basics/3-add-memory.mdx
@@ -16,7 +16,9 @@ LangGraph solves this problem through **persistent checkpointing**. If you provi
 We will see later that **checkpointing** is _much_ more powerful than simple chat memory - it lets you save and resume complex state at any time for error recovery, human-in-the-loop workflows, time travel interactions, and more. But first, let's add checkpointing to enable multi-turn conversations.
 
 <Note>
-  **For LangGraph Platform deployments**: When you deploy your graph to LangGraph Platform, checkpointing and memory are provided automatically - you don't need to configure a checkpointer. This tutorial shows local development setup; when deploying, you can remove the checkpointer configuration.
+If you're [deploying your graph to LangGraph Platform](/langgraph-platform/deployment-options), you do not need to set up a checkpointer manually—checkpointing and memory are handled for you automatically.
+
+This tutorial focuses on local development, where you do need to configure a checkpointer. When you're ready to deploy, remove this checkpointer configuration.
 </Note>
 
 ## 1. Create a `MemorySaver` checkpointer


### PR DESCRIPTION
I've noticed a couple customers have gotten confused when deploying LG agents to LGP, because they configure custom checkpointers and stores. But this is not supported with LGP, because these are provided out of the box. This docs change adds a Note on step 3 of getting started which explains this.

I don't think this will stop many cases of this confusion, so long term maybe we should think about a simpler way to show "getting started on LGP". This tutorial is pretty long to begin with....