### PR TITLE
Test updated observability sidebar for LangSmith

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -694,7 +694,7 @@
                   "langsmith/observability-concepts",
                   "langsmith/observability-llm-tutorial",
                   {
-                    "group": "Set up tracing",
+                    "group": "Tracing setup",
                     "pages": [
                       {
                         "group": "Integrations",
@@ -715,37 +715,49 @@
                         ]
                       },
                       {
-                        "group": "Manual",
+                        "group": "Manual instrumentation",
                         "pages": [
-                          {
-                            "group": "Instrument code",
-                            "pages": [
-                              "langsmith/annotate-code",
-                              "langsmith/log-llm-trace",
-                              "langsmith/log-retriever-trace"
-                            ]
-                          },
-                          "langsmith/trace-with-api"
+                          "langsmith/annotate-code",
+                          "langsmith/trace-with-api",
+                          "langsmith/log-llm-trace",
+                          "langsmith/log-retriever-trace"
                         ]
-                      },
+                      }
+                    ]
+                  },
+                  {
+                    "group":"Configuration & troubleshooting",
+                    "pages": [
                       {
-                        "group": "Configuration",
+                        "group": "Project & environment settings",
                         "pages": [
                           "langsmith/log-traces-to-project",
                           "langsmith/trace-without-env-vars",
-                          "langsmith/threads",
-                          "langsmith/sample-traces",
-                          "langsmith/add-metadata-tags",
+                          "langsmith/sample-traces"
+                        ]
+                      },
+                      {
+                        "group": "Advanced tracing techniques",
+                        "pages": [
                           "langsmith/distributed-tracing",
-                          "langsmith/access-current-span",
-                          "langsmith/calculate-token-based-costs",
-                          "langsmith/log-multimodal-traces",
-                          "langsmith/mask-inputs-outputs",
-                          "langsmith/trace-generator-functions",
+                          "langsmith/threads",
                           "langsmith/serverless-environments",
+                          "langsmith/log-multimodal-traces",
+                          "langsmith/trace-generator-functions"
+                        ]
+                      },
+                      {
+                        "group": "Data & privacy",
+                        "pages": [
+                          "langsmith/add-metadata-tags",
+                          "langsmith/mask-inputs-outputs",
+                          "langsmith/upload-files-with-traces"
+                        ]
+                      },
+                      {
+                        "group": "Troubleshooting guides",
+                        "pages": [
                           "langsmith/nest-traces",
-                          "langsmith/upload-files-with-traces",
-                          "langsmith/output-detailed-logs",
                           "langsmith/troubleshooting-variable-caching",
                           "langsmith/collector-proxy"
                         ]
@@ -753,7 +765,7 @@
                     ]
                   },
                   {
-                    "group": "View traces",
+                    "group": "Viewing & managing traces",
                     "pages": [
                       "langsmith/filter-traces-in-application",
                       "langsmith/export-traces",
@@ -767,26 +779,26 @@
                     "group": "Automations",
                     "pages": [
                       "langsmith/rules",
-                      "langsmith/webhooks",
-                      "langsmith/alerts-webhook",
+                      "langsmith/webhooks"
+                    ]
+                  },
+                  {
+                    "group": "Feedback & evaluation",
+                    "pages": [
+                      "langsmith/attach-user-feedback",
                       "langsmith/online-evaluations"
                     ]
                   },
                   {
-                    "group": "Human Feedback",
-                    "pages": [
-                      "langsmith/attach-user-feedback"
-                    ]
-                  },
-                  {
-                    "group": "Monitoring",
+                    "group": "Monitoring & alerting",
                     "pages": [
                       "langsmith/dashboards",
-                      "langsmith/alerts"
+                      "langsmith/alerts",
+                      "langsmith/alerts-webhook"
                     ]
                   },
                   {
-                    "group": "Common data types",
+                    "group": "Data type reference",
                     "pages": [
                       "langsmith/run-data-format",
                       "langsmith/feedback-data-format",
@@ -1746,9 +1758,10 @@
                 "tab": "Observability",
                 "pages": [
                   "langsmith/observability",
+                  "langsmith/observability-concepts",
                   "langsmith/observability-llm-tutorial",
                   {
-                    "group": "Set up tracing",
+                    "group": "Tracing setup",
                     "pages": [
                       {
                         "group": "Integrations",
@@ -1769,37 +1782,49 @@
                         ]
                       },
                       {
-                        "group": "Manual",
+                        "group": "Manual instrumentation",
                         "pages": [
-                          {
-                            "group": "Instrument code",
-                            "pages": [
-                              "langsmith/annotate-code",
-                              "langsmith/log-llm-trace",
-                              "langsmith/log-retriever-trace"
-                            ]
-                          },
-                          "langsmith/trace-with-api"
+                          "langsmith/annotate-code",
+                          "langsmith/trace-with-api",
+                          "langsmith/log-llm-trace",
+                          "langsmith/log-retriever-trace"
                         ]
-                      },
+                      }
+                    ]
+                  },
+                  {
+                    "group":"Configuration & troubleshooting",
+                    "pages": [
                       {
-                        "group": "Configuration",
+                        "group": "Project & environment settings",
                         "pages": [
                           "langsmith/log-traces-to-project",
                           "langsmith/trace-without-env-vars",
-                          "langsmith/threads",
-                          "langsmith/sample-traces",
-                          "langsmith/add-metadata-tags",
+                          "langsmith/sample-traces"
+                        ]
+                      },
+                      {
+                        "group": "Advanced tracing techniques",
+                        "pages": [
                           "langsmith/distributed-tracing",
-                          "langsmith/access-current-span",
-                          "langsmith/calculate-token-based-costs",
-                          "langsmith/log-multimodal-traces",
-                          "langsmith/mask-inputs-outputs",
-                          "langsmith/trace-generator-functions",
+                          "langsmith/threads",
                           "langsmith/serverless-environments",
+                          "langsmith/log-multimodal-traces",
+                          "langsmith/trace-generator-functions"
+                        ]
+                      },
+                      {
+                        "group": "Data & privacy",
+                        "pages": [
+                          "langsmith/add-metadata-tags",
+                          "langsmith/mask-inputs-outputs",
+                          "langsmith/upload-files-with-traces"
+                        ]
+                      },
+                      {
+                        "group": "Troubleshooting guides",
+                        "pages": [
                           "langsmith/nest-traces",
-                          "langsmith/upload-files-with-traces",
-                          "langsmith/output-detailed-logs",
                           "langsmith/troubleshooting-variable-caching",
                           "langsmith/collector-proxy"
                         ]
@@ -1807,7 +1832,7 @@
                     ]
                   },
                   {
-                    "group": "View traces",
+                    "group": "Viewing & managing traces",
                     "pages": [
                       "langsmith/filter-traces-in-application",
                       "langsmith/export-traces",
@@ -1821,26 +1846,26 @@
                     "group": "Automations",
                     "pages": [
                       "langsmith/rules",
-                      "langsmith/webhooks",
-                      "langsmith/alerts-webhook",
+                      "langsmith/webhooks"
+                    ]
+                  },
+                  {
+                    "group": "Feedback & evaluation",
+                    "pages": [
+                      "langsmith/attach-user-feedback",
                       "langsmith/online-evaluations"
                     ]
                   },
                   {
-                    "group": "Human Feedback",
-                    "pages": [
-                      "langsmith/attach-user-feedback"
-                    ]
-                  },
-                  {
-                    "group": "Monitoring",
+                    "group": "Monitoring & alerting",
                     "pages": [
                       "langsmith/dashboards",
-                      "langsmith/alerts"
+                      "langsmith/alerts",
+                      "langsmith/alerts-webhook"
                     ]
                   },
                   {
-                    "group": "Common data types",
+                    "group": "Data type reference",
                     "pages": [
                       "langsmith/run-data-format",
                       "langsmith/feedback-data-format",

--- a/src/langsmith/alerts-webhook.mdx
+++ b/src/langsmith/alerts-webhook.mdx
@@ -1,6 +1,6 @@
 ---
 title: Configure webhook notifications for LangSmith alerts
-sidebarTitle: Configure webhook notifications
+sidebarTitle: Configure webhook notifications for alerts
 ---
 
 ## Overview

--- a/src/langsmith/webhooks.mdx
+++ b/src/langsmith/webhooks.mdx
@@ -1,6 +1,6 @@
 ---
-title: Set up webhook notifications for rules
-sidebarTitle: Set up webhook notifications for rules
+title: Configure webhook notifications for rules
+sidebarTitle: Configure webhook notifications for rules
 ---
 
 When you add a webhook URL on an automation action, we will make a POST request to your webhook endpoint any time the rules you defined match any new runs.


### PR DESCRIPTION
Preview an updated observability sidebar. This version groups some of the pages differently to make the huge list of pages under the "configuration" group more digestible. 

Instead, the groups provide more descriptive subgroups to direct users to the correct docs area quicker.

### Latest preview for this sidebar:

https://langchain-5e9cc07a-preview-testob-1758285277-a523468.mintlify.app/langsmith/observability

