### PR TITLE
Add `Listeners > Use Cases` section for LGP `Hybrid` conceptual guide page

### DIFF
--- a/src/langgraph-platform/deploy-hybrid.mdx
+++ b/src/langgraph-platform/deploy-hybrid.mdx
@@ -19,10 +19,10 @@ Before deploying, review the [conceptual guide for the Hybrid](/langgraph-platfo
 ### Prerequisites
 
 1. `KEDA` is installed on your cluster.
-```bash
-  helm repo add kedacore https://kedacore.github.io/charts
-  helm install keda kedacore/keda --namespace keda --create-namespace
-```
+    ```bash
+      helm repo add kedacore https://kedacore.github.io/charts
+      helm install keda kedacore/keda --namespace keda --create-namespace
+    ```
 2. A valid `Ingress` controller is installed on your cluster.
 3. You have slack space in your cluster for multiple deployments. `Cluster-Autoscaler` is recommended to automatically provision new nodes.
 4. You will need to enable egress to two control plane URLs. The listener polls these endpoints for deployments:
@@ -32,7 +32,7 @@ Before deploying, review the [conceptual guide for the Hybrid](/langgraph-platfo
 ### Setup
 
 1. Provide your LangSmith organization ID to us. Your LangSmith organization will be configured to deploy the data plane in your cloud.
-2. Create a listener from the LangSmith UI. The `Listener` data model is configured for the actual ["listener" application](./data-plane#”listener”-application).
+2. Create a listener from the LangSmith UI. The `Listener` data model is configured for the actual ["listener" application](/langgraph-platform/data-plane#”listener”-application).
     1. In the left-hand navigation, select `LangGraph Platform` > `Listeners`.
     2. In the top-right of the page, select `+ Create Listener`.
     3. Enter a unique `Compute ID` for the listener. The `Compute ID` is a user-defined identifier that should be unique across all listeners in the current LangSmith workspace. Ensure that the `Compute ID` provides context to the end user about where their LangGraph Server deployments will be deployed to. For example, a `Compute ID` can be set to `k8s-cluster-name-dev-01`. In this example, the name of the Kubernetes cluster is `k8s-cluster-name`, `dev` denotes that the cluster is reserved for "development" workloads, and `01` is a numerical suffix to reduce naming collisions.
@@ -40,7 +40,7 @@ Before deploying, review the [conceptual guide for the Hybrid](/langgraph-platfo
     5. In the top-right on the page, select `Submit`.
     6. After the listener is created, copy the listener ID. You will use it later when installing the actual "listener" application.
 3. A [Helm chart](https://github.com/langchain-ai/helm/tree/main/charts/langgraph-dataplane) is provided to install the necesssary components in your Kubernetes cluster.
-    - `langgraph-listener`: This is a service that listens to LangChain's [control plane](/langgraph-platform/control-plane) for changes to your deployments and creates/updates downstream CRDs. This is the ["listener" application](./data-plane#”listener”-application).
+    - `langgraph-listener`: This is a service that listens to LangChain's [control plane](/langgraph-platform/control-plane) for changes to your deployments and creates/updates downstream CRDs. This is the ["listener" application](/langgraph-platform/data-plane#”listener”-application).
     - `LangGraphPlatform CRD`: A CRD for LangGraph Platform deployments. This contains the spec for managing an instance of a LangGraph Platform deployment.
     - `langgraph-platform-operator`: This operator handles changes to your LangGraph Platform CRDs.
 4. Configure your `langgraph-dataplane-values.yaml` file.

--- a/src/langgraph-platform/hybrid.mdx
+++ b/src/langgraph-platform/hybrid.mdx
@@ -35,3 +35,49 @@ For information on how to deploy a [LangGraph Server](/langgraph-platform/langgr
 <Tip>
   If you would like to deploy to Kubernetes, you can follow the [Hybrid deployment guide](/langgraph-platform/deploy-hybrid).
 </Tip>
+
+## Listeners
+
+In a hybrid deployment, one or more ["listener" applications](/langgraph-platform/data-plane#”listener”-application) can be deployed depending on the organization of LangSmith workspaces and Kubernetes clusters.
+
+**Kubernetes cluster organization**
+- One or more listeners can be deployed on a Kubernetes cluster.
+- A listener can be configured to deploy to one or more Kubernetes namespaces in the cluster.
+- It's the responsibility of the owner of Kubernetes to decide the optimal organization of listeners for their use case. This requires planning ahead of time for how LangGraph Server deployments should be organized.
+
+**LangSmith workspace organization**
+- A workspace can have one or more listeners associated with it.
+- LangGraph Server deployments in a workspace can only be deployed to Kubernetes clusters where each of the listeners of the workspace is deployed to.
+
+### Use Cases
+
+The following sections describe use cases for how listeners can be configured depending on the organization of LangSmith workspaces and Kubernetes clusters. However, these not hard requirements. They are a non-exhaustive list of examples.
+
+**Each LangSmith workspace deploys to a separate Kubernetes cluster**
+
+Example:
+- Kubernetes cluster `alpha` is for workspace `A`
+- Kubernetes cluster `beta` is for workspace `B`
+
+**Each LangSmith workspace deploys to a separate Kubernetes cluster, but “dev” workloads can be deployed to a shared Kubernetes cluster**
+
+In this use case, mulitple LangSmith workspaces deploy to a single Kubernetes cluster.
+
+Example:
+- Kubernetes cluster `alpha` is for workspace `A`
+- Kubernetes cluster `beta` is for workspace `B`
+- Kubernetes cluster `dev` is for workspaces `A` and `B`
+- Both workspaces have two listeners associated with them
+- Kubernetes cluster `dev` has two listener deployments
+
+**Deploy to one Kubernetes cluster, in one Kubernetes namespace**
+
+Example:
+- Kubernetes cluster `alpha` is for workspace `A`
+- Kubernetes cluster `alpha` is for workspace `B`
+
+**Deploy to one Kubernetes cluster, but in multiple Kubernetes namespaces**
+
+Example:
+- Kubernetes cluster `alpha` and namespace `1` is for workspace `A` 
+- Kubernetes cluster `alpha` and namespace `2` is for workspace `B`

--- a/src/langgraph-platform/hybrid.mdx
+++ b/src/langgraph-platform/hybrid.mdx
@@ -53,13 +53,13 @@ In a hybrid deployment, one or more ["listener" applications](/langgraph-platfor
 
 The following sections describe use cases for how listeners can be configured depending on the organization of LangSmith workspaces and Kubernetes clusters. However, these not hard requirements. They are a non-exhaustive list of examples.
 
-**Each LangSmith workspace deploys to a separate Kubernetes cluster**
+#### Each LangSmith workspace deploys to a separate Kubernetes cluster
 
 Example:
 - Kubernetes cluster `alpha` is for workspace `A`
 - Kubernetes cluster `beta` is for workspace `B`
 
-**Each LangSmith workspace deploys to a separate Kubernetes cluster, but “dev” workloads can be deployed to a shared Kubernetes cluster**
+#### Each LangSmith workspace deploys to a separate Kubernetes cluster, but “dev” workloads can be deployed to a shared Kubernetes cluster
 
 In this use case, mulitple LangSmith workspaces deploy to a single Kubernetes cluster.
 
@@ -70,13 +70,13 @@ Example:
 - Both workspaces have two listeners associated with them
 - Kubernetes cluster `dev` has two listener deployments
 
-**Deploy to one Kubernetes cluster, in one Kubernetes namespace**
+#### Deploy to one Kubernetes cluster, in one Kubernetes namespace
 
 Example:
 - Kubernetes cluster `alpha` is for workspace `A`
 - Kubernetes cluster `alpha` is for workspace `B`
 
-**Deploy to one Kubernetes cluster, but in multiple Kubernetes namespaces**
+#### Deploy to one Kubernetes cluster, but in multiple Kubernetes namespaces
 
 Example:
 - Kubernetes cluster `alpha` and namespace `1` is for workspace `A` 


### PR DESCRIPTION
### Summary
Closes [LGP-420](https://linear.app/langchain/issue/LGP-420/write-best-practices-guide-for-creating-and-managing-listeners)

Add a "use cases" section for listeners to help hybrid deployment users understand how to setup/configure listeners with respect to Kubernetes clusters and LangSmith workspaces.