### PR TITLE
feat: Add LangSmith Release Versions page

### DIFF
--- a/src/langsmith/administration-overview.mdx
+++ b/src/langsmith/administration-overview.mdx
@@ -359,3 +359,7 @@ Usage limits can be updated from the `Settings` page under `Usage and Billing`. 
 ### Related content
 
 * Tutorial on how to [optimize spend](/langsmith/billing#optimize-your-tracing-spend)
+
+## Additional Resources
+
+* **[Release Versions](/langsmith/release-versions)**: Learn about LangSmith's version support policy, including Active, Critical, End of Life, and Deprecated support levels.

--- a/src/langsmith/release-versions.mdx
+++ b/src/langsmith/release-versions.mdx
@@ -1,0 +1,86 @@
+---
+title: Release Versions
+---
+
+LangSmith provides different support levels for different versions, which may include new features, bug fixes, or security patches:
+
+## Support Levels
+
+### Active
+The current minor version (N) receives full support including:
+- New features and capabilities
+- Bug fixes and regressions
+- Security patches
+- Quality-of-life improvements
+- High confidence changes that are narrowly scoped
+
+### Critical
+The previous minor version (N-1) receives limited support including:
+- Critical security fixes
+- Installation fixes
+- No new features or general bug fixes
+- Transitioned from Active when a newer minor version is released
+
+### End of Life (EOL)
+Versions older than N-2 (N-2, N-3, etc.) receive no support:
+- No new patch releases
+- No bug fixes, including known bugs
+- No security updates
+- Users should upgrade to a supported version
+
+### Deprecated
+Versions that are no longer maintained:
+- All versions prior to the first stable release
+- Versions that have been explicitly deprecated
+- No support or maintenance provided
+
+## Version Support Policy
+
+LangSmith follows an N-2 support policy for minor versions:
+
+- **N (Current)**: Active support
+- **N-1**: Critical support  
+- **N-2 and older**: End of Life
+
+Where N represents the latest minor version (e.g., 0.1, 0.2, etc.).
+
+### Minor Version Support
+
+Minor versions include new features and capabilities and are supported according to the N-2 policy. When we refer to a minor version, such as v0.1, we always mean its latest available patch release (v0.1.x).
+
+### Patch Releases
+
+During the support window for each version:
+
+- **Active Support**: Regular patch releases with bug fixes, regressions, and new features
+- **Critical Support**: Security-only releases for critical fixes related to security and installation
+- **End of Life**: No new patches released
+
+## Current Version Support
+
+To check the current supported versions and their support levels, refer to the [LangSmith changelog](https://github.com/langchain-ai/langsmith/releases) for the latest release information.
+
+## Recommendations
+
+- **Stay Current**: We recommend upgrading to the latest minor version to receive full support and access to new features
+- **Plan Upgrades**: Monitor the changelog for upcoming version changes and plan upgrades accordingly
+- **Security**: Critical security fixes are only provided for Active and Critical support versions
+- **Testing**: Test your applications with newer versions before upgrading in production
+
+## Version Compatibility
+
+When upgrading between minor versions:
+- Review the changelog for breaking changes
+- Test your applications thoroughly
+- Follow the upgrade guides provided in the documentation
+- Consider the support timeline for your current version
+
+## Self-Hosted Considerations
+
+For self-hosted LangSmith installations:
+- Ensure you're running a supported version to receive security updates
+- Plan regular upgrades to maintain support
+- Monitor the [Helm chart releases](https://github.com/langchain-ai/langsmith-helm-charts/releases) for updates
+- Follow the [self-hosted upgrade guide](/langsmith/self-host-upgrades) for detailed instructions
+
+For specific version information and upgrade guides, see the [LangSmith changelog](https://github.com/langchain-ai/langsmith/releases).

--- a/src/langsmith/release-versions.mdx
+++ b/src/langsmith/release-versions.mdx
@@ -7,7 +7,7 @@ LangSmith provides different support levels for different versions, which may in
 ## Support Levels
 
 ### Active
-The current minor version (N) receives full support including:
+The current minor version (N) receives full support, including:
 - New features and capabilities
 - Bug fixes and regressions
 - Security patches

--- a/src/langsmith/release-versions.mdx
+++ b/src/langsmith/release-versions.mdx
@@ -80,7 +80,7 @@ When upgrading between minor versions:
 For self-hosted LangSmith installations:
 - Ensure you're running a supported version to receive security updates
 - Plan regular upgrades to maintain support
-- Monitor the [Helm chart releases](https://github.com/langchain-ai/langsmith-helm-charts/releases) for updates
+- Monitor [Helm chart releases](https://github.com/langchain-ai/langsmith-helm-charts/releases) for updates
 - Follow the [self-hosted upgrade guide](/langsmith/self-host-upgrades) for detailed instructions
 
 For specific version information and upgrade guides, see the [LangSmith changelog](https://github.com/langchain-ai/langsmith/releases).

--- a/src/langsmith/release-versions.mdx
+++ b/src/langsmith/release-versions.mdx
@@ -15,7 +15,7 @@ The current minor version (N) receives full support including:
 - High confidence changes that are narrowly scoped
 
 ### Critical
-The previous minor version (N-1) receives limited support including:
+The previous minor version (N-1) receives limited support:
 - Critical security fixes
 - Installation fixes
 - No new features or general bug fixes

--- a/src/langsmith/release-versions.mdx
+++ b/src/langsmith/release-versions.mdx
@@ -2,7 +2,7 @@
 title: Release Versions
 ---
 
-LangSmith provides different support levels for different versions, which may include new features, bug fixes, or security patches:
+LangSmith provides different support levels for different versions, which may include new features, bug fixes, or security patches.
 
 ## Support Levels
 


### PR DESCRIPTION
- Create new release-versions.mdx page explaining N-2 version support policy
- Add support levels: Active, Critical, End of Life, and Deprecated
- Include version support policy details and recommendations
- Add self-hosted considerations section
- Update administration overview to include the new page under Additional Resources
- Link to LangSmith changelog and Helm chart releases for current version info