### PR TITLE
fix: reverse proxy reference docs

### DIFF
--- a/reference/vercel.json
+++ b/reference/vercel.json
@@ -1,15 +1,48 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
-  "outputDirectory": "dist",
-  "public": true,
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "noindex, nofollow, noarchive, nosnippet, noimageindex"
+        }
+      ]
+    },
+    {
+      "source": "/javascript/(.*)",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "index, follow"
+        }
+      ]
+    },
+    {
+      "source": "/python/(.*)",
+      "headers": [
+        {
+          "key": "X-Robots-Tag",
+          "value": "index, follow"
+        }
+      ]
+    }
+  ],
   "redirects": [
     {
       "source": "/",
       "destination": "https://docs.langchain.com"
+    }
+  ],
+  "rewrites": [
+    {
+      "source": "/javascript/:path*",
+      "destination": "/dist/javascript/:path*"
     },
     {
-      "source": "/python/versions/latest",
-      "destination": "/python"
+      "source": "/python/:path*",
+      "destination": "/dist/python/:path*"
     }
   ]
 }


### PR DESCRIPTION
Instead of sourcing from a `dist` folder, `rewrites` will modify web assets to point to the appropriate subpath. Fixes web assets not loading on reference docs