### PR TITLE
Improve double texting overview for confusing support text

### DIFF
--- a/src/langsmith/double-texting.mdx
+++ b/src/langsmith/double-texting.mdx
@@ -13,35 +13,34 @@ For instance, a user may send one message and before the graph has finished runn
 More generally, users may invoke the graph a second time before the first run has finished.
 We call this "double texting".
 
-Currently, LangGraph only addresses this as part of [LangSmith](/langsmith/home), not in the open source.
-The reason for this is that in order to handle this we need to know how the graph is deployed, and since LangSmith deals with deployment the logic needs to live there.
-If you do not want to use LangSmith, we describe the options we have implemented in detail below.
+<Note>
+Double texting is a feature of LangSmith Deployment. It is not available in the [LangGraph open source framework](/oss/langgraph/overview).
+</Note>
 
 ![Double-text strategies across first vs. second run: Reject keeps only the first; Enqueue runs the second afterward; Interrupt halts the first to run the second; Rollback reverts the first and reruns with the second.](/langsmith/images/double-texting.png)
 
 ## Reject
 
-This is the simplest option, this just rejects any follow-up runs and does not allow double texting.
-See the [how-to guide](/langsmith/reject-concurrent) for configuring the reject double text option.
+This option rejects any additional incoming runs while a current run is in progress and prevents concurrent execution or double texting.
+
+For configuring the reject double text option, refer to the [how-to guide](/langsmith/reject-concurrent).
 
 ## Enqueue
 
-This is a relatively simple option which continues the first run until it completes the whole run, then sends the new input as a separate run.
-See the [how-to guide](/langsmith/enqueue-concurrent) for configuring the enqueue double text option.
+This option allows the current run to finish before processing any new input. Incoming requests are queued and executed sequentially once prior runs complete.
+
+For configuring the enqueue double text option, refer to the [how-to guide](/langsmith/enqueue-concurrent).
 
 ## Interrupt
 
-This option interrupts the current execution but saves all the work done up until that point.
-It then inserts the user input and continues from there.
+This option halts the current execution and preserves the progress made up to the interruption point. The new user input is then inserted, and execution continues from that state.
 
-If you enable this option, your graph should be able to handle weird edge cases that may arise.
-For example, you could have called a tool but not yet gotten back a result from running that tool.
-You may need to remove that tool call in order to not have a dangling tool call.
+When using this option, your graph must account for potential edge cases. For example, a tool call may have been initiated but not yet completed at the time of interruption. In these cases, handling or removing partial tool calls may be necessary to avoid unresolved operations.
 
-See the [how-to guide](/langsmith/interrupt-concurrent) for configuring the interrupt double text option.
+For configuring the interrupt double text option, refer to the [how-to guide](/langsmith/interrupt-concurrent).
 
 ## Rollback
 
-This option interrupts the current execution AND rolls back all work done up until that point, including the original run input. It then sends the new user input in, basically as if it was the original input.
+This option halts the current execution and reverts all progress—including the initial run input—before processing the new user input. The new input is treated as a fresh run, starting from the initial state.
 
-See the [how-to guide](/langsmith/rollback-concurrent) for configuring the rollback double text option.
+For configuring the rollback double text option, refer to the [how-to guide](/langsmith/rollback-concurrent).


### PR DESCRIPTION
On the double texting overview page, there was a sentence about it not being included in LG OSS, however the phrasing made it seem like users should use the described options in order to get around that. This PR corrects that and improves some of the content on the page generally.