### PR TITLE
fix(docs): replace state_modifier with system_prompt in create_agent

### DIFF
--- a/src/langsmith/run-backtests-new-agent.mdx
+++ b/src/langsmith/run-backtests-new-agent.mdx
@@ -91,7 +91,7 @@ rate_limiter = InMemoryRateLimiter(requests_per_second=0.08)
 # tools = [DuckDuckGoSearchRun(rate_limiter=rate_limiter)]
 tools = [TavilySearchResults(max_results=5, rate_limiter=rate_limiter)]
 
-agent = create_agent(gpt_3_5_turbo, tools=tools, prompt=instructions)
+agent = create_agent(gpt_3_5_turbo, tools=tools, system_prompt=instructions)
 ```
 
 ### Simulate production data

--- a/src/langsmith/test-react-agent-pytest.mdx
+++ b/src/langsmith/test-react-agent-pytest.mdx
@@ -196,7 +196,7 @@ agent = create_agent(
     model="openai:gpt-4o-mini",
     tools=[code_tool, search_tool, polygon_aggregates],
     response_format=AgentOutputFormat,
-    prompt="You are a financial expert. Respond to the users query accurately",
+    system_prompt="You are a financial expert. Respond to the users query accurately",
 )
 ```
 
@@ -767,7 +767,7 @@ Remember to also add the config files for [Vitest](#config-files-for-vitestjest)
     model="openai:gpt-4o-mini",
     tools=[code_tool, search_tool, polygon_aggregates],
     response_format=AgentOutputFormat,
-    prompt="You are a financial expert. Respond to the users query accurately",
+    system_prompt="You are a financial expert. Respond to the users query accurately",
   )
   ```
 


### PR DESCRIPTION
create_react_agent had a state_modifier property (which is now system_prompt) but when we did a big find-and-replace with create_agent, this property was not updated