### PR TITLE
Update LGP landing page

### DIFF
--- a/src/langgraph-platform/deployment-options.mdx
+++ b/src/langgraph-platform/deployment-options.mdx
@@ -3,9 +3,9 @@ title: Deployment options
 sidebarTitle: Deployment options
 ---
 
+<Tip>
 You can [run LangGraph Platform locally for free](/langgraph-platform/local-server) for testing and development.
-
-## Production deployment
+</Tip>
 
 There are 3 main options for deploying with [LangGraph Platform](/langgraph-platform/index):
 

--- a/src/langgraph-platform/index.mdx
+++ b/src/langgraph-platform/index.mdx
@@ -1,26 +1,103 @@
 ---
-title: LangGraph Platform
+title: Get started with LangGraph Platform
+sidebarTitle: Get started
 ---
 
-Develop, deploy, scale, and manage agents with **LangGraph Platform**—the platform for hosting long-running, agentic workflows.
+LangGraph Platform is a runtime for deploying and managing long-running, stateful agent workflows in production. It provides APIs for execution, persistence, monitoring, and scaling of agent applications. Agents built with [LangGraph](/oss/python/overview) or other frameworks can be hosted on the platform and exposed through managed endpoints.
 
 <Tip>
-  **Get started with LangGraph Platform**<br/>
-  Check out the quickstart guides for instructions on how to use LangGraph Platform to run a LangGraph application [locally](/langgraph-platform/local-server) or deploy to [cloud](/langgraph-platform/deployment-quickstart).
+**Quickstart**  
+- [Run locally](/langgraph-platform/local-server) using the LangGraph server process.  
+- [Deploy to cloud](/langgraph-platform/deployment-quickstart) for a managed endpoint.
 </Tip>
 
-## Why use LangGraph Platform?
+<Columns cols={2}>
 
-<div align="center"><iframe width="560" height="315" src="https://www.youtube.com/embed/pfAQxBS5z88?si=XGS6Chydn6lhSO1S" title="What is LangGraph Platform?" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" referrerpolicy="strict-origin-when-cross-origin" allowfullscreen></iframe></div>
+  <Card
+    title="Deployment Options"
+    icon="cloud"
+    href="/langgraph-platform/deployment-options"
+    arrow="true"
+    cta="Learn more"
+  >
+    Choose from cloud, hybrid, or self-hosted deployments based
+    on your infrastructure requirements.
+  </Card>
 
-LangGraph Platform makes it easy to get your agent running in production —  whether it's built with LangGraph or another framework — so you can focus on your app logic, not infrastructure. Deploy with one click to get a live endpoint, and use our robust APIs and built-in task queues to handle production scale.
+  <Card
+    title="LangGraph Studio"
+    icon="layout"
+    href="/langgraph-platform/langgraph-studio"
+    arrow="true"
+    cta="Learn more"
+  >
+    Visualize, debug, and interact with agent workflows.
+    Includes integrations with LangSmith for tracing and evaluation.
+  </Card>
 
