### PR TITLE
Add link to LS self-hosted docs in LangGraph Control Plane API reference page

### DIFF
--- a/src/langgraph-platform/api-ref-control-plane.mdx
+++ b/src/langgraph-platform/api-ref-control-plane.mdx
@@ -14,7 +14,7 @@ LangGraph Control Plane hosts for Cloud data regions:
 |----|----|
 | `https://api.host.langchain.com` | `https://eu.api.host.langchain.com` |
 
-**Note**: Self-hosted deployments of LangGraph Platform will have a custom host for the LangGraph Control Plane.
+**Note**: Self-hosted deployments of LangGraph Platform will have a custom host for the LangGraph Control Plane. The control plane APIs can be access at the path `/api-host`. For example, `http(s)://<host>/api-host/v2/deployments`. See [here](../langsmith/self-host-usage#configuring-the-application-you-want-to-use-with-langsmith) for more details.
 
 ## Authentication
 

--- a/src/langgraph-platform/api-ref-control-plane.mdx
+++ b/src/langgraph-platform/api-ref-control-plane.mdx
@@ -14,7 +14,7 @@ LangGraph Control Plane hosts for Cloud data regions:
 |----|----|
 | `https://api.host.langchain.com` | `https://eu.api.host.langchain.com` |
 
-**Note**: Self-hosted deployments of LangGraph Platform will have a custom host for the LangGraph Control Plane. The control plane APIs can be access at the path `/api-host`. For example, `http(s)://<host>/api-host/v2/deployments`. See [here](../langsmith/self-host-usage#configuring-the-application-you-want-to-use-with-langsmith) for more details.
+**Note**: Self-hosted deployments of LangGraph Platform will have a custom host for the LangGraph Control Plane. The control plane APIs can be accessed at the path `/api-host`. For example, `http(s)://<host>/api-host/v2/deployments`. See [here](../langsmith/self-host-usage#configuring-the-application-you-want-to-use-with-langsmith) for more details.
 
 ## Authentication
 


### PR DESCRIPTION
## Overview
A user didn't know that a self-hosted LGP Control Plane API host needs to have the path `/api-host`.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- Slack thread: https://langchain.slack.com/archives/C073E3GM2G0/p1758231928583519?thread_ts=1748620141.436189&cid=C073E3GM2G0

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- [x] I have gotten approval from the relevant reviewers
- [x] (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
N/A
