### PR TITLE
docs(oss): add langchain/production test docs

### DIFF
--- a/src/oss/langchain-test.mdx
+++ b/src/oss/langchain-test.mdx
@@ -1,3 +1,931 @@
 ---
-title: (Coming Soon) Test
+title: Test
 ---
+
+Agentic applications give an LLM freedom over control flow in order to solve problems. While this freedom can be extremely powerful, the black box nature of LLMs can make it difficult to understand how changes in one part of your agent will affect others downstream. This makes testing your agents especially important.
+
+## Unit testing
+
+For logic that doesn't require an API call, you can replace the real LLM with an in-memory stub. LangChain provides fake models for mocking responses.
+
+:::python
+LangChain provides `GenericFakeChatModel` for mocking text responses. It accepts an iterator of responses and returns one per invocation. It supports both regular and streaming usage.
+
+### Basic invocation
+
+We can pre-load three responses into the model and test 
+
+```python
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain.agents import create_agent
+
+model = GenericFakeChatModel(messages=iter(["foo", "bar"]))
+
+agent = create_agent(model, tools=[], prompt="Echo: {input}")
+
+def test_prompt_formatting():
+    result = agent.invoke({"messages": [
+        {"role": "user", "content": "hello"}
+    ]})
+    assert result["messages"][-1].content_blocks == [{'type': 'text', 'text': 'foo'}]
+
+    result = agent.invoke({"messages": [
+        {"role": "user", "content": "hello, again!"}
+    ]})
+    assert result["messages"][-1].content_blocks == [{'type': 'text', 'text': 'bar'}]
+```
+:::
+
+:::js
+LangChain provides `FakeChatModel` for mocking text responses. It accepts an array of responses and returns one per invocation.
+
+### Basic invocation
+
+We can pre-load responses into the model and test:
+
+```typescript
+import { FakeChatModel } from "@langchain/core/utils/testing";
+import { createAgent } from "langchain";
+
+const model = new FakeChatModel({
+  responses: ["foo", "bar"]
+});
+
+const agent = createAgent({
+  llm: model,
+  tools: [],
+  prompt: "Echo: {input}"
+});
+
+async function testPromptFormatting() {
+  const result = await agent.invoke({
+    messages: [{ role: "user", content: "hello" }]
+  });
+  expect(result.messages[result.messages.length - 1].contentBlocks).toBe([{type: "text", text: "foo"}]);
+
+  const result2 = await agent.invoke({
+    messages: [{ role: "user", content: "hello, again!" }]
+  });
+  expect(result2.messages[result2.messages.length - 1].contentBlocks).toBe([{type: "text", text: "bar"}]);
+}
+```
+:::
+
+### Testing stateful logic
+
+You can simulate multiple turns to test state-dependent behavior, such as switching models based on conversation length.
+
+In this example, we configure a `checkpointer` to persist the agent's state between invocations. This allows us to simulate the multiple conversation turns that might occur during a live invocation, where the model can call tools, respond to human interrupts, and so on.
+
+:::python
+```python
+from itertools import repeat
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain.agents import create_agent, AgentState
+from langchain_core.messages import AIMessage
+from langgraph.runtime import Runtime
+from langgraph.checkpoint.memory import InMemorySaver
+
+small_model = GenericFakeChatModel(messages=repeat("small response", 3))
+large_model = GenericFakeChatModel(messages=repeat("large response", 1))
+
+def choose_model(state: AgentState, runtime: Runtime):
+    """Choose model based on conversation complexity."""
+    messages = state["messages"]
+    ai_message_count = sum(isinstance(m, AIMessage) for m in messages)
+
+    print(messages)
+    print(ai_message_count)
+
+    return large_model if ai_message_count > 2 else small_model
+
+agent = create_agent(
+    choose_model, 
+    tools=[],
+    checkpointer=InMemorySaver()
+)
+
+def test_model_switching():
+    # Simulate 4 conversation turns
+    for i in range(4):
+        result = agent.invoke(
+            {"messages": [{"role": "user", "content": f"message {i}"}]}, 
+            {"configurable": {"thread_id": "1"}}
+        )
+    
+    assert result["messages"][-1].content_blocks == [{'type': 'text', 'text': 'large response'}]
+```
+:::
+
+:::js
+```typescript
+import { FakeChatModel } from "@langchain/core/utils/testing";
+import { createAgent } from "langchain"
+import { AIMessage } from "@langchain/core/messages";
+import { MemorySaver } from "@langchain/langgraph";
+
+const smallModel = new FakeChatModel({
+  responses: Array(3).fill("small response")
+});
+
+const largeModel = new FakeChatModel({
+  responses: ["large response"]
+});
+
+function chooseModel(state: any): any {
+  const messages = state.messages;
+  const aiMessageCount = messages.filter((m: any) => m instanceof AIMessage).length;
+
+  console.log(messages);
+  console.log(aiMessageCount);
+
+  return aiMessageCount > 2 ? largeModel : smallModel;
+}
+
+const agent = createAgent({
+  llm: chooseModel,
+  tools: [],
+  checkpointer: new MemorySaver()
+});
+
+async function testModelSwitching() {
+  // Simulate 4 conversation turns
+  for (let i = 0; i < 4; i++) {
+    const result = await agent.invoke(
+      { messages: [{ role: "user", content: `message ${i}` }] },
+      { configurable: { thread_id: "1" } }
+    );
+  }
+  
+  expect(result.messages[result.messages.length - 1].contentBlocks).toBe([{type: "text", text: "large response"}]);
+}
+```
+:::
+
+## Integration testing
+
+Many agent behaviors only emerge when using a real LLM, such as which tool the agent decides to call, how it formats responses, or whether a prompt modification affects the entire execution trajectory. LangChain offers an `agentevals` package that provides evaluators specifically designed for testing agent trajectories with live models.
+
+AgentEvals lets you easily evaluate the trajectory of your agent (i.e. the agent's message history) by matching it against a [reference trajectory](#trajectory-match-evaluator) or by using an [LLM judge](#llm-as-judge-evaluator).
+
+### Installing agentevals
+
+:::python
+```bash
+pip install agentevals
+```
+:::
+
+:::js
+```bash
+npm install agentevals @langchain/core
+```
+:::
+
+Or, clone the [AgentEvals repo](https://github.com/langchain-ai/agentevals) directly.
+
+### Trajectory match evaluator
+
+:::python
+AgentEvals offers the `create_trajectory_match_evaluator` function to match your agent's trajectory against a reference trajectory. You can customize its behavior in a few ways:
+
+- Setting `trajectory_match_mode` to [`strict`](#strict-match), [`unordered`](#unordered-match), [`subset`](#subset-and-superset-match), or [`superset`](#subset-and-superset-match) to provide the general strategy the evaluator will use to compare trajectories
+- Setting [`tool_args_match_mode`](#tool-args-match-modes) and/or [`tool_args_match_overrides`](#tool-args-match-modes) to customize how the evaluator considers equality between tool calls in the actual trajectory vs. the reference. By default, only tool calls with the same arguments to the same tool are considered equal.
+:::
+
+:::js
+AgentEvals offers the `createTrajectoryMatchEvaluator` function to match your agent's trajectory against a reference trajectory. You can customize its behavior in a few ways:
+
+- Setting `trajectoryMatchMode` to [`strict`](#strict-match), [`unordered`](#unordered-match), [`subset`](#subset-and-superset-match), or [`superset`](#subset-and-superset-match) to provide the general strategy the evaluator will use to compare trajectories
+- Setting [`toolArgsMatchMode`](#tool-args-match-modes) and/or [`toolArgsMatchOverrides`](#tool-args-match-modes) to customize how the evaluator considers equality between tool calls in the actual trajectory vs. the reference. By default, only tool calls with the same arguments to the same tool are considered equal.
+:::
+
+#### Strict match
+
+The `strict` mode ensures trajectories contain identical messages in the same order with the same tool calls, though it allows for differences in message content. This is useful when you need to enforce a specific sequence of operations, such as requiring a policy lookup before authorizing an action.
+
+:::python
+```python highlight={13-15}
+from langchain.agents import create_agent
+from langchain_core.tools import tool
+from langchain_core.messages import HumanMessage, AIMessage, ToolMessage
+from agentevals.trajectory.match import create_trajectory_match_evaluator
+
+@tool
+def get_weather(city: str):
+    """Get weather information for a city."""
+    return f"It's 75 degrees and sunny in {city}."
+
+agent = create_agent("openai:gpt-4o", tools=[get_weather])
+
+evaluator = create_trajectory_match_evaluator(
+    trajectory_match_mode="strict",
+)
+
+def test_weather_tool_called_strict():
+    result = agent.invoke({
+        "messages": [HumanMessage(content="What's the weather in San Francisco?")]
+    })
+    
+    reference_trajectory = [
+        HumanMessage(content="What's the weather in San Francisco?"),
+        AIMessage(content="", tool_calls=[
+            {"id": "call_1", "name": "get_weather", "args": {"city": "San Francisco"}}
+        ]),
+        ToolMessage(content="It's 75 degrees and sunny in San Francisco.", tool_call_id="call_1"),
+        AIMessage(content="The weather in San Francisco is 75 degrees and sunny."),
+    ]
+
+    evaluation = evaluator(
+        outputs=result["messages"], 
+        reference_outputs=reference_trajectory
+    )
+    # {
+    #     'key': 'trajectory_strict_match',
+    #     'score': True,
+    #     'comment': None,
+    # }
+    assert evaluation["score"] is True
+```
+:::
+
+:::js
+```typescript highlight={25-27}
+import { createAgent } from "langchain"
+import { tool } from "@langchain/core/tools";
+import { HumanMessage, AIMessage, ToolMessage } from "@langchain/core/messages";
+import { createTrajectoryMatchEvaluator } from "agentevals";
+import { z } from "zod";
+
+const getWeather = tool(
+  async ({ city }: { city: string }) => {
+    return `It's 75 degrees and sunny in ${city}.`;
+  },
+  {
+    name: "get_weather",
+    description: "Get weather information for a city.",
+    schema: z.object({
+      city: z.string(),
+    }),
+  }
+);
+
+const agent = createAgent({
+  llm: "openai:gpt-4o",
+  tools: [getWeather]
+});
+
+const evaluator = createTrajectoryMatchEvaluator({
+  trajectoryMatchMode: "strict",
+});
+
+async function testWeatherToolCalledStrict() {
+  const result = await agent.invoke({
+    messages: [new HumanMessage("What's the weather in San Francisco?")]
+  });
+  
+  const referenceTrajectory = [
+    new HumanMessage("What's the weather in San Francisco?"),
+    new AIMessage({
+      content: "",
+      tool_calls: [
+        { id: "call_1", name: "get_weather", args: { city: "San Francisco" } }
+      ]
+    }),
+    new ToolMessage({
+      content: "It's 75 degrees and sunny in San Francisco.",
+      tool_call_id: "call_1"
+    }),
+    new AIMessage("The weather in San Francisco is 75 degrees and sunny."),
+  ];
+
+  const evaluation = await evaluator({
+    outputs: result.messages,
+    referenceOutputs: referenceTrajectory
+  });
+  // {
+  //     'key': 'trajectory_strict_match',
+  //     'score': true,
+  //     'comment': null,
+  // }
+  expect(evaluation.score).toBe(true);
+}
+```
+:::
+
+#### Unordered match
+
+The `unordered` mode allows the same tool calls in any order, which is helpful when you want to verify that specific information was retrieved but don't care about the sequence. For example, an agent might need to check both weather and events for a city, but the order doesn't matter.
+
+:::python
+```python highlight={18-20}
+from langchain.agents import create_agent
+from langchain_core.tools import tool
+from langchain_core.messages import HumanMessage, AIMessage, ToolMessage
+from agentevals.trajectory.match import create_trajectory_match_evaluator
+
+@tool
+def get_weather(city: str):
+    """Get weather information for a city."""
+    return f"It's 75 degrees and sunny in {city}."
+
+@tool
+def get_events(city: str):
+    """Get events happening in a city."""
+    return f"Concert at the park in {city} tonight."
+
+agent = create_agent("openai:gpt-4o", tools=[get_weather, get_events])
+
+evaluator = create_trajectory_match_evaluator(
+    trajectory_match_mode="unordered",
+)
+
+def test_multiple_tools_any_order():
+    result = agent.invoke({
+        "messages": [HumanMessage(content="What's happening in SF today?")]
+    })
+    
+    # Reference shows tools called in different order than actual execution
+    reference_trajectory = [
+        HumanMessage(content="What's happening in SF today?"),
+        AIMessage(content="", tool_calls=[
+            {"id": "call_1", "name": "get_events", "args": {"city": "SF"}},
+            {"id": "call_2", "name": "get_weather", "args": {"city": "SF"}},
+        ]),
+        ToolMessage(content="Concert at the park in SF tonight.", tool_call_id="call_1"),
+        ToolMessage(content="It's 75 degrees and sunny in SF.", tool_call_id="call_2"),
+        AIMessage(content="Today in SF: 75 degrees and sunny with a concert at the park tonight."),
+    ]
+    
+    evaluation = evaluator(
+        outputs=result["messages"], 
+        reference_outputs=reference_trajectory,
+    )
+    # {
+    #     'key': 'trajectory_unordered_match',
+    #     'score': True,
+    # }
+    assert evaluation["score"] is True
+```
+:::
+
+:::js
+```typescript highlight={34-36}
+import { createAgent } from "langchain"
+import { tool } from "@langchain/core/tools";
+import { HumanMessage, AIMessage, ToolMessage } from "@langchain/core/messages";
+import { createTrajectoryMatchEvaluator } from "agentevals";
+import { z } from "zod";
+
+const getWeather = tool(
+  async ({ city }: { city: string }) => {
+    return `It's 75 degrees and sunny in ${city}.`;
+  },
+  {
+    name: "get_weather",
+    description: "Get weather information for a city.",
+    schema: z.object({ city: z.string() }),
+  }
+);
+
+const getEvents = tool(
+  async ({ city }: { city: string }) => {
+    return `Concert at the park in ${city} tonight.`;
+  },
+  {
+    name: "get_events",
+    description: "Get events happening in a city.",
+    schema: z.object({ city: z.string() }),
+  }
+);
+
+const agent = createAgent({
+  llm: "openai:gpt-4o",
+  tools: [getWeather, getEvents]
+});
+
+const evaluator = createTrajectoryMatchEvaluator({
+  trajectoryMatchMode: "unordered",
+});
+
+async function testMultipleToolsAnyOrder() {
+  const result = await agent.invoke({
+    messages: [new HumanMessage("What's happening in SF today?")]
+  });
+  
+  // Reference shows tools called in different order than actual execution
+  const referenceTrajectory = [
+    new HumanMessage("What's happening in SF today?"),
+    new AIMessage({
+      content: "",
+      tool_calls: [
+        { id: "call_1", name: "get_events", args: { city: "SF" } },
+        { id: "call_2", name: "get_weather", args: { city: "SF" } },
+      ]
+    }),
+    new ToolMessage({
+      content: "Concert at the park in SF tonight.",
+      tool_call_id: "call_1"
+    }),
+    new ToolMessage({
+      content: "It's 75 degrees and sunny in SF.",
+      tool_call_id: "call_2"
+    }),
+    new AIMessage("Today in SF: 75 degrees and sunny with a concert at the park tonight."),
+  ];
+  
+  const evaluation = await evaluator({
+    outputs: result.messages,
+    referenceOutputs: referenceTrajectory,
+  });
+  // {
+  //     'key': 'trajectory_unordered_match',
+  //     'score': true,
+  // }
+  expect(evaluation.score).toBe(true);
+}
+```
+:::
+
+#### Subset and superset match
+
+The `superset` and `subset` modes match partial trajectories. The `superset` mode verifies that the agent called at least the tools in the reference trajectory, allowing additional tool calls. The `subset` mode ensures the agent did not call any tools beyond those in the reference.
+
+:::python
+```python highlight={18-20}
+from langchain.agents import create_agent
+from langchain_core.tools import tool
+from langchain_core.messages import HumanMessage, AIMessage, ToolMessage
+from agentevals.trajectory.match import create_trajectory_match_evaluator
+
+@tool
+def get_weather(city: str):
+    """Get weather information for a city."""
+    return f"It's 75 degrees and sunny in {city}."
+
+@tool
+def get_detailed_forecast(city: str):
+    """Get detailed weather forecast for a city."""
+    return f"Detailed forecast for {city}: sunny all week."
+
+agent = create_agent("openai:gpt-4o", tools=[get_weather, get_detailed_forecast])
+
+evaluator = create_trajectory_match_evaluator(
+    trajectory_match_mode="superset",
+)
+
+def test_agent_calls_required_tools_plus_extra():
+    result = agent.invoke({
+        "messages": [HumanMessage(content="What's the weather in Boston?")]
+    })
+    
+    # Reference only requires get_weather, but agent may call additional tools
+    reference_trajectory = [
+        HumanMessage(content="What's the weather in Boston?"),
+        AIMessage(content="", tool_calls=[
+            {"id": "call_1", "name": "get_weather", "args": {"city": "Boston"}},
+        ]),
+        ToolMessage(content="It's 75 degrees and sunny in Boston.", tool_call_id="call_1"),
+        AIMessage(content="The weather in Boston is 75 degrees and sunny."),
+    ]
+    
+    evaluation = evaluator(
+        outputs=result["messages"], 
+        reference_outputs=reference_trajectory,
+    )
+    # {
+    #     'key': 'trajectory_superset_match',
+    #     'score': True,
+    #     'comment': None,
+    # }
+    assert evaluation["score"] is True
+```
+:::
+
+:::js
+```typescript highlight={34-36}
+import { createAgent } from "langchain"
+import { tool } from "@langchain/core/tools";
+import { HumanMessage, AIMessage, ToolMessage } from "@langchain/core/messages";
+import { createTrajectoryMatchEvaluator } from "agentevals";
+import { z } from "zod";
+
+const getWeather = tool(
+  async ({ city }: { city: string }) => {
+    return `It's 75 degrees and sunny in ${city}.`;
+  },
+  {
+    name: "get_weather",
+    description: "Get weather information for a city.",
+    schema: z.object({ city: z.string() }),
+  }
+);
+
+const getDetailedForecast = tool(
+  async ({ city }: { city: string }) => {
+    return `Detailed forecast for ${city}: sunny all week.`;
+  },
+  {
+    name: "get_detailed_forecast",
+    description: "Get detailed weather forecast for a city.",
+    schema: z.object({ city: z.string() }),
+  }
+);
+
+const agent = createAgent({
+  llm: "openai:gpt-4o",
+  tools: [getWeather, getDetailedForecast]
+});
+
+const evaluator = createTrajectoryMatchEvaluator({
+  trajectoryMatchMode: "superset",
+});
+
+async function testAgentCallsRequiredToolsPlusExtra() {
+  const result = await agent.invoke({
+    messages: [new HumanMessage("What's the weather in Boston?")]
+  });
+  
+  // Reference only requires getWeather, but agent may call additional tools
+  const referenceTrajectory = [
+    new HumanMessage("What's the weather in Boston?"),
+    new AIMessage({
+      content: "",
+      tool_calls: [
+        { id: "call_1", name: "get_weather", args: { city: "Boston" } },
+      ]
+    }),
+    new ToolMessage({
+      content: "It's 75 degrees and sunny in Boston.",
+      tool_call_id: "call_1"
+    }),
+    new AIMessage("The weather in Boston is 75 degrees and sunny."),
+  ];
+  
+  const evaluation = await evaluator({
+    outputs: result.messages,
+    referenceOutputs: referenceTrajectory,
+  });
+  // {
+  //     'key': 'trajectory_superset_match',
+  //     'score': true,
+  //     'comment': null,
+  // }
+  expect(evaluation.score).toBe(true);
+}
+```
+:::
+
+### LLM-as-judge evaluator
+
+:::python
+When you don't have a predefined reference trajectory, you can use an LLM to evaluate the agent's execution path. The `create_trajectory_llm_as_judge` function uses a separate LLM to assess whether the trajectory is reasonable and efficient.
+
+```python highlight={13-16}
+from langchain.agents import create_agent
+from langchain_core.tools import tool
+from langchain_core.messages import HumanMessage, AIMessage, ToolMessage
+from agentevals.trajectory.llm import create_trajectory_llm_as_judge, TRAJECTORY_ACCURACY_PROMPT
+
+@tool
+def get_weather(city: str):
+    """Get weather information for a city."""
+    return f"It's 75 degrees and sunny in {city}."
+
+agent = create_agent("openai:gpt-4o", tools=[get_weather])
+
+evaluator = create_trajectory_llm_as_judge(
+    model="openai:o3-mini",
+    prompt=TRAJECTORY_ACCURACY_PROMPT,
+)
+
+def test_trajectory_quality():
+    result = agent.invoke({
+        "messages": [HumanMessage(content="What's the weather in Seattle?")]
+    })
+    
+    evaluation = evaluator(
+        outputs=result["messages"],
+    )
+    # {
+    #     'key': 'trajectory_accuracy',
+    #     'score': True,
+    #     'comment': 'The provided agent trajectory is reasonable...'
+    # }
+    assert evaluation["score"] is True
+```
+
+You can also provide a reference trajectory to the LLM judge for comparison. Use `TRAJECTORY_ACCURACY_PROMPT_WITH_REFERENCE` and pass both the actual and reference trajectories:
+
+```python
+evaluator = create_trajectory_llm_as_judge(
+    model="openai:o3-mini",
+    prompt=TRAJECTORY_ACCURACY_PROMPT_WITH_REFERENCE,
+)
+evaluation = judge_with_reference(
+    outputs=result["messages"],
+    reference_outputs=reference_trajectory,
+)
+```
+:::
+
+:::js
+When you don't have a predefined reference trajectory, you can use an LLM to evaluate the agent's execution path. The `createTrajectoryLLMAsJudge` function uses a separate LLM to assess whether the trajectory is reasonable and efficient.
+
+```typescript highlight={23-26}
+import { createAgent } from "langchain"
+import { tool } from "@langchain/core/tools";
+import { HumanMessage, AIMessage, ToolMessage } from "@langchain/core/messages";
+import { createTrajectoryLLMAsJudge, TRAJECTORY_ACCURACY_PROMPT } from "agentevals";
+import { z } from "zod";
+
+const getWeather = tool(
+  async ({ city }: { city: string }) => {
+    return `It's 75 degrees and sunny in ${city}.`;
+  },
+  {
+    name: "get_weather",
+    description: "Get weather information for a city.",
+    schema: z.object({ city: z.string() }),
+  }
+);
+
+const agent = createAgent({
+  llm: "openai:gpt-4o",
+  tools: [getWeather]
+});
+
+const evaluator = createTrajectoryLLMAsJudge({
+  model: "openai:o3-mini",
+  prompt: TRAJECTORY_ACCURACY_PROMPT,
+});
+
+async function testTrajectoryQuality() {
+  const result = await agent.invoke({
+    messages: [new HumanMessage("What's the weather in Seattle?")]
+  });
+  
+  const evaluation = await evaluator({
+    outputs: result.messages,
+  });
+  // {
+  //     'key': 'trajectory_accuracy',
+  //     'score': true,
+  //     'comment': 'The provided agent trajectory is reasonable...'
+  // }
+  expect(evaluation.score).toBe(true);
+}
+```
+
+You can also provide a reference trajectory to the LLM judge for comparison. Use `TRAJECTORY_ACCURACY_PROMPT_WITH_REFERENCE` and pass both the actual and reference trajectories:
+
+```typescript
+import { TRAJECTORY_ACCURACY_PROMPT_WITH_REFERENCE } from "agentevals";
+
+const evaluator = createTrajectoryLLMAsJudge({
+  model: "openai:o3-mini",
+  prompt: TRAJECTORY_ACCURACY_PROMPT_WITH_REFERENCE,
+});
+
+const evaluation = await evaluator({
+  outputs: result.messages,
+  referenceOutputs: referenceTrajectory,
+});
+```
+:::
+
+:::python
+### Async support
+
+All `agentevals` evaluators support Python asyncio. For evaluators that use factory functions, async versions are available by adding `async` after `create_` in the function name.
+
+```python
+from agentevals.trajectory.llm import create_async_trajectory_llm_as_judge, TRAJECTORY_ACCURACY_PROMPT
+from agentevals.trajectory.match import create_async_trajectory_match_evaluator
+
+async_judge = create_async_trajectory_llm_as_judge(
+    model="openai:o3-mini",
+    prompt=TRAJECTORY_ACCURACY_PROMPT,
+)
+
+async_evaluator = create_async_trajectory_match_evaluator(
+    trajectory_match_mode="strict",
+)
+
+async def test_async_evaluation():
+    result = await agent.ainvoke({
+        "messages": [HumanMessage(content="What's the weather?")]
+    })
+    
+    evaluation = await async_judge(outputs=result["messages"])
+    assert evaluation["score"] is True
+```
+:::
+
+## LangSmith integration
+
+For tracking experiments over time, you can log evaluator results to [LangSmith](https://smith.langchain.com/), a platform for building production-grade LLM applications that includes tracing, evaluation, and experimentation tools.
+
+First, set up LangSmith by setting the required environment variables:
+
+```bash
+export LANGSMITH_API_KEY="your_langsmith_api_key"
+export LANGSMITH_TRACING="true"
+```
+
+:::python
+LangSmith offers two main approaches for running evaluations: [pytest](/langsmith/pytest) integration and the `evaluate` function.
+
+### Using pytest integration
+
+```python
+import pytest
+from langsmith import testing as t
+from agentevals.trajectory.llm import create_trajectory_llm_as_judge, TRAJECTORY_ACCURACY_PROMPT
+
+trajectory_evaluator = create_trajectory_llm_as_judge(
+    model="openai:o3-mini",
+    prompt=TRAJECTORY_ACCURACY_PROMPT,
+)
+
+@pytest.mark.langsmith
+def test_trajectory_accuracy():
+    result = agent.invoke({
+        "messages": [HumanMessage(content="What's the weather in SF?")]
+    })
+    
+    reference_trajectory = [
+        HumanMessage(content="What's the weather in SF?"),
+        AIMessage(content="", tool_calls=[
+            {"id": "call_1", "name": "get_weather", "args": {"city": "SF"}},
+        ]),
+        ToolMessage(content="It's 75 degrees and sunny in SF.", tool_call_id="call_1"),
+        AIMessage(content="The weather in SF is 75 degrees and sunny."),
+    ]
+    
+    # Log inputs, outputs, and reference outputs to LangSmith
+    t.log_inputs({})
+    t.log_outputs({"messages": result["messages"]})
+    t.log_reference_outputs({"messages": reference_trajectory})
+    
+    trajectory_evaluator(
+        outputs=result["messages"],
+        reference_outputs=reference_trajectory
+    )
+```
+
+Run the evaluation with pytest:
+
+```bash
+pytest test_trajectory.py --langsmith-output
+```
+
+### Using the evaluate function
+
+Alternatively, you can create a dataset in LangSmith and use the `evaluate` function:
+
+```python
+from langsmith import Client
+from agentevals.trajectory.llm import create_trajectory_llm_as_judge, TRAJECTORY_ACCURACY_PROMPT
+
+client = Client()
+
+trajectory_evaluator = create_trajectory_llm_as_judge(
+    model="openai:o3-mini",
+    prompt=TRAJECTORY_ACCURACY_PROMPT,
+)
+
+def run_agent(inputs):
+    """Your agent function that returns trajectory messages."""
+    return agent.invoke(inputs)["messages"]
+
+experiment_results = client.evaluate(
+    run_agent,
+    data="your_dataset_name",
+    evaluators=[trajectory_evaluator]
+)
+```
+
+Results will be automatically logged to LangSmith.
+
+<Tip>
+To learn more about evaluating your agent, see the [LangSmith docs](/langsmith/pytest).
+</Tip>
+:::
+
+:::js
+LangSmith offers two main approaches for running evaluations: [Vitest/Jest](/langsmith/vitest-jest) integration and the `evaluate` function.
+
+### Using Vitest/Jest integration
+
+```typescript
+import * as ls from "langsmith/vitest";
+// import * as ls from "langsmith/jest";
+
+import { createTrajectoryLLMAsJudge, TRAJECTORY_ACCURACY_PROMPT } from "agentevals";
+
+const trajectoryEvaluator = createTrajectoryLLMAsJudge({
+  model: "openai:o3-mini",
+  prompt: TRAJECTORY_ACCURACY_PROMPT,
+});
+
+ls.describe("trajectory accuracy", () => {
+  ls.test("accurate trajectory", {
+    inputs: {
+      messages: [
+        {
+          role: "user",
+          content: "What is the weather in SF?"
+        }
+      ]
+    },
+    referenceOutputs: {
+      messages: [
+        new HumanMessage("What is the weather in SF?"),
+        new AIMessage({
+          content: "",
+          tool_calls: [
+            { id: "call_1", name: "get_weather", args: { city: "SF" } }
+          ]
+        }),
+        new ToolMessage({
+          content: "It's 75 degrees and sunny in SF.",
+          tool_call_id: "call_1"
+        }),
+        new AIMessage("The weather in SF is 75 degrees and sunny."),
+      ],
+    },
+  }, async ({ inputs, referenceOutputs }) => {
+    const result = await agent.invoke({
+      messages: [new HumanMessage("What is the weather in SF?")]
+    });
+    
+    ls.logOutputs({ messages: result.messages });
+
+    await trajectoryEvaluator({
+      inputs,
+      outputs: result.messages,
+      referenceOutputs,
+    });
+  });
+});
+```
+
+Run the evaluation with your test runner:
+
+```bash
+vitest run test_trajectory.eval.ts
+# or
+jest test_trajectory.eval.ts
+```
+
+### Using the evaluate function
+
+Alternatively, you can create a dataset in LangSmith and use the `evaluate` function:
+
+```typescript
+import { evaluate } from "langsmith/evaluation";
+import { createTrajectoryLLMAsJudge, TRAJECTORY_ACCURACY_PROMPT } from "agentevals";
+
+const trajectoryEvaluator = createTrajectoryLLMAsJudge({
+  model: "openai:o3-mini",
+  prompt: TRAJECTORY_ACCURACY_PROMPT,
+});
+
+async function runAgent(inputs: any) {
+  const result = await agent.invoke(inputs);
+  return result.messages;
+}
+
+await evaluate(
+  runAgent,
+  {
+    data: "your_dataset_name",
+    evaluators: [trajectoryEvaluator],
+  }
+);
+```
+
+Results will be automatically logged to LangSmith.
+
+<Tip>
+To learn more about evaluating your agent, see the [LangSmith docs](/langsmith/vitest-jest).
+</Tip>
+:::
+
+## Caching
+
+Integration tests that call real LLM APIs can be slow and expensive, especially when run frequently in CI/CD pipelines. We recommend using a caching library to recording HTTP requests and responses during the first test run, then replaying them in subsequent runs without making actual network calls.
+
+:::python
+Use `vcrpy` to achieve this. If you're using `pytest`, the [`pytest-vcr` plugin](https://pytest-vcr.readthedocs.io/en/latest/) provides a simple way to enable this via minimal configuration.
+
+<Note>
+When you modify prompts, add new tools, or change expected trajectories, delete the corresponding cassette files and rerun the tests to record fresh interactions. VCR will automatically handle complex scenarios like streaming responses, multiple tool calls, and error conditions, making your integration tests both deterministic and cost-effective.
+</Note>
+:::
+
+:::js
+**// TODO: caching http requests in JS? similar to VCR casettes**
+:::
+


### PR DESCRIPTION
Add docs on testing `create_agent()`, covering:
* Unit testing
  * Basic mock model
  * Testing stateful logic that doesn't necessitate a network call
* Intergration testing with [AgentEvals](https://github.com/langchain-ai/agentevals)
  * Agent trajectory matching
  * LLM-as-a-judge
* Integration with LangSmith pytest/vitest/jest
* Caching with `vcrpy`

TODO
* @christian-bromann christian-bromann to check js snippets