-* **[Streaming Support](/langgraph-platform/streaming)**: As agents grow more sophisticated, they often benefit from streaming both token outputs and intermediate states back to the user. Without this, users are left waiting for potentially long operations with no feedback. LangGraph Server provides multiple streaming modes optimized for various application needs.
-* **[Background Runs](/langgraph-platform/background-run)**: For agents that take longer to process (e.g., hours), maintaining an open connection can be impractical. The LangGraph Server supports launching agent runs in the background and provides both polling endpoints and webhooks to monitor run status effectively.
-* **Support for long runs**: Regular server setups often encounter timeouts or disruptions when handling requests that take a long time to complete. LangGraph Server's API provides robust support for these tasks by sending regular heartbeat signals, preventing unexpected connection closures during prolonged processes.
-* **Handling Burstiness**: Certain applications, especially those with real-time user interaction, may experience "bursty" request loads where numerous requests hit the server simultaneously. LangGraph Server includes a task queue, ensuring requests are handled consistently without loss, even under heavy loads.
-* **[Double-texting](/langgraph-platform/interrupt-concurrent)**: In user-driven applications, it's common for users to send multiple messages rapidly. This "double texting" can disrupt agent flows if not handled properly. LangGraph Server offers built-in strategies to address and manage such interactions.
-* **[Checkpointers and memory management](/oss/persistence#checkpoints)**: For agents needing persistence (e.g., conversation memory), deploying a robust storage solution can be complex. LangGraph Platform includes optimized [checkpointers](/oss/persistence#checkpoints) and a [memory store](/oss/persistence#memory-store), managing state across sessions without the need for custom solutions.
-* **[Human-in-the-loop support](/langgraph-platform/add-human-in-the-loop)**: In many applications, users require a way to intervene in agent processes. LangGraph Server provides specialized endpoints for human-in-the-loop scenarios, simplifying the integration of manual oversight into agent workflows.
-* **[LangGraph Studio](/langgraph-platform/langgraph-studio)**: Enables visualization, interaction, and debugging of agentic systems that implement the LangGraph Server API protocol. Studio also integrates with LangSmith to enable tracing, evaluation, and prompt engineering.
-* **[Deployment](/langgraph-platform/deployment-options)**: There are three ways to deploy on LangGraph Platform: [Cloud](/langgraph-platform/cloud), [Hybrid](/langgraph-platform/hybrid), and [Self-Hosted](/langgraph-platform/self-hosted).
+  <Card
+    title="Streaming Support"
+    icon="waves"
+    href="/langgraph-platform/streaming"
+    arrow="true"
+    cta="Learn more"
+  >
+    Stream token outputs and intermediate states back to the client in real time,
+    reducing wait times during long operations.
+  </Card>
+
+  <Card
+    title="Background Runs"
+    icon="clock"
+    href="/langgraph-platform/background-run"
+    arrow="true"
+    cta="Learn more"
+  >
+    Run agents asynchronously for long-duration tasks (minutes to hours),
+    with monitoring via polling endpoints or webhooks.
+  </Card>
+
+  <Card
+    title="Burst Handling"
+    icon="server"
+    href="/langgraph-platform/background-run"
+    arrow="true"
+    cta="Learn more"
+  >
+    Use the built-in task queue to handle bursty request loads without data loss
+    or service disruption.
+  </Card>
+
+  <Card
+    title="Interrupt Handling"
+    icon="message-square"
+    href="/langgraph-platform/interrupt-concurrent"
+    arrow="true"
+    cta="Learn more"
+  >
+    Manage overlapping or rapid user inputs (“double texting”) without breaking
+    agent state.
+  </Card>
+
+  <Card
+    title="Checkpointers & Memory"
+    icon="database"
+    href="/oss/persistence#checkpoints"
+    arrow="true"
+    cta="Learn more"
+  >
+    Persist agent state with built-in checkpointing and memory storage,
+    removing the need for custom solutions.
+  </Card>
+
+  <Card
+    title="Human-in-the-Loop"
+    icon="user-check"
+    href="/langgraph-platform/add-human-in-the-loop"
+    arrow="true"
+    cta="Learn more"
+  >
+    Insert human review or intervention into an agent run through dedicated APIs.
+  </Card>
+
+</Columns>

--- a/src/langgraph-platform/index.mdx
+++ b/src/langgraph-platform/index.mdx
@@ -1,32 +1,40 @@
 ---
 title: Get started with LangGraph Platform
 sidebarTitle: Get started
+mode: wide
 ---
 
 LangGraph Platform is a runtime for deploying and managing long-running, stateful agent workflows in production. It provides APIs for execution, persistence, monitoring, and scaling of agent applications. Agents built with [LangGraph](/oss/python/overview) or other frameworks can be hosted on the platform and exposed through managed endpoints.
 
-<Tip>
-**Quickstart**  
-- [Run locally](/langgraph-platform/local-server) using the LangGraph server process.  
-- [Deploy to cloud](/langgraph-platform/deployment-quickstart) for a managed endpoint.
-</Tip>
+Choose from cloud, hybrid, or self-hosted deployments based on your infrastructure requirements. For more details, refer to the [Deployment options](/langgraph-platform/deployment-options) page.
 
-<Columns cols={2}>
+## Quickstarts
+
+<Columns cols={3}>
 
   <Card
-    title="Deployment Options"
-    icon="cloud"
-    href="/langgraph-platform/deployment-options"
+    title="Run a LangGraph app locally"
+    icon="laptop"
+    href="/langgraph-platform/local-server"
     arrow="true"
     cta="Learn more"
   >
-    Choose from cloud, hybrid, or self-hosted deployments based
-    on your infrastructure requirements.
+    Test and develop your app using the LangGraph server process locally.
+  </Card>
+
+  <Card
+    title="Deploy to cloud"
+    icon="cloud"
+    href="/langgraph-platform/deployment-quickstart"
+    arrow="true"
+    cta="Learn more"
+  >
+    Run your app in a fully managed cloud deployment.
   </Card>
 
   <Card
     title="LangGraph Studio"
-    icon="layout"
+    icon="play"
     href="/langgraph-platform/langgraph-studio"
     arrow="true"
     cta="Learn more"
@@ -35,9 +43,15 @@ LangGraph Platform is a runtime for deploying and managing long-running, statefu
     Includes integrations with LangSmith for tracing and evaluation.
   </Card>
 
+</Columns>
+
+## Features
+
+<Columns cols={3}>
+
   <Card
     title="Streaming Support"
-    icon="waves"
+    icon="signal"
     href="/langgraph-platform/streaming"
     arrow="true"
     cta="Learn more"
@@ -60,7 +74,7 @@ LangGraph Platform is a runtime for deploying and managing long-running, statefu
   <Card
     title="Burst Handling"
     icon="server"
-    href="/langgraph-platform/background-run"
+    href="/langgraph-platform/data-plane#redis"
     arrow="true"
     cta="Learn more"
   >
@@ -70,7 +84,7 @@ LangGraph Platform is a runtime for deploying and managing long-running, statefu
 
   <Card
     title="Interrupt Handling"
-    icon="message-square"
+    icon="split"
     href="/langgraph-platform/interrupt-concurrent"
     arrow="true"
     cta="Learn more"


### PR DESCRIPTION
This PR updates the LGP landing page to provide better direction to the quickstarts and reduce the "sales" language. Here is the preview: https://langchain-5e9cc07a-preview-lgplan-1756309673-03e45ea.mintlify.app/langgraph-platform

Also, a small update to the deployment options page to remove some clutter.