### PR TITLE
Improve Use RemoteGraph page lgp

### DIFF
--- a/src/langgraph-platform/use-remote-graph.mdx
+++ b/src/langgraph-platform/use-remote-graph.mdx
@@ -3,14 +3,14 @@ title: How to interact with a deployment using RemoteGraph
 sidebarTitle: Interact with a deployment using RemoteGraph
 ---
 
-[`RemoteGraph`](https://langchain-ai.github.io/langgraph/reference/remote_graph) is a client-side interface that allows you to interact with your [deployment](/langgraph-platform/deployment-options) as if it were a local graph. It provides API parity with [`CompiledGraph`](/oss/python/langgraph/graph-api#compiling-your-graph), which means that you can use the same methods (`invoke`, `stream`, `get_state`, etc.) in your development and production environments. This page describes how to initialize a `RemoteGraph` and interact with it.
+[`RemoteGraph`](https://langchain-ai.github.io/langgraph/reference/remote_graph) is a client-side interface that allows you to interact with your [deployment](/langgraph-platform/deployment-options) as if it were a local graph. It provides API parity with [`CompiledGraph`](/oss/langgraph/graph-api#compiling-your-graph), which means that you can use the same methods (`invoke()`, `stream()`, `get_state()`, etc.) in your development and production environments. This page describes how to initialize a `RemoteGraph` and interact with it.
 
 `RemoteGraph` is useful for the following:
 
 - Separation of development and deployment: Build and test a graph locally with `CompiledGraph`, deploy it to LangGraph Platform, and then [use `RemoteGraph`](#initialize-the-graph) to call it in production while working with the same API interface.
 - Thread-level persistence: [Persist and fetch the state](#persist-state-at-the-thread-level) of a conversation across calls with a thread ID.
 - Subgraph embedding: Compose modular graphs for a multi-agent workflow by embedding a `RemoteGraph` as a [subgraph](#use-as-a-subgraph) within another graph.
-- Reusable workflows: Use deployed graphs as nodes or [tools](https://langchain-ai.github.io/langgraph/reference/remote_graph#meth-as-tool), so that you can reuse and expose complex logic.
+- Reusable workflows: Use deployed graphs as nodes or [tools](https://langchain-ai.github.io/langgraph/reference/remote_graph/#langgraph.pregel.remote.RemoteGraph.as_tool), so that you can reuse and expose complex logic.
 
 ## Prerequisites
 
@@ -43,28 +43,28 @@ If you pass both `client` or `sync_client` as well as the `url` argument, they w
 ```python Python
 from langgraph.pregel.remote import RemoteGraph
 
-url = <DEPLOYMENT_URL>
+url = "<DEPLOYMENT_URL>"
 
 # Using graph name (uses default assistant)
 graph_name = "agent"
 remote_graph = RemoteGraph(graph_name, url=url)
 
 # Using assistant ID
-assistant_id = <ASSISTANT_ID>
+assistant_id = "<ASSISTANT_ID>"
 remote_graph = RemoteGraph(assistant_id, url=url)
 ```
 
 ```typescript JavaScript
 import { RemoteGraph } from "@langchain/langgraph/remote";
 
-const url = `<DEPLOYMENT_URL>`;
+const url = "<DEPLOYMENT_URL>";
 
 // Using graph name (uses default assistant)
 const graphName = "agent";
 const remoteGraph = new RemoteGraph({ graphId: graphName, url });
 
 // Using assistant ID
-const assistantId = `<ASSISTANT_ID>`;
+const assistantId = "<ASSISTANT_ID>";
 const remoteGraph = new RemoteGraph({ graphId: assistantId, url });
 ```
 
@@ -78,7 +78,7 @@ const remoteGraph = new RemoteGraph({ graphId: assistantId, url });
 from langgraph_sdk import get_client, get_sync_client
 from langgraph.pregel.remote import RemoteGraph
 
-url = <DEPLOYMENT_URL>
+url = "<DEPLOYMENT_URL>"
 client = get_client(url=url)
 sync_client = get_sync_client(url=url)
 
@@ -87,7 +87,7 @@ graph_name = "agent"
 remote_graph = RemoteGraph(graph_name, client=client, sync_client=sync_client)
 
 # Using assistant ID
-assistant_id = <ASSISTANT_ID>
+assistant_id = "<ASSISTANT_ID>"
 remote_graph = RemoteGraph(assistant_id, client=client, sync_client=sync_client)
 ```
 
@@ -95,14 +95,14 @@ remote_graph = RemoteGraph(assistant_id, client=client, sync_client=sync_client)
 import { Client } from "@langchain/langgraph-sdk";
 import { RemoteGraph } from "@langchain/langgraph/remote";
 
-const client = new Client({ apiUrl: `<DEPLOYMENT_URL>` });
+const client = new Client({ apiUrl: "<DEPLOYMENT_URL>" });
 
 // Using graph name (uses default assistant)
 const graphName = "agent";
 const remoteGraph = new RemoteGraph({ graphId: graphName, client });
 
 // Using assistant ID
-const assistantId = `<ASSISTANT_ID>`;
+const assistantId = "<ASSISTANT_ID>";
 const remoteGraph = new RemoteGraph({ graphId: assistantId, client });
 ```
 
@@ -115,7 +115,6 @@ const remoteGraph = new RemoteGraph({ graphId: assistantId, client });
 ### Asynchronously
 
 <Note>
-To use the graph asynchronously, you must provide either the `url` or `client` when initializing the `RemoteGraph`.
 To use the graph asynchronously, you must provide either the `url` or `client` when initializing the `RemoteGraph`.
 </Note>
 
@@ -153,7 +152,6 @@ for await (const chunk of await remoteGraph.stream({
 
 <Note>
 To use the graph synchronously, you must provide either the `url` or `sync_client` when initializing the `RemoteGraph`.
-To use the graph synchronously, you must provide either the `url` or `sync_client` when initializing the `RemoteGraph`.
 </Note>
 
 <CodeGroup>
@@ -183,7 +181,8 @@ If you want to preserve the outputs of a run—for example, to support human-in-
 
 ```python Python
 from langgraph_sdk import get_sync_client
-url = <DEPLOYMENT_URL>
+
+url = "<DEPLOYMENT_URL>"
 graph_name = "agent"
 sync_client = get_sync_client(url=url)
 remote_graph = RemoteGraph(graph_name, url=url)
@@ -206,7 +205,7 @@ print(thread_state)
 import { Client } from "@langchain/langgraph-sdk";
 import { RemoteGraph } from "@langchain/langgraph/remote";
 
-const url = `<DEPLOYMENT_URL>`;
+const url = "<DEPLOYMENT_URL>";
 const graphName = "agent";
 const client = new Client({ apiUrl: url });
 const remoteGraph = new RemoteGraph({ graphId: graphName, url });
@@ -231,10 +230,9 @@ console.log(threadState);
 
 <Note>
 If you need to use a `checkpointer` with a graph that has a `RemoteGraph` subgraph node, make sure to use UUIDs as thread IDs.
-If you need to use a `checkpointer` with a graph that has a `RemoteGraph` subgraph node, make sure to use UUIDs as thread IDs.
 </Note>
 
-A graph can also call out to multiple `RemoteGraph` instances as [_subgraph_](/oss/python/langgraph/subgraphs) nodes. This allows for modular, scalable workflows where different responsibilities are split across separate graphs.
+A graph can also call out to multiple `RemoteGraph` instances as [_subgraph_](/oss/langgraph/subgraphs) nodes. This allows for modular, scalable workflows where different responsibilities are split across separate graphs.
 
 `RemoteGraph` exposes the same interface as a regular `CompiledGraph`, so you can use it directly as a subgraph inside another graph. For example:
 
@@ -245,7 +243,7 @@ from langgraph_sdk import get_sync_client
 from langgraph.graph import StateGraph, MessagesState, START
 from typing import TypedDict
 
-url = <DEPLOYMENT_URL>
+url = "<DEPLOYMENT_URL>"
 graph_name = "agent"
 remote_graph = RemoteGraph(graph_name, url=url)
 
@@ -273,7 +271,7 @@ for chunk in graph.stream({
 import { MessagesAnnotation, StateGraph, START } from "@langchain/langgraph";
 import { RemoteGraph } from "@langchain/langgraph/remote";
 
-const url = `<DEPLOYMENT_URL>`;
+const url = "<DEPLOYMENT_URL>";
 const graphName = "agent";
 const remoteGraph = new RemoteGraph({ graphId: graphName, url });
 


### PR DESCRIPTION
DOC-40

- Adds more detail on use case for the RemoteGraph feature — a couple of recent comments suggested that users/internal folks weren't understanding what you could use this for. 
- Updates to `<CodeGroup>` for global page syncing of code blocks.
- Updates language for docs style.
- Makes headings consistent.
- Updates possible python variable error.

## Preview

https://langchain-5e9cc07a-preview-improv-1756931698-528fb72.mintlify.app/langgraph-platform/use-remote-graph