### PR TITLE
fix(oss): update JS examples in messages

### DIFF
--- a/src/oss/langchain-messages.mdx
+++ b/src/oss/langchain-messages.mdx
@@ -65,7 +65,7 @@ response = model.invoke(messages)  # Returns AIMessage
 
 :::js
 ```typescript
-import { initChatModel } from "langchain/chat_models";
+import { initChatModel } from "langchain";
 
 const model = await initChatModel("openai:gpt-5-nano");
 
@@ -119,7 +119,7 @@ response = model.invoke(messages)
 
 :::js
 ```typescript
-import { SystemMessage, HumanMessage, AIMessage } from "@langchain/core/messages";
+import { SystemMessage, HumanMessage, AIMessage } from "langchain";
 
 const messages = [
     new SystemMessage("You are a poetry expert"),
@@ -154,7 +154,7 @@ response = model.invoke(messages)
 
 :::js
 ```typescript
-import { SystemMessage, HumanMessage, AIMessage } from "@langchain/core/messages";
+import { SystemMessage, HumanMessage, AIMessage } from "langchain";
 
 const messages = [
     { role: "system", content: "You are a poetry expert" },
@@ -187,7 +187,7 @@ response = model.invoke(messages)
 
 :::js
 ```typescript Basic instructions
-import { SystemMessage, HumanMessage, AIMessage } from "@langchain/core/messages";
+import { SystemMessage, HumanMessage, AIMessage } from "langchain";
 
 const systemMsg = new SystemMessage("You are a helpful coding assistant.");
 
@@ -219,7 +219,7 @@ response = model.invoke(messages)
 
 :::js
 ```typescript Detailed persona
-import { SystemMessage, HumanMessage } from "@langchain/core/messages";
+import { SystemMessage, HumanMessage } from "langchain";
 
 const systemMsg = new SystemMessage(`
 You are a senior TypeScript developer with expertise in web frameworks.
@@ -346,7 +346,7 @@ response = model.invoke(messages)
 
 :::js
 ```typescript
-import { AIMessage, SystemMessage, HumanMessage } from "@langchain/core/messages";
+import { AIMessage, SystemMessage, HumanMessage } from "langchain";
 
 const aiMsg = new AIMessage("I'd be happy to help you with that question!");
 
@@ -429,7 +429,7 @@ for tool_call in response.tool_calls:
 
 :::js
 ```typescript
-const modelWithTools = model.bind_tools([getWeather]);
+const modelWithTools = model.bindTools([getWeather]);
 const response = await modelWithTools.invoke("What's the weather in Paris?");
 
 for (const toolCall of response.tool_calls) {
@@ -474,7 +474,7 @@ for await (const chunk of model.stream("Write a poem")) {
 ```
 
 ```typescript Combine chunks
-import { AIMessageChunk } from "@langchain/core/messages";
+import { AIMessageChunk } from "langchain";
 
 const finalChunk = chunks.reduce(
     (acc, chunk) => acc.concat(chunk.text),
@@ -521,7 +521,7 @@ response = model.invoke(messages)  # Model processes the result
 
 :::js
 ```typescript
-import { AIMessage, ToolMessage } from "@langchain/core/messages";
+import { AIMessage, ToolMessage } from "langchain";
 
 const aiMessage = new AIMessage({
     content: [],
@@ -604,7 +604,7 @@ const response = await model.invoke(messages);  // Model processes the result
         title="Example: Using artifact for raw data"
     >
         ```typescript
-        import { ToolMessage } from "@langchain/core/messages";
+        import { ToolMessage } from "langchain";
 
         // Tool execution returns structured data
         const rawData = { temperature: 72, condition: "Sunny" };
@@ -616,7 +616,7 @@ const response = await model.invoke(messages);  // Model processes the result
         });
 
         // Later, access the raw data programmatically
-        const weatherInfo = toolMessage.artifact["raw_data"];
+        const weatherInfo = toolMessage.artifact.raw_data;
         console.log(`Raw weather data: ${JSON.stringify(weatherInfo)}`);
         ```
     </Accordion>
@@ -646,7 +646,7 @@ human_message = HumanMessage(content_blocks=[
 
 :::js
 ```typescript
-import { HumanMessage } from "@langchain/core/messages";
+import { HumanMessage } from "langchain";
 
 // String content
 const humanMessage = new HumanMessage("Hello, how are you?");
@@ -842,12 +842,12 @@ response = model.invoke([message])
 :::js
 <CodeGroup>
 ```typescript PDF document analysis
-import { readFileSync } from 'fs';
-import { HumanMessage } from '@langchain/core/messages';
+import { readFileSync } from "node:fs";
+import { HumanMessage } from "langchain";
 
 // Read and encode PDF
 const pdfData = readFileSync("report.pdf");
-const pdfBase64 = pdfData.toString('base64');
+const pdfBase64 = pdfData.toString("base64");
 
 const message = new HumanMessage({
     contentBlocks: [
@@ -860,12 +860,12 @@ const response = await model.invoke([message]);
 ```
 
 ```typescript Audio transcription
-import { readFileSync } from 'fs';
-import { HumanMessage } from '@langchain/core/messages';
+import { readFileSync } from "node:fs";
+import { HumanMessage } from "langchain";
 
 // Read and encode audio file
 const audioData = readFileSync("meeting.mp3");
-const audioBase64 = audioData.toString('base64');
+const audioBase64 = audioData.toString("base64");
 
 const message = new HumanMessage({
     contentBlocks: [
@@ -878,12 +878,12 @@ const response = await model.invoke([message]);
 ```
 
 ```typescript Video analysis
-import { readFileSync } from 'fs';
-import { HumanMessage } from '@langchain/core/messages';
+import { readFileSync } from "node:fs";
+import { HumanMessage } from "langchain";
 
 // Read and encode video file
 const videoData = readFileSync("demo.mp4");
-const videoBase64 = videoData.toString('base64');
+const videoBase64 = videoData.toString("base64");
 
 const message = new HumanMessage({
     contentBlocks: [
@@ -1453,7 +1453,7 @@ must adhere to one of the following block types:
 Each of these content blocks mentioned above are indvidually addressable as types when importing the `ContentBlock` type.
 
 ```typescript
-import { ContentBlock } from "@langchain/core/messages";
+import { ContentBlock } from "langchain";
 
 // Text block
 const textBlock: ContentBlock.Text = {
@@ -1642,7 +1642,7 @@ while True:
 :::js
 <CodeGroup>
 ```typescript Basic chat loop
-import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { HumanMessage, SystemMessage } from "langchain";
 
 // Initialize conversation
 const messages = [
@@ -1670,10 +1670,12 @@ while (true) {
 ```
 
 ```typescript Context window management
-import { BaseMessage, filterMessages } from "@langchain/core/messages";
+import { BaseMessage, filterMessages } from "langchain";
 
-function manageConversationWindow(messages: BaseMessage[], maxMessages: number = 10): BaseMessage[] {
-    const systemMsgs = filterMessages(messages, include_types: "system");
+function manageConversationWindow(messages: BaseMessage[], maxMessages = 10): BaseMessage[] {
+    const systemMsgs = filterMessages(messages, {
+        includeTypes: "system"
+    });
     const recentMsgs = messages.slice(-(maxMessages - systemMsgs.length));
     return systemMsgs.concat(recentMsgs);
 }


### PR DESCRIPTION
Some updates to the JS examples in messages:
- let's import message primitives from `langchain` directly, same for `initChatModel`
- technically there is no difference between importing from `fs` vs `node:fs`, I think using latter gives a more clear picture that the example uses a Node.js primitive