### PR TITLE
minor fix in messages guide

### DIFF
--- a/src/oss/langchain/messages.mdx
+++ b/src/oss/langchain/messages.mdx
@@ -429,7 +429,7 @@ response = model.invoke("Hello!")
 response.usage_metadata
 ```
 
-```json
+```
 {'input_tokens': 8,
  'output_tokens': 304,
  'total_tokens': 312,


### PR DESCRIPTION
cell is not valid json, renders red

it is valid python, but since it's output I thought customary to not syntax highlight (lmk if I'm mistaken)