### PR TITLE
fix: cache_creation not cache_write

### DIFF
--- a/src/langsmith/calculate-token-based-costs.mdx
+++ b/src/langsmith/calculate-token-based-costs.mdx
@@ -66,7 +66,7 @@ For specifying pricing breakdowns, here are the detailed token count types used 
 ```python
 # Standardized
 cache_read
-cache_write
+cache_creation
 reasoning
 audio
 image


### PR DESCRIPTION
## Overview

The standard key is `cache_creation` not `cache_write`.

## Type of change
<!-- Check the relevant box -->
- [ ] New documentation page
- [ ] Update existing documentation
- [x] Fix typo, bug, broken link, or formatting issue
- [ ] Remove outdated content
- [ ] Other (please describe):

## Related issues/PRs
<!-- Link to related issues, feature PRs, or discussions (if applicable) -->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Check all that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- [x] I have gotten approval from the relevant reviewers
- [x] (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
