### PR TITLE
fix(oss): improved typing of runtime parameter in long term memory JS example

### DIFF
--- a/src/oss/langchain-long-term-memory.mdx
+++ b/src/oss/langchain-long-term-memory.mdx
@@ -170,13 +170,13 @@ await store.put(
 
 const getUserInfo = tool(
   // Look up user info.
-  async (_, config: AgentRuntime<z.infer<typeof contextSchema>>) => {
+  async (_, runtime: AgentRuntime<z.infer<typeof contextSchema>>) => {
     // Same as that provided to `createReactAgent`
-    const userId = config.context?.userId;
+    const userId = runtime.context?.userId;
     if (!userId) {
       throw new Error("userId is required");
     }
-    const userInfo = await config.store?.get(["users"], userId);
+    const userInfo = await runtime.store?.get(["users"], userId);
     return userInfo?.value ? JSON.stringify(userInfo.value) : "Unknown user";
   },
   {
@@ -284,13 +284,13 @@ const UserInfo = z.object({
 });
 
 const saveUserInfo = tool(
-  async (userInfo, config: AgentRuntime<z.infer<typeof contextSchema>>) => {
-    const userId = config.context?.userId;
+  async (userInfo, runtime: AgentRuntime<z.infer<typeof contextSchema>>) => {
+    const userId = runtime.context?.userId;
     if (!userId) {
       throw new Error("userId is required");
     }
     // Same as that provided to `createReactAgent`
-    await config.store?.put(["users"], userId, userInfo);
+    await runtime.store?.put(["users"], userId, userInfo);
     return "Successfully saved user info.";
   },
   {

--- a/src/oss/langchain-long-term-memory.mdx
+++ b/src/oss/langchain-long-term-memory.mdx
@@ -151,8 +151,8 @@ agent.invoke(
 :::js
 ```typescript title="A tool the agent can use to look up user information" highlight={5,9-17,24,38}
 import { z } from "zod";
-import { createReactAgent, tool } from "langchain";
-import { LangGraphRunnableConfig, InMemoryStore } from "@langchain/langgraph";
+import { createReactAgent, tool, type AgentRuntime } from "langchain";
+import { InMemoryStore } from "@langchain/langgraph";
 
 const store = new InMemoryStore();
 const contextSchema = z.object({
@@ -170,9 +170,12 @@ await store.put(
 
 const getUserInfo = tool(
   // Look up user info.
-  async (_, config: LangGraphRunnableConfig) => {
+  async (_, config: AgentRuntime<z.infer<typeof contextSchema>>) => {
     // Same as that provided to `createReactAgent`
     const userId = config.context?.userId;
+    if (!userId) {
+      throw new Error("userId is required");
+    }
     const userInfo = await config.store?.get(["users"], userId);
     return userInfo?.value ? JSON.stringify(userInfo.value) : "Unknown user";
   },
@@ -267,8 +270,8 @@ store.get(("users",), "user_123").value
 :::js
 ```typescript title="Example of a tool that updates user information" highlight={5,11-14,19,39}
 import { z } from "zod";
-import { tool, createReactAgent } from "langchain";
-import { LangGraphRunnableConfig, InMemoryStore } from "@langchain/langgraph";
+import { tool, createReactAgent, type AgentRuntime } from "langchain";
+import { InMemoryStore } from "@langchain/langgraph";
 
 const store = new InMemoryStore();
 
@@ -281,8 +284,11 @@ const UserInfo = z.object({
 });
 
 const saveUserInfo = tool(
-  async (userInfo, config: LangGraphRunnableConfig) => {
+  async (userInfo, config: AgentRuntime<z.infer<typeof contextSchema>>) => {
     const userId = config.context?.userId;
+    if (!userId) {
+      throw new Error("userId is required");
+    }
     // Same as that provided to `createReactAgent`
     await config.store?.put(["users"], userId, userInfo);
     return "Successfully saved user info.";


### PR DESCRIPTION
Let's not use `LangGraphRunnableConfig` and instead the ported `AgentRuntime` type.