### PR TITLE
docs(ls): set sampling rate per client

### DIFF
--- a/src/langsmith/sample-traces.mdx
+++ b/src/langsmith/sample-traces.mdx
@@ -21,7 +21,7 @@ This works for the `traceable` decorator and `RunTree` objects.
 
 ## Set different sampling rates per client
 
-You can also set sampling rates on specific `Client` instances and using the `tracing_context` context manager:
+You can also set sampling rates on specific `Client` instances and use the `tracing_context` context manager:
 
 ```python
 from langsmith import Client, tracing_context

--- a/src/langsmith/sample-traces.mdx
+++ b/src/langsmith/sample-traces.mdx
@@ -3,6 +3,8 @@ title: Set a sampling rate for traces
 sidebarTitle: Set a sampling rate for traces
 ---
 
+When working with high-volume applications, you may not want to log every trace to LangSmith. Sampling rates allow you to control what percentage of traces are logged, helping you balance observability needs with cost considerations.
+
 ## Set global sampling rate
 
 <Note>

--- a/src/langsmith/sample-traces.mdx
+++ b/src/langsmith/sample-traces.mdx
@@ -3,6 +3,8 @@ title: Set a sampling rate for traces
 sidebarTitle: Set a sampling rate for traces
 ---
 
+## Set global sampling rate
+
 <Note>
 This section is relevant for those using the LangSmith SDK or LangChain, not for those logging directly with the LangSmith API.
 </Note>
@@ -14,3 +16,31 @@ export LANGSMITH_TRACING_SAMPLING_RATE=0.75
 ```
 
 This works for the `traceable` decorator and `RunTree` objects.
+
+## Setting different sampling rates per client
+
+You can also set sampling rates on specific `Client` instances and using the `tracing_context` context manager:
+
+```python
+from langsmith import Client, tracing_context
+
+# Create clients with different sampling rates
+client_1 = Client(tracing_sampling_rate=0.5)  # 50% sampling
+client_2 = Client(tracing_sampling_rate=0.25)  # 25% sampling
+client_no_trace = Client(tracing_sampling_rate=0.0)  # No tracing
+
+# Use different sampling rates for different operations
+with tracing_context(client=client_1):
+    # Your code here - will be traced with 50% sampling rate
+    agent_1.invoke(...)
+
+with tracing_context(client=client_2):
+    # Your code here - will be traced with 25% sampling rate
+    agent_1.invoke(...)
+
+with tracing_context(client=client_no_trace):
+    # Your code here - will not be traced
+    agent_1.invoke(...)
+```
+
+This allows you to control sampling rates at the operation level.

--- a/src/langsmith/sample-traces.mdx
+++ b/src/langsmith/sample-traces.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Set a sampling rate for traces
 
 When working with high-volume applications, you may not want to log every trace to LangSmith. Sampling rates allow you to control what percentage of traces are logged, helping you balance observability needs with cost considerations.
 
-## Set global sampling rate
+## Set a global sampling rate
 
 <Note>
 This section is relevant for those using the LangSmith SDK or LangChain, not for those logging directly with the LangSmith API.

--- a/src/langsmith/sample-traces.mdx
+++ b/src/langsmith/sample-traces.mdx
@@ -19,7 +19,7 @@ export LANGSMITH_TRACING_SAMPLING_RATE=0.75
 
 This works for the `traceable` decorator and `RunTree` objects.
 
-## Setting different sampling rates per client
+## Set different sampling rates per client
 
 You can also set sampling rates on specific `Client` instances and using the `tracing_context` context manager:
 


### PR DESCRIPTION
## Overview
Added example of how to set different sampling rates for tracing per client. 

## Type of change

**Type:** Update existing documentation 

<!-- For LangChain employees, if applicable: -->
- Slack thread: https://langchain.slack.com/archives/C04GMBZ9Y1Y/p1755641768396229

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- [x] I have gotten approval from the relevant reviewers
- [x] Preview Link: https://langchain-5e9cc07a-preview-viclsp-1758121517-5f7a1aa.mintlify.app/oss/python/langchain/overview