### PR TITLE
add snippet js translation missing callout

### DIFF
--- a/src/snippets/js-snippet-missing.mdx
+++ b/src/snippets/js-snippet-missing.mdx
@@ -1,4 +1,4 @@
 <Callout icon="hand-holding-hand" color="#FFC107" iconType="regular">
-    We don’t have this code snippet in JavaScript yet. Want to help?
+    We don’t have this code example in JavaScript yet. Want to help?
     Contribute your snippet in the [docs repo](https://github.com/langchain-ai/docs).
 </Callout>

--- a/src/snippets/js-snippet-missing.mdx
+++ b/src/snippets/js-snippet-missing.mdx
@@ -1,0 +1,4 @@
+<Callout icon="hand-holding-hand" color="#FFC107" iconType="regular">
+    We don’t have this code snippet in JavaScript yet. Want to help?
+    Contribute your snippet in the [docs repo](https://github.com/langchain-ai/docs).
+</Callout>


### PR DESCRIPTION
Added a snippet for js translations. No need to merge until we need to use it. 

Idea is to make sure we have an easy way to identify which code blocks need to be translated!