### PR TITLE
chore: update API key docs for new orgs-scoped service keys

### DIFF
--- a/src/langsmith/administration-overview.mdx
+++ b/src/langsmith/administration-overview.mdx
@@ -100,7 +100,7 @@ PATs are prefixed with `lsv2_pt_`
 
 #### Service keys
 
-Service keys are similar to PATs, but are used to authenticate requests to the LangSmith API on behalf of a service account. Only admins can create service keys. We recommend using these for applications / services that need to interact with the LangSmith API, such as LangGraph agents or other integrations. Service keys are scoped to a workspace and can be used to authenticate requests to the LangSmith API for that workspace.
+Service keys are similar to PATs, but are used to authenticate requests to the LangSmith API on behalf of a service account. Only admins can create service keys. We recommend using these for applications / services that need to interact with the LangSmith API, such as LangGraph agents or other integrations. Service keys may be scoped to a single workspace, multiple workspaces, or the entire organization, and can be used to authenticate requests to the LangSmith API for whichever workspace(s) it can has access to.
 
 Service keys are prefixed with `lsv2_sk_`
 

--- a/src/langsmith/create-account-api-key.mdx
+++ b/src/langsmith/create-account-api-key.mdx
@@ -7,7 +7,7 @@ sidebarTitle: Create an account and API key
 
 To get started with LangSmith, you need to create an account. You can sign up for a free account [here](https://smith.langchain.com). We support logging in with Google, GitHub, and email.
 
-![](/langsmith/images/create-account.png)
+![Create account](/langsmith/images/create-account.png)
 
 ## API keys
 
@@ -25,7 +25,7 @@ To create either type of API key head to the [Settings page](https://smith.langc
 The API key will be shown only once, so make sure to copy it and store it in a safe place.
 </Note>
 
-![](/langsmith/images/create-api-key.png)
+![Create API key](/langsmith/images/create-api-key.png)
 
 ## Configure the SDK
 
@@ -33,8 +33,12 @@ You may set the following environment variables in addition to `LANGSMITH_API_KE
 
 This is only required if using the EU instance.
 
-`LANGSMITH_ENDPOINT=``https://api.smith.langchain.com`
+`LANGSMITH_ENDPOINT=https://eu.api.smith.langchain.com`
 
 This is only required for keys scoped to more than one workspace.
 
 `LANGSMITH_WORKSPACE_ID=<Workspace ID>`
+
+## Using API keys outside of the SDK
+
+See [instructions for managing your organization via API](/langsmith/manage-organization-by-api).

--- a/src/langsmith/manage-organization-by-api.mdx
+++ b/src/langsmith/manage-organization-by-api.mdx
@@ -16,7 +16,7 @@ Before diving into this content, it might be helpful to read the following:
 There are a few limitations that will be lifted soon:
 
 * The LangSmith SDKs do not support these organization management actions yet.
-* [Service Keys](/langsmith/administration-overview#api-keys) don't have access to newly-added workspaces yet (we're adding support soon). We recommend using a PAT of an Organization Admin for now, which by default has the required permissions for these actions.
+* Organization-scoped [service keys](/langsmith/administration-overview#service-keys) with Organization Admin permission may be used for these actions.
 </Note>
 
 Some commonly-used endpoints and use cases are listed below. For a complete list of available endpoints, see the [API docs](https://api.smith.langchain.com/redoc). **The `X-Organization-Id` header should be present on all requests, and `X-Tenant-Id` header should be present on requests that are scoped to a particular workspace.**
@@ -42,8 +42,9 @@ Some commonly-used endpoints and use cases are listed below. For a complete list
 
 Organization level:
 
-* [List organization members](https://api.smith.langchain.com/redoc#tag/orgs/operation/get_current_org_members_api_v1_orgs_current_members_get)
-* [Invite a user to the organization and one or more workspaces](https://api.smith.langchain.com/redoc#tag/workspaces/operation/add_member_to_current_workspace_api_v1_workspaces_current_members_post) . This should be used when the user is not already a member in the organization.
+* [List active organization members](https://api.smith.langchain.com/redoc#tag/orgs/operation/get_current_active_org_members_api_v1_orgs_current_members_active_get)
+* [List pending organization members](https://api.smith.langchain.com/redoc#tag/orgs/operation/get_current_pending_org_members_api_v1_orgs_current_members_pending_get)
+* [Invite a user to the organization and one or more workspaces](https://api.smith.langchain.com/redoc#tag/orgs/operation/add_members_to_current_org_batch_api_v1_orgs_current_members_batch_post) . This should be used when the user is not already a member in the organization.
 * [Update a user's organization role](https://api.smith.langchain.com/redoc#tag/workspaces/operation/add_member_to_current_workspace_api_v1_workspaces_current_members_post)
 * [Remove someone from the organization](https://api.smith.langchain.com/redoc#tag/orgs/operation/remove_member_from_current_org_api_v1_orgs_current_members__identity_id__delete)
 
@@ -61,7 +62,7 @@ These params should be omitted: `read_only` (deprecated), `password` and `full_n
 ## API keys
 
 <Note>
-Use the `X-Tenant-Id` header to specify which workspace to target. If the header is not present, operations will default to the workspace the API key was initially created in.
+Use the `X-Tenant-Id` header to specify which workspace to target. If the header is not present, operations will default to the workspace the API key was initially created in. **If `X-Tenant-Id` is not specified when accessing workspace-scoped resources with an organization-scoped API key, the request will fail with `403 Forbidden`.**
 </Note>
 
 * [Create a service key](https://api.smith.langchain.com/redoc#tag/api-key/operation/generate_api_key_api_v1_api_key_post)


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
* update usage instructions to account for new organization-scoped API keys:
![Org-Scoped-API-2](https://github.com/user-attachments/assets/004fb25f-ca5d-486d-bb5f-52c54fd722a2)

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue: ent-114
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- [ ] I have gotten approval from the relevant reviewers
- [ ] (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
