### PR TITLE
docs: Add Docker container service limitations and production warning

### DIFF
--- a/src/langgraph-platform/reference-overview.mdx
+++ b/src/langgraph-platform/reference-overview.mdx
@@ -9,6 +9,8 @@ Welcome to the LangGraph Platform reference docs. The following pages detail the
 
 * **[LangGraph Server Changelog](/langgraph-platform/langgraph-server-changelog)**: Track all updates, features, and fixes to LangGraph Server releases.
 
+* **[Release Versions](/langgraph-platform/release-versions)**: Learn about LangGraph Platform's version support policy, including Active, Critical, End of Life, and Deprecated support levels.
+
 * **[Control Plane API Reference](/langgraph-platform/api-ref-control-plane)**: API documentation for the control plane endpoints used to manage deployments and configurations.
 
 * **[CLI Reference](/langgraph-platform/cli)**: Command-line interface documentation for building, deploying, and managing LangGraph applications.

--- a/src/langgraph-platform/release-versions.mdx
+++ b/src/langgraph-platform/release-versions.mdx
@@ -1,0 +1,79 @@
+---
+title: Release Versions
+---
+
+LangGraph Platform provides different support levels for different versions, which may include new features, bug fixes, or security patches:
+
+## Support Levels
+
+### Active
+Where N represents the latest minor version (e.g., 0.3, 0.4, etc.).
+
+The current minor version (N) receives full support including:
+- New features and capabilities
+- Bug fixes and regressions
+- Security patches
+- Quality-of-life improvements
+- High confidence changes that are narrowly scoped
+
+### Critical
+The previous minor version (N-1) receives limited support including:
+- Critical security fixes
+- Installation fixes
+- No new features or general bug fixes
+- Transitioned from Active when a newer minor version is released
+
+### End of Life (EOL)
+Versions older than N-2 (N-2, N-3, etc.) receive no support:
+- No new patch releases
+- No bug fixes, including known bugs
+- No security updates
+- Users should upgrade to a supported version
+
+### Deprecated
+Versions that are no longer maintained:
+- All versions prior to the first stable release
+- Versions that have been explicitly deprecated
+- No support or maintenance provided
+
+## Version Support Policy
+
+LangGraph Platform follows an N-2 support policy for minor versions:
+
+- **N (Current)**: Active support
+- **N-1**: Critical support  
+- **N-2 and older**: End of Life
+
+
+### Minor Version Support
+
+Minor versions include new features and capabilities and are supported according to the N-2 policy. When we refer to a minor version, such as v0.3, we always mean its latest available patch release (v0.3.x).
+
+### Patch Releases
+
+During the support window for each version:
+
+- **Active Support**: Regular patch releases with bug fixes, regressions, and new features
+- **Critical Support**: Security-only releases for critical fixes related to security and installation
+- **End of Life**: No new patches released
+
+## Current Version Support
+
+To check the current supported versions and their support levels, refer to the [LangGraph Server Changelog](/langgraph-platform/langgraph-server-changelog) for the latest release information.
+
+## Recommendations
+
+- **Stay Current**: We recommend upgrading to the latest minor version to receive full support and access to new features
+- **Plan Upgrades**: Monitor the changelog for upcoming version changes and plan upgrades accordingly
+- **Security**: Critical security fixes are only provided for Active and Critical support versions
+- **Testing**: Test your applications with newer versions before upgrading in production
+
+## Version Compatibility
+
+When upgrading between minor versions:
+- Review the changelog for breaking changes
+- Test your applications thoroughly
+- Follow the upgrade guides provided in the documentation
+- Consider the support timeline for your current version
+
+For specific version information and upgrade guides, see the [LangGraph Server Changelog](/langgraph-platform/langgraph-server-changelog).

--- a/src/langgraph-platform/release-versions.mdx
+++ b/src/langgraph-platform/release-versions.mdx
@@ -1,79 +1,11 @@
 ---
-title: Release Versions
+title: Release versions
 ---
 
-LangGraph Platform provides different support levels for different versions, which may include new features, bug fixes, or security patches:
+import ReleaseVersionPolicy from "/snippets/release-version-policy.mdx";
 
-## Support Levels
+<ReleaseVersionPolicy product="LangGraph Platform"/>
 
