### PR TITLE
Update LGP control plane API data models

### DIFF
--- a/src/langgraph-platform/control-plane.mdx
+++ b/src/langgraph-platform/control-plane.mdx
@@ -26,13 +26,23 @@ The Control Plane UI is embedded in [LangSmith](https://docs.smith.langchain.com
 
 This section describes the data model of the control plane API. The API is used to create, update, and delete deployments. See the [control plane API reference](/langgraph-platform/api-ref-control-plane) for more details.
 
-### Deployment
+### Integrations
+
+An integration is an abstraction for a `git` repository provider (e.g. GitHub). It contains all of the required metadata needed to connect with and deploy from a `git` repository.
+
+### Deployments
 
 A deployment is an instance of a LangGraph Server. A single deployment can have many revisions.
 
-### Revision
+### Revisions
 
 A revision is an iteration of a deployment. When a new deployment is created, an initial revision is automatically created. To deploy code changes or update secrets for a deployment, a new revision must be created.
+
+### Listeners
+
+A listener is an instance of a ["listener" application](./data-plane#”listener”-application). A listener contains metadata about the application (e.g. version) and metadata about the compute infrastructure where it can deploy to (e.g. Kubernetes namespaces).
+
+The listener data model only applies for [Hybrid](./hybrid) and [Self-Hosted](./self-hosted) deployments.
 
 ## Control Plane Features
 

--- a/src/langgraph-platform/control-plane.mdx
+++ b/src/langgraph-platform/control-plane.mdx
@@ -40,9 +40,9 @@ A revision is an iteration of a deployment. When a new deployment is created, an
 
 ### Listeners
 
-A listener is an instance of a ["listener" application](./data-plane#”listener”-application). A listener contains metadata about the application (e.g. version) and metadata about the compute infrastructure where it can deploy to (e.g. Kubernetes namespaces).
+A listener is an instance of a ["listener" application](/langgraph-platform/data-plane#”listener”-application). A listener contains metadata about the application (e.g. version) and metadata about the compute infrastructure where it can deploy to (e.g. Kubernetes namespaces).
 
-The listener data model only applies for [Hybrid](./hybrid) and [Self-Hosted](./self-hosted) deployments.
+The listener data model only applies for [Hybrid](/langgraph-platform/hybrid) and [Self-Hosted](/langgraph-platform/self-hosted) deployments.
 
 ## Control Plane Features
 


### PR DESCRIPTION
### Summary
Quick updates to the LGP Control Plane API data models.
1. Updated all of the data model heads to be plural (`Deployment` --> `Deployments`).
1. Added `Integrations` data model. This data model was always there, but we never exposed it in the API spec until recently.
1. Added `Listeners` data model. This data model is new.

### Next Steps
1. Update `Deploy to Hybrid` page with new instructions for deploying to configuring a `Listener`. Will do this in a different PR.