### PR TITLE
Fix rendering on table with comma in headers

### DIFF
--- a/src/langsmith/self-host-scale.mdx
+++ b/src/langsmith/self-host-scale.mdx
@@ -91,11 +91,11 @@ For write load (trace ingestion):
 The exact optimal configuration depends on your usage and trace payloads. Use the examples below in combination with the information above and your specific usage to update your LangSmith configuration as you see fit. If you have any questions, please reach out to the LangChain team.
 </Note>
 
-### Low reads, low writes
+### Low reads, low writes <a name="low-reads-low-writes"></a>
 
 The default LangSmith configuration will handle this load. No custom resource configuration is needed here.
 
-### Low reads, high writes
+### Low reads, high writes <a name="low-reads-high-writes"></a>
 
 You have a very high scale of trace ingestions, but single digit number of users on the frontend querying traces at any one time.
 
@@ -172,7 +172,7 @@ commonEnv:
     value: "0"
 ```
 
-### High reads, low writes
+### High reads, low writes <a name="high-reads-low-writes"></a>
 
 You have a relatively low scale of trace ingestions, but many frontend users querying traces and/or have scripts that hit the `/runs/query` or `/runs/<run-id>` endpoints frequently.
 
@@ -221,7 +221,7 @@ clickhouse:
     cluster: "replicated"
 ```
 
-### Medium reads, medium writes
+### Medium reads, medium writes <a name="medium-reads-medium-writes"></a>
 
 This is a good all around configuration that should be able to handle most usage patterns of LangSmith. In internal testing, this configuration allowed us to scale to 100 traces ingested per second and 40 read requests per second.
 
@@ -291,7 +291,7 @@ commonEnv:
 If you still notice slow reads with the above configuration, we recommend moving to a [replicated Clickhouse cluster setup](/langsmith/self-host-external-clickhouse#ha-replicated-clickhouse-cluster)
 </Warning>
 
-### High reads, high writes
+### High reads, high writes <a name="high-reads-high-writes"></a>
 
 You have a very high rate of trace ingestion (approaching 1000 traces submitted per second) and also have many users querying traces on the frontend (over 50 users) and/or scripts that are consistently making requests to `/runs/query` or `/runs/<run-id>` endpoints.
 


### PR DESCRIPTION
Fixing a table render issue as described on Slack. Looks like the commas in the headers were messing things up, so this PR adds anchor links to each.