### PR TITLE
Fix documentation formatting

### DIFF
--- a/build/oss/javascript/langgraph/INVALID_CHAT_HISTORY.mdx
+++ b/build/oss/javascript/langgraph/INVALID_CHAT_HISTORY.mdx
@@ -37,7 +37,8 @@ To resolve this, you can do one of the following:
   **NOTE**: this will append the messages to the history and run the graph from the START node.
   * manually update the state and resume the graph from the interrupt:
     1. get the list of most recent messages from the graph state with `graph.getState(config)`
-    2. modify the list of messages to either remove unanswered tool calls from AIMessages
-
-or add ToolMessages with `toolCallId`s that match unanswered tool calls 3. call `graph.updateState(config, {messages: ...})` with the modified list of messages 4. resume the graph, e.g. call `graph.invoke(null, config)`
+    2. modify the list of messages to either remove unanswered tool calls from AIMessages 
+                                      or add ToolMessages with `toolCallId`s that match unanswered tool calls 
+    3. call `graph.updateState(config, {messages: ...})` with the modified list of messages 
+    4. resume the graph, e.g. call `graph.invoke(null, config)`
 


### PR DESCRIPTION
Fix indentation for points 3 and 4 under TroubleShooting

## Overview
Under the troubleshooting section of the INVALID_CHAT_HISTORY page, the indentation of the troubleshooting steps for steps 3 and steps 4 are mangled.

## Type of change

**Type:** Fix formatting

## Related issues/PRs
Not applicable, this is not linked to any other issues/PRs

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- [!] I have gotten approval from the relevant reviewers

## Additional notes
Refer to screenshot

<img width="1904" height="1207" alt="Screenshot 2025-10-02 at 3 57 34 PM" src="https://github.com/user-attachments/assets/3aeb3b6b-a85e-4774-b0be-76da30d6dc1f" />

User Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.6 Safari/605.1.15