### PR TITLE
fix stripe toolkit import in the guide

### DIFF
--- a/src/oss/python/integrations/tools/stripe.mdx
+++ b/src/oss/python/integrations/tools/stripe.mdx
@@ -54,7 +54,7 @@ It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain
 Here we show how to create an instance of the Stripe Toolkit
 
 ```python
-from stripe_agent_toolkit.crewai.toolkit import StripeAgentToolkit
+from stripe_agent_toolkit.langchain.toolkit import StripeAgentToolkit
 
 stripe_agent_toolkit = StripeAgentToolkit(
     secret_key=os.getenv("STRIPE_SECRET_KEY"),


### PR DESCRIPTION
mirror of https://github.com/langchain-ai/langchain/pull/33044
_______
**Description:**
Stripe tools integration guide incorrectly referenced the `crewai` toolkit. Updated the import to use the correct `langchain` toolkit.

Stripe docs reference: https://docs.stripe.com/agents?framework=langchain&lang=python