### PR TITLE
Reorganize TLS Docs for Self-Hosted

### DIFF
--- a/src/langsmith/self-host-custom-tls-certificates.mdx
+++ b/src/langsmith/self-host-custom-tls-certificates.mdx
@@ -3,35 +3,20 @@ title: Configure custom TLS certificates
 sidebarTitle: Configure custom TLS certificates
 ---
 
-Use this guide to configure custom TLS certificates in LangSmith. This is required when connecting securely to model providers or external services, especially if you rely on self-signed certificates or internal certificate authorities. This page describes two related tasks:
+Use this guide to configure TLS in LangSmith. Start by mounting internal certificate authorities (CAs) so your deployment trusts the right roots system‑wide, for database or external service calls. You can then configure Playground-specific mTLS for communicating securely with supported model providers.
 
-- Using custom TLS certificates for model providers (such as Azure, OpenAI, or a custom model server)
-- Mounting internal certificate authorities (CAs) to enable TLS connections for databases and other external services.
+This page covers:
 
-## Use custom TLS certificates for model providers
-
-<Note>
-This feature is currently only available for the following model providers:
-
-* Azure OpenAI
-* OpenAI
-* Custom (our custom model server). Refer to the [custom model server documentation](/langsmith/custom-endpoint) for more information.
-
-These TLS settings will apply to all invocations of the selected model providers including when used through Online Evaluation.
-</Note>
-
-You can use custom TLS certificates to connect to model providers in the LangSmith playground. This is useful if you are using a self-signed certificate, a certificate from a custom certificate authority or mutual TLS authentication.
-
-To use custom TLS certificates, you need to set the following environment variables. See the [self hosted deployment section](/langsmith/architectural-overview) for more information on how to set up application configuration.
-
-* `LANGSMITH_PLAYGROUND_TLS_MODEL_PROVIDERS`: A comma-separated list of model providers that require custom TLS certificates. Note that `azure_openai`, `openai` and `custom` are currently the only supported model provider that supports custom TLS certificates, but more providers will be supported in the future.
-* `LANGSMITH_PLAYGROUND_TLS_CA`: The custom certificate authority (CA) certificate in PEM format. This must be a file path (for a mounted volume).
-* \[Optional] `LANGSMITH_PLAYGROUND_TLS_KEY`: The private key in PEM format. This must be a file path (for a mounted volume). This is usually only necessary for mutual TLS authentication.
-* \[Optional] `LANGSMITH_PLAYGROUND_TLS_CERT`: The certificate in PEM format. This must be a file path (for a mounted volume). This is usually only necessary for mutual TLS authentication.
-
-Once you have set these environment variables, enter the LangSmith Playground **Settings** page and select the **Provider** that requires custom TLS certificates. Set your model provider configuration as usual, and the custom TLS certificates will be used when connecting to the model provider.
+- Mounting internal certificate authorities (CAs) system-wide to enable TLS for database connections and Playground model calls
+- Using Playground-specific TLS settings to provide client certs/keys for mTLS with supported model providers
 
 ## Mount internal CAs for TLS
+
+<Note>
+You must use Helm chart version 0.11.9 or later to mount internal CAs using the configuration below.
+</Note>
+
+Use this approach to make internal/public CAs trusted system‑wide by LangSmith (Playground model calls and database/external service connections).
 
 1. Create a file containing all CAs required for TLS with databases and external services. If your deployment is communicating directly to `beacon.langchain.com` without a proxy, make sure to include a public trusted CA. All certs should be concatenated in this file with an empty line in between.
 ```
@@ -66,3 +51,27 @@ postgres:
 4. Make sure to use TLS supported connection strings:
     - <b>Postgres</b>: Add `?sslmode=verify-full&sslrootcert=system` to the end.
     - <b>Redis</b>: Use `rediss://` instead of `redis://` as the prefix.
+
+## Use custom TLS certificates for model providers
+
+<Note>
+This feature is currently only available for the following model providers:
+
+* Azure OpenAI
+* OpenAI
+* Custom (our custom model server). Refer to the [custom model server documentation](/langsmith/custom-endpoint) for more information.
+
+These TLS settings apply to all invocations of the selected model providers (including Online Evaluation). Use them when the provider requires mutual TLS (client cert/key) or when you must override trust with a specific CA for provider calls. They complement the internal CA bundle configured above.
+</Note>
+
+You can use custom TLS certificates to connect to model providers in the LangSmith Playground. This is useful if you are using a self-signed certificate, a certificate from a custom certificate authority, or mutual TLS authentication.
+
+To use custom TLS certificates, set the following environment variables. See the [self hosted deployment section](/langsmith/architectural-overview) for more information on how to configure application settings.
+
+* `LANGSMITH_PLAYGROUND_TLS_MODEL_PROVIDERS`: A comma-separated list of model providers that require custom TLS certificates. Note that `azure_openai`, `openai`, and `custom` are currently the only supported model providers, but more providers will be supported in the future.
+* \[Optional] `LANGSMITH_PLAYGROUND_TLS_KEY`: The private key in PEM format. This must be a file path (for a mounted volume). This is usually only necessary for mutual TLS authentication.
+* \[Optional] `LANGSMITH_PLAYGROUND_TLS_CERT`: The certificate in PEM format. This must be a file path (for a mounted volume). This is usually only necessary for mutual TLS authentication.
+* [Optional] `LANGSMITH_PLAYGROUND_TLS_CA`: The custom certificate authority (CA) certificate in PEM format. This must be a file path (for a mounted volume). Use this to mount CAs only if you're using a helm version below `0.11.9`; otherwise, use the [Mount internal CAs for TLS](./self-host-custom-tls-certificates#mount-internal-cas-for-tls) section above.
+
+
+Once you have set these environment variables, enter the LangSmith Playground **Settings** page and select the **Provider** that requires custom TLS certificates. Set your model provider configuration as usual, and the custom TLS certificates will be used when connecting to the model provider.

--- a/src/langsmith/self-host-custom-tls-certificates.mdx
+++ b/src/langsmith/self-host-custom-tls-certificates.mdx
@@ -69,8 +69,8 @@ You can use custom TLS certificates to connect to model providers in the LangSmi
 To use custom TLS certificates, set the following environment variables. See the [self hosted deployment section](/langsmith/architectural-overview) for more information on how to configure application settings.
 
 * `LANGSMITH_PLAYGROUND_TLS_MODEL_PROVIDERS`: A comma-separated list of model providers that require custom TLS certificates. Note that `azure_openai`, `openai`, and `custom` are currently the only supported model providers, but more providers will be supported in the future.
-* \[Optional] `LANGSMITH_PLAYGROUND_TLS_KEY`: The private key in PEM format. This must be a file path (for a mounted volume). This is usually only necessary for mutual TLS authentication.
-* \[Optional] `LANGSMITH_PLAYGROUND_TLS_CERT`: The certificate in PEM format. This must be a file path (for a mounted volume). This is usually only necessary for mutual TLS authentication.
+* [Optional] `LANGSMITH_PLAYGROUND_TLS_KEY`: The private key in PEM format. This must be a file path (for a mounted volume). This is usually only necessary for mutual TLS authentication.
+* [Optional] `LANGSMITH_PLAYGROUND_TLS_CERT`: The certificate in PEM format. This must be a file path (for a mounted volume). This is usually only necessary for mutual TLS authentication.
 * [Optional] `LANGSMITH_PLAYGROUND_TLS_CA`: The custom certificate authority (CA) certificate in PEM format. This must be a file path (for a mounted volume). Use this to mount CAs only if you're using a helm version below `0.11.9`; otherwise, use the [Mount internal CAs for TLS](./self-host-custom-tls-certificates#mount-internal-cas-for-tls) section above.
 
 


### PR DESCRIPTION
## Overview
Switched the sections around so we emphasize the new way of doing. Added version requirement for new way.
Made CA for playground method optional, instead pointing to the main section.

## Type of change

**Type:** Update existing documentation

To automatically close an issue when this PR is merged, use closing keywords:
- Closes INF-837

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [X] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)