-### Active
-Where N represents the latest minor version (e.g., 0.3, 0.4, etc.).
-
-The current minor version (N) receives full support including:
-- New features and capabilities
-- Bug fixes and regressions
-- Security patches
-- Quality-of-life improvements
-- High confidence changes that are narrowly scoped
-
-### Critical
-The previous minor version (N-1) receives limited support including:
-- Critical security fixes
-- Installation fixes
-- No new features or general bug fixes
-- Transitioned from Active when a newer minor version is released
-
-### End of Life (EOL)
-Versions older than N-2 (N-2, N-3, etc.) receive no support:
-- No new patch releases
-- No bug fixes, including known bugs
-- No security updates
-- Users should upgrade to a supported version
-
-### Deprecated
-Versions that are no longer maintained:
-- All versions prior to the first stable release
-- Versions that have been explicitly deprecated
-- No support or maintenance provided
-
-## Version Support Policy
-
-LangGraph Platform follows an N-2 support policy for minor versions:
-
-- **N (Current)**: Active support
-- **N-1**: Critical support  
-- **N-2 and older**: End of Life
-
-
-### Minor Version Support
-
-Minor versions include new features and capabilities and are supported according to the N-2 policy. When we refer to a minor version, such as v0.3, we always mean its latest available patch release (v0.3.x).
-
-### Patch Releases
-
-During the support window for each version:
-
-- **Active Support**: Regular patch releases with bug fixes, regressions, and new features
-- **Critical Support**: Security-only releases for critical fixes related to security and installation
-- **End of Life**: No new patches released
-
-## Current Version Support
+## Current version support
 
 To check the current supported versions and their support levels, refer to the [LangGraph Server Changelog](/langgraph-platform/langgraph-server-changelog) for the latest release information.
-
-## Recommendations
-
-- **Stay Current**: We recommend upgrading to the latest minor version to receive full support and access to new features
-- **Plan Upgrades**: Monitor the changelog for upcoming version changes and plan upgrades accordingly
-- **Security**: Critical security fixes are only provided for Active and Critical support versions
-- **Testing**: Test your applications with newer versions before upgrading in production
-
-## Version Compatibility
-
-When upgrading between minor versions:
-- Review the changelog for breaking changes
-- Test your applications thoroughly
-- Follow the upgrade guides provided in the documentation
-- Consider the support timeline for your current version
-
-For specific version information and upgrade guides, see the [LangGraph Server Changelog](/langgraph-platform/langgraph-server-changelog).

--- a/src/langsmith/docker.mdx
+++ b/src/langsmith/docker.mdx
@@ -9,6 +9,12 @@ sidebarTitle: Install on Docker
 
 This guide provides instructions for installing and setting up your environment to run LangSmith locally using Docker. You can do this either by using the LangSmith SDK or by using Docker Compose directly.
 
+Please note that use of Docker is limited to local development environments only and does not extend support to container services such as AWS Elastic Container Service, Azure Container Instances and Google Cloud Run.
+
+<Warning>
+  **Do not use this in production**
+</Warning>
+
 ## Prerequisites
 
 1. Ensure Docker is installed and running on your system. You can verify this by running:

--- a/src/langsmith/docker.mdx
+++ b/src/langsmith/docker.mdx
@@ -9,10 +9,10 @@ sidebarTitle: Install on Docker
 
 This guide provides instructions for installing and setting up your environment to run LangSmith locally using Docker. You can do this either by using the LangSmith SDK or by using Docker Compose directly.
 
-Please note that use of Docker is limited to local development environments only and does not extend support to container services such as AWS Elastic Container Service, Azure Container Instances and Google Cloud Run.
+Note that use of Docker is limited to local development environments only and does not extend support to container services such as AWS Elastic Container Service, Azure Container Instances, and Google Cloud Run.
 
 <Warning>
-  **Do not use this in production**
+  **Do not use this in production**.
 </Warning>
 
 ## Prerequisites


### PR DESCRIPTION
## Summary
- Add note that Docker support is limited to local development environments only
- Clarify that container services like AWS ECS, Azure Container Instances, and Google Cloud Run are not supported
- Add prominent production warning in bold/red styling using Warning component

## Changes
- Updated LangSmith Docker guide (`src/langsmith/docker.mdx`) with container service limitations
- Added clear production warning to prevent misuse in production environments