### PR TITLE
fix: SCIM links & remove incorrect docs

### DIFF
--- a/src/langsmith/self-host-sso.mdx
+++ b/src/langsmith/self-host-sso.mdx
@@ -85,7 +85,6 @@ In some scenarios, it may be necessary to override which claim is used as the `s
 For example, in SCIM, the resolved `sub` claim and SCIM `externalId` must match in order for login to succeed.
 If there are restrictions on the source attribute of the `sub` claim and/or the SCIM `externalId`, set the `ISSUER_SUB_CLAIM_OVERRIDES` environment variable to select which OIDC JWT claim is used as the `sub`.
 
-
 If an issuer URL **starts with** one of the URLs in this configuration, the `sub` claim is taken from the field name specified.
 For example, with the following configuration, a token with the issuer `https://idp.yourdomain.com/application/uuid` would use the `customClaim` value as the `sub`:
 
@@ -178,7 +177,6 @@ This method of configuration is required in order to use SCIM with Okta.
 1. Click **Save**.
 1. Configure LangSmith to use this OAuth application (see [general configuration section](#configuration) for details about `initialOrgAdminEmail`):
 
-
 <CodeGroup>
 
 ```yaml Helm
@@ -232,7 +230,6 @@ SCIM is not compatible with this method of configuration. Refer to [**Via Okta I
 1. (Optional) Under **General > Login** set **Login initiated by** to `Either Okta or App` to enable IdP-initiated login.
 1. (Recommended) Under **General > Login > Email verification experience** fill in the **Callback URI** with the LangSmith URL, e.g., `https://langsmith.yourdomain.com`.
 1. Configure LangSmith to use this OAuth application (see [general configuration section](#configuration) for details about `initialOrgAdminEmail`):
-
 
 <CodeGroup>
 

--- a/src/langsmith/user-management.mdx
+++ b/src/langsmith/user-management.mdx
@@ -464,7 +464,7 @@ While specific instructions depending on the identity provider may vary, these m
    If your company has a group naming policy, you should instead map from the `description` identity provider attribute and
    set the description based on the [Group Naming Convention](#group-naming-convention) section.
 
-### Step 1: Configure SAML SSO (Cloud only)
+### Step 1 - Configure SAML SSO (Cloud only)
 
 There are two scenarios for [SAML SSO](#set-up-saml-sso-for-your-organization) configuration:
 
@@ -485,7 +485,7 @@ The NameID should not be an email address or username because email addresses an
 
 The NameID format must be `Persistent`, unless you are using a field, like email, that requires a different format.
 
-### Step 2: Disable JIT provisioning
+### Step 2 - Disable JIT provisioning
 
 Before enabling SCIM, disable [Just-in-time (JIT) provisioning](/langsmith/user-management#just-in-time-jit-provisioning) to prevent conflicts between automatic and manual user provisioning.
 
@@ -510,7 +510,7 @@ commonEnv:
     value: "false"
 ```
 
-### Step 3: Generate SCIM bearer token
+### Step 3 - Generate SCIM bearer token
 
 <Note>
 In self-hosted environments, the full URL below may look like `https://langsmith.yourdomain.com/api/v1/platform/orgs/current/scim/tokens` (without a subdomain, note the `/api/v1` path prefix) or `https://langsmith.yourdomain.com/subdomain/api/v1/platform/orgs/current/scim/tokens` (with a subdomain) - see the [ingress docs](/langsmith/self-host-ingress) for more details.
@@ -532,7 +532,7 @@ Note that the SCIM Bearer Token value is not available outside of the response t
 - `PATCH /v1/platform/orgs/current/scim/tokens/{scim_token_id}` (only the `description` field is supported)
 - `DELETE /v1/platform/orgs/current/scim/tokens/{scim_token_id}`
 
-### Step 4: Configure your Identity Provider
+### Step 4 - Configure your Identity Provider
 
 <Note>
 If you use Azure Entra ID (formerly Azure AD) or Okta, there are specific instructions for identity provider setup (refer to [Azure Entra ID](#azure-entra-id-configuration-steps), [Okta](#okta)). The requirements and steps above are applicable for all identity providers.
@@ -648,7 +648,7 @@ See [SAML SSO setup](#okta) for cloud or [OAuth2.0 setup](/langsmith/self-host-s
 
 1. In the Provisioning tab, select `Integration`.
 1. Select `Edit` then `Enable API integration`.
-1. For API Token, paste the SCIM token you [generated above](#step-3:-generate-scim-bearer-token).
+1. For API Token, paste the SCIM token you [generated above](#step-3-generate-scim-bearer-token).
 1. Keep `Import Groups` checked.
 1. To verify the configuration, select Test API Credentials.
 1. Select Save.

--- a/src/langsmith/user-management.mdx
+++ b/src/langsmith/user-management.mdx
@@ -99,7 +99,7 @@ SAML SSO is available for organizations on the [Enterprise plan](https://www.lan
 - Your Identity Provider (IdP) must support the SAML 2.0 standard.
 - Only [`Organization Admins`](/langsmith/observability-concepts#organization-roles) can configure SAML SSO.
 
-For instructions on using SCIM along with SAML for user provisioning and deprovisioning, refer to the [SCIM setup](#user-management).
+For instructions on using SCIM along with SAML for user provisioning and deprovisioning, refer to the [SCIM setup](#set-up-scim-for-your-organization).
 
 ### Initial configuration
 
@@ -490,6 +490,7 @@ The NameID format must be `Persistent`, unless you are using a field, like email
 Before enabling SCIM, disable [Just-in-time (JIT) provisioning](/langsmith/user-management#just-in-time-jit-provisioning) to prevent conflicts between automatic and manual user provisioning.
 
 #### Disabling JIT for Cloud
+
 Use the `PATCH /orgs/current/info` [endpoint](https://api.smith.langchain.com/redoc#tag/orgs/operation/update_current_organization_info_api_v1_orgs_current_info_patch):
 
 ```bash
@@ -500,7 +501,9 @@ curl -X PATCH $LANGCHAIN_ENDPOINT/orgs/current/info \
 ```
 
 #### Disabling JIT for Self-Hosted
+
 As of LangSmith chart version **0.11.14**, you can disable JIT provisioning for your self-hosted organization using SSO. To disable, set the following values:
+
 ```yaml
 commonEnv:
   - name: SELF_HOSTED_JIT_PROVISIONING_ENABLED
@@ -518,7 +521,6 @@ Generate a SCIM Bearer Token for your organization. This token will be used by y
 ```bash
 curl -X POST $LANGCHAIN_ENDPOINT/v1/platform/orgs/current/scim/tokens \
   -H "X-Api-Key: $LANGCHAIN_API_KEY" \
-  -H "X-Organization-Id: $LANGCHAIN_ORGANIZATION_ID" \
   -H "Content-Type: application/json" \
   -d '{"description": "Your description here"}'
 ```
@@ -646,7 +648,7 @@ See [SAML SSO setup](#okta) for cloud or [OAuth2.0 setup](/langsmith/self-host-s
 
 1. In the Provisioning tab, select `Integration`.
 1. Select `Edit` then `Enable API integration`.
-1. For API Token, paste the SCIM token you [generated above](#step-3-generate-scim-bearer-token).
+1. For API Token, paste the SCIM token you [generated above](#step-3:-generate-scim-bearer-token).
 1. Keep `Import Groups` checked.
 1. To verify the configuration, select Test API Credentials.
 1. Select Save.

--- a/src/langsmith/user-management.mdx
+++ b/src/langsmith/user-management.mdx
@@ -644,14 +644,8 @@ See [SAML SSO setup](#okta) for cloud or [OAuth2.0 setup](/langsmith/self-host-s
 
 **Step 2: Configure API Integration**
 
-1. In the Provisioning tab, select Configure API integration.
-1. Select Enable API integration.
-1. For Base URL (if present):
-
-- US: `https://api.smith.langchain.com/scim/v2`
-- EU: `https://eu.api.smith.langchain.com/scim/v2`
-- Self-hosted: `<langsmith_url>/scim/v2` (note there is no `/api/v1` path prefix) or if a subdomain is configured `<langsmith_url>/subdomain/scim/v2`
-
+1. In the Provisioning tab, select `Integration`.
+1. Select `Edit` then `Enable API integration`.
 1. For API Token, paste the SCIM token you [generated above](#step-3-generate-scim-bearer-token).
 1. Keep `Import Groups` checked.
 1. To verify the configuration, select Test API Credentials.

--- a/src/langsmith/user-management.mdx
+++ b/src/langsmith/user-management.mdx
@@ -269,6 +269,8 @@ Have a user with access sign in via the unique login URL from the **SSO Configur
 - SP-initiated SSO
 - Just-In-Time provisioning
 - Enforce SSO only
+- Import Users
+- Import Groups
 
 #### Configuration steps
 


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
* fix broken links
* remove incorrect SCIM setup steps (these were for without using OIN, but Okta requires using OIN)
* add missing supported features for Okta SCIM

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue: part of ent-100
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
