### PR TITLE
langchain: dynamic system prompt w/ middleware docs

### DIFF
--- a/src/oss/langchain/agents.mdx
+++ b/src/oss/langchain/agents.mdx
@@ -465,8 +465,79 @@ const agent = createAgent({
 
 When no `prompt` is provided, the agent will infer its task from the messages directly.
 
+#### Dynamic prompts with middleware
+
+For more advanced use cases where you need to modify the system prompt based on runtime context or agent state, you can use the `DynamicSystemPromptMiddleware`. This is especially useful for personalizing prompts based on user roles, conversation context, or other dynamic factors:
+
+:::python
+```python wrap
+from langchain.agents import create_agent
+from langchain.agents.middleware import DynamicSystemPromptMiddleware
+from langgraph.runtime import Runtime
+from typing import TypedDict
+
+class Context(TypedDict):
+    user_role: str
+
+def dynamic_system_prompt(state, runtime: Runtime[Context]) -> str:
+    user_role = runtime.context.get("user_role", "user")
+    base_prompt = "You are a helpful assistant."
+    
+    if user_role == "expert":
+        return f"{base_prompt} Provide detailed technical responses."
+    elif user_role == "beginner":
+        return f"{base_prompt} Explain concepts simply and avoid jargon."
+    return base_prompt
+
+agent = create_agent(
+    model="openai:gpt-4o",
+    tools=tools,
+    middleware=[DynamicSystemPromptMiddleware(dynamic_system_prompt)],
+)
+
+# The system prompt will be set dynamically based on context
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "Explain machine learning"}]},
+    {"context": {"user_role": "expert"}}
+)
+```
+:::
+
+:::js
+```typescript wrap
+import { createAgent } from "langchain";
+import { dynamicSystemPromptMiddleware } from "langchain/middleware";
+
+const agent = createAgent({
+    model: "openai:gpt-4o",
+    tools,
+    middleware: [
+        dynamicSystemPromptMiddleware({
+            systemPromptFunction: (state, runtime) => {
+                const userRole = runtime?.context?.userRole || "user";
+                const basePrompt = "You are a helpful assistant.";
+                
+                if (userRole === "expert") {
+                    return `${basePrompt} Provide detailed technical responses.`;
+                } else if (userRole === "beginner") {
+                    return `${basePrompt} Explain concepts simply and avoid jargon.`;
+                }
+                return basePrompt;
+            }
+        }),
+    ],
+});
+
+// The system prompt will be set dynamically based on context
+const result = await agent.invoke(
+    { messages: [{ role: "user", content: "Explain machine learning" }] },
+    { context: { userRole: "expert" } }
+);
+```
+:::
+
 <Tip>
-For more details on message types and formatting, see [Messages](/oss/langchain/messages).
+For more details on message types and formatting, see [Messages](/oss/langchain/messages). For comprehensive middleware documentation, see [Middleware](/oss/langchain/middleware).
 </Tip>
 
 ## Advanced configuration

--- a/src/oss/langchain/middleware.mdx
+++ b/src/oss/langchain/middleware.mdx
@@ -151,6 +151,7 @@ LangChain provides several built in middleware to use off-the-shelf
 - [Summarization](#summarization)
 - [Human-in-the-loop](#human-in-the-loop)
 - [Anthropic prompt caching](#anthropic-prompt-caching)
+- [Dynamic system prompt](#dynamic-system-prompt)
 
 ### Summarization
 
@@ -464,6 +465,124 @@ const config = { configurable: { thread_id: "1" } };
 const result = await agent.invoke({ messages: [HumanMessage("Hi, my name is Bob")] }, config);
 
 const result = await agent.invoke({ messages: [HumanMessage("What's my name?")] }, config);
+```
+:::
+
+### Dynamic system prompt
+
+`DynamicSystemPromptMiddleware` allows you to set the system prompt dynamically right before each model invocation. This middleware is particularly useful when the prompt depends on the current agent state or runtime context.
+
+For example, you can adjust the system prompt based on the user's expertise level:
+
+:::python
+```python
+from typing import TypedDict
+
+from langchain.agents import create_agent
+from langchain.agents.middleware import DynamicSystemPromptMiddleware
+from langgraph.runtime import Runtime
+
+class Context(TypedDict):
+    user_role: str
+
+def dynamic_system_prompt(state, runtime: Runtime[Context]) -> str:
+    user_role = runtime.context.get("user_role", "user")
+    base_prompt = "You are a helpful assistant."
+
+    if user_role == "expert":
+        return f"{base_prompt} Provide detailed technical responses."
+    elif user_role == "beginner":
+        return f"{base_prompt} Explain concepts simply and avoid jargon."
+    return base_prompt
+
+agent = create_agent(
+    model="openai:gpt-4o",
+    tools=[web_search],
+    middleware=[
+        DynamicSystemPromptMiddleware(dynamic_system_prompt),
+    ],
+)
+
+# Use with context
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "Explain async programming"}]},
+    {"context": {"user_role": "expert"}}
+)
+```
+:::
+
+:::js
+```typescript
+import { createAgent } from "langchain";
+import { dynamicSystemPromptMiddleware } from "langchain/middleware";
+
+const agent = createAgent({
+    model: "openai:gpt-4o",
+    tools: [weatherTool, calculatorTool],
+    middleware: [
+        dynamicSystemPromptMiddleware({
+            systemPromptFunction: (state, runtime) => {
+                const userRole = runtime?.context?.userRole || "user";
+                const basePrompt = "You are a helpful assistant.";
+
+                if (userRole === "expert") {
+                    return `${basePrompt} Provide detailed technical responses.`;
+                } else if (userRole === "beginner") {
+                    return `${basePrompt} Explain concepts simply and avoid jargon.`;
+                }
+                return basePrompt;
+            }
+        }),
+    ],
+});
+
+// Use with context
+const result = await agent.invoke(
+    { messages: [{ role: "user", content: "Explain async programming" }] },
+    { context: { userRole: "expert" } }
+);
+```
+:::
+
+Alternatively, you can adjust the system prompt based on the conversation length:
+
+:::python
+```python
+from langchain.agents.middleware import DynamicSystemPromptMiddleware
+
+def simple_prompt(state) -> str:
+    message_count = len(state["messages"])
+
+    if message_count > 10:
+        return "You are in an extended conversation. Be more concise."
+    return "You are a helpful assistant."
+
+agent = create_agent(
+    model="openai:gpt-4o",
+    tools=[search_tool],
+    middleware=[DynamicSystemPromptMiddleware(simple_prompt)],
+)
+```
+:::
+
+:::js
+```typescript
+const agent = createAgent({
+    model: "openai:gpt-4o",
+    tools: [searchTool],
+    middleware: [
+        dynamicSystemPromptMiddleware({
+            systemPromptFunction: (state) => {
+                const messageCount = state.messages.length;
+
+                if (messageCount > 10) {
+                    return "You are in an extended conversation. Be more concise.";
+                }
+                return "You are a helpful assistant.";
+            }
+        }),
+    ],
+});
 ```
 :::
 


### PR DESCRIPTION
This feels overcomplicated and like we should probably expose

```py
create_agent("openai:gpt-4o-mini", system_prompt=dynamic_prompt_func, middleware=[A, B])
```