### PR TITLE
fix: wrong perigon integration links

### DIFF
--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -2086,7 +2086,7 @@ title: "All providers"
     <Card
         title="Perigon"
         icon="link"
-        href="/oss/integrations/providers/perigon_search"
+        href="/oss/integrations/providers/perigon"
         arrow="true"
         cta="View provider guide"
     />

--- a/src/oss/python/integrations/providers/index.mdx
+++ b/src/oss/python/integrations/providers/index.mdx
@@ -136,7 +136,7 @@ These providers have standalone `langchain-{provider}` packages for improved ver
 | [MCP Toolbox](/oss/integrations/providers/toolbox-langchain/) | [toolbox-langchain](https://pypi.org/project/toolbox-langchain/) | ![Downloads](https://static.pepy.tech/badge/toolbox-langchain/month) | ![PyPI - Version](https://img.shields.io/pypi/v/toolbox-langchain?style=flat-square&label=%20&color=orange) | ❌ |
 | [Scrapeless](/oss/integrations/providers/scrapeless/) | [langchain-scrapeless](https://pypi.org/project/langchain-scrapeless/) | ![Downloads](https://static.pepy.tech/badge/langchain-scrapeless/month) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-scrapeless?style=flat-square&label=%20&color=orange) | ❌ |
 | [ZeusDB](/oss/integrations/providers/zeusdb/) | [langchain-zeusdb](https://pypi.org/project/langchain-zeusdb/) | ![Downloads](https://static.pepy.tech/badge/langchain-zeusdb/month) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-zeusdb?style=flat-square&label=%20&color=orange) | ❌ |
-| [Perigon](/oss/integrations/providers/perigon_search/) | [langchain-perigon](https://pypi.org/project/langchain-perigon/) | ![Downloads](https://static.pepy.tech/badge/langchain-perigon/month) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-perigon?style=flat-square&label=%20&color=orange) | ❌ |
+| [Perigon](/oss/integrations/providers/perigon/) | [langchain-perigon](https://pypi.org/project/langchain-perigon/) | ![Downloads](https://static.pepy.tech/badge/langchain-perigon/month) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-perigon?style=flat-square&label=%20&color=orange) | ❌ |
 
 ## All Providers
 


### PR DESCRIPTION
## Overview

Fix the perigon langchain docs internal links.

## Type of change

**Type:** Update existing documentation 

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- See #627

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)
