### PR TITLE
Restructure Kubernetes Install Instructions to Emphasize External Databases

### DIFF
--- a/src/langsmith/kubernetes.mdx
+++ b/src/langsmith/kubernetes.mdx
@@ -64,7 +64,7 @@ For more information, refer to the following setup guides for external services:
 - [ClickHouse](/langsmith/self-host-external-clickhouse)
 
 
-### Kubernetes Cluster Requirements
+### Kubernetes cluster requirements
 
 1. You will need a working Kubernetes cluster that you can access via `kubectl`. Your cluster should have the following minimum requirements:
 

--- a/src/langsmith/kubernetes.mdx
+++ b/src/langsmith/kubernetes.mdx
@@ -29,22 +29,51 @@ You can click on the links above to see the documentation for each module. These
 </Note>
 
 ## Prerequisites
-
 Ensure you have the following tools/items ready. Some items are marked optional:
 
-1. A working Kubernetes cluster that you can access via `kubectl`. Your cluster should have the following minimum requirements:
+1. LangSmith License Key
+
+   1. You can get this from your LangChain representative. [Contact our sales team](https://www.langchain.com/contact-sales) for more information.
+
+2. Api Key Salt
+
+   1. This is a secret key that you can generate. It should be a random string of characters.
+   2. You can generate this using the following command:
+
+   ```bash
+   openssl rand -base64 32
+   ```
+
+3. JWT Secret (Optional but used for basic auth)
+
+   1. This is a secret key that you can generate. It should be a random string of characters.
+   2. You can generate this using the following command:
+
+   ```bash
+   openssl rand -base64 32
+   ```
+
+### Databases
+
+LangSmith relies on `PostgreSQL` database, `Redis` cache, and `ClickHouse` database for storing traces. By default, our installation will install these services inside your Kubernetes cluster.
+However, we strongly recommend that you use external databases. For `PostgreSQL` and `Redis`, we recommend using your cloud provider's managed services.
+For more information, see instructions for external `PostgreSQL` [here](/langsmith/self-host-external-postgres), `Redis`, [here](/langsmith/self-host-external-redis), and `ClickHouse` [here](/langsmith/self-host-external-clickhouse).
+
+
+### Kubernetes Cluster Requirements
+
+1. You will need a working Kubernetes cluster that you can access via `kubectl`. Your cluster should have the following minimum requirements:
 
    1. Recommended: At least 16 vCPUs, 64GB Memory available
 
-      * You may need to tune resource requests/limits for all of our different services based off of organization size/usage
-      * We recommend using a cluster autoscaler to handle scaling up/down of nodes based on resource usage
-      * We recommend setting up the metrics server so that autoscaling can be turned on
-      * You must have a node with at least 4 vCPUs and 16GB of memory **allocatable** as ClickHouse will request this amount of resources by default.
+      * You may need to tune resource requests/limits for all of our different services based off of organization size/usage. Our recommendations can be found [here](/langsmith/self-host-scale).
+      * We recommend using a cluster autoscaler to handle scaling up/down of nodes based on resource usage.
+      * We recommend setting up the metrics server so that autoscaling can be turned on.
+      * If you are running Clickhouse in-cluster, you must have a node with at least 4 vCPUs and 16GB of memory **allocatable** as ClickHouse will request this amount of resources by default.
 
-   2. Valid Dynamic PV provisioner or PVs available on your cluster.
+   2. Valid Dynamic PV provisioner or PVs available on your cluster (required only if you are running databases in-cluster)
 
-      * We will be using a `PostgreSQL` database, `Redis` cache, and `ClickHouse` database for storing traces. These services require persistent storage.
-      * Our base installation, which assumes no external databases, will try to install these services inside your cluster. To enable persistence, we will try to provision volumes for these services.
+      * To enable persistence, we will try to provision volumes for any database running in-cluster.
       * If using PVs in your cluster, we highly recommend setting up backups in a production environment.
       * **We strongly encourage using a storage class backed by SSDs for better performance. We recommend 7000 IOPS and 1000 MiB/s throughput.**
       * On EKS, you may need to ensure you have the `ebs-csi-driver` installed and configured for dynamic provisioning. Refer to the [EBS CSI Driver documentation](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) for more information.
@@ -72,41 +101,19 @@ Ensure you have the following tools/items ready. Some items are marked optional:
 
    1. To install `helm` refer to the [Helm documentation](https://helm.sh/docs/intro/install/)
 
-3. LangSmith License Key
 
-   1. You can get this from your LangChain representative. [Contact our sales team](https://www.langchain.com/contact-sales) for more information.
-
-4. Api Key Salt
-
-   1. This is a secret key that you can generate. It should be a random string of characters.
-   2. You can generate this using the following command:
-
-   ```bash
-   openssl rand -base64 32
-   ```
-
-5. JWT Secret (Optional but used for basic auth)
-
-   1. This is a secret key that you can generate. It should be a random string of characters.
-   2. You can generate this using the following command:
-
-   ```bash
-   openssl rand -base64 32
-   ```
-
-6. Egress to `https://beacon.langchain.com` (if not running in offline mode)
+3. Egress to `https://beacon.langchain.com` (if not running in offline mode)
 
    1. LangSmith requires egress to `https://beacon.langchain.com` for license verification and usage reporting. This is required for LangSmith to function properly. You can find more information on egress requirements in the [Egress](/langsmith/self-host-egress) section.
 
-7. Configuration
 
-   1. There are several configuration options that you can set in the `langsmith_config.yaml` file. You can find more information on specific configuration options in the [Configuration](/langsmith/architectural-overview) section.
-   2. If you are new to Kubernetes or Helm, we’d recommend starting with one of the example configurations in the examples directory of the Helm Chart repository here: [LangSmith helm chart examples](https://github.com/langchain-ai/helm/tree/main/charts/langsmith/examples).
-   3. You can see a full list of configuration options in the `values.yaml` file in the Helm Chart repository here: [LangSmith Helm Chart](https://github.com/langchain-ai/helm/tree/main/charts/langsmith/values.yaml)
 
 ## Configure your Helm Charts:
 
 1. Create a new file called `langsmith_config.yaml` with the configuration options from the previous step.
+   1. There are several configuration options that you can set in the `langsmith_config.yaml` file. You can find more information on specific configuration options in the [Configuration](/langsmith/architectural-overview) section.
+   2. If you are new to Kubernetes or Helm, we’d recommend starting with one of the example configurations in the examples directory of the Helm Chart repository here: [LangSmith helm chart examples](https://github.com/langchain-ai/helm/tree/main/charts/langsmith/examples).
+   3. You can see a full list of configuration options in the `values.yaml` file in the Helm Chart repository here: [LangSmith Helm Chart](https://github.com/langchain-ai/helm/tree/main/charts/langsmith/values.yaml)
 
 2. At a minimum, you will need to set the following configuration options (using basic auth):
 
@@ -121,6 +128,7 @@ Ensure you have the following tools/items ready. Some items are marked optional:
        initialOrgAdminPassword: "secure-password" # Must be at least 12 characters long and have at least one lowercase, uppercase, and symbol
        jwtSecret: <your jwt salt> # A random string of characters used to sign JWT tokens for basic auth.
    ```
+You will also need to specify connection details for any external databases you are using.
 
 ## Deploying to Kubernetes:
 

--- a/src/langsmith/kubernetes.mdx
+++ b/src/langsmith/kubernetes.mdx
@@ -55,9 +55,13 @@ Ensure you have the following tools/items ready. Some items are marked optional:
 
 ### Databases
 
-LangSmith relies on `PostgreSQL` database, `Redis` cache, and `ClickHouse` database for storing traces. By default, our installation will install these services inside your Kubernetes cluster.
-However, we strongly recommend that you use external databases. For `PostgreSQL` and `Redis`, we recommend using your cloud provider's managed services.
-For more information, see instructions for external `PostgreSQL` [here](/langsmith/self-host-external-postgres), `Redis`, [here](/langsmith/self-host-external-redis), and `ClickHouse` [here](/langsmith/self-host-external-clickhouse).
+LangSmith uses a PostgreSQL database, a Redis cache, and a ClickHouse database to store traces. By default, these services are installed inside your Kubernetes cluster. However, we highly recommend using external databases instead. For PostgreSQL and Redis, the best option is your cloud provider’s managed services.
+
+For more information, refer to the following setup guides for external services:
+
+- [PostgreSQL](/langsmith/self-host-external-postgres)
+- [Redis](/langsmith/self-host-external-redis)
+- [ClickHouse](/langsmith/self-host-external-clickhouse)
 
 
 ### Kubernetes Cluster Requirements


### PR DESCRIPTION
## Overview
Our documentation currently sends you down the path of running databases in-cluster, which is not what we want our customers doing. These changes maintain the existing instructions while advising the user to use external databases instead.

## Type of change

**Type:** Update existing documentation 

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
