### PR TITLE
docs: add more information about egress in LGP hybrid

### DIFF
--- a/src/langgraph-platform/hybrid.mdx
+++ b/src/langgraph-platform/hybrid.mdx
@@ -37,12 +37,13 @@ If you would like to deploy to Kubernetes, you can follow the [Hybrid deployment
 </Tip>
 
 ### Egress to LangSmith and the control plane
+
 In the hybrid deployment model, your self-hosted data plane will send network requests to the control plane to poll for changes that need to be implemented in the data plane. Traces from data plane deployments also get sent to the LangSmith instance integrated with the control plane. This traffic to the control plane is encrypted, over HTTPS. The data plane authenticates with the control plane with a LangSmith API key.
 
-In order to enable this egress, you may need to update internal Firewall rules or cloud resources such as Security Groups. You can find a list of IP addresses to allow [here](/langsmith/cloud-architecture-and-scalability#ingress-into-langchain-saas).
+In order to enable this egress, you may need to update internal firewall rules or cloud resources (such as Security Groups) to [allow certain IP addresses](/langsmith/cloud-architecture-and-scalability#ingress-into-langchain-saas).
 
 <Warning>
-We do not currently support traffic over Private Link or Private Service Connect. This traffic will go over the internet.
+AWS/Azure PrivateLink or GCP Private Service Connect is currently not supported. This traffic will go over the internet.
 </Warning>
 
 ## Listeners


### PR DESCRIPTION
## Overview
Adding an egress section to the lgp hybrid docs that give more color to how this traffic is sent, encrypted, authenticated.
Once diagram is updated to be excalidraw, i can add an icon showing this encrypted traffic for egress.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue: INF-900
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->

Tested by running locally:

<img width="1465" height="661" alt="Screenshot 2025-10-02 at 1 15 49 PM" src="https://github.com/user-attachments/assets/b2b95617-d34e-44dd-a96c-5f063dbdc32b" />
