### PR TITLE
fix: self-hosted Okta SSO configuration ApiUrlBase field

### DIFF
--- a/src/langsmith/self-host-sso.mdx
+++ b/src/langsmith/self-host-sso.mdx
@@ -164,8 +164,8 @@ This method of configuration is required in order to use SCIM with Okta.
 1. Find and select the LangSmith application.
 1. On the application overview page, select Add Integration.
 1. Fill in `ApiUrlBase`:
-   * `https://<langsmith_url>/api/v1`, e.g., `https://langsmith.yourdomain.com/api/v1`.
-   * If your installation is configured with a subdomain / path prefix, include that in the URL, e.g., `https://langsmith.yourdomain.com/prefix/api/v1`.
+   * Your LangSmith API URL **without the protocol** (`https://`) formatted as `<langsmith_domain>/api/v1`, e.g., `langsmith.yourdomain.com/api/v1`.
+   * If your installation is configured with a subdomain / path prefix, include that in the URL, e.g., `langsmith.yourdomain.com/prefix/api/v1`.
 1. Leave `AuthHost` empty.
 1. (Optional, if planning to use [SCIM](/langsmith/user-management#set-up-scim-for-your-organization) as well) Fill in `LangSmithUrl`: The `<langsmith_url>` portion from above, e.g., `langsmith.yourdomain.com`.
 1. Under Application Visibility, keep the box unchecked.


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
* fix documentation for the `ApiUrlBase` field when configuring Okta using the Okta Integration Network

## Type of change

**Type:** Fix typo

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue: part of ent-100
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
