### PR TITLE
docs(oss): add langchain/production observability docs

### DIFF
--- a/src/oss/langchain-observability.mdx
+++ b/src/oss/langchain-observability.mdx
@@ -201,8 +201,6 @@ with ls.tracing_context(
 ```
 :::
 
-:::
-
 :::js
 ```ts
 import { LangChainTracer } from "@langchain/core/tracers/tracer_langchain";


### PR DESCRIPTION
Add docs on observing `create_agent()` with LangSmith, covering how to:
* Enable LS tracing
* Trace selectively
* Log to a specific project
* Add metadata to traces
