### PR TITLE
update otel docs

### DIFF
--- a/src/langsmith/trace-with-opentelemetry.mdx
+++ b/src/langsmith/trace-with-opentelemetry.mdx
@@ -274,6 +274,8 @@ When sending traces to LangSmith via OpenTelemetry, the following attributes are
 | `gen_ai.completion.{n}.content`         | `outputs.messages[n].content` | Content for the nth output message                            |
 | `gen_ai.completion.{n}.message.role`    | `outputs.messages[n].role`    | Alternative format for role                                   |
 | `gen_ai.completion.{n}.message.content` | `outputs.messages[n].content` | Alternative format for content                                |
+| `gen_ai.input.messages`                 | `inputs.messages`             | Array of input messages                                       |
+| `gen_ai.output.messages`                | `outputs.messages`            | Array of output messages                                      |
 | `gen_ai.tool.name`                      | `invocation_params.tool_name` | Tool name, also sets run type to "tool"                       |
 
 ### GenAI request parameters
@@ -301,6 +303,7 @@ When sending traces to LangSmith via OpenTelemetry, the following attributes are
 | `gen_ai.usage.total_tokens`      | `usage_metadata.total_tokens`  | Total number of tokens used               |
 | `gen_ai.usage.prompt_tokens`     | `usage_metadata.input_tokens`  | Number of input tokens used (deprecated)  |
 | `gen_ai.usage.completion_tokens` | `usage_metadata.output_tokens` | Number of output tokens used (deprecated) |
+| `gen_ai.usage.details.reasoning_tokens` | `usage_metadata.reasoning_tokens` | Number of reasoning tokens used |
 
 ### TraceLoop attributes
 


### PR DESCRIPTION
## Overview
Adds the following attributes to otel docs for most recent GenAI spec.
Inputs, Ouputs: "gen_ai.input.messages", "gen_ai.output.messages"
Reasoning Tokens: "gen_ai.usage.details.reasoning_tokens"
## Type of change
Update existing docs

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
