### PR TITLE
fix(oss): update JS examples in models page

### DIFF
--- a/src/oss/langchain-models.mdx
+++ b/src/oss/langchain-models.mdx
@@ -106,7 +106,7 @@ The easiest way to get started with a model in LangChain is to use `initChatMode
 
 <CodeGroup>
 ```typescript Initialize a chat model
-import { initChatModel } from "langchain/chat_models";
+import { initChatModel } from "langchain";
 
 const model = initChatModel("openai:gpt-5-nano");
 const response = await model.invoke("Why do parrots talk?");
@@ -265,7 +265,7 @@ A list of messages can be provided to a model to represent conversation history.
 
 :::js
 ```typescript Conversation history
-import { HumanMessage, AIMessage, SystemMessage } from "langchain/messages";
+import { HumanMessage, AIMessage, SystemMessage } from "langchain";
 
 const conversation = [
     new SystemMessage("You are a helpful assistant that translates English to French."),
@@ -314,7 +314,7 @@ Calling @[`stream()`][stream] returns an <Tooltip tip="An object that progressiv
     ```typescript Basic text streaming
     const stream = await model.stream("Why do parrots have colorful feathers?");
     for await (const chunk of stream) {
-        console.log(chunk.text, end="|", flush=True)
+        console.log(chunk.text)
     }
     ```
 
@@ -650,8 +650,9 @@ for tool_call in response.tool_calls:
 
 :::js
 ```typescript Binding user tools highlight={17}
-import { tool } from "@langchain/core/tools";
+import { tool } from "langchain";
 import { z } from "zod";
+import { ChatOpenAI } from "@langchain/openai";
 
 const getWeather = tool(
   (input) => {
@@ -666,10 +667,12 @@ const getWeather = tool(
   }
 )
 
-const modelWithTools = model.bind_tools([get_weather])
+const model = new ChatOpenAI({ model: "gpt-4o" })
+const modelWithTools = model.bindTools([getWeather])
 
 const response = await modelWithTools.invoke("What's the weather like in Boston?")
-for (const tool_call of response.tool_calls) {
+const toolCalls = response.tool_calls || []
+for (const tool_call of toolCalls) {
     // View tool calls made by the model
     console.log(`Tool: ${tool_call.name}`);
     console.log(`Args: ${tool_call.args}`);
@@ -815,7 +818,7 @@ Below, we show some common ways you can get use tool calling.
 
         ```typescript Tool execution loop
         //  Bind (potentially multiple) tools to the model
-        const modelWithTools = model.bind_tools([get_weather])
+        const modelWithTools = model.bindTools([get_weather])
 
         // Step 1: Model generates tool calls
         const messages = [{"role": "user", "content": "What's the weather in Boston?"}]
@@ -823,7 +826,7 @@ Below, we show some common ways you can get use tool calling.
         messages.push(response)
 
         // Step 2: Execute tools and collect results
-        for (const tool_call of response.tool_calls) {
+        for (const tool_call of response.tool_calls || []) {
             // Execute the tool with the generated arguments
             const tool_result = await get_weather.invoke(tool_call)
             messages.push(tool_result)
@@ -879,7 +882,7 @@ Below, we show some common ways you can get use tool calling.
         
         // Execute all tools (can be done in parallel with async)
         const results = []
-        for (const tool_call of response.tool_calls) {
+        for (const tool_call of response.tool_calls || []) {
             if (tool_call.name === 'get_weather') {
                 const result = await get_weather.invoke(tool_call)
                 results.push(result)


### PR DESCRIPTION
Minor updates:
- core langchain primitives are imported from root - we want to avoid having developers require to know an import path
- `tool_calls` can be typed as `undefined` so we need to have an empty array fallback