### PR TITLE
fix(langchain): update python reference to reflected changes in namespace

### DIFF
--- a/reference/python/docs/langchain/documents.md
+++ b/reference/python/docs/langchain/documents.md
@@ -1,8 +1,0 @@
-# Documents
-
-::: langchain_core.documents.Document
-    options:
-        members:
-        - id
-        - page_content
-        - metadata

--- a/reference/python/docs/langchain/storage.md
+++ b/reference/python/docs/langchain/storage.md
@@ -1,3 +1,0 @@
-# Storage
-
-::: langchain_classic.storage


### PR DESCRIPTION
Delete stuff no longer exposed in langchain v1