### PR TITLE
Add X-Tenant-Id header info in the API key section

### DIFF
--- a/src/langsmith/administration-overview.mdx
+++ b/src/langsmith/administration-overview.mdx
@@ -107,8 +107,8 @@ Service keys are prefixed with `lsv2_sk_`
 <Warning>
 Use the `X-Tenant-Id` header to specify the target workspace.
 
-- If the header is omitted, the request defaults to the workspace where the API key was created (unless the key is organization-scoped).
-- When using an organization-scoped service key, you must include the `X-Tenant-Id` header for workspace-scoped resources; otherwise the request will return 403 Forbidden.
+- When using PATs, if you don't provide this header, operations will default to the selected default workspace upon key creation.
+- When using an organization-scoped service key, you must include the `X-Tenant-Id` header for workspace-scoped resources; otherwise the request will return `403 Forbidden`.
 </Warning>
 
 <Note>

--- a/src/langsmith/administration-overview.mdx
+++ b/src/langsmith/administration-overview.mdx
@@ -107,7 +107,7 @@ Service keys are prefixed with `lsv2_sk_`
 <Warning>
 Use the `X-Tenant-Id` header to specify the target workspace.
 
-- When using PATs, if you don't provide this header, operations will default to the selected default workspace upon key creation.
+- When using PATs, if you don't provide this header, operations will default to the default workspace that was selected when creating the key.
 - When using an organization-scoped service key, you must include the `X-Tenant-Id` header for workspace-scoped resources; otherwise the request will return `403 Forbidden`.
 </Warning>
 

--- a/src/langsmith/administration-overview.mdx
+++ b/src/langsmith/administration-overview.mdx
@@ -104,6 +104,13 @@ Service keys are similar to PATs, but are used to authenticate requests to the L
 
 Service keys are prefixed with `lsv2_sk_`
 
+<Warning>
+Use the `X-Tenant-Id` header to specify the target workspace.
+
+- If the header is omitted, the request defaults to the workspace where the API key was created (unless the key is organization-scoped).
+- When using an organization-scoped service key, you must include the `X-Tenant-Id` header for workspace-scoped resources; otherwise the request will return 403 Forbidden.
+</Warning>
+
 <Note>
 To see how to create a service key or Personal Access Token, see the [setup guide](/langsmith/create-account-api-key)
 </Note>

--- a/src/langsmith/administration-overview.mdx
+++ b/src/langsmith/administration-overview.mdx
@@ -107,8 +107,8 @@ Service keys are prefixed with `lsv2_sk_`
 <Warning>
 Use the `X-Tenant-Id` header to specify the target workspace.
 
-- When using PATs, if you don't provide this header, operations will default to the default workspace that was selected when creating the key.
-- When using an organization-scoped service key, you must include the `X-Tenant-Id` header for workspace-scoped resources; otherwise the request will return `403 Forbidden`.
+- **When using PATs**: If this header is omitted, requests will run against the default workspace associated with the key.
+- **When using organization-scoped service keys**: You must include the `X-Tenant-Id` header when accessing workspace-scoped resources. Without it, the request will fail with a `403 Forbidden` error.
 </Warning>
 
 <Note>


### PR DESCRIPTION
## Overview
Customers didn't know to include X-tenant-Id header. Doesn't hurt to mention it in the section where we explain what each API key is.

## Type of change

**Type:**
Update existing documentation

To automatically close an issue when this PR is merged, use closing keywords:
- Closes INF-868



<!-- For LangChain employees, if applicable: -->
- Linear issue: https://linear.app/langchain/issue/INF-868/add-to-docs-that-you-need-to-add-x-tenant-id-in-the-header-with

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [] All code examples have been tested and work correctly
- [] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
