### PR TITLE
Docs for Custom CA for Self-hosted deployment

### DIFF
--- a/src/langsmith/self-host-custom-tls-certificates.mdx
+++ b/src/langsmith/self-host-custom-tls-certificates.mdx
@@ -1,7 +1,9 @@
 ---
-title: Use custom TLS certificates for model providers
-sidebarTitle: Use custom TLS certificates for model providers
+title: Custom TLS Certificates
+sidebarTitle: Custom TLS Certificates
 ---
+
+## Use custom TLS certificates for model providers
 
 <Note>
 This feature is currently only available for the following model providers:
@@ -25,3 +27,38 @@ To use custom TLS certificates, you need to set the following environment variab
 Once you have set these environment variables, enter the playground and select the model provider that requires custom TLS certificates. Set your model provider configuration as usual, and the custom TLS certificates will be used when connecting to the model provider.
 
 ![](/langsmith/images/azure-playground.png)
+
+## Mount internal CAs to LangSmith applications for TLS
+
+You can mount custom CAs to your LangSmith instance for TLS handshakes with Postgres/ClickHouse/Redis.
+
+1. Create a file containing all CAs required for TLS with your databases. If your deployment is communicating directly to `beacon.langchain.com` without a proxy, make sure to include a public CA that is trusted by beacon (Digicert). All certs should be concatenated in the file, with a space in between.
+```
+-----BEGIN CERTIFICATE-----
+<PUBLIC_CA>
+-----END CERTIFICATE-----
+
+-----BEGIN CERTIFICATE-----
+<INTERNAL_CA>
+-----END CERTIFICATE-----
+
+...
+```
+2. Create a Kubernetes secret containing this file. Example command: `kubectl create secret generic langsmith-tls-cert --from-file=ca.crt=<CA_BUNDLE_PATH> -n langsmith`
+3. Provide the following values:
+```yaml Helm
+config:
+  customCa:
+    secretName: <SECRET_NAME> # The name of the secret created in step 2.
+    secretKey: <SECRET_KEY> # The key in the secret containing the CA bundle.
+
+clickhouse:
+  external:
+    tls: true # Only enable if you want TLS for Clickhouse.
+postgres:
+  external:
+    tls: true # Only enable if you want TLS for Postgres.
+```
+4. Make sure to use TLS supported connection strings:
+    - Postgres: Add `?sslmode=verify-full&sslrootcert=system` to the end of your connection string
+    - Redis: Use `rediss://` instead of `redis://` as the prefix

--- a/src/langsmith/self-host-custom-tls-certificates.mdx
+++ b/src/langsmith/self-host-custom-tls-certificates.mdx
@@ -28,11 +28,9 @@ Once you have set these environment variables, enter the playground and select t
 
 ![](/langsmith/images/azure-playground.png)
 
-## Mount internal CAs to LangSmith applications for TLS
+## Mount internal CAs for TLS
 
-You can mount custom CAs to your LangSmith instance for TLS handshakes with Postgres/ClickHouse/Redis.
-
-1. Create a file containing all CAs required for TLS with your databases. If your deployment is communicating directly to `beacon.langchain.com` without a proxy, make sure to include a public CA that is trusted by beacon (Digicert). All certs should be concatenated in the file, with a space in between.
+1. Create a file containing all CAs required for TLS with databases and external services. If your deployment is communicating directly to `beacon.langchain.com` without a proxy, make sure to include a public trusted CA. All certs should be concatenated in this file with an empty line in between.
 ```
 -----BEGIN CERTIFICATE-----
 <PUBLIC_CA>
@@ -44,8 +42,9 @@ You can mount custom CAs to your LangSmith instance for TLS handshakes with Post
 
 ...
 ```
