### PR TITLE
Provide more detail in the customize run name note LS

### DIFF
--- a/src/langsmith/trace-with-langchain.mdx
+++ b/src/langsmith/trace-with-langchain.mdx
@@ -210,10 +210,10 @@ await chain.invoke(
 
 ## Add metadata and tags to traces
 
-You can annotate your traces with arbitrary metadata and tags by providing them in the [Config](https://api.python.langchain.com/en/latest/runnables/langchain_core.runnables.config.RunnableConfig.html#langchain-core-runnables-config-runnableconfig). This is useful for associating additional information with a trace, such as the environment in which it was executed, or the user who initiated it. For information on how to query traces and runs by metadata and tags, see [this guide](/langsmith/export-traces)
+You can annotate your traces with arbitrary metadata and tags by providing them in the [`RunnableConfig`](https://api.python.langchain.com/en/latest/runnables/langchain_core.runnables.config.RunnableConfig.html#langchain-core-runnables-config-runnableconfig). This is useful for associating additional information with a trace, such as the environment in which it was executed, or the user who initiated it. For information on how to query traces and runs by metadata and tags, see [this guide](/langsmith/export-traces)
 
 <Note>
-When you attach metadata or tags to a runnable (either through the RunnableConfig or at runtime with invocation params), they are inherited by all child runnables of that runnable.
+When you attach metadata or tags to a runnable (either through the `RunnableConfig` or at runtime with invocation params), they are inherited by all child runnables of that runnable.
 </Note>
 
 <CodeGroup>
@@ -301,7 +301,7 @@ To give the LLM run a more meaningful name, you can either:
 
 ## Customize run ID
 
-You can customize the ID of a given run when invoking or streaming your LangChain code by providing it in the [Config](https://api.python.langchain.com/en/latest/runnables/langchain_core.runnables.config.RunnableConfig.html#langchain-core-runnables-config-runnableconfig). This ID is used to uniquely identify the run in LangSmith and can be used to query specific runs. The ID can be useful for linking runs across different systems or for implementing custom tracking logic. This can be done by setting a `run_id` in the `RunnableConfig` object at construction or by passing a `run_id` in the invocation parameters in JS/TS.
+You can customize the ID of a given run when invoking or streaming your LangChain code by providing it in the [Config](https://api.python.langchain.com/en/latest/runnables/langchain_core.runnables.config.RunnableConfig.html#langchain-core-runnables-config-runnableconfig). This ID is used to uniquely identify the run in LangSmith and can be used to query specific runs. The ID can be useful for linking runs across different systems or for implementing custom tracking logic. This can be done by setting a `run_id` in the `RunnableConfig` object at construction or by passing a `run_id` in the invocation parameters.
 
 <Note>
 This feature is not currently supported directly for LLM objects.

--- a/src/langsmith/trace-with-langchain.mdx
+++ b/src/langsmith/trace-with-langchain.mdx
@@ -289,9 +289,7 @@ await chain.invoke({ input: "What is the meaning of life?" }, {runName: "MyCusto
 </CodeGroup>
 
 <Note>
-The `run_name` parameter only changes the name of the runnable you invoke (e.g., a chain, function). It does not rename the nested run automatically created when you invoke an LLM object like `ChatOpenAI` (`gpt-4o-mini`).
-
-In the example, the enclosing run will appear in LangSmith as `MyCustomChain`, while the nested LLM run still shows the model’s default name.
+The `run_name` parameter only changes the name of the runnable you invoke (e.g., a chain, function). It does not rename the nested run automatically created when you invoke an LLM object like `ChatOpenAI` (`gpt-4o-mini`). In the example, the enclosing run will appear in LangSmith as `MyCustomChain`, while the nested LLM run still shows the model’s default name.
 
 To give the LLM run a more meaningful name, you can either:
 

--- a/src/langsmith/trace-with-langchain.mdx
+++ b/src/langsmith/trace-with-langchain.mdx
@@ -210,7 +210,7 @@ await chain.invoke(
 
 ## Add metadata and tags to traces
 
-You can send annotate your traces with arbitrary metadata and tags by providing them in the [Config](https://api.python.langchain.com/en/latest/runnables/langchain_core.runnables.config.RunnableConfig.html#langchain-core-runnables-config-runnableconfig). This is useful for associating additional information with a trace, such as the environment in which it was executed, or the user who initiated it. For information on how to query traces and runs by metadata and tags, see [this guide](/langsmith/export-traces)
+You can annotate your traces with arbitrary metadata and tags by providing them in the [Config](https://api.python.langchain.com/en/latest/runnables/langchain_core.runnables.config.RunnableConfig.html#langchain-core-runnables-config-runnableconfig). This is useful for associating additional information with a trace, such as the environment in which it was executed, or the user who initiated it. For information on how to query traces and runs by metadata and tags, see [this guide](/langsmith/export-traces)
 
 <Note>
 When you attach metadata or tags to a runnable (either through the RunnableConfig or at runtime with invocation params), they are inherited by all child runnables of that runnable.
@@ -266,10 +266,6 @@ await chain.invoke({input: "What is the meaning of life?"}, {tags: ["invoke-tag"
 
 You can customize the name of a given run when invoking or streaming your LangChain code by providing it in the [Config](https://api.python.langchain.com/en/latest/runnables/langchain_core.runnables.config.RunnableConfig.html#langchain-core-runnables-config-runnableconfig). This name is used to identify the run in LangSmith and can be used to filter and group runs. The name is also used as the title of the run in the LangSmith UI. This can be done by setting a `run_name` in the `RunnableConfig` object at construction or by passing a `run_name` in the invocation parameters in JS/TS.
 
-<Note>
-This feature is not currently supported directly for LLM objects.
-</Note>
-
 <CodeGroup>
 
 ```python Python
@@ -291,6 +287,17 @@ await chain.invoke({ input: "What is the meaning of life?" }, {runName: "MyCusto
 ```
 
 </CodeGroup>
+
+<Note>
+The `run_name` parameter only changes the name of the runnable you invoke (e.g., a chain, function). It does not rename the nested run automatically created when you invoke an LLM object like `ChatOpenAI` (`gpt-4o-mini`).
+
+In the example, the enclosing run will appear in LangSmith as `MyCustomChain`, while the nested LLM run still shows the model’s default name.
+
+To give the LLM run a more meaningful name, you can either:
+
+- Wrap the model in another runnable and assign a `run_name` to that step.
+- Use a tracing decorator or helper (e.g., `@traceable` in Python, or `traceable` from `langsmith` in JS/TS) to create a custom run around the model call.
+</Note>
 
 ## Customize run ID
 


### PR DESCRIPTION
Fixes DOC-62

Provides more information about the custom run name behavior. @mdrxy pointed out that the current note doesn't provide context on "LLM objects" or workarounds.

## Preview

https://langchain-5e9cc07a-preview-custom-1757090078-b891f4e.mintlify.app/langsmith/trace-with-langchain#customize-run-name