### PR TITLE
replace create_agent with create_react_agent

### DIFF
--- a/src/oss/python/releases/langchain-v1.mdx
+++ b/src/oss/python/releases/langchain-v1.mdx
@@ -195,7 +195,7 @@ To better support structured output, `create_agent` no longer supports pre-bound
 ```python
 # No longer supported
 model_with_tools = ChatOpenAI().bind_tools([some_tool])
-agent = create_agent(model_with_tools, tools=[])
+agent = create_react_agent(model_with_tools, tools=[])
 
 # Use instead
 agent = create_agent("openai:gpt-4o-mini", tools=[some_tool])


### PR DESCRIPTION
create_react_agent has moved from langgraph.prebuilts to langchain.agents. So old code should reference the previous signature.

## Overview
old code should reference the old signature.

## Type of change

**Type:** Fix typo

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- [ ] I have gotten approval from the relevant reviewers

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
