### PR TITLE
docs: Fixing Azure AI Env variable names 

### DIFF
--- a/src/oss/python/integrations/chat/azure_ai.mdx
+++ b/src/oss/python/integrations/chat/azure_ai.mdx
@@ -26,19 +26,19 @@ To access AzureAIChatCompletionsModel models, you'll need to create an [Azure ac
 
 ### Credentials
 
-Head to the [Azure docs](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/develop/sdk-overview?tabs=sync&pivots=programming-language-python) to see how to create your deployment and generate an API key. Once your model is deployed, you click the 'get endpoint' button in AI Foundry. This will show you your endpoint and api key. Once you've done this, set the AZURE_INFERENCE_CREDENTIAL and AZURE_INFERENCE_ENDPOINT environment variables:
+Head to the [Azure docs](https://learn.microsoft.com/en-us/azure/ai-studio/how-to/develop/sdk-overview?tabs=sync&pivots=programming-language-python) to see how to create your deployment and generate an API key. Once your model is deployed, you click the 'get endpoint' button in AI Foundry. This will show you your endpoint and api key. Once you've done this, set the AZURE_AI_CREDENTIAL and AZURE_AI_ENDPOINT environment variables:
 
 ```python
 import getpass
 import os
 
-if not os.getenv("AZURE_INFERENCE_CREDENTIAL"):
-    os.environ["AZURE_INFERENCE_CREDENTIAL"] = getpass.getpass(
+if not os.getenv("AZURE_AI_CREDENTIAL"):
+    os.environ["AZURE_AI_CREDENTIAL"] = getpass.getpass(
         "Enter your AzureAIChatCompletionsModel API key: "
     )
 
-if not os.getenv("AZURE_INFERENCE_ENDPOINT"):
-    os.environ["AZURE_INFERENCE_ENDPOINT"] = getpass.getpass(
+if not os.getenv("AZURE_AI_ENDPOINT"):
+    os.environ["AZURE_AI_ENDPOINT"] = getpass.getpass(
         "Enter your model endpoint: "
     )
 ```

--- a/src/oss/python/integrations/providers/azure_ai.mdx
+++ b/src/oss/python/integrations/providers/azure_ai.mdx
@@ -28,8 +28,8 @@ uv add langchain-azure-ai
 Configure your API key and Endpoint.
 
 ```bash
-export AZURE_INFERENCE_CREDENTIAL=your-api-key
-export AZURE_INFERENCE_ENDPOINT=your-endpoint
+export AZURE_AI_CREDENTIAL=your-api-key
+export AZURE_AI_ENDPOINT=your-endpoint
 ```
 
 ```python
@@ -60,8 +60,8 @@ uv add langchain-azure-ai
 Configure your API key and Endpoint.
 
 ```bash
-export AZURE_INFERENCE_CREDENTIAL=your-api-key
-export AZURE_INFERENCE_ENDPOINT=your-endpoint
+export AZURE_AI_CREDENTIAL=your-api-key
+export AZURE_AI_ENDPOINT=your-endpoint
 ```
 
 ```python

--- a/src/oss/python/integrations/providers/microsoft.mdx
+++ b/src/oss/python/integrations/providers/microsoft.mdx
@@ -62,8 +62,8 @@ from langchain_openai import AzureChatOpenAI
 Configure your API key and Endpoint.
 
 ```bash
-export AZURE_INFERENCE_CREDENTIAL=your-api-key
-export AZURE_INFERENCE_ENDPOINT=your-endpoint
+export AZURE_AI_CREDENTIAL=your-api-key
+export AZURE_AI_ENDPOINT=your-endpoint
 ```
 
 ```python
@@ -128,8 +128,8 @@ from langchain_openai import AzureOpenAIEmbeddings
 Configure your API key and Endpoint.
 
 ```bash
-export AZURE_INFERENCE_CREDENTIAL=your-api-key
-export AZURE_INFERENCE_ENDPOINT=your-endpoint
+export AZURE_AI_CREDENTIAL=your-api-key
+export AZURE_AI_ENDPOINT=your-endpoint
 ```
 
 ```python


### PR DESCRIPTION
## Overview
Updated the Azure AI integration documentation to use the correct environment variable names: `AZURE_AI_CREDENTIAL` and `AZURE_AI_ENDPOINT` (previously `AZURE_INFERENCE_CREDENTIAL` and `AZURE_INFERENCE_ENDPOINT`). This ensures users set the proper variables when initializing chat models, especially with `init_chat_model`.

## Type of change
Type: Update existing documentation

## Related issues/PRs
GitHub issue: NA
Feature PR: NA

## Checklist

 I have read the contributing guidelines
 I have tested my changes locally using docs dev
 All code examples have been tested and work correctly
 I have used root relative paths for internal links
 I have updated navigation in [docs.json](https://fictional-guide-955rj9gxr9qfjv5.github.dev/) if needed
I have gotten approval from the relevant reviewers
(Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://fictional-guide-955rj9gxr9qfjv5.github.dev/)

## Additional notes
This change aligns the documentation with the latest Azure AI SDK requirements and prevents user confusion when setting up environment variables for chat model initialization.