-2. Create a Kubernetes secret containing this file. Example command: `kubectl create secret generic langsmith-tls-cert --from-file=ca.crt=<CA_BUNDLE_PATH> -n langsmith`
-3. Provide the following values:
+2. Create a Kubernetes secret with a key containing the contents of this file.
+    - Example: `kubectl create secret generic <SECRET_NAME> --from-file=<SECRET_KEY>=<CA_BUNDLE_FILE_PATH> -n <NAMESPACE>`
+3. If using custom CA for TLS with your databases, provide the following values to your LangSmith helm chart:
 ```yaml Helm
 config:
   customCa:
@@ -57,8 +56,8 @@ clickhouse:
     tls: true # Only enable if you want TLS for Clickhouse.
 postgres:
   external:
-    tls: true # Only enable if you want TLS for Postgres.
+    customTls: true # Only enable if you want TLS for Postgres.
 ```
 4. Make sure to use TLS supported connection strings:
-    - Postgres: Add `?sslmode=verify-full&sslrootcert=system` to the end of your connection string
-    - Redis: Use `rediss://` instead of `redis://` as the prefix
+    - <b>Postgres</b>: Add `?sslmode=verify-full&sslrootcert=system` to the end.
+    - <b>Redis</b>: Use `rediss://` instead of `redis://` as the prefix.

--- a/src/langsmith/self-host-custom-tls-certificates.mdx
+++ b/src/langsmith/self-host-custom-tls-certificates.mdx
@@ -1,7 +1,12 @@
 ---
-title: Custom TLS Certificates
-sidebarTitle: Custom TLS Certificates
+title: Configure custom TLS certificates
+sidebarTitle: Configure custom TLS certificates
 ---
+
+Use this guide to configure custom TLS certificates in LangSmith. This is required when connecting securely to model providers or external services, especially if you rely on self-signed certificates or internal certificate authorities. This page describes two related tasks:
+
+- Using custom TLS certificates for model providers (such as Azure, OpenAI, or a custom model server)
+- Mounting internal certificate authorities (CAs) to enable TLS connections for databases and other external services.
 
 ## Use custom TLS certificates for model providers
 
@@ -43,7 +48,9 @@ Once you have set these environment variables, enter the playground and select t
 ...
 ```
 2. Create a Kubernetes secret with a key containing the contents of this file.
-    - Example: `kubectl create secret generic <SECRET_NAME> --from-file=<SECRET_KEY>=<CA_BUNDLE_FILE_PATH> -n <NAMESPACE>`
+```bash
+kubectl create secret generic <SECRET_NAME> --from-file=<SECRET_KEY>=<CA_BUNDLE_FILE_PATH> -n <NAMESPACE>
+```
 3. If using custom CA for TLS with your databases, provide the following values to your LangSmith helm chart:
 ```yaml Helm
 config:

--- a/src/langsmith/self-host-custom-tls-certificates.mdx
+++ b/src/langsmith/self-host-custom-tls-certificates.mdx
@@ -51,7 +51,7 @@ Once you have set these environment variables, enter the playground and select t
 ```bash
 kubectl create secret generic <SECRET_NAME> --from-file=<SECRET_KEY>=<CA_BUNDLE_FILE_PATH> -n <NAMESPACE>
 ```
-3. If using custom CA for TLS with your databases, provide the following values to your LangSmith helm chart:
+3. If using custom CA for TLS with your databases and other external services, provide the following values to your LangSmith helm chart:
 ```yaml Helm
 config:
   customCa:


### PR DESCRIPTION
## Overview
Modify the existing TLS Self-hosted page to be called "Custom TLS Certificates". Added a new section for mounting custom CAs into a LangSmith deployment.

## Type of change
<!-- Check the relevant box -->
- [ ] New documentation page
- [X] Update existing documentation
- [ ] Fix typo, bug, broken link, or formatting issue
- [ ] Remove outdated content
- [ ] Other (please describe):

## Related issues/PRs
<!-- Link to related issues, feature PRs, or discussions (if applicable) -->
- GitHub issue: 
- Feature PR: https://github.com/langchain-ai/langchainplus/pull/12017

<!-- For LangChain employees, if applicable: -->
- Linear issue: INF-758
- Slack thread:

## Checklist
<!-- Check all that apply -->
- [X] I have read the [contributing guidelines](README.md)
- [X] I have tested my changes locally using `docs dev`
- [X] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- [ ] I have gotten approval from the relevant reviewers
- [ ] (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
