### PR TITLE
chore(langchain): clean up mcp

### DIFF
--- a/src/oss/langchain/mcp.mdx
+++ b/src/oss/langchain/mcp.mdx
@@ -13,8 +13,6 @@ import AlphaCallout from '/snippets/alpha-lc-callout.mdx';
 [Model Context Protocol (MCP)](https://modelcontextprotocol.io/introduction) is an open protocol that standardizes how applications provide tools and context to LLMs. LangChain agents can use tools defined on MCP servers using the [`langchain-mcp-adapters`](https://github.com/langchain-ai/langchainjs/tree/main/libs/langchain-mcp-adapters/adapters) library.
 :::
 
-![MCP](/oss/images/mcp.png)
-
 ## Install
 
 :::python
@@ -392,37 +390,6 @@ const PORT = process.env.PORT || 8000;
 app.listen(PORT, () => {
     console.log(`Weather MCP server running on port ${PORT}`);
 });
-```
-:::
-
-:::python
-## Expose LangChain tools via MCP
-
-You can also expose existing LangChain tools through an MCP server using the `to_fastmcp` function. This allows you to make your LangChain tools available to any MCP client.
-
-```python Make LangChain tools available via MCP icon="tool"
-from langchain.tools import tool
-from langchain_mcp_adapters.tools import to_fastmcp
-from mcp.server.fastmcp import FastMCP
-
-
-@tool
-def add(a: int, b: int) -> int:
-    """Add two numbers"""
-    return a + b
-
-@tool
-def get_user_info(user_id: str) -> str:
-    """Get information about a user"""
-    return f"User {user_id} is active"
-
-
-# Convert LangChain tools to FastMCP
-fastmcp_tools = [to_fastmcp(tool) for tool in (add, get_user_info)]
-
-# Create server using converted tools
-mcp = FastMCP("LangChain Tools", tools=fastmcp_tools)
-mcp.run(transport="stdio")
 ```
 :::
 


### PR DESCRIPTION
Clean up MCP page:

1. Remove conceptual diagram -- it's too big visually and doesn't help enough
2. Remove the fastmcp server integration since there are now two difference fastmcps (the well known github package and the built-in implementation into the official mcp sdk)