### PR TITLE
fix(oss): package naming in release policy docs

### DIFF
--- a/src/oss/release-policy.mdx
+++ b/src/oss/release-policy.mdx
@@ -11,17 +11,32 @@ This page explains the LangChain and LangGraph release policies. Click on the ta
 <Tabs>
 <Tab title="LangChain">
 
+:::python
 The LangChain ecosystem is composed of different component packages (e.g., `langchain-core`, `langchain`, `langchain-community`, partner packages, etc.)
+:::
+:::js
+The LangChain ecosystem is composed of different component packages (e.g., `@langchain/core`, `langchain`, `@langchain/community`, partner packages, etc.)
+:::
 
 ## Release cadence
 
+:::python
 We expect to space out **minor** releases (e.g., from 0.2.x to 0.3.0) of `langchain` and `langchain-core` by at least 2-3 months, as such releases may contain breaking changes.
+:::
+:::js
+We expect to space out **minor** releases (e.g., from 0.2.x to 0.3.0) of `langchain` and `@langchain/core` by at least 2-3 months, as such releases may contain breaking changes.
+:::
 
 Patch versions are released frequently, up to a few times per week, as they contain bug fixes and new features.
 
 ## API stability
 
+:::python
 The development of LLM applications is a rapidly evolving field, and we are constantly learning from our users and the community. As such, we expect that the APIs in `langchain` and `langchain-core` will continue to evolve to better serve the needs of our users.
+:::
+:::js
+The development of LLM applications is a rapidly evolving field, and we are constantly learning from our users and the community. As such, we expect that the APIs in `langchain` and `@langchain/core` will continue to evolve to better serve the needs of our users.
+:::
 
 - Breaking changes to the public API will result in a minor version bump (the second digit)
 - Any bug fixes or new features will result in a patch version bump (the third digit)
@@ -32,14 +47,24 @@ We will generally try to avoid making unnecessary changes, and will provide a de
 
 The stability of other packages in the LangChain ecosystem may vary:
 
+:::python
 - `langchain-community` is a community maintained package that contains 3rd party integrations. While we do our best to review and test changes in `langchain-community`, `langchain-community` is expected to experience more breaking changes than `langchain` and `langchain-core` as it contains many community contributions.
+:::
+:::js
+- `@langchain/community` is a community maintained package that contains 3rd party integrations. While we do our best to review and test changes in `@langchain/community`, `@langchain/community` is expected to experience more breaking changes than `langchain` and `@langchain/core` as it contains many community contributions.
+:::
 - Partner packages may follow different stability and versioning policies, and users should refer to the documentation of those packages for more information; however, in general these packages are expected to be stable.
 
 ## Deprecation policy
 
 We will generally avoid deprecating features until a better alternative is available.
 
+:::python
 When a feature is deprecated, it will continue to work in the current and next minor version of `langchain` and `langchain-core`. After that, the feature will be removed.
+:::
+:::js
+When a feature is deprecated, it will continue to work in the current and next minor version of `langchain` and `@langchain/core`. After that, the feature will be removed.
+:::
 
 Since we're expecting to space out minor releases by at least 2-3 months, this means that a feature can be removed within 2-6 months of being deprecated.
 

--- a/src/oss/versioning.mdx
+++ b/src/oss/versioning.mdx
@@ -116,12 +116,12 @@ print(langgraph.__version__)
 <CodeGroup>
 
 ```javascript LangChain
-import { version } from "langchain/version";
+import { version } from "langchain/package.json";
 console.log(version);
 ```
 
 ```javascript LangGraph
-import { version } from "@langchain/langgraph";
+import { version } from "@langchain/langgraph/package.json";
 console.log(version);
 ```
 </CodeGroup>


### PR DESCRIPTION
This patch:
- shows correct package names when in JS
- fixes version example