### PR TITLE
langgraph docs: fix broken internal link to subgraphs page

### DIFF
--- a/src/oss/langgraph/test.mdx
+++ b/src/oss/langgraph/test.mdx
@@ -181,7 +181,7 @@ test('individual node execution', async () => {
 
 ## Partial execution
 
-For agents made up of larger graphs, you may wish to test partial execution paths within your agent rather than the entire flow end-to-end. In some cases, it may make semantic sense to [restructure these sections as subgraphs](/oss/langgraph/subgraphs), which you can invoke in isolation as normal.
+For agents made up of larger graphs, you may wish to test partial execution paths within your agent rather than the entire flow end-to-end. In some cases, it may make semantic sense to [restructure these sections as subgraphs](/oss/langgraph/use-subgraphs), which you can invoke in isolation as normal.
 
 However, if you do not wish to make changes to your agent graph's overall structure, you can use LangGraph's persistence mechanisms to simulate a state where your agent is paused right before the beginning of the desired section, and will pause again at the end of the desired section. The steps are as follows:
 


### PR DESCRIPTION
## Overview
Fixed a broken internal link on the LangGraph testing instructions page.  
The link to the **Subgraphs** page was previously pointing to the "subgraphs" page, but that doesn't exist and it should instead point to "use-subgraphs".

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue: N/A
- Feature PR: N/A

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- [ ] I have gotten approval from the relevant reviewers
- [ ] (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)
