### PR TITLE
nit(oss): remove page desc

### DIFF
--- a/src/oss/javascript/releases-v1.mdx
+++ b/src/oss/javascript/releases-v1.mdx
@@ -1,7 +1,6 @@
 ---
 title: LangChain JavaScript v1.0
 sidebarTitle: v1.0
-description: LangChain JavaScript v1 release information
 ---
 
 import AlphaCallout from '/snippets/alpha-lc-callout.mdx';

--- a/src/oss/python/releases-v1.mdx
+++ b/src/oss/python/releases-v1.mdx
@@ -1,7 +1,6 @@
 ---
 title: LangChain Python v1.0
 sidebarTitle: v1.0
-description: LangChain Python v1 release information
 ---
 
 import AlphaCallout from '/snippets/alpha-lc-callout.mdx';


### PR DESCRIPTION
<img width="450" height="116" alt="Screenshot" src="https://github.com/user-attachments/assets/5087e6b4-7e19-49f3-923b-c0aaee3fe606" />

If we need the description for SEO purposes, maybe a way to hide it? `LangChain Python v1` twice in quick succession feels like it was accidentally duplicated