### PR TITLE
Fix to pricing link in new LS site

### DIFF
--- a/src/langsmith/pricing-plans.mdx
+++ b/src/langsmith/pricing-plans.mdx
@@ -1,5 +1,5 @@
 ---
 title: Pricing plans
 sidebarTitle: Plans
-url: "https://docs.smith.langchain.com/pricing/plans"
+url: "https://langchain.com/pricing"
 ---


### PR DESCRIPTION
Fixes pricing link (this was using the link to the old site).