### PR TITLE
docs: add troubleshooting step for clickhouse and aquasec

### DIFF
--- a/src/langsmith/troubleshooting.mdx
+++ b/src/langsmith/troubleshooting.mdx
@@ -195,7 +195,8 @@ clickhouse:
 ```
 
 #### Docker
-1. Edit your `docker-compose.yaml` and set the `AQUA_SKIP_LD_PRELOAD` environment variable. This might look something like this:
+
+Edit your `docker-compose.yaml` and set the `AQUA_SKIP_LD_PRELOAD` environment variable:
 
 ```yaml
 langchain-clickhouse:


### PR DESCRIPTION
## Overview
Update langsmith self hosted documentation with a troubleshooting guide when running in environments with AquaSec.

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
