### PR TITLE
docs(oss): add langchain/production deploy docs

### DIFF
--- a/src/oss/langchain-deploy.mdx
+++ b/src/oss/langchain-deploy.mdx
@@ -15,11 +15,13 @@ Before you begin, ensure you have the following:
 * A [GitHub account](https://github.com/)
 * A [LangSmith account](https://smith.langchain.com/) (free to sign up)
 
-## 1. Create a repository on GitHub
+## Deploy your agent on LangGraph Platform
+
+### 1. Create a repository on GitHub
 
 Your application's code must reside in a GitHub repository to be deployed on LangGraph Platform. Both public and private repositories are supported. For this quickstart, first make sure your app is LangGraph-compatible by following the [local server setup guide](./langchain-studio#setup-local-langgraph-server). Then, upload your code to a GitHub repository.
 
-## 2. Deploy to LangGraph Platform
+### 2. Deploy to LangGraph Platform
 
 1. Log in to [LangSmith](https://smith.langchain.com/).
 2. In the left sidebar, select **Deployments**.
@@ -29,7 +31,7 @@ Your application's code must reside in a GitHub repository to be deployed on Lan
 6. Click **Submit** to deploy.
   This may take about 15 minutes to complete. You can check the status in the **Deployment details** view.
 
-## 3. Test your application in LangGraph Studio
+### 3. Test your application in LangGraph Studio
 
 Once your application is deployed:
 
@@ -40,12 +42,12 @@ Once your application is deployed:
 For an in-depth look at LangGraph Studio, check out our [LangGraph Studio overview](/langgraph-platform/langgraph-studio).
 </Tip>
 
-## 4. Get the API URL for your deployment
+### 4. Get the API URL for your deployment
 
 1. In the **Deployment details** view in LangGraph, click the **API URL** to copy it to your clipboard.
 2. Click the `URL` to copy it to the clipboard.
 
-## 5. Test the API
+### 5. Test the API
 
 You can now test the API:
 

--- a/src/oss/langchain-deploy.mdx
+++ b/src/oss/langchain-deploy.mdx
@@ -1,7 +1,162 @@
 ---
-title: (Coming Soon) Deploy
+title: Deploy
 ---
 
 import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
 
 <AlphaCallout />
+ 
+ LangGraph Platform is the easiest way to deploy agents. Traditional hosts are built for stateless, short-lived web apps, while LangGraph is **purpose-built for stateful, long-running agents**, so you can go from repo to reliable cloud deployment in minutes.
+ 
+## Prerequisites
+
+Before you begin, ensure you have the following:
+
+* A [GitHub account](https://github.com/)
+* A [LangSmith account](https://smith.langchain.com/) (free to sign up)
+
+## 1. Create a repository on GitHub
+
+Your application's code must reside in a GitHub repository to be deployed on LangGraph Platform. Both public and private repositories are supported. For this quickstart, first make sure your app is LangGraph-compatible by following the [local server setup guide](./langchain-studio#setup-local-langgraph-server). Then, upload your code to a GitHub repository.
+
+## 2. Deploy to LangGraph Platform
+
+1. Log in to [LangSmith](https://smith.langchain.com/).
+2. In the left sidebar, select **Deployments**.
+3. Click the **+ New Deployment** button. A pane will open where you can fill in the required fields.
+4. If you are a first time user or adding a private repository that has not been previously connected, click the **Import from GitHub** button and follow the instructions to connect your GitHub account.
+5. Select your application's repository.
+6. Click **Submit** to deploy.
+  This may take about 15 minutes to complete. You can check the status in the **Deployment details** view.
+
+## 3. Test your application in LangGraph Studio
+
+Once your application is deployed:
+
+1. Select the deployment you just created to view more details.
+2. Click the **LangGraph Studio** button in the top right corner. [LangGraph Studio](/langgraph-platform/langgraph-studio) will open to display your graph.
+
+<Tip>
+For an in-depth look at LangGraph Studio, check out our [LangGraph Studio overview](/langgraph-platform/langgraph-studio).
+</Tip>
+
+## 4. Get the API URL for your deployment
+
+1. In the **Deployment details** view in LangGraph, click the **API URL** to copy it to your clipboard.
+2. Click the `URL` to copy it to the clipboard.
+
+## 5. Test the API
+
+You can now test the API:
+
+<Tabs>
+  <Tab title="Python SDK (Async)">
+    1. Install the LangGraph Python SDK:
+      ```shell
+      pip install langgraph-sdk
+      ```
+    2. Send a message to the agent (threadless run):
+      ```python
+      from langgraph_sdk import get_client
+      
+      client = get_client(url="your-deployment-url", api_key="your-langsmith-api-key")
+      
+      async for chunk in client.runs.stream(
+          None,  # Threadless run
+          "agent", # Name of assistant. Defined in langgraph.json.
+          input={
+              "messages": [{
+                  "role": "human",
+                  "content": "What is LangGraph?",
+              }],
+          },
+          stream_mode="updates",
+      ):
+          print(f"Receiving new event of type: {chunk.event}...")
+          print(chunk.data)
+          print("\n\n")
+      ```
+  </Tab>
+  <Tab title="Python SDK (Sync)">
+    1. Install the LangGraph Python SDK:
+      ```shell
+      pip install langgraph-sdk
+      ```
+    2. Send a message to the assistant (threadless run):
+      ```python
+      from langgraph_sdk import get_sync_client
+      
+      client = get_sync_client(url="your-deployment-url", api_key="your-langsmith-api-key")
+      
+      for chunk in client.runs.stream(
+          None,  # Threadless run
+          "agent", # Name of assistant. Defined in langgraph.json.
+          input={
+              "messages": [{
+                  "role": "human",
+                  "content": "What is LangGraph?",
+              }],
+          },
+          stream_mode="updates",
+      ):
+          print(f"Receiving new event of type: {chunk.event}...")
+          print(chunk.data)
+          print("\n\n")
+      ```
+  </Tab>
+  <Tab title="JavaScript SDK">
+    1. Install the LangGraph JS SDK
+      ```shell
+      npm install @langchain/langgraph-sdk
+      ```
+    2. Send a message to the assistant (threadless run):
+      ```js
+      const { Client } = await import("@langchain/langgraph-sdk");
+      
+      const client = new Client({ apiUrl: "your-deployment-url", apiKey: "your-langsmith-api-key" });
+      
+      const streamResponse = client.runs.stream(
+          null, // Threadless run
+          "agent", // Assistant ID
+          {
+              input: {
+                  "messages": [
+                      { "role": "user", "content": "What is LangGraph?"}
+                  ]
+              },
+              streamMode: "messages",
+          }
+      );
+      
+      for await (const chunk of streamResponse) {
+          console.log(`Receiving new event of type: ${chunk.event}...`);
+          console.log(JSON.stringify(chunk.data));
+          console.log("\n\n");
+      }
+      ```
+  </Tab>
+  <Tab title="Rest API">
+    ```bash
+    curl -s --request POST \
+        --url <DEPLOYMENT_URL>/runs/stream \
+        --header 'Content-Type: application/json' \
+        --header "X-Api-Key: <LANGSMITH API KEY> \
+        --data "{
+            \"assistant_id\": \"agent\",
+            \"input\": {
+                \"messages\": [
+                    {
+                        \"role\": \"human\",
+                        \"content\": \"What is LangGraph?\"
+                    }
+                ]
+            },
+            \"stream_mode\": \"updates\"
+        }" 
+    ```
+    </Tab>
+  </Tabs>
+
+<Tip>
+LangGraph Platform offers additional deployment options, including self-hosted and hybrid. For more information, please see [Deployment options](/langgraph-platform/deployment-options).
+</Tip>

--- a/src/oss/langchain-deploy.mdx
+++ b/src/oss/langchain-deploy.mdx
@@ -15,7 +15,7 @@ Before you begin, ensure you have the following:
 * A [GitHub account](https://github.com/)
 * A [LangSmith account](https://smith.langchain.com/) (free to sign up)
 
-## Deploy your agent on LangGraph Platform
+## Deploy your agent
 
 ### 1. Create a repository on GitHub
 


### PR DESCRIPTION
Add docs on deploying `create_agent()`, covering how to:
* Deploy your agent on LangGraph Platform

