### PR TITLE
Remove duplicate import of StateGraph

### DIFF
--- a/src/oss/langgraph/test.mdx
+++ b/src/oss/langgraph/test.mdx
@@ -41,7 +41,6 @@ import pytest
 from typing_extensions import TypedDict
 from langgraph.graph import StateGraph, START, END
 from langgraph.checkpoint.memory import MemorySaver
-from langgraph.graph import StateGraph
 
 def create_graph() -> StateGraph:
     class MyState(TypedDict):


### PR DESCRIPTION
## Overview
Remove duplicate import of StateGraph on testing LangGraph

## Type of change

**Type:** Fix typo/bug/link/formatting 

## Related issues/PRs


## Checklist

- [ x] I have read the [contributing guidelines](README.md)
- [x ] I have tested my changes locally using `docs dev`
- [x ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- [ ] I have gotten approval from the relevant reviewers
- [ ] (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes

