### PR TITLE
Correct intro paragraph on run eval prompt playground page

### DIFF
--- a/src/langsmith/run-evaluation-from-prompt-playground.mdx
+++ b/src/langsmith/run-evaluation-from-prompt-playground.mdx
@@ -3,7 +3,7 @@ title: Run an evaluation from the prompt playground
 sidebarTitle: With the UI
 ---
 
-LangSmith allows you to run evaluations directly in the . The prompt playground allows you to test your prompt and/or model configuration over a series of inputs to see how well it scores across different contexts or scenarios, without having to write any code.
+LangSmith allows you to run evaluations directly in the UI. The [**Prompt Playground**](/langsmith/prompt-engineering#prompt-playground) allows you to test your prompt or model configuration over a series of inputs to see how well it scores across different contexts or scenarios, without having to write any code.
 
 Before you run an evaluation, you need to have an [existing dataset](/langsmith/evaluation-concepts#datasets). Learn how to [create a dataset from the UI](/langsmith/manage-datasets-in-application#set-up-your-dataset).
 


### PR DESCRIPTION
Quick correction to missing word.