### PR TITLE
docs: add undatasio integration page and add undatasio to loader index

### DIFF
--- a/src/oss/python/integrations/document_loaders/index.mdx
+++ b/src/oss/python/integrations/document_loaders/index.mdx
@@ -67,6 +67,7 @@ The below document loaders allow you to load PDF documents.
 | [PDFMiner](/oss/integrations/document_loaders/pdfminer) | Load PDF files using PDFMiner | Package |
 | [Upstage Document Parse Loader](/oss/integrations/document_loaders/upstage) | Load PDF files using UpstageDocumentParseLoader | Package |
 | [Docling](/oss/integrations/document_loaders/docling) | Load PDF files using Docling | Package |
+| [UnDatasIO](/oss/integrations/document_loaders/undatasio) | Load PDF files using UnDatasIO | Package |
 
 
 ### Cloud Providers
@@ -314,6 +315,7 @@ The below document loaders allow you to load data from common data formats.
 <Card title="Trello" icon="link" href="/oss/integrations/document_loaders/trello" arrow="true" cta="View guide"></Card>
 <Card title="TSV" icon="link" href="/oss/integrations/document_loaders/tsv" arrow="true" cta="View guide"></Card>
 <Card title="Twitter" icon="link" href="/oss/integrations/document_loaders/twitter" arrow="true" cta="View guide"></Card>
+<Card title="UnDatasIO" icon="link" href="/oss/integrations/document_loaders/undatasio" arrow="true" cta="View guide"></Card>
 <Card title="Unstructured" icon="link" href="/oss/integrations/document_loaders/unstructured_file" arrow="true" cta="View guide"></Card>
 <Card title="UnstructuredMarkdownLoader" icon="link" href="/oss/integrations/document_loaders/unstructured_markdown" arrow="true" cta="View guide"></Card>
 <Card title="UnstructuredPDFLoader" icon="link" href="/oss/integrations/document_loaders/unstructured_pdfloader" arrow="true" cta="View guide"></Card>

--- a/src/oss/python/integrations/document_loaders/undatasio.mdx
+++ b/src/oss/python/integrations/document_loaders/undatasio.mdx
@@ -1,0 +1,110 @@
+---
+title: UnDatasIO
+---
+
+This notebook provides a quick overview for getting started with the __UnDatasIO document loader__. UnDatasIO enables efficient loading and parsing of various document formats including PDF, PNG, JPG, JPEG, and JFIF, with features like document lazy loading and native async support, all through UnDatasIO's secure cloud API. These capabilities make the processed data ready for generative AI workflows like RAG.
+
+For detailed documentation on all features and configurations, refer to the official API reference.
+
+## Overview
+
+### Loader features
+
+| Source | Document Lazy Loading | Native Async Support |
+| :---: | :---: | :---: |
+| UnDatasIOLoader | ✅ | ✅ |
+
+## Setup
+
+### Credentials
+
+UnDatasIO requires an API token.  
+Generate a free token at [undatas.io](https://undatas.io) and set it in the cell below:
+
+```python
+import getpass
+import os
+
+if "UNDATASIO_TOKEN" not in os.environ:
+    os.environ["UNDATASIO_TOKEN"] = getpass.getpass(
+        "Enter your UnDatasIO API token: "
+    )
+```
+
+### Installation
+
+#### Normal Installation
+
+The following packages are required to run the rest of this notebook.
+
+```python
+# Install package, compatible with API partitioning
+%pip install langchain-undatasio
+```
+
+### Initialization
+
+The __UnDatasIOLoader__ supports single-file upload & parsing via the UnDatasIO cloud API.
+
+```python
+from langchain_undatasio import UnDatasIOLoader
+
+loader = UnDatasIOLoader(
+    token=os.environ["UNDATASIO_TOKEN"],
+    file_path="demo.pdf"
+)
+```
+
+### Load
+
+```python
+docs = loader.load()
+docs[0]
+```
+
+```output
+Document(
+    metadata={'source': 'demo.pdf', 'task_id': 't1', 'file_id': 'f1'},
+    page_content='Growing a Tail: Increasing Output Diversity in Large Language Models\n\nAuthors: Michal Shur-Ofry1, Bar Horowitz-Amsalem1†, Adir Rahamim2, Yonatan Belinkov2*\n\nAffiliations:\n\n1Law Faculty, Hebrew University of Jerusalem; Jerusalem, Israel.\n\n2Faculty of Computer Science, Technion – I'
+)
+```
+
+```python
+print(docs[0].page_content[:300])
+```
+
+```output
+Growing a Tail: Increasing Output Diversity in Large Language Models
+
+Authors: Michal Shur-Ofry1, Bar Horowitz-Amsalem1†, Adir Rahamim2, Yonatan Belinkov2*
+
+Affiliations:
+
+1Law Faculty, Hebrew University of Jerusalem; Jerusalem, Israel.
+
+2Faculty of Computer Science, Technion – I
+```
+
+### Lazy Load
+
+__UnDatasIOLoader__ supports lazy loading for memory-efficient iteration.
+
+```python
+pages = []
+for doc in loader.lazy_load():
+    pages.append(doc)
+
+pages[0]
+```
+
+```output
+Document(
+    metadata={'source': 'demo.pdf', 'task_id': 't1', 'file_id': 'f1'},
+    page_content='Growing a Tail: Increasing Output Diversity in Large Language Models\n\nAuthors: Michal Shur-Ofry1, Bar Horowitz-Amsalem1†, Adir Rahamim2, Yonatan Belinkov2*\n\nAffiliations:\n\n1Law Faculty, Hebrew University of Jerusalem; Jerusalem, Israel.\n\n2Faculty of Computer Science, Technion – I'
+)
+```
+
+## See Also
+
+- [UnDatasIO](https://undatas.io)
+- [langchain-undatasio](https://pypi.org/project/langchain-undatasio/)


### PR DESCRIPTION
## Overview  
<!-- Brief description of what documentation is being added/updated -->  
Adds a complete integration page for **UnDatasIO** (`langchain-undatasio`) document loader, covering installation, initialization, single/multi-file parsing, and lazy-loading usage examples.

## Type of change  
**Type:** New documentation page

## Related issues/PRs  
- GitHub issue: -  
- Feature PR: -  
<!-- For LangChain employees, if applicable: -->  
- Linear issue: -  
- Slack thread: -  

## Checklist  
<!-- Put an 'x' in all boxes that apply -->  
- [x] I have read the [contributing guidelines](README.md)  
- [x] I have tested my changes locally using `docs dev`  
- [x] All code examples have been tested and work correctly  
- [x] I have used **root relative** paths for internal links  
- [ ] I have updated navigation in `src/docs.json` if needed  
- [ ] I have gotten approval from the relevant reviewers  
- [ ] (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)  

## Additional notes  
<!-- Any other information that would be helpful for reviewers -->  
- New file: `docs/src/oss/python/integrations/document_loaders/undatasio.mdx`  
- Also appended `UndatasIO` to the loader index (`index.mdx`) for discoverability.