### PR TITLE
fix: add a2a card to docs

### DIFF
--- a/src/langgraph-platform/server-a2a.mdx
+++ b/src/langgraph-platform/server-a2a.mdx
@@ -7,6 +7,16 @@ sidebarTitle: A2A endpoint in LangGraph Server
 
 The A2A endpoint is available in [LangGraph Server](/langgraph-platform/langgraph-server) at `/a2a/{assistant_id}`.
 
+## Agent Card Discovery
+
+Each assistant automatically exposes an A2A Agent Card that describes its capabilities and provides the information needed for other agents to connect. You can retrieve the agent card for any assistant using:
+
+```
+GET /.well-known/agent-card.json?assistant_id={assistant_id}
+```
+
+The agent card includes the assistant's name, description, available skills, supported input/output modes, and the A2A endpoint URL for communication.
+
 ## Requirements
 
 To use A2A, ensure you have the following dependencies installed:


### PR DESCRIPTION
## Overview
Customer that tried out the /a2a endpoint asked where to find the agent card. It was previously unfindable, so this makes things more clear.

## Type of change
**Type:** Update existing documentation

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- [ ] I have gotten approval from the relevant reviewers
- [ ] (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)
