### PR TITLE
Add callout

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -118,7 +118,7 @@
         "version": "Python",
         "dropdowns": [
           {
-            "dropdown": "OSS frameworks",
+            "dropdown": "OSS (v1-alpha)",
             "icon": "/images/brand/langgraph-pill.svg",
             "description": "LangChain and LangGraph",
             "tabs": [

--- a/src/oss/langchain-agents.mdx
+++ b/src/oss/langchain-agents.mdx
@@ -2,6 +2,10 @@
 title: Agents
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 ## Overview
 
 - System prompt (link to messages)

--- a/src/oss/langchain-context-engineering.mdx
+++ b/src/oss/langchain-context-engineering.mdx
@@ -2,6 +2,10 @@
 title: Context Engineering in Agents
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 The hard part of building agents (or any LLM application) is making them reliable enough.
 While they may work for a prototype, they often mess up in more real world and widespread use cases.
 

--- a/src/oss/langchain-deploy.mdx
+++ b/src/oss/langchain-deploy.mdx
@@ -1,3 +1,7 @@
 ---
 title: Deploy
 ---
+
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />

--- a/src/oss/langchain-evals.mdx
+++ b/src/oss/langchain-evals.mdx
@@ -2,8 +2,9 @@
 title: Evaluate agent performance
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
 
-
+<AlphaCallout />
 
 To evaluate your agent's performance you can use `LangSmith` [evaluations](https://docs.smith.langchain.com/evaluation). You would need to first define an evaluator function to judge the results from an agent, such as final outputs or trajectory. Depending on your evaluation technique, this may or may not involve a reference output:
 

--- a/src/oss/langchain-human-in-the-loop.mdx
+++ b/src/oss/langchain-human-in-the-loop.mdx
@@ -2,6 +2,9 @@
 title: Human-in-the-loop
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
 
 ## Overview
 

--- a/src/oss/langchain-installation.mdx
+++ b/src/oss/langchain-installation.mdx
@@ -2,6 +2,10 @@
 title: Installation
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 To install the core LangChain package
 
 :::python

--- a/src/oss/langchain-long-term-memory.mdx
+++ b/src/oss/langchain-long-term-memory.mdx
@@ -2,6 +2,10 @@
 title: Long Term Memory
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 ## Overview
 
 ## Memory Types

--- a/src/oss/langchain-mcp.mdx
+++ b/src/oss/langchain-mcp.mdx
@@ -2,7 +2,9 @@
 title: MCP
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
 
+<AlphaCallout />
 
 ## Overview
 

--- a/src/oss/langchain-messages.mdx
+++ b/src/oss/langchain-messages.mdx
@@ -2,6 +2,10 @@
 title: Messages
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 ## Overview
 
 ## System Message

--- a/src/oss/langchain-migrations-v1-0-0.mdx
+++ b/src/oss/langchain-migrations-v1-0-0.mdx
@@ -2,6 +2,10 @@
 title: Migrate LangChain to v1.0.0
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 # Migrate LangChain to v1.0.0
 
 This guide helps you migrate from LangChain 0.x to v1.0.0.

--- a/src/oss/langchain-models.mdx
+++ b/src/oss/langchain-models.mdx
@@ -2,7 +2,9 @@
 title: Models
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
 
+<AlphaCallout />
 
 ## `init_chat_model`
 

--- a/src/oss/langchain-multi-agent.mdx
+++ b/src/oss/langchain-multi-agent.mdx
@@ -2,6 +2,10 @@
 title: Multi-agent
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 ## Overview
 
 ## Calling inside tools

--- a/src/oss/langchain-observability.mdx
+++ b/src/oss/langchain-observability.mdx
@@ -1,3 +1,7 @@
 ---
 title: Observability
 ---
+
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />

--- a/src/oss/langchain-overview.mdx
+++ b/src/oss/langchain-overview.mdx
@@ -2,7 +2,9 @@
 title: Overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
 
+<AlphaCallout />
 
 
 LangChain is the easiest way to start building with LLMs, letting you get started on building agents with OpenAI, Anthropic, Google and more in under 10 lines of code.

--- a/src/oss/langchain-philosophy.mdx
+++ b/src/oss/langchain-philosophy.mdx
@@ -2,6 +2,10 @@
 title: Philosophy
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 `langchain` is driven by a few core beliefs:
 - LLMs are great, powerful new technology
 - LLMs are even better when you combine them with external sources of data computation

--- a/src/oss/langchain-quickstart.mdx
+++ b/src/oss/langchain-quickstart.mdx
@@ -2,7 +2,9 @@
 title: Quickstart
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
 
+<AlphaCallout />
 
 Super quick start
 :::python

--- a/src/oss/langchain-retrieval.mdx
+++ b/src/oss/langchain-retrieval.mdx
@@ -2,6 +2,10 @@
 title: Retrieval
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 ## Overview
 
 ## Document Loaders

--- a/src/oss/langchain-runtime.mdx
+++ b/src/oss/langchain-runtime.mdx
@@ -2,6 +2,10 @@
 title: Runtime
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 ## Overview
 
 ## Access

--- a/src/oss/langchain-short-term-memory.mdx
+++ b/src/oss/langchain-short-term-memory.mdx
@@ -2,6 +2,10 @@
 title: Short Term Memory
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 ## Overview
 
 ## Usage

--- a/src/oss/langchain-streaming.mdx
+++ b/src/oss/langchain-streaming.mdx
@@ -2,6 +2,10 @@
 title: Streaming
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 ## Overview
 
 ## Agent Progress

--- a/src/oss/langchain-structured-output.mdx
+++ b/src/oss/langchain-structured-output.mdx
@@ -2,6 +2,9 @@
 title: Structured Output
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
 ## Overview
 
 ## Native vs Tool Calling

--- a/src/oss/langchain-studio.mdx
+++ b/src/oss/langchain-studio.mdx
@@ -1,3 +1,7 @@
 ---
 title: Studio
 ---
+
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />

--- a/src/oss/langchain-tools.mdx
+++ b/src/oss/langchain-tools.mdx
@@ -2,6 +2,9 @@
 title: Tools
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
 
 ## Overview
 

--- a/src/oss/langgraph/1-build-basic-chatbot.mdx
+++ b/src/oss/langgraph/1-build-basic-chatbot.mdx
@@ -3,7 +3,9 @@ title: 1. Build a basic chatbot
 ---
 
 import ChatModelTabs from '/snippets/chat-model-tabs.mdx';
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 In this tutorial, you will build a basic chatbot. This chatbot is the basis for the following series of tutorials where you will progressively add more sophisticated capabilities, and be introduced to key LangGraph concepts along the way. Let's dive in! 🌟
 

--- a/src/oss/langgraph/2-add-tools.mdx
+++ b/src/oss/langgraph/2-add-tools.mdx
@@ -2,10 +2,10 @@
 title: 2. Add tools
 ---
 
-
-
-
 import chatTabs from '/snippets/chat-model-tabs.mdx';
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />
 
 To handle queries that your chatbot can't answer "from memory", integrate a web search tool. The chatbot can use this tool to find relevant information and provide better responses.
 

--- a/src/oss/langgraph/3-add-memory.mdx
+++ b/src/oss/langgraph/3-add-memory.mdx
@@ -2,10 +2,10 @@
 title: 3. Add memory
 ---
 
-
-
-
 import chatTabs from '/snippets/chat-model-tabs.mdx';
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />
 
 The chatbot can now [use tools](/oss/2-add-tools) to answer user questions, but it does not remember the context of previous interactions. This limits its ability to have coherent, multi-turn conversations.
 

--- a/src/oss/langgraph/4-human-in-the-loop.mdx
+++ b/src/oss/langgraph/4-human-in-the-loop.mdx
@@ -2,10 +2,10 @@
 title: 4. Add human-in-the-loop controls
 ---
 
-
-
-
 import chatTabs from '/snippets/chat-model-tabs.mdx';
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />
 
 Agents can be unreliable and may need human input to successfully accomplish tasks. Similarly, for some actions, you may want to require human approval before running to ensure that everything is running as intended.
 

--- a/src/oss/langgraph/5-customize-state.mdx
+++ b/src/oss/langgraph/5-customize-state.mdx
@@ -2,10 +2,10 @@
 title: 5. Customize state
 ---
 
-
-
-
 import chatTabs from '/snippets/chat-model-tabs.mdx';
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />
 
 In this tutorial, you will add additional fields to the state to define complex behavior without relying on the message list. The chatbot will use its search tool to find specific information and forward them to a human for review.
 

--- a/src/oss/langgraph/6-time-travel.mdx
+++ b/src/oss/langgraph/6-time-travel.mdx
@@ -2,10 +2,10 @@
 title: 6. Time travel
 ---
 
-
-
-
 import chatTabs from '/snippets/chat-model-tabs.mdx';
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />
 
 In a typical chatbot workflow, the user interacts with the bot one or more times to accomplish a task. [Memory](/oss/3-add-memory) and a [human-in-the-loop](/oss/4-human-in-the-loop) enable checkpoints in the graph state and control future responses.
 

--- a/src/oss/langgraph/GRAPH_RECURSION_LIMIT.mdx
+++ b/src/oss/langgraph/GRAPH_RECURSION_LIMIT.mdx
@@ -2,7 +2,9 @@
 title: GRAPH_RECURSION_LIMIT
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 Your LangGraph [`StateGraph`](https://langchain-ai.github.io/langgraph/reference/graphs/#langgraph.graph.state.StateGraph) reached the maximum number of steps before hitting a stop condition.
 This is often due to an infinite loop caused by code like the example below:

--- a/src/oss/langgraph/INVALID_CHAT_HISTORY.mdx
+++ b/src/oss/langgraph/INVALID_CHAT_HISTORY.mdx
@@ -2,7 +2,9 @@
 title: INVALID_CHAT_HISTORY
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 :::python
 This error is raised in the prebuilt @[create_react_agent][create_react_agent] when the `call_model` graph node receives a malformed list of messages. Specifically, it is malformed when there are `AIMessages` with `tool_calls` (LLM requesting to call a tool) that do not have a corresponding `ToolMessage` (result of a tool invocation to return to the LLM).

--- a/src/oss/langgraph/INVALID_CONCURRENT_GRAPH_UPDATE.mdx
+++ b/src/oss/langgraph/INVALID_CONCURRENT_GRAPH_UPDATE.mdx
@@ -2,7 +2,9 @@
 title: INVALID_CONCURRENT_GRAPH_UPDATE
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 A LangGraph [`StateGraph`](https://langchain-ai.github.io/langgraph/reference/graphs/#langgraph.graph.state.StateGraph) received concurrent updates to its state from multiple nodes to a state property that doesn't
 support it.

--- a/src/oss/langgraph/INVALID_GRAPH_NODE_RETURN_VALUE.mdx
+++ b/src/oss/langgraph/INVALID_GRAPH_NODE_RETURN_VALUE.mdx
@@ -2,7 +2,9 @@
 title: INVALID_GRAPH_NODE_RETURN_VALUE
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 :::python
 A LangGraph [`StateGraph`](https://langchain-ai.github.io/langgraph/reference/graphs/#langgraph.graph.state.StateGraph)

--- a/src/oss/langgraph/MULTIPLE_SUBGRAPHS.mdx
+++ b/src/oss/langgraph/MULTIPLE_SUBGRAPHS.mdx
@@ -2,7 +2,9 @@
 title: MULTIPLE_SUBGRAPHS
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 You are calling subgraphs multiple times within a single LangGraph node with checkpointing enabled for each subgraph.
 

--- a/src/oss/langgraph/add-human-in-the-loop.mdx
+++ b/src/oss/langgraph/add-human-in-the-loop.mdx
@@ -2,8 +2,9 @@
 title: Enable human intervention
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 To review, edit, and approve tool calls in an agent or workflow, use interrupts to pause a graph and wait for human input. Interrupts use LangGraph's [persistence](/oss/persistence) layer, which saves the graph state, to indefinitely pause graph execution until you resume.
 

--- a/src/oss/langgraph/add-memory.mdx
+++ b/src/oss/langgraph/add-memory.mdx
@@ -2,7 +2,9 @@
 title: Add and manage memory
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 AI applications need [memory](/oss/memory) to share context across multiple interactions. In LangGraph, you can add two types of memory:
 

--- a/src/oss/langgraph/agent-supervisor.mdx
+++ b/src/oss/langgraph/agent-supervisor.mdx
@@ -3,7 +3,9 @@ title: Build a multi-agent supervisor
 sidebarTitle: Multi-agent supervisor
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 [**Supervisor**](/oss/multi-agent#supervisor) is a multi-agent architecture where **specialized** agents are coordinated by a central **supervisor agent**. The supervisor agent controls all communication flow and task delegation, making decisions about which agent to invoke based on the current context and task requirements.
 

--- a/src/oss/langgraph/agentic-architectures.mdx
+++ b/src/oss/langgraph/agentic-architectures.mdx
@@ -3,8 +3,9 @@ title: Common architectures
 sidebarTitle: Overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 This guide reviews common patterns for agentic systems. In describing these systems, it can be useful to make a distinction between **workflows** and **agents**: 
 

--- a/src/oss/langgraph/agentic-rag.mdx
+++ b/src/oss/langgraph/agentic-rag.mdx
@@ -3,7 +3,9 @@ title: Build a RAG agent
 sidebarTitle: Agentic RAG
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 In this tutorial we will build a [retrieval agent](https://python.langchain.com/docs/tutorials/qa_chat_history). Retrieval agents are useful when you want an LLM to make a decision about whether to retrieve context from a vectorstore or respond to the user directly.
 

--- a/src/oss/langgraph/application-structure.mdx
+++ b/src/oss/langgraph/application-structure.mdx
@@ -2,8 +2,9 @@
 title: Application Structure
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 ## Overview
 

--- a/src/oss/langgraph/call-tools.mdx
+++ b/src/oss/langgraph/call-tools.mdx
@@ -2,7 +2,9 @@
 title: Call tools
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 [Tools](/oss/tools) encapsulate a callable function and its input schema. These can be passed to compatible chat models, allowing the model to decide whether to invoke a tool and determine the appropriate arguments.
 

--- a/src/oss/langgraph/case-studies.mdx
+++ b/src/oss/langgraph/case-studies.mdx
@@ -2,7 +2,9 @@
 title: Case studies
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 This list of companies using LangGraph and their success stories is compiled from public sources. If your company uses LangGraph, we'd love for you to share your story and add it to the list. You’re also welcome to contribute updates based on publicly available information from other companies, such as blog posts or press releases.
 

--- a/src/oss/langgraph/common-errors.mdx
+++ b/src/oss/langgraph/common-errors.mdx
@@ -3,8 +3,9 @@ title: Error troubleshooting
 sidebarTitle: Overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 This page contains guides around resolving common errors you may find while building with LangGraph.
 Errors referenced below will have an `lc_error_code` property corresponding to one of the below codes when they are thrown in code.

--- a/src/oss/langgraph/community-agents.mdx
+++ b/src/oss/langgraph/community-agents.mdx
@@ -5,6 +5,10 @@
 title: Community Agents
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />
+
 If you’re looking for other prebuilt libraries, explore the community-built options
 below. These libraries can extend LangGraph's functionality in various ways.
 

--- a/src/oss/langgraph/context.mdx
+++ b/src/oss/langgraph/context.mdx
@@ -2,7 +2,9 @@
 title: Context overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 **Context engineering** is the practice of building dynamic systems that provide the right information and tools, in the right format, so that an AI application can accomplish a task. Context can be characterized along two key dimensions:
 

--- a/src/oss/langgraph/deploy.mdx
+++ b/src/oss/langgraph/deploy.mdx
@@ -1,3 +1,7 @@
 ---
 title: Deploy
 ---
+
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />

--- a/src/oss/langgraph/durable-execution.mdx
+++ b/src/oss/langgraph/durable-execution.mdx
@@ -2,8 +2,9 @@
 title: Durable execution
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 **Durable execution** is a technique in which a process or workflow saves its progress at key points, allowing it to pause and later resume exactly where it left off. This is particularly useful in scenarios that require [human-in-the-loop](/oss/human-in-the-loop), where users can inspect, validate, or modify the process before continuing, and in long-running tasks that might encounter interruptions or errors (e.g., calls to an LLM timing out). By preserving completed work, durable execution enables a process to resume without reprocessing previous steps -- even after a significant delay (e.g., a week later).
 

--- a/src/oss/langgraph/evals.mdx
+++ b/src/oss/langgraph/evals.mdx
@@ -2,8 +2,9 @@
 title: Evaluate agent performance
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 To evaluate your agent's performance you can use `LangSmith` [evaluations](https://docs.smith.langchain.com/evaluation). You would need to first define an evaluator function to judge the results from an agent, such as final outputs or trajectory. Depending on your evaluation technique, this may or may not involve a reference output:
 

--- a/src/oss/langgraph/functional-api.mdx
+++ b/src/oss/langgraph/functional-api.mdx
@@ -3,8 +3,9 @@ title: Functional API overview
 sidebarTitle: Overview
 ---
 
-
-
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+  
+<AlphaCallout />
 
 The **Functional API** allows you to add LangGraph's key features — [persistence](/oss/persistence), [memory](/oss/add-memory), [human-in-the-loop](/oss/human-in-the-loop), and [streaming](/oss/streaming) — to your applications with minimal changes to your existing code.
 

--- a/src/oss/langgraph/graph-api.mdx
+++ b/src/oss/langgraph/graph-api.mdx
@@ -3,8 +3,9 @@ title: Graph API concepts
 sidebarTitle: Overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 ## Graphs
 

--- a/src/oss/langgraph/human-in-the-loop.mdx
+++ b/src/oss/langgraph/human-in-the-loop.mdx
@@ -3,8 +3,9 @@ title: Human-in-the-loop overview
 sidebarTitle: Overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 To review, edit, and approve tool calls in an agent or workflow, [use LangGraph's human-in-the-loop features](/oss/add-human-in-the-loop) to enable human intervention at any point in a workflow. This is especially useful in large language model (LLM)-driven applications where model output may require validation, correction, or additional context.
 

--- a/src/oss/langgraph/installation.mdx
+++ b/src/oss/langgraph/installation.mdx
@@ -2,6 +2,10 @@
 title: Installation
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />
+
 To install the base LangGraph package:
 
 :::python

--- a/src/oss/langgraph/local-server.mdx
+++ b/src/oss/langgraph/local-server.mdx
@@ -2,8 +2,9 @@
 title: Run a local server
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 This guide shows you how to run a LangGraph application locally.
 

--- a/src/oss/langgraph/mcp.mdx
+++ b/src/oss/langgraph/mcp.mdx
@@ -3,7 +3,9 @@ title: MCP overview
 sidebarTitle: Overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) is an open protocol that standardizes how applications provide tools and context to language models. LangGraph agents can use tools defined on MCP servers through the `langchain-mcp-adapters` library.
 

--- a/src/oss/langgraph/memory.mdx
+++ b/src/oss/langgraph/memory.mdx
@@ -2,8 +2,9 @@
 title: Memory overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 [Memory](/oss/add-memory) is a system that remembers information about previous interactions. For AI agents, memory is crucial because it lets them remember previous interactions, learn from feedback, and adapt to user preferences. As agents tackle more complex tasks with numerous user interactions, this capability becomes essential for both efficiency and user satisfaction.
 

--- a/src/oss/langgraph/models.mdx
+++ b/src/oss/langgraph/models.mdx
@@ -2,8 +2,9 @@
 title: Models
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 import ChatModelTabs from '/snippets/chat-model-tabs.mdx';
 

--- a/src/oss/langgraph/multi-agent-custom.mdx
+++ b/src/oss/langgraph/multi-agent-custom.mdx
@@ -3,8 +3,9 @@ title: Build custom multi-agent systems
 sidebarTitle: Build custom
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 A single agent might struggle if it needs to specialize in multiple domains or manage many tools. To tackle this, you can break your agent into smaller, independent agents and composing them into a [multi-agent system](/oss/multi-agent).
 

--- a/src/oss/langgraph/multi-agent-prebuilts.mdx
+++ b/src/oss/langgraph/multi-agent-prebuilts.mdx
@@ -3,8 +3,9 @@ title: Use prebuilt multi-agent systems
 sidebarTitle: Use prebuilts
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 A single agent might struggle if it needs to specialize in multiple domains or manage many tools. To tackle this, you can break your agent into smaller, independent agents and compose them into a [multi-agent system](/oss/multi-agent).
 

--- a/src/oss/langgraph/multi-agent.mdx
+++ b/src/oss/langgraph/multi-agent.mdx
@@ -3,8 +3,9 @@ title: Multi-agent systems overview
 sidebarTitle: Overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 An [agent](/oss/agentic-architectures#agent-architectures) is _a system that uses an LLM to decide the control flow of an application_. As you develop these systems, they might grow more complex over time, making them harder to manage and scale. For example, you might run into the following problems:
 

--- a/src/oss/langgraph/observability.mdx
+++ b/src/oss/langgraph/observability.mdx
@@ -1,3 +1,7 @@
 ---
 title: Observability
 ---
+
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />

--- a/src/oss/langgraph/overview.mdx
+++ b/src/oss/langgraph/overview.mdx
@@ -2,6 +2,10 @@
 title: Overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />
+
 Trusted by companies shaping the future of agents – including Klarna, Replit, Elastic, and more – LangGraph is a low-level orchestration framework for building, managing, and deploying long-running, stateful agents.
 
 LangGraph is very low-level, and focused entirely on agent **orchestration**. Before using LangGraph, it is recommended you familiarize yourself with some of the components used to build agents, starting with [models](/langchain/models) and [tools](/langchain/tools). We will commonly use [LangChain](/langchain/overview) components throughout the documentation, but you do not need to use LangChain to use LangGraph.

--- a/src/oss/langgraph/persistence.mdx
+++ b/src/oss/langgraph/persistence.mdx
@@ -2,8 +2,9 @@
 title: Persistence
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 LangGraph has a built-in persistence layer, implemented through checkpointers. When you compile a graph with a checkpointer, the checkpointer saves a `checkpoint` of the graph state at every super-step. Those checkpoints are saved to a `thread`, which can be accessed after graph execution. Because `threads` allow access to graph's state after execution, several powerful capabilities including human-in-the-loop, memory, time travel, and fault-tolerance are all possible. Below, we'll discuss each of these concepts in more detail.
 

--- a/src/oss/langgraph/philosophy.mdx
+++ b/src/oss/langgraph/philosophy.mdx
@@ -1,0 +1,7 @@
+---
+title: Philosophy
+---
+
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />

--- a/src/oss/langgraph/prebuilt-vs-low-level.mdx
+++ b/src/oss/langgraph/prebuilt-vs-low-level.mdx
@@ -5,6 +5,9 @@ sidebarTitle: Prebuilt vs. low-level
 
 import prebuiltsTable from '/snippets/prebuilts-table-python.mdx';
 import prebuiltsTableJS from '/snippets/prebuilts-table-js.mdx';
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />
 
 LangGraph provides two distinct approaches for building AI agent workflows, each designed for different use cases and development preferences. Understanding when to use each approach will help you choose the right path for your project.
 

--- a/src/oss/langgraph/prebuilts.mdx
+++ b/src/oss/langgraph/prebuilts.mdx
@@ -3,11 +3,11 @@ title: Agent development using prebuilt components
 sidebarTitle: Use prebuilt components
 ---
 
-
-
-
 import prebuiltsTable from '/snippets/prebuilts-table-python.mdx';
 import prebuiltsTableJS from '/snippets/prebuilts-table-js.mdx';
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />
 
 LangGraph provides both low-level primitives and high-level prebuilt components for building agent-based applications. This section focuses on the prebuilt, ready-to-use components designed to help you construct agentic systems quickly and reliably—without the need to implement orchestration, memory, or human feedback handling from scratch.
 

--- a/src/oss/langgraph/pregel.mdx
+++ b/src/oss/langgraph/pregel.mdx
@@ -2,8 +2,9 @@
 title: LangGraph runtime
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 :::python
 @[Pregel] implements LangGraph's runtime, managing the execution of LangGraph applications.

--- a/src/oss/langgraph/quickstart.mdx
+++ b/src/oss/langgraph/quickstart.mdx
@@ -2,6 +2,10 @@
 title: Quickstart
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />
+
 Using Graph API
 :::python
 ```python

--- a/src/oss/langgraph/run-an-agent.mdx
+++ b/src/oss/langgraph/run-an-agent.mdx
@@ -2,8 +2,9 @@
 title: Run an agent
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 Agents support both synchronous and asynchronous execution using either `.invoke()` / `await .ainvoke()` for full responses, or `.stream()` / `.astream()` for **incremental** [streaming](/oss/streaming) output. This section explains how to provide input, interpret output, enable streaming, and control execution limits.
 

--- a/src/oss/langgraph/run-id-langsmith.mdx
+++ b/src/oss/langgraph/run-id-langsmith.mdx
@@ -2,7 +2,9 @@
 title: How to pass custom run ID or set tags and metadata for graph runs in LangSmith
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 <Tip>
   **Prerequisites**

--- a/src/oss/langgraph/sql-agent.mdx
+++ b/src/oss/langgraph/sql-agent.mdx
@@ -3,7 +3,9 @@ title: Build a SQL agent
 sidebarTitle: SQL agent
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 In this tutorial, we will walk through how to build an agent that can answer questions about a SQL database.
 

--- a/src/oss/langgraph/streaming.mdx
+++ b/src/oss/langgraph/streaming.mdx
@@ -3,8 +3,9 @@ title: Streaming overview
 sidebarTitle: Overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 LangGraph implements a streaming system to surface real-time updates, allowing for responsive and transparent user experiences.
 

--- a/src/oss/langgraph/studio.mdx
+++ b/src/oss/langgraph/studio.mdx
@@ -1,3 +1,7 @@
 ---
 title: Studio
 ---
+
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
+
+<AlphaCallout />    

--- a/src/oss/langgraph/subgraphs.mdx
+++ b/src/oss/langgraph/subgraphs.mdx
@@ -3,7 +3,9 @@ title: Subgraphs overview
 sidebarTitle: Overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 A subgraph is a [graph](/oss/graph-api#graphs) that is used as a [node](/oss/graph-api#nodes) in another graph — this is the concept of encapsulation applied to LangGraph. Subgraphs allow you to build complex systems with multiple components that are themselves graphs.
 

--- a/src/oss/langgraph/template-applications.mdx
+++ b/src/oss/langgraph/template-applications.mdx
@@ -2,8 +2,9 @@
 title: Template applications
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 Templates are open source reference applications designed to help you get started quickly when building with LangGraph. They provide working examples of common agentic workflows that can be customized to your needs.
 

--- a/src/oss/langgraph/time-travel.mdx
+++ b/src/oss/langgraph/time-travel.mdx
@@ -3,8 +3,9 @@ title: Time travel overview
 sidebarTitle: Overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 When working with non-deterministic systems that make model-based decisions (e.g., agents powered by LLMs), it can be useful to examine their decision-making process in detail:
 

--- a/src/oss/langgraph/tools.mdx
+++ b/src/oss/langgraph/tools.mdx
@@ -3,8 +3,9 @@ title: Tools overview
 sidebarTitle: Overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 Many AI applications interact with users via natural language. However, some use cases require models to interface directly with external systems—such as APIs, databases, or file systems—using structured input. In these scenarios, [tool calling](/oss/call-tools) enables models to generate requests that conform to a specified input schema.
 

--- a/src/oss/langgraph/trace-agent.mdx
+++ b/src/oss/langgraph/trace-agent.mdx
@@ -2,8 +2,9 @@
 title: Trace an agent
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 Traces are a series of steps that your application takes to go from input to output. Each of these individual steps is represented by a run. You can use [LangSmith](https://smith.langchain.com/) to visualize these execution steps. To use it, [enable tracing for your application](/oss/trace-agent). This enables you to do the following:
 

--- a/src/oss/langgraph/ui.mdx
+++ b/src/oss/langgraph/ui.mdx
@@ -2,8 +2,9 @@
 title: Use chat UI
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 You can use a prebuilt chat UI for interacting with any LangGraph agent through the [Agent Chat UI](https://github.com/langchain-ai/agent-chat-ui). Using the [deployed version](https://agentchat.vercel.app) is the quickest way to get started, and allows you to interact with both local and deployed graphs.
 

--- a/src/oss/langgraph/use-functional-api.mdx
+++ b/src/oss/langgraph/use-functional-api.mdx
@@ -2,7 +2,9 @@
 title: Use the functional API
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 The [**Functional API**](/oss/functional-api) allows you to add LangGraph's key features — [persistence](/oss/persistence), [memory](/oss/add-memory), [human-in-the-loop](/oss/human-in-the-loop), and [streaming](/oss/streaming) — to your applications with minimal changes to your existing code.
 

--- a/src/oss/langgraph/use-graph-api.mdx
+++ b/src/oss/langgraph/use-graph-api.mdx
@@ -2,7 +2,9 @@
 title: Use the graph API
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 import ChatModelTabs from '/snippets/chat-model-tabs.mdx';
 

--- a/src/oss/langgraph/use-mcp.mdx
+++ b/src/oss/langgraph/use-mcp.mdx
@@ -2,8 +2,9 @@
 title: Use MCP
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) is an open protocol that standardizes how applications provide tools and context to language models. LangGraph agents can use tools defined on MCP servers through the `langchain-mcp-adapters` library.
 

--- a/src/oss/langgraph/use-streaming.mdx
+++ b/src/oss/langgraph/use-streaming.mdx
@@ -2,7 +2,9 @@
 title: Stream outputs
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 You can [stream outputs](/oss/streaming) from a LangGraph agent or workflow.
 

--- a/src/oss/langgraph/use-subgraphs.mdx
+++ b/src/oss/langgraph/use-subgraphs.mdx
@@ -2,7 +2,9 @@
 title: Use subgraphs
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 This guide explains the mechanics of using [subgraphs](/oss/subgraphs). A common application of subgraphs is to build [multi-agent](/oss/multi-agent) systems.
 

--- a/src/oss/langgraph/use-time-travel.mdx
+++ b/src/oss/langgraph/use-time-travel.mdx
@@ -2,7 +2,9 @@
 title: Use time-travel
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
+<AlphaCallout />
 
 To use [time-travel](/oss/time-travel) in LangGraph:
 

--- a/src/oss/langgraph/why-langgraph.mdx
+++ b/src/oss/langgraph/why-langgraph.mdx
@@ -3,8 +3,9 @@ title: Low-level orchestration with LangGraph
 sidebarTitle: Overview
 ---
 
+import AlphaCallout from '/snippets/alpha-lg-callout.mdx';
 
-
+<AlphaCallout />
 
 LangGraph is built for developers who want to build powerful, adaptable AI agents. Developers choose LangGraph for:
 

--- a/src/oss/release-policy.mdx
+++ b/src/oss/release-policy.mdx
@@ -2,6 +2,10 @@
 title: Release policy
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 This page explains the LangChain and LangGraph release policies. Click on the tabs below to view the release policies for each:
 
 <Tabs>

--- a/src/oss/releases.mdx
+++ b/src/oss/releases.mdx
@@ -2,6 +2,10 @@
 title: Releases
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 This section contains release notes and migration guides for LangChain and LangGraph v1.
 
 ## Latest release

--- a/src/oss/versioning.mdx
+++ b/src/oss/versioning.mdx
@@ -2,6 +2,10 @@
 title: Versioning
 ---
 
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
 Each LangChain and LangGraph version number follows the format: `MAJOR.MINOR.PATCH`
 
 - **Major**: Breaking API updates that require code changes.

--- a/src/snippets/alpha-lc-callout.mdx
+++ b/src/snippets/alpha-lc-callout.mdx
@@ -1,0 +1,5 @@
+<Warning>
+**Alpha Notice:** These docs cover the **v1-alpha** release. Content is incomplete and subject to change.
+
+For the latest stable version, see the current [LangChain Python](https://python.langchain.com/docs/introduction/) or [LangChain JavaScript](https://js.langchain.com/docs/introduction/) docs.
+</Warning>

--- a/src/snippets/alpha-lg-callout.mdx
+++ b/src/snippets/alpha-lg-callout.mdx
@@ -1,0 +1,5 @@
+<Warning>
+**Alpha Notice:** These docs cover the **v1-alpha** release. Content is incomplete and subject to change.
+
+For the latest stable version, see the current [LangGraph Python](https://langchain-ai.github.io/langgraph/) or [LangGraph JavaScript](https://langchain-ai.github.io/langgraphjs/) docs.
+</Warning>

--- a/src/style.css
+++ b/src/style.css
@@ -264,3 +264,16 @@ button.version-picker-button svg {
   font-size: inherit !important; /* Match callout text size */
   color: inherit !important; /* Match callout text color */
 }
+
+/* Ensure bold and italic text inherit callout formatting */
+.callout strong,
+.callout b,
+.callout em,
+.callout i,
+[class*="callout"] strong,
+[class*="callout"] b,
+[class*="callout"] em,
+[class*="callout"] i {
+  font-size: inherit !important; /* Match callout text size */
+  color: inherit !important; /* Match callout text color */
+}


### PR DESCRIPTION
Adds a callout to all OSS pages that these are alpha docs
- Links to LG or LC, depending on the page
- Not added to integration docs (too many)

<img width="1275" height="820" alt="image" src="https://github.com/user-attachments/assets/b89c3ad1-6919-4ddb-b59e-016d157bd93f" />
