### PR TITLE
mark agent auth feature as beta

### DIFF
--- a/src/langgraph-platform/agent-auth.mdx
+++ b/src/langgraph-platform/agent-auth.mdx
@@ -1,5 +1,5 @@
 ---
-title: Set up Agent Auth
+title: Set up Agent Auth (Beta)
 description: Enable secure access from agents to any system using OAuth 2.0 credentials with Agent Auth.
 ---
 

--- a/src/langgraph-platform/agent-auth.mdx
+++ b/src/langgraph-platform/agent-auth.mdx
@@ -3,6 +3,8 @@ title: Set up Agent Auth (Beta)
 description: Enable secure access from agents to any system using OAuth 2.0 credentials with Agent Auth.
 ---
 
+<Note>Agent Auth is in **Beta** and under active development. To provide feedback or use this feature, reach out to the [LangChain team](https://forum.langchain.com).</Note>
+
 ## Installation
 
 Install the Agent Auth client library from PyPI:

--- a/src/langgraph-platform/agent-auth.mdx
+++ b/src/langgraph-platform/agent-auth.mdx
@@ -3,7 +3,7 @@ title: Set up Agent Auth (Beta)
 description: Enable secure access from agents to any system using OAuth 2.0 credentials with Agent Auth.
 ---
 
-<Note>Agent Auth is in **Beta** and under active development. To provide feedback or use this feature, reach out to the [LangChain team](https://forum.langchain.com).</Note>
+<Note>Agent Auth is in **Beta** and under active development. To provide feedback or use this feature, reach out to the [LangChain team](https://forum.langchain.com/c/help/langsmith/).</Note>
 
 ## Installation
 


### PR DESCRIPTION
we discussed two days ago with marketing and GTM that the agent auth feature will be a Beta as of the end of month launch week, so this PR marks it as such

i have no strong opinions on the best way to show this in our docs, or if it needs to be more extensive. feel free to suggest any other way of showing this.
