### PR TITLE
fix: pepy download upstream rate limited

### DIFF
--- a/reference/python/docs/langchain/rate_limiters.md
+++ b/reference/python/docs/langchain/rate_limiters.md
@@ -1,3 +1,0 @@
-# Rate Limiters
-
-::: langchain.rate_limiters

--- a/reference/python/mkdocs.yml
+++ b/reference/python/mkdocs.yml
@@ -165,7 +165,15 @@ plugins:
   - tags
 
   # https://squidfunk.github.io/mkdocs-material/plugins/privacy/#configuration
-  - privacy
+  - privacy:
+      assets_exclude:
+        # https://squidfunk.github.io/mkdocs-material/plugins/privacy/#config.assets_exclude
+        # Disable downloading of external assets for specific origins
+        - img.shields.io/*
+      links_attr_map:
+        # https://squidfunk.github.io/mkdocs-material/plugins/privacy/#config.links_attr_map
+        # Open all external links in a new tab
+        target: _blank
 
   # https://squidfunk.github.io/mkdocs-material/setup/adding-a-git-repository/#document-authors
   # TODO: revisit if we want this later on


### PR DESCRIPTION
#950

also make links open in new tab