### PR TITLE
Advertise LG dev through NPM package

### DIFF
--- a/src/langgraph-platform/quick-start-studio.mdx
+++ b/src/langgraph-platform/quick-start-studio.mdx
@@ -30,18 +30,18 @@ Next, install the [LangGraph CLI](/langgraph-platform/langgraph-cli):
 <CodeGroup>
 ```bash pip
 pip install -U "langgraph-cli[inmem]"
+langgraph dev
 ```
 
 ```bash uv
 uv add langgraph-cli[inmem]
-```
-</CodeGroup>
-
-Run:
-
-```bash
 langgraph dev
 ```
+
+```bash npm
+npx @langchain/langgraph-cli dev
+```
+</CodeGroup>
 
 <Warning>
 **Browser Compatibility**

--- a/src/langgraph-platform/set-up-custom-auth.mdx
+++ b/src/langgraph-platform/set-up-custom-auth.mdx
@@ -49,6 +49,10 @@ langgraph dev
 uv add .
 langgraph dev
 ```
+
+```bash npm
+npx @langchain/langgraph-cli dev
+```
 </CodeGroup>
 
 The server will start and open the studio in your browser:


### PR DESCRIPTION
As a JavaScript developer I may not have Python installed and prefer a snippet using NPM.

cc @dqbd  

fwiw: I don't think [these docs](https://docs.langchain.com/langgraph-platform/local-server#node-server) are helpful for JS folks to onboard, due to following reasons:

- `npx @langchain/langgraph-cli` doesn't install langgraph CLI (it just downloads the CLI and executes it)
- `langgraph new path/to/your/app --template new-langgraph-project-js` doesn't work because the JS version of LG CLI doesn't have a `new` command, it has `dev`, `dockerfile`, `build`, `up`, `sysinfo` and `help` but no `new`