### PR TITLE
fix(code-evals): added docs for js code evals [LSP-525]

### DIFF
--- a/src/langsmith/bind-evaluator-to-dataset.mdx
+++ b/src/langsmith/bind-evaluator-to-dataset.mdx
@@ -35,7 +35,9 @@ For custom code evaluators bound to a dataset, the evaluator function takes in t
 
 The code below shows an example of a simple evaluator function that checks that the outputs exactly equal the reference outputs.
 
-```python
+<CodeGroup>
+
+```python Python
 import numpy as np
 
 def perform_eval(run, example):
@@ -47,6 +49,22 @@ def perform_eval(run, example):
 
     return { "exact_match": output_match }
 ```
+
+```javascript JavaScript
+function perform_eval(run, example) {
+    // run is a Run object
+    // example is an Example object
+    const output = run.outputs.output;
+    const refOutput = example.outputs.outputs;
+
+    // Deep equality check for arrays/objects
+    const outputMatch = JSON.stringify(output) === JSON.stringify(refOutput);
+
+    return { "exact_match": outputMatch };
+}
+```
+
+</CodeGroup>
 
 ## Next steps
 

--- a/src/langsmith/online-evaluations.mdx
+++ b/src/langsmith/online-evaluations.mdx
@@ -108,7 +108,9 @@ They return a single value:
 
 In the below screenshot, you can see an example of a simple function that validates that each run in the experiment has a known json field:
 
-```python
+<CodeGroup>
+
+```python Python
 import json
 
 def perform_eval(run):
@@ -131,6 +133,34 @@ def perform_eval(run):
 
   return {"formatted": True}
 ```
+
+```javascript JavaScript
+function perform_eval(run) {
+    const outputToValidate = run.outputs;
+
+    // Assert you can serialize/deserialize as json
+    try {
+        JSON.stringify(outputToValidate);
+        JSON.parse(JSON.stringify(outputToValidate));
+    } catch (e) {
+        return { "formatted": false };
+    }
+
+    // Assert output facts exist
+    if (!("facts" in outputToValidate)) {
+        return { "formatted": false };
+    }
+
+    // Assert required fields exist
+    if (!outputToValidate["facts"].hasOwnProperty("years_mentioned")) {
+        return { "formatted": false };
+    }
+
+    return { "formatted": true };
+}
+```
+
+</CodeGroup>
 
 #### Test and save your evaluation function
 


### PR DESCRIPTION
## Overview
We recently added JS Code Evals on LangSmith for both `dataset` and `session`, so updating docs to reflect this latest change!

## Type of change

**Type:** Update Existing Documentation 

<!-- For LangChain employees, if applicable: -->
- Linear issue: [LSP-525](https://linear.app/langchain/issue/LSP-525/create-docs-pr-js-evals)

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
