### PR TITLE
fix: correct links in quickstart guide of LangChain

### DIFF
--- a/build/oss/python/langchain/quickstart.mdx
+++ b/build/oss/python/langchain/quickstart.mdx
@@ -94,7 +94,7 @@ Let's walk through each step:
     </Step>
     <Step title="Create tools">
         [Tools](/oss/python/langchain/tools) let a model interact with external systems by calling functions you define.
-        Tools can depend on [runtime context](/oss/python/langchain/runtime) and also interact with [agent memory](/oss/python/langchain/memory).
+        Tools can depend on [runtime context](/oss/python/langchain/runtime) and also interact with [agent memory](/oss/python/langchain/short-term-memory).
 
         Notice below how the `get_user_location` tool uses runtime context:
 
@@ -120,7 +120,7 @@ Let's walk through each step:
 
         <Tip>
             Tools should be well-documented: their name, description, and argument names become part of the model's prompt.
-            We've defined them here as plain Python functions, but LangChain's [@tool](https://python.langchain.com/api_reference/core/tools/langchain_core.tools.base.tool.html#langchain_core.tools.convert.tool.html) decorator is often used to add extra metadata.
+            We've defined them here as plain Python functions, but LangChain's [@tool](oss/python/langchain/tools#basic-tool-definition) decorator is often used to add extra metadata.
         </Tip>
 
 
@@ -178,7 +178,7 @@ Let's walk through each step:
 
         <Info>
             In production, use a persistent checkpointer that saves to a database.
-            See [add and manage memory](/oss/python/python/langgraph/add-memory) for more details.
+            See [add and manage memory](oss/python/langchain/short-term-memory#in-production) for more details.
         </Info>
     </Step>
     <Step title="Create and run the agent">

--- a/build/oss/python/langchain/quickstart.mdx
+++ b/build/oss/python/langchain/quickstart.mdx
@@ -178,7 +178,7 @@ Let's walk through each step:
 
         <Info>
             In production, use a persistent checkpointer that saves to a database.
-            See [add and manage memory](oss/python/langchain/short-term-memory#in-production) for more details.
+            See [add and manage memory](/oss/python/langchain/short-term-memory#in-production) for more details.
         </Info>
     </Step>
     <Step title="Create and run the agent">

--- a/build/oss/python/langchain/quickstart.mdx
+++ b/build/oss/python/langchain/quickstart.mdx
@@ -120,7 +120,7 @@ Let's walk through each step:
 
         <Tip>
             Tools should be well-documented: their name, description, and argument names become part of the model's prompt.
-            We've defined them here as plain Python functions, but LangChain's [@tool](oss/python/langchain/tools#basic-tool-definition) decorator is often used to add extra metadata.
+            We've defined them here as plain Python functions, but LangChain's [@tool](/oss/python/langchain/tools#basic-tool-definition) decorator is often used to add extra metadata.
         </Tip>
 
 


### PR DESCRIPTION
## Overview
Fixed broken/incorrect links in the Quickstart guide to ensure readers are directed to the correct resources.

## Type of change

**Type:**  Fix typo/bug/link/formatting

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

