### PR TITLE
Remove code from long headings to fix render issue (export traces)

### DIFF
--- a/src/langsmith/export-traces.mdx
+++ b/src/langsmith/export-traces.mdx
@@ -3,7 +3,6 @@ title: Query traces (SDK)
 sidebarTitle: Query traces (SDK)
 ---
 
-
 <Tip>
 **Recommended Reading**
 
@@ -277,7 +276,7 @@ client.listRuns({projectName: "<your_project>", filter: 'neq(error, null)'})
 
 </CodeGroup>
 
-### List all runs where `start_time` is greater than a specific timestamp
+### List all runs where start_time is greater than a specific timestamp
 
 <CodeGroup>
 
@@ -339,7 +338,7 @@ client.listRuns({
 
 </CodeGroup>
 
-### Complex query: List all runs where `tags` include "experimental" or "beta" and `latency` is greater than 2 seconds
+### Complex query: List all runs where tags include "experimental" or "beta" and latency is greater than 2 seconds
 
 <CodeGroup>
 


### PR DESCRIPTION
This PR fixes heading render issues on the Export traces page where code formatting in the H3 headers was causing the title to misalign when the window was not wide enough. Easiest fix is to just not include the code in the headings here.