### PR TITLE
reflect new imports from langchain.tools namespace

### DIFF
--- a/src/oss/langchain/multi-agent.mdx
+++ b/src/oss/langchain/multi-agent.mdx
@@ -153,7 +153,7 @@ There are two main levers to control the input that the main agent passes to a s
 ```python
 from typing import Annotated
 from langchain.agents import AgentState
-from langchain.agents.tool_node import InjectedState
+from langchain.tools import InjectedState
 
 @tool(
     name="subagent1_name",

--- a/src/oss/langchain/short-term-memory.mdx
+++ b/src/oss/langchain/short-term-memory.mdx
@@ -517,7 +517,7 @@ This annotation hides the state from the tool signature (so the model doesn't se
 ```python
 from typing import Annotated
 from langchain.agents import create_agent, AgentState
-from langchain.agents.tool_node import InjectedState
+from langchain.tools import InjectedState
 
 class CustomState(AgentState):
     user_id: str
@@ -599,7 +599,7 @@ from langchain_core.tools import InjectedToolCallId
 from langchain_core.runnables import RunnableConfig
 from langchain_core.messages import ToolMessage
 from langchain.agents import create_agent, AgentState
-from langchain.agents.tool_node import InjectedState
+from langchain.tools import InjectedState
 from langgraph.runtime import get_runtime
 from langgraph.types import Command
 from pydantic import BaseModel

--- a/src/oss/langchain/tools.mdx
+++ b/src/oss/langchain/tools.mdx
@@ -185,7 +185,7 @@ ToolNode is a prebuilt LangGraph component that handles tool calls within an age
 
 :::python
 ```python wrap
-from langchain.agents import ToolNode
+from langchain.tools import ToolNode
 
 tool_node = ToolNode(
     tools=[...],              # List of tools or callables
@@ -332,7 +332,8 @@ Pass a configured `ToolNode` directly to `create_agent()`:
 
 ```python
 from langchain_openai import ChatOpenAI
-from langchain.agents import ToolNode, create_agent
+from langchain.agents import create_agent
+from langchain.tools import ToolNode
 import random
 
 @tool

--- a/src/oss/python/releases/langchain-v1.mdx
+++ b/src/oss/python/releases/langchain-v1.mdx
@@ -212,7 +212,8 @@ agent = create_agent("openai:gpt-4o-mini", tools=[some_tool])
 from langgraph.prebuilt import create_react_agent, ToolNode, AgentState
 
 # After
-from langchain.agents import create_agent, ToolNode, AgentState
+from langchain.agents import create_agent, AgentState
+from langchain.tools import ToolNode
 ```
 
 ## <Icon icon="bullhorn" /> Reporting issues


### PR DESCRIPTION
## Pull Request Overview

This pull request updates import statements across documentation files to reflect changes in the langchain.tools namespace. Tool-related classes like `ToolNode` and `InjectedState` are now imported from `langchain.tools` instead of `langchain.agents`.

### Key changes:
- Updated import paths for `ToolNode` from `langchain.agents` to `langchain.tools`
- Updated import paths for `InjectedState` from `langchain.agents.tool_node` to `langchain.tools`
- Split combined import statements to separate lines for clarity

### Reviewed Changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated no comments.

| File | Description |
| ---- | ----------- |
| src/oss/python/releases/langchain-v1.mdx | Updated example code to import `ToolNode` from the new namespace |
| src/oss/langchain/tools.mdx | Updated two code examples to use the new import path for `ToolNode` |
| src/oss/langchain/short-term-memory.mdx | Updated two instances of `InjectedState` import from old to new namespace |
| src/oss/langchain/multi-agent.mdx | Updated `InjectedState` import to use the new namespace |



