### PR TITLE
feat(langchain): add docs on dynamic tools

### DIFF
--- a/src/oss/langchain/dynamic-tools.mdx
+++ b/src/oss/langchain/dynamic-tools.mdx
@@ -1,0 +1,224 @@
+---
+title: Dynamic Tools
+---
+
+import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
+
+<AlphaCallout />
+
+When you have hundreds or thousands of tools, always giving all of them to the model is costly and counterproductive:
+
+- **Context pressure**: Long tool name/description lists consume context and can truncate important content.
+- **Worse tool choice**: Too many options confuse models, increasing wrong or spurious calls.
+- **Latency and cost**: Bigger prompts and more tool calls slow things down and cost more.
+
+Instead, dynamically select a small, relevant subset of tools per turn. With `createAgent`, you can do this cleanly using a light middleware that gates and filters tools based on state/context.
+
+<Tip>
+For deeper middleware capabilities (approval gates, retries, editing requests, etc.), see the middleware guide: [Middleware](/oss/langchain/middleware).
+</Tip>
+
+<Info>
+Keep the active tool set small (e.g., top 3-10). This maximizes signal-to-noise for the model while keeping prompts lean.
+</Info>
+
+## How it works with `createAgent`
+
+Pass the full tool catalog to `createAgent` and use middleware hooks (prefer `modifyModelRequest`) to set `request.tools` to a small, relevant subset each turn. This avoids overflowing the prompt while keeping the validation superset intact.
+
+### Simple: context/state-gated tool choice
+
+Select tools using a user property (e.g., VCS provider: GitHub vs GitLab).
+
+```ts icon="square-js"
+import { z } from "zod";
+import { createAgent, createMiddleware, tool, HumanMessage } from "langchain";
+
+// GitHub tools
+const githubCreateIssue = tool(
+  async ({ repo, title }) => ({ url: `https://github.com/${repo}/issues/1`, title }),
+  {
+    name: "github_create_issue",
+    description: "Create an issue in a GitHub repository",
+    schema: z.object({ repo: z.string(), title: z.string() }),
+  }
+);
+
+// GitLab tools
+const gitlabCreateIssue = tool(
+  async ({ project, title }) => ({ url: `https://gitlab.com/${project}/-/issues/1`, title }),
+  {
+    name: "gitlab_create_issue",
+    description: "Create an issue in a GitLab project",
+    schema: z.object({ project: z.string(), title: z.string() }),
+  }
+);
+
+const allTools = [githubCreateIssue, gitlabCreateIssue];
+
+// Choose tools based on user context (e.g., vcsProvider = "github" | "gitlab")
+const vcsToolGate = createMiddleware({
+  name: "VcsToolGate",
+  contextSchema: z.object({ vcsProvider: z.string() }),
+  modifyModelRequest: (request, _state, runtime) => {
+    const provider = (runtime?.context?.vcsProvider ?? "github").toLowerCase();
+    const active = provider === "gitlab" ? [gitlabCreateIssue] : [githubCreateIssue];
+    return { ...request, tools: active };
+  },
+});
+
+const agent = createAgent({
+  model: "openai:gpt-4o",
+  tools: allTools, // superset for validation; middleware narrows per turn
+  middleware: [vcsToolGate],
+});
+
+// GitHub user
+await agent.invoke(
+  { messages: [new HumanMessage("Open an issue titled 'Bug: login fails' in my auth repo")] },
+  { context: { vcsProvider: "github" } }
+);
+
+// GitLab user
+await agent.invoke(
+  { messages: [new HumanMessage("Open an issue titled 'Bug: login fails' in my auth project")] },
+  { context: { vcsProvider: "gitlab" } }
+);
+```
+
+When a middleware defines a `contextSchema`, its properties become required on the agent invocation `context`.
+
+- In the example above, `vcsProvider` must be set in `{ context: { vcsProvider: "github" | "gitlab" } }`.
+- Add any additional fields your middleware requires, or provide defaults in the schema to make them optional.
+
+Prefer context for stable configuration (env, flags, tenant), and state for dynamic properties that change during the run (recent tool outcomes, user choices). See [Middleware](/oss/langchain/middleware) .
+
+See [Middleware](/oss/langchain/middleware) for details on `contextSchema`, type enforcement and more structured context/state patterns.
+
+### Advanced: semantic similarity over a large tool catalog
+
+For large catalogs, rank tools by semantic similarity between the user request and each tool’s name/description. Expose only the top-k most relevant tools via middleware.
+
+```ts icon="square-js"
+import { z } from "zod";
+import { createAgent, createMiddleware, tool, HumanMessage, type Tool } from "langchain";
+import { OpenAIEmbeddings } from "@langchain/openai";
+
+// 1) Define tools with good names/descriptions
+const bookFlight = tool(
+  async ({ from, to }) => `Booked from ${from} to ${to}`,
+  {
+    name: "book_flight",
+    description: "Book commercial flights between cities",
+    schema: z.object({ from: z.string(), to: z.string() }),
+  }
+);
+
+const lookupVisa = tool(
+  async ({ country }) => `Visa info for ${country}`,
+  {
+    name: "lookup_visa_requirements",
+    description: "Check visa requirements and documentation by destination country",
+    schema: z.object({ country: z.string() }),
+  }
+);
+
+const localWeather = tool(
+  async ({ city }) => `Weather in ${city}: Sunny`,
+  {
+    name: "local_weather",
+    description: "Get current weather and short-term forecast for a city",
+    schema: z.object({ city: z.string() }),
+  }
+);
+
+const fullCatalog = [bookFlight, lookupVisa, localWeather];
+
+// 2) Precompute and cache embeddings for tool metadata
+const embedder = new OpenAIEmbeddings({ model: "text-embedding-3-small" });
+const toolTexts = fullCatalog.map((t) => `${t.name}: ${t.description}`);
+const toolVectors = await embedder.embedDocuments(toolTexts);
+
+type CatalogItem = { tool: Tool; vector: number[] };
+const catalog: CatalogItem[] = fullCatalog.map((tool, i) => ({ tool, vector: toolVectors[i] }));
+
+function cosineSimilarity(a: number[], b: number[]) {
+  const dot = a.reduce((s, v, i) => s + v * b[i], 0);
+  const na = Math.hypot(...a);
+  const nb = Math.hypot(...b);
+  return na && nb ? dot / (na * nb) : 0;
+}
+
+async function selectTopKBySimilarity(query: string, k = 6) {
+  const qv = await embedder.embedQuery(query);
+  return catalog
+    .map((c) => ({ c, score: cosineSimilarity(qv, c.vector) }))
+    .sort((a, b) => b.score - a.score)
+    .slice(0, k)
+    .map(({ c }) => c.tool);
+}
+
+// 3) Use middleware to expose only the top-k most relevant tools each turn
+const semanticToolGate = createMiddleware({
+  name: "SemanticToolGate",
+  modifyModelRequest: async (request, state) => {
+    const last = state.messages.at(-1);
+    const active = last?.content
+      ? await selectTopKBySimilarity(last.content, 8)
+      : fullCatalog.slice(0, 5);
+    return { ...request, tools: active };
+  },
+});
+
+const semanticAgent = createAgent({
+  model: "openai:gpt-4o",
+  tools: fullCatalog, // superset for validation and typing
+  middleware: [semanticToolGate],
+});
+
+await semanticAgent.invoke({
+  messages: [new HumanMessage("I need to travel to Japan next month—what visas do I need?")],
+});
+```
+
+<Note>
+Production tips:
+
+- Precompute tool embeddings offline and refresh on change. Cache them in memory or a vector DB.
+- Use top-k and score thresholds; fall back to a small safe default tool set if confidence is low.
+- Log and evaluate tool recall/precision. Adjust names/descriptions—they matter for retrieval quality.
+- Combine with middleware for safety gates (human approval, rate limiting, tenancy filtering). See [Middleware](/oss/langchain/middleware).
+</Note>
+
+## Design guidelines
+
+Use these pragmatic guidelines to keep large tool catalogs efficient, accurate, and safe:
+
+<Steps>
+  <Step title="Keep catalogs clean" icon="sparkles">
+    Good names and concise descriptions beat long, noisy ones.
+  </Step>
+  <Step title="Gate early" icon="filter">
+    First filter by domain/tenant/feature flag, then apply semantic ranking.
+  </Step>
+  <Step title="Keep k small" icon="scissors">
+    Start with 3-10 tools exposed per turn; increase only if needed.
+  </Step>
+  <Step title="Measure" icon="clock">
+    Track tool usage, errors, and latency to tune k and thresholds.
+  </Step>
+  <Step title="Safety first" icon="shield-check">
+    Use middleware to restrict or approve high-impact tools.
+  </Step>
+</Steps>
+
+#### For more information
+
+<Columns cols={2}>
+  <Card title="Tools" icon="hammer" href="/oss/langchain/tools" arrow="true" cta="View tools docs">
+    Learn about tool design, ToolNode, and execution control.
+  </Card>
+  <Card title="Middleware" icon="shield" href="/oss/langchain/middleware" arrow="true" cta="View middleware docs">
+    Gate, filter, and orchestrate behavior with middleware hooks.
+  </Card>
+</Columns>

--- a/src/oss/langchain/structured-output.mdx
+++ b/src/oss/langchain/structured-output.mdx
@@ -60,7 +60,7 @@ const agent = createAgent({
     You can control the behavior by wrapping `ResponseFormat` in a `toolStrategy` or `providerStrategy` function call:
 
     ```ts
-    import { toolStrategy, providerStrategy } from "langchain/agents";
+    import { toolStrategy, providerStrategy } from "langchain";
 
     const agent = createAgent({
         // use a provider strategy if supported by the model


### PR DESCRIPTION
This docs page covers the advanced usage of "Dynamic Tools" explaining how users can implement smart ways to choose tools based on context (simple) or semantic similarity (advanced).

Happy to add Python code examples if we are ok with current structure.