### PR TITLE
Remove `LANGSMITH_RUNS_ENDPOINTS` from reference

### DIFF
--- a/src/langgraph-platform/env-var.mdx
+++ b/src/langgraph-platform/env-var.mdx
@@ -54,13 +54,17 @@ For example, if a deployment is scaled up to 10 replicas and `LANGGRAPH_POSTGRES
 
 Defaults to `150` connections.
 
-## `LANGSMITH_RUNS_ENDPOINTS`
+## `LANGSMITH_API_KEY`
 
 For deployments with [self-hosted LangSmith](/langsmith/architectural-overview) only.
 
-Set this environment variable to have a deployment send traces to a self-hosted LangSmith instance. The value of `LANGSMITH_RUNS_ENDPOINTS` is a JSON string: `{"<SELF_HOSTED_LANGSMITH_HOSTNAME>":"<LANGSMITH_API_KEY>"}`.
+To send traces to a self-hosted LangSmith instance, set `LANGSMITH_API_KEY` to an API key created from the self-hosted instance.
 
-`SELF_HOSTED_LANGSMITH_HOSTNAME` is the hostname of the self-hosted LangSmith instance. It must be accessible to the deployment. `LANGSMITH_API_KEY` is a LangSmith API generated from the self-hosted LangSmith instance.
+## `LANGSMITH_ENDPOINT`
+
+For deployments with [self-hosted LangSmith](/langsmith/architectural-overview) only.
+
+To send traces to a self-hosted LangSmith instance, set `LANGSMITH_ENDPOINT` to the hostname of the self-hosted instance.
 
 ## `LANGSMITH_TRACING`
 


### PR DESCRIPTION
## Overview
Remove `LANGSMITH_RUNS_ENDPOINTS` from the LGP environment variables reference page. Replace with `LANGSMITH_API_KEY` and `LANGSMITH_ENDPOINT`.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- Feature PR: https://github.com/langchain-ai/langchainplus/pull/12249

## Checklist
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
This is a feature for Betclic.
