### PR TITLE
fix code cell for streaming

### DIFF
--- a/src/oss/langchain/messages.mdx
+++ b/src/oss/langchain/messages.mdx
@@ -422,25 +422,14 @@ for chunk in model.stream("Hi"):
 
 :::js
 <CodeGroup>
-    ```typescript Stream and collect chunks
-    const chunks = [];
-    const stream = await model.stream("Write a poem");
-    for await (const chunk of stream) {
-        chunks.push(chunk);
-        console.log(chunk.text);
-    }
-    ```
+```typescript
+import { AIMessageChunk } from "langchain";
 
-    ```typescript Combine chunks
-    import { AIMessageChunk } from "langchain";
-
-    let finalChunk: AIMessageChunk | undefined;
-    for (const chunk of chunks) {
-        finalChunk = finalChunk ? finalChunk.concat(chunk) : chunk;
-    }
-
-    console.log(`Full response: ${finalChunk?.text}`);
-    ```
+let finalChunk: AIMessageChunk | undefined;
+for (const chunk of chunks) {
+    finalChunk = finalChunk ? finalChunk.concat(chunk) : chunk;
+}
+```
 </CodeGroup>
 :::
 

--- a/src/oss/langchain/messages.mdx
+++ b/src/oss/langchain/messages.mdx
@@ -407,25 +407,17 @@ for (const toolCall of response.tool_calls) {
 
 #### Streaming and chunks
 
-During streaming, you'll receive `AIMessageChunk` objects that can be combined:
+During streaming, you'll receive `AIMessageChunk` objects that can be combined into a full message:
 
 :::python
-<CodeGroup>
-    ```python Stream and collect chunks
-    chunks = []
-    for chunk in model.stream("Write a poem"):
-        chunks.append(chunk)
-        print(chunk.text)
-    ```
-
-    ```python Combine chunks
-    from langchain_core.messages import AIMessage
-
-    # Combine chunks into final message
-    final_message = sum(chunks, AIMessage(""))
-    print(f"Full response: {final_message.text}")
-    ```
-</CodeGroup>
+```python
+chunks = []
+full_message = None
+for chunk in model.stream("Hi"):
+    chunks.append(chunk)
+    print(chunk.text)
+    full_message = chunk if full_message is None else full_message + chunk
+```
 :::
 
 :::js


### PR DESCRIPTION
Currently we split the streaming loop and combination into separate code blocks.

There are a few problems with the code block for combining chunks:

1. It doesn't work (we sum an AIMessage, which results in a ChatPromptTemplate):
```python
from langchain_core.messages import AIMessage, AIMessageChunk

chunks = [AIMessageChunk("foo"), AIMessageChunk(" bar")]

final_message = sum(chunks, AIMessage(""))  # ChatPromptTemplate
```

2. More nitpicky, but I think aggregating chunks is important and also concise enough that we can display it in the first cell with just two additional lines.

Here we demonstrate aggregation in the first cell (and also remove an import).