### PR TITLE
Add warning about RemoteGraph deadlock risk

### DIFF
--- a/src/langgraph-platform/use-remote-graph.mdx
+++ b/src/langgraph-platform/use-remote-graph.mdx
@@ -12,6 +12,12 @@ sidebarTitle: Interact with a deployment using RemoteGraph
 - Subgraph embedding: Compose modular graphs for a multi-agent workflow by embedding a `RemoteGraph` as a [subgraph](#use-as-a-subgraph) within another graph.
 - Reusable workflows: Use deployed graphs as nodes or [tools](https://langchain-ai.github.io/langgraph/reference/remote_graph/#langgraph.pregel.remote.RemoteGraph.as_tool), so that you can reuse and expose complex logic.
 
+<Warning>
+**Important: Avoid calling the same deployment**
+
+`RemoteGraph` is designed to call graphs on other deployments. Do not use `RemoteGraph` to call itself or another graph on the same deployment, as this can lead to deadlocks and resource exhaustion. Instead, use local graph composition or [subgraphs](/oss/langgraph/use-subgraphs) for graphs within the same deployment.
+</Warning>
+
 ## Prerequisites
 
 Before getting started with `RemoteGraph`, make sure you have:


### PR DESCRIPTION
## Summary
- Add prominent warning in RemoteGraph documentation about deadlock risks
- Clarify that RemoteGraph is designed for calling graphs on other deployments
- Warn against using RemoteGraph to call the same deployment

## Changes
- Added a Warning callout box in the RemoteGraph documentation
- Positioned the warning early in the document for maximum visibility
- Used clear, grammatically correct language consistent with existing documentation

## Context
RemoteGraph should not be used to call itself or another graph on the same deployment as this can lead to deadlocks and resource exhaustion. This warning helps users understand the intended use case and avoid common pitfalls.