### PR TITLE
Change link in top nav

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -60,6 +60,10 @@
         "header": "Resources",
         "items": [
           {
+            "label": "Forum",
+            "href": "https://forum.langchain.com/"
+          },
+          {
             "label": "Changelog",
             "href": "https://changelog.langchain.com/"
           },
@@ -118,8 +122,8 @@
     ],
     "primary": {
       "type": "button",
-      "label": "Forum",
-      "href": "https://forum.langchain.com/"
+      "label": "Try LangSmith",
+      "href": "https://smith.langchain.com/"
     }
   },
   "navigation": {


### PR DESCRIPTION
## Overview
- Change link in top nav to point to LangSmith console


## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
