### PR TITLE
fix: remove if using enterprise phrasing

### DIFF
--- a/src/langgraph-platform/deploy-standalone-server.mdx
+++ b/src/langgraph-platform/deploy-standalone-server.mdx
@@ -24,7 +24,7 @@ Before deploying, review the [conceptual guide for the Standalone Server](/langg
       `<database_name_1>` and `database_name_2` are different databases within the same instance, but `<hostname_1>` is shared. **The same database cannot be used for separate deployments**.
     </Note>
   3. `LANGSMITH_API_KEY`: LangSmith API key.
-  4. `LANGGRAPH_CLOUD_LICENSE_KEY`: (if using [Enterprise](/langgraph-platform/data-plane#licensing)) LangGraph Platform license key. This will be used to authenticate ONCE at server start up.
+  4. `LANGGRAPH_CLOUD_LICENSE_KEY`: LangGraph Platform license key. This will be used to authenticate ONCE at server start up.
   5. `LANGSMITH_ENDPOINT`: To send traces to a [self-hosted LangSmith](https://docs.smith.langchain.com/self_hosting) instance, set `LANGSMITH_ENDPOINT` to the hostname of the self-hosted LangSmith instance.
 4. Egress to `https://beacon.langchain.com` from your network. This is required for license verification and usage reporting if not running in air-gapped mode. See the [Egress documentation](/langgraph-platform/egress-metrics-metadata) for more details.
 


### PR DESCRIPTION
this does not apply anymore, because we no longer support running standalone server without a license key

@anyone feel free to just merge this when you approve