### PR TITLE
chore(lgp): document middleware_order setting

### DIFF
--- a/src/langgraph-platform/custom-middleware.mdx
+++ b/src/langgraph-platform/custom-middleware.mdx
@@ -58,6 +58,26 @@ Add the following to your `langgraph.json` configuration file. Make sure the pat
 }
 ```
 
+### Customize middleware ordering
+By default, custom middleware runs before authentication and authorization logic. To run custom middleware _after_ authentication and authorization, set `middleware_order` to `auth_first` in your `http` configuration.
+
+```json
+{
+  "dependencies": ["."],
+  "graphs": {
+    "agent": "./src/agent/graph.py:graph"
+  },
+  "env": ".env",
+  "http": {
+    "app": "./src/agent/webapp.py:app",
+    "middleware_order": "auth_first"
+  },
+  "auth": {
+    "path": "./auth.py:my_auth"
+  }
+}
+```
+
 ## Start server
 
 Test the server out locally:


### PR DESCRIPTION
## Overview
This documents the `middleware_order` feature shipped with `langgraph-api` v0.4.35.

## Type of change

**Type:** Update existing documentation