### PR TITLE
imap retriever integration package

### DIFF
--- a/src/oss/python/integrations/retrievers/imap.mdx
+++ b/src/oss/python/integrations/retrievers/imap.mdx
@@ -4,7 +4,7 @@ title: Imap
 
 # ImapRetriever
 
-This guide will help you get started with the IMAP [retriever](/docs/concepts/retrievers). The `ImapRetriever` enables search and retrieval of emails from IMAP servers as LangChain `Document` objects.
+This guide will help you get started with the IMAP [retriever](/oss/integrations/retrievers). The `ImapRetriever` enables search and retrieval of emails from IMAP servers as LangChain `Document` objects.
 
 ## Integration details
 


### PR DESCRIPTION
## Overview

Added comprehensive documentation for the `ImapRetriever` integration, enabling users to search and retrieve emails from IMAP servers as LangChain Document objects.

## Type of change

**Type:** New documentation page

## Related issues/PRs

- GitHub issue:
- Feature PR:

## Checklist

- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- [ ] I have gotten approval from the relevant reviewers
- [ ] (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes

This documentation was created based on:
- The `langchain-imap` package README
- The retrievers notebook example from the package repository

The documentation includes:
- Installation instructions (including optional docling extra for full document processing)
- Configuration examples for both production IMAP servers (Gmail) and test environments (GreenMail)
- Basic usage examples with various IMAP search query patterns
- Attachment handling modes explanation
- Complete chain integration example showing how to use the retriever with an LLM for question answering over emails
- Links to the GitHub repository and additional resources

The code examples are directly adapted from the package documentation notebook.
