### PR TITLE
Add links to ingress documentation from LGP docs

### DIFF
--- a/src/langgraph-platform/deploy-hybrid.mdx
+++ b/src/langgraph-platform/deploy-hybrid.mdx
@@ -23,7 +23,7 @@ The Hybrid deployment option requires an [Enterprise](/langgraph-platform/plans)
       helm repo add kedacore https://kedacore.github.io/charts
       helm install keda kedacore/keda --namespace keda --create-namespace
     ```
-2. A valid `Ingress` controller is installed on your cluster.
+2. A valid `Ingress` controller is installed on your cluster. See [here](/langsmith/self-host-ingress) more more information about configuring ingress for your deployment.
 3. You have slack space in your cluster for multiple deployments. `Cluster-Autoscaler` is recommended to automatically provision new nodes.
 4. You will need to enable egress to two control plane URLs. The listener polls these endpoints for deployments:
     - https://api.host.langchain.com

--- a/src/langgraph-platform/deploy-hybrid.mdx
+++ b/src/langgraph-platform/deploy-hybrid.mdx
@@ -23,7 +23,7 @@ The Hybrid deployment option requires an [Enterprise](/langgraph-platform/plans)
       helm repo add kedacore https://kedacore.github.io/charts
       helm install keda kedacore/keda --namespace keda --create-namespace
     ```
-2. A valid `Ingress` controller is installed on your cluster. See [here](/langsmith/self-host-ingress) more more information about configuring ingress for your deployment.
+2. A valid `Ingress` controller is installed on your cluster. For more information about configuring ingress for your deployment, refer to [Create an ingress for installations](/langsmith/self-host-ingress).
 3. You have slack space in your cluster for multiple deployments. `Cluster-Autoscaler` is recommended to automatically provision new nodes.
 4. You will need to enable egress to two control plane URLs. The listener polls these endpoints for deployments:
     - https://api.host.langchain.com

--- a/src/langgraph-platform/self-hosted.mdx
+++ b/src/langgraph-platform/self-hosted.mdx
@@ -28,7 +28,7 @@ The Full Platform deployment model is a fully self-hosted solution where you man
 * You use `langgraph-cli` and/or [LangGraph Studio](/langgraph-platform/langgraph-studio) app to test graph locally.
 * You use `langgraph build` command to build image.
 * You have a Self-Hosted LangSmith instance deployed.
-* You are using Ingress for your LangSmith instance. All agents will be deployed as Kubernetes services behind this ingress.
+* You are using [Ingress](/langsmith/self-host-ingress) for your LangSmith instance. All agents will be deployed as Kubernetes services behind this ingress.
 
 ### Architecture
 


### PR DESCRIPTION
## Overview
The LGP docs for hybrid and full self hosted mention a need for configuring ingress. It might be nice to link to these docs from there.

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
