### PR TITLE
fix(js/middleware): have users use re-exported Command from LangGraph

### DIFF
--- a/src/oss/langchain/middleware.mdx
+++ b/src/oss/langchain/middleware.mdx
@@ -271,9 +271,8 @@ agent = create_agent(
 
 :::js
 ```typescript
-import { createAgent } from "langchain";
+import { createAgent, Command } from "langchain";
 import { humanInTheLoopMiddleware } from "langchain/middleware";
-import { Command } from "@langchain/langgraph";
 
 const agent = createAgent({
     model: "openai:gpt-4o",


### PR DESCRIPTION
Small example fix to avoid type issues with incompatible LangGraph versions.

Blocked on release of https://github.com/langchain-ai/langchainjs/pull/8907