### PR TITLE
docs: swap to standalone server verbiage

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -45,7 +45,7 @@
           "icon": "file",
           "href": "https://docs.langchain.com/llms.txt"
         },
-      "chatgpt", 
+      "chatgpt",
       "claude"
       ]
   },
@@ -154,8 +154,8 @@
                   }
                 ]
               },
-              { 
-                "group": "LangGraph Studio", 
+              {
+                "group": "LangGraph Studio",
                 "pages": [
                   "langgraph-platform/langgraph-studio",
                   "langgraph-platform/invoke-studio",
@@ -188,7 +188,7 @@
                   "langgraph-platform/deploy-to-cloud",
                   "langgraph-platform/deploy-hybrid",
                   "langgraph-platform/deploy-self-hosted-full-platform",
-                  "langgraph-platform/deploy-data-plane-only",
+                  "langgraph-platform/deploy-standalone-server-only",
                   "langgraph-platform/use-remote-graph"
                 ]
               },
@@ -211,15 +211,15 @@
             "tab": "Manage",
             "groups": [
 
-              { 
-                "group": "Authentication & access control", 
+              {
+                "group": "Authentication & access control",
                 "pages": [
                   "langgraph-platform/auth",
                   "langgraph-platform/custom-auth",
                   "langgraph-platform/set-up-custom-auth",
                   "langgraph-platform/resource-auth",
                   "langgraph-platform/add-auth-server",
-                  "langgraph-platform/openapi-security"                
+                  "langgraph-platform/openapi-security"
                 ]
               },
               {
@@ -228,21 +228,21 @@
                   "langgraph-platform/scalability-and-resilience"
                 ]
               },
-              { 
+              {
                 "group": "Server customization",
                 "pages": [
                   "langgraph-platform/custom-lifespan",
                   "langgraph-platform/custom-middleware",
                   "langgraph-platform/custom-routes"
-                ] 
+                ]
               },
-              { 
-                "group": "Data management", 
+              {
+                "group": "Data management",
                 "pages": [
                   "langgraph-platform/data-storage-and-privacy",
                   "langgraph-platform/semantic-search",
                   "langgraph-platform/configure-ttl"
-                ] 
+                ]
               },
               {
                 "group": "Tutorials",

--- a/src/langgraph-platform/deploy-standalone-server-only.mdx
+++ b/src/langgraph-platform/deploy-standalone-server-only.mdx
@@ -1,8 +1,8 @@
 ---
-title: How to deploy self-hosted data plane only
-sidebarTitle: Deploy self-hosted data plane only
+title: How to deploy self-hosted standalone server
+sidebarTitle: Deploy self-hosted standalone server only
 ---
-Before deploying, review the [conceptual guide for the Data Plane Only](/langgraph-platform/self-hosted#data-plane-only) deployment option.
+Before deploying, review the [conceptual guide for the Standalone Server](/langgraph-platform/self-hosted#standalone-server) deployment option.
 
 ## Prerequisites
 
@@ -13,14 +13,14 @@ Before deploying, review the [conceptual guide for the Data Plane Only](/langgra
     <Note>
       **Shared Redis Instance**
       Multiple self-hosted deployments can share the same Redis instance. For example, for `Deployment A`, `REDIS_URI` can be set to `redis://<hostname_1>:<port>/1` and for `Deployment B`, `REDIS_URI` can be set to `redis://<hostname_1>:<port>/2`.
-      
+
       `1` and `2` are different database numbers within the same instance, but `<hostname_1>` is shared. **The same database number cannot be used for separate deployments**.
     </Note>
   2. `DATABASE_URI`: Postgres connection details. Postgres will be used to store assistants, threads, runs, persist thread state and long term memory, and to manage the state of the background task queue with 'exactly once' semantics. The value of `DATABASE_URI` must be a valid [Postgres connection URI](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS).
     <Note>
       **Shared Postgres Instance**
       Multiple self-hosted deployments can share the same Postgres instance. For example, for `Deployment A`, `DATABASE_URI` can be set to `postgres://<user>:<password>@/<database_name_1>?host=<hostname_1>` and for `Deployment B`, `DATABASE_URI` can be set to `postgres://<user>:<password>@/<database_name_2>?host=<hostname_1>`.
-      
+
       `<database_name_1>` and `database_name_2` are different databases within the same instance, but `<hostname_1>` is shared. **The same database cannot be used for separate deployments**.
     </Note>
   3. `LANGSMITH_API_KEY`: LangSmith API key.
@@ -49,9 +49,9 @@ docker run \
 
 <Note>
   * You need to replace `my-image` with the name of the image you built in the prerequisite steps (from `langgraph build`)
-  
+
   and you should provide appropriate values for `REDIS_URI`, `DATABASE_URI`, and `LANGSMITH_API_KEY`.
-  
+
   * If your application requires additional environment variables, you can pass them in a similar way.
 </Note>
 

--- a/src/langgraph-platform/deployment-options.mdx
+++ b/src/langgraph-platform/deployment-options.mdx
@@ -3,7 +3,7 @@ title: Deployment options
 sidebarTitle: Deployment options
 ---
 
-You can [run LangGraph Platform locally for free](/langgraph-platform/local-server) for testing and development. 
+You can [run LangGraph Platform locally for free](/langgraph-platform/local-server) for testing and development.
 
 ## Production deployment
 
@@ -11,11 +11,11 @@ There are 3 main options for deploying with [LangGraph Platform](/langgraph-plat
 
 1. [Cloud](#cloud)
 2. [Hybrid](#hybrid)
-3. [Self-Hosted](#self-hosted)
+3. [Fully Self-Hosted](#fully-self-hosted)
 
 A quick comparison:
 
-|                      | **Cloud** | **Hybrid** | **Self-Hosted** |
+|                      | **Cloud** | **Hybrid** | **Fully Self-Hosted** |
 |----------------------|----------------|-------------|-----------------|
 | **Description** | All components run in LangChain's cloud | Control plane runs in LangChain's cloud; data plane in your cloud | All components run in your cloud |
 | **CI/CD** | Managed internally by platform | Managed externally by you | Managed externally by you |
@@ -52,7 +52,7 @@ For more information, please see:
 * [Hybrid Conceptual Guide](/langgraph-platform/hybrid)
 * [How to deploy the Hybrid](/langgraph-platform/deploy-hybrid)
 
-## Self-Hosted
+## Fully Self-Hosted
 
 <Info>
   **Important**
@@ -64,17 +64,17 @@ The Self-Hosted deployment option allows you to run all components entirely with
 You can deploy either:
 
 1. **[Full Platform](/langgraph-platform/self-hosted#full-platform)**: Deploy both control plane and data plane with full UI/API management capabilities
-2. **[Data Plane Only](/langgraph-platform/self-hosted#data-plane-only)**: Deploy standalone instances of a LangGraph Server without the control plane UI
+2. **[Standalone Server](/langgraph-platform/self-hosted#standalone-server)**: Deploy standalone instances of a LangGraph Server without the control plane UI
 
 With the full platform option, build a Docker image using the [LangGraph CLI](/langgraph-platform/langgraph-cli) and deploy your LangGraph Server from the [control plane UI](/langgraph-platform/control-plane#control-plane-ui) or using the container deployment tooling of your choice.
 
-Supported Compute Platforms: [Kubernetes](https://kubernetes.io/) (for Control Plane), any compute platform (for Data Plane Only)
+Supported Compute Platforms: [Kubernetes](https://kubernetes.io/) (for Control Plane), any compute platform (for Standalone Server Only)
 
 For more information, please see:
 
 * [Self-Hosted Conceptual Guide](/langgraph-platform/self-hosted)
 * [How to deploy the Self-Hosted Full Platform](/langgraph-platform/deploy-self-hosted-full-platform)
-* [How to deploy Self-Hosted Data Plane Only](/langgraph-platform/deploy-data-plane-only)
+* [How to deploy Self-Hosted Standalone Server only](/langgraph-platform/deploy-standalone-server-only)
 
 ## Related
 

--- a/src/langgraph-platform/self-hosted.mdx
+++ b/src/langgraph-platform/self-hosted.mdx
@@ -4,7 +4,7 @@ title: Self-hosted
 The Self-Hosted deployment option allows you to run all components entirely within your own cloud environment. You can choose between two deployment models:
 
 1. **[Full Platform](#full-platform)**: Deploy both control plane and data plane with full UI/API management capabilities
-2. **[Data Plane Only](#data-plane-only)**: Deploy standalone instances of a LangGraph Server without the control plane UI
+2. **[Data Plane Only](#standalone-server)**: Deploy standalone instances of a LangGraph Server without the control plane UI
 
 <Info>
   **Important**
@@ -42,11 +42,11 @@ The Full Platform deployment model is a fully self-hosted solution where you man
   If you would like to enable this on your LangSmith instance, please follow the [Self-Hosted Full Platform deployment guide](/langgraph-platform/deploy-self-hosted-full-platform).
 </Tip>
 
-## Data Plane Only
+## Standalone Server
 
 ### Overview
 
-The Data Plane Only deployment model is the least restrictive option for deployment. There is no [control plane](/langgraph-platform/control-plane). [Data plane](/langgraph-platform/data-plane) infrastructure is managed by you.
+The Data Plane Only deployment model is the least restrictive option for deployment. There is no [control plane](/langgraph-platform/control-plane). A simplified version of the [Data plane](/langgraph-platform/data-plane) infrastructure is managed by you.
 
 |                   | [Control plane](/langgraph-platform/control-plane) | [Data plane](/langgraph-platform/data-plane) |
 |-------------------|-------------------|------------|
@@ -73,5 +73,5 @@ The Data Plane Only deployment model supports deploying data plane infrastructur
 The Data Plane Only deployment model supports deploying data plane infrastructure to any Docker-supported compute platform.
 
 <Tip>
-  To deploy a [LangGraph Server](/langgraph-platform/langgraph-server), follow the how-to guide for [how to deploy Data Plane Only](/langgraph-platform/deploy-data-plane-only).
+  To deploy a [LangGraph Server](/langgraph-platform/langgraph-server), follow the how-to guide for [how to deploy Data Plane Only](/langgraph-platform/deploy-standalone-server-only).
 </Tip>


### PR DESCRIPTION
Previous mapping of helm charts to deployment versions:
- None -> "cloud"
- langgraph-dataplane -> "hybrid"
- langgraph-cloud -> "dataplane"    <-- THIS WAS THE CONFUSING PART BC DATAPLANE HELM CHART DIDNT MAP TO DATAPLANE DOCS SECTION
- langsmith -> "full platform"

Now the mapping in our docs (and verbiage around it) is like this:
Previous mapping of helm charts to deployment versions:
- None -> "cloud"
- langgraph-dataplane -> "hybrid"
- langgraph-cloud -> "standalone container"    <-- ONLY THING THAT CHANGED
- langsmith -> "full platform"