### PR TITLE
fix: wrong uv commands

### DIFF
--- a/src/oss/langchain/install.mdx
+++ b/src/oss/langchain/install.mdx
@@ -17,7 +17,7 @@ To install the core LangChain package:
     ```
 
     ```bash uv
-    uv add langchain@pre
+    uv add --prerelease=allow langchain
     ```
 </CodeGroup>
 :::

--- a/src/oss/langchain/overview.mdx
+++ b/src/oss/langchain/overview.mdx
@@ -37,7 +37,7 @@ pip install --pre -U langchain
 ```
 
 ```bash uv
-uv add langchain@pre
+uv add --prerelease=allow langchain
 ```
 </CodeGroup>
 :::

--- a/src/oss/langgraph/install.mdx
+++ b/src/oss/langgraph/install.mdx
@@ -16,7 +16,7 @@ pip install --pre -U langgraph
 ```
 
 ```bash uv
-uv add langgraph@pre
+uv add --prerelease=allow langgraph
 ```
 </CodeGroup>
 :::
@@ -55,7 +55,7 @@ pip install --pre -U langchain
 ```
 
 ```bash uv
-uv add langchain@pre
+uv add --prerelease=allow langchain
 ```
 </CodeGroup>
 :::

--- a/src/oss/langgraph/overview.mdx
+++ b/src/oss/langgraph/overview.mdx
@@ -23,7 +23,7 @@ pip install --pre -U langgraph
 ```
 
 ```bash uv
-uv add langgraph@pre
+uv add --prerelease=allow langgraph
 ```
 </CodeGroup>
 :::


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

Fixed uv command.

`uv add langchain@pre` seems to be an incorrect command, and the uv equivalent of `pip install --pre` appears to be `uv add --prerelease=allow`.

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]
Update existing documentation

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- [x] I have gotten approval from the relevant reviewers
- [ ] (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
