### PR TITLE
fix: dont make preview branches for community PRs

### DIFF
--- a/.github/workflows/create-preview-branch.yml
+++ b/.github/workflows/create-preview-branch.yml
@@ -23,6 +23,9 @@ jobs:
       contents: write
     runs-on: ubuntu-latest
 
+    # Skip for PRs from forks - they don't have write access
+    if: github.event.pull_request.head.repo.full_name == github.repository || github.event_name == 'workflow_dispatch'
+
     # Expose the generated preview branch name for the next job
     outputs:
       preview_branch: ${{ steps.branch-name.outputs.branch_name }}


### PR DESCRIPTION
If you make a PR against this repo, the preview branch step will always fail since the runner doesn't have access to create branches against the fork