### PR TITLE
docs: fix code formatting on deployment docs

### DIFF
--- a/src/langgraph-platform/deploy-hybrid.mdx
+++ b/src/langgraph-platform/deploy-hybrid.mdx
@@ -19,35 +19,45 @@ Before deploying, review the [conceptual guide for the Hybrid](/langgraph-platfo
 ### Prerequisites
 
 1. `KEDA` is installed on your cluster.
+```bash
   helm repo add kedacore https://kedacore.github.io/charts
   helm install keda kedacore/keda --namespace keda --create-namespace
+```
 2. A valid `Ingress` controller is installed on your cluster.
 3. You have slack space in your cluster for multiple deployments. `Cluster-Autoscaler` is recommended to automatically provision new nodes.
 4. You will need to enable egress to two control plane URLs. The listener polls these endpoints for deployments:
-  https://api.host.langchain.com
-  https://api.smith.langchain.com
+    - https://api.host.langchain.com
+    - https://api.smith.langchain.com
 
 ### Setup
 
 1. You give us your LangSmith organization ID. We will enable the Self-Hosted Data Plane for your organization.
 2. We provide you a [Helm chart](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-dataplane) which you run to setup your Kubernetes cluster. This chart contains a few important components.
-  1. `langgraph-listener`: This is a service that listens to LangChain's [control plane](/langgraph-platform/control-plane) for changes to your deployments and creates/updates downstream CRDs.
-  2. `LangGraphPlatform CRD`: A CRD for LangGraph Platform deployments. This contains the spec for managing an instance of a LangGraph Platform deployment.
-  3. `langgraph-platform-operator`: This operator handles changes to your LangGraph Platform CRDs.
+    1. `langgraph-listener`: This is a service that listens to LangChain's [control plane](/langgraph-platform/control-plane) for changes to your deployments and creates/updates downstream CRDs.
+    2. `LangGraphPlatform CRD`: A CRD for LangGraph Platform deployments. This contains the spec for managing an instance of a LangGraph Platform deployment.
+    3. `langgraph-platform-operator`: This operator handles changes to your LangGraph Platform CRDs.
 3. Configure your `langgraph-dataplane-values.yaml` file.
+```bash
   config:
-  langsmithApiKey: "" # API Key of your Workspace
-  langsmithWorkspaceId: "" # Workspace ID
-  hostBackendUrl: "https://api.host.langchain.com" # Only override this if on EU
-  smithBackendUrl: "https://api.smith.langchain.com" # Only override this if on EU
+    langsmithApiKey: "" # API Key of your Workspace
+    langsmithWorkspaceId: "" # Workspace ID
+    hostBackendUrl: "https://api.host.langchain.com" # Only override this if on EU
+    smithBackendUrl: "https://api.smith.langchain.com" # Only override this if on EU
+```
 4. Deploy `langgraph-dataplane` Helm chart.
+```bash
   helm repo add langchain https://github.com/langchain-ai/helm
   helm repo update
-  helm upgrade -i langgraph-dataplane langchain/langgraph-dataplane --values langgraph-dataplane-values.yaml
-5. If successful, you will see two services start up in your namespace.
-  NAME                                          READY   STATUS              RESTARTS   AGE
-  langgraph-dataplane-listener-7fccd788-wn2dx   0/1     Running             0          9s
-  langgraph-dataplane-redis-0                   0/1     ContainerCreating   0          9s
+  helm upgrade -i langgraph-dataplane langchain/langgraph-dataplane --values langgraph-dataplane-values.yaml --wait --debug
+```
+5. If successful, you will see three services start up in your namespace.
+```bash
+  NAME                                            READY   STATUS              RESTARTS   AGE
+  langgraph-dataplane-listener-6dd4749445-zjmr4   0/1     ContainerCreating   0          26s
+  langgraph-dataplane-operator-6b88879f9b-t76gk   1/1     Running             0          26s
+  langgraph-dataplane-redis-0                     1/1     Running             0          25s
+```
+
 6. You create a deployment from the [control plane UI](/langgraph-platform/control-plane#control-plane-ui).
 
 ## Amazon ECS

--- a/src/langgraph-platform/deploy-self-hosted-full-platform.mdx
+++ b/src/langgraph-platform/deploy-self-hosted-full-platform.mdx
@@ -16,35 +16,43 @@ Before deploying, review the [conceptual guide for the Self-Hosted Full Platform
 3. Use the [LangGraph CLI](/langgraph-platform/langgraph-cli) to [test your application locally](/langgraph-platform/local-server).
 4. Use the [LangGraph CLI](/langgraph-platform/langgraph-cli) to build a Docker image (i.e. `langgraph build`) and push it to a registry your Kubernetes cluster has access to.
 5. `KEDA` is installed on your cluster.
+```bash
   helm repo add kedacore https://kedacore.github.io/charts
   helm install keda kedacore/keda --namespace keda --create-namespace
+```
 6. Ingress Configuration
-  1. You must set up an ingress for your LangSmith instance. All agents will be deployed as Kubernetes services behind this ingress.
-  2. You can use this guide to [set up an ingress](https://docs.smith.langchain.com/self_hosting/configuration/ingress) for your instance.
+    1. You must set up an ingress for your LangSmith instance. All agents will be deployed as Kubernetes services behind this ingress.
+    2. You can use this guide to [set up an ingress](https://docs.smith.langchain.com/self_hosting/configuration/ingress) for your instance.
 7. You have slack space in your cluster for multiple deployments. `Cluster-Autoscaler` is recommended to automatically provision new nodes.
 8. A valid Dynamic PV provisioner or PVs available on your cluster. You can verify this by running:
+```bash
   kubectl get storageclass
+```
 9. Egress to `https://beacon.langchain.com` from your network. This is required for license verification and usage reporting if not running in air-gapped mode. See the [Egress documentation](/langgraph-platform/egress-metrics-metadata) for more details.
 
 ## Setup
 
 1. As part of configuring your Self-Hosted LangSmith instance, you enable the `langgraphPlatform` option. This will provision a few key resources.
-  1. `listener`: This is a service that listens to the [control plane](/langgraph-platform/control-plane) for changes to your deployments and creates/updates downstream CRDs.
-  2. `LangGraphPlatform CRD`: A CRD for LangGraph Platform deployments. This contains the spec for managing an instance of a LangGraph platform deployment.
-  3. `operator`: This operator handles changes to your LangGraph Platform CRDs.
-  4. `host-backend`: This is the [control plane](/langgraph-platform/control-plane).
+    1. `listener`: This is a service that listens to the [control plane](/langgraph-platform/control-plane) for changes to your deployments and creates/updates downstream CRDs.
+    2. `LangGraphPlatform CRD`: A CRD for LangGraph Platform deployments. This contains the spec for managing an instance of a LangGraph platform deployment.
+    3. `operator`: This operator handles changes to your LangGraph Platform CRDs.
+    4. `host-backend`: This is the [control plane](/langgraph-platform/control-plane).
 2. Two additional images will be used by the chart. Use the images that are specified in the latest release.
+```bash
   hostBackendImage:
-  repository: "docker.io/langchain/hosted-langserve-backend"
-  pullPolicy: IfNotPresent
+    repository: "docker.io/langchain/hosted-langserve-backend"
+    pullPolicy: IfNotPresent
   operatorImage:
-  repository: "docker.io/langchain/langgraph-operator"
-  pullPolicy: IfNotPresent
+    repository: "docker.io/langchain/langgraph-operator"
+    pullPolicy: IfNotPresent
+```
 3. In your config file for langsmith (usually `langsmith_config.yaml`), enable the `langgraphPlatform` option. Note that you must also have a valid ingress setup:
+```bash
   config:
-  langgraphPlatform:
-  enabled: true
-  langgraphPlatformLicenseKey: "YOUR_LANGGRAPH_PLATFORM_LICENSE_KEY"
+    langgraphPlatform:
+      enabled: true
+      langgraphPlatformLicenseKey: "YOUR_LANGGRAPH_PLATFORM_LICENSE_KEY"
+```
 4. In your `values.yaml` file, configure the `hostBackendImage` and `operatorImage` options (if you need to mirror images)
 5. You can also configure base templates for your agents by overriding the base templates [here](https://github.com/langchain-ai/helm/blob/main/charts/langsmith/values.yaml#L898).
 6. You create a deployment from the [control plane UI](/langgraph-platform/control-plane#control-plane-ui).


### PR DESCRIPTION
## Testing
Ran `docs dev`:

<img width="735" height="676" alt="Screenshot 2025-08-05 at 11 25 59 AM" src="https://github.com/user-attachments/assets/115cb117-b117-4de5-ab15-8068d0e66c44" />
<img width="891" height="686" alt="Screenshot 2025-08-05 at 11 26 12 AM" src="https://github.com/user-attachments/assets/9a040774-04e3-4961-b69f-3e3c6adfa9a9" />
