### PR TITLE
fix: templates (for the last time)?

### DIFF
--- a/.github/ISSUE_TEMPLATE/langchain-labs.yml
+++ b/.github/ISSUE_TEMPLATE/langchain-labs.yml
@@ -1,4 +1,4 @@
-name: Documentation
+name: LangChain Labs Documentation
 description: Report an issue related to the LangChain Labs documentation.
 title: "[langchain-labs]: <Please write a comprehensive title>"
 labels: [langchain-labs]

--- a/.github/ISSUE_TEMPLATE/langchain.yml
+++ b/.github/ISSUE_TEMPLATE/langchain.yml
@@ -1,4 +1,4 @@
-name: Documentation
+name: LangChain Documentation
 description: Report an issue related to the LangChain documentation.
 title: "[langchain]: <Please write a comprehensive title>"
 labels: [langchain]

--- a/.github/ISSUE_TEMPLATE/langgraph-platform.yml
+++ b/.github/ISSUE_TEMPLATE/langgraph-platform.yml
@@ -1,4 +1,4 @@
-name: Documentation
+name: LangGraph Platform Documentation
 description: Report an issue related to the LangGraph Platform documentation.
 title: "[langgraph-platform]: <Please write a comprehensive title>"
 labels: [langgraph-platform]

--- a/.github/ISSUE_TEMPLATE/langgraph.yml
+++ b/.github/ISSUE_TEMPLATE/langgraph.yml
@@ -1,4 +1,4 @@
-name: Documentation
+name: LangGraph Documentation
 description: Report an issue related to the LangGraph documentation.
 title: "[langgraph]: <Please write a comprehensive title>"
 labels: [langgraph]

--- a/.github/ISSUE_TEMPLATE/langsmith.yml
+++ b/.github/ISSUE_TEMPLATE/langsmith.yml
@@ -1,4 +1,4 @@
-name: Documentation
+name: LangSmith Documentation
 description: Report an issue related to the LangSmith documentation.
 title: "[langsmith]: <Please write a comprehensive title>"
 labels: [langsmith]

--- a/.github/ISSUE_TEMPLATE/simple.yml
+++ b/.github/ISSUE_TEMPLATE/simple.yml
@@ -1,7 +1,0 @@
-name: Test Template
-description: A simple test
-body:
-  - type: textarea
-    attributes:
-      label: Test
-      description: Just a test


### PR DESCRIPTION
This reverts commit 3dd02825a668a2089f25487e009ef0d0130e65b8.

Also looking to fix other yaml syntax.

<img width="989" height="169" alt="Screenshot 2025-09-09 at 6 12 35 PM" src="https://github.com/user-attachments/assets/e6c563c4-da2e-4953-a465-90d42799c377" />