### PR TITLE
fix: banner width w css override

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -138,3 +138,7 @@ code,
   position: relative !important;
   z-index: 1 !important;
 }
+
+#banner {
+  max-width: 100% !important;
+}


### PR DESCRIPTION
<img width="2856" height="968" alt="Screenshot 2025-08-18 at 11 10 42 AM" src="https://github.com/user-attachments/assets/b64121e0-ce29-4ae7-9e36-456ae336e82b" />
