### PR TITLE
fix(docs): added missing ltree in self-host external postgres guide

### DIFF
--- a/src/langsmith/self-host-external-postgres.mdx
+++ b/src/langsmith/self-host-external-postgres.mdx
@@ -17,7 +17,7 @@ LangSmith uses a PostgreSQL database as the primary data store for transactional
 
 * A user with admin access to the PostgreSQL database. This user will be used to create the necessary tables, indexes, and schemas.
 
-* This user will also need to have the ability to create extensions in the database. We use/will try to install the btree\_gin, btree\_gist, pgcrypto, citext, and pg\_trgm extensions.
+* This user will also need to have the ability to create extensions in the database. We use/will try to install the btree\_gin, btree\_gist, pgcrypto, citext, ltree, and pg\_trgm extensions.
 
 * If using a schema other than public, ensure that you do not have any other schemas with the extensions enabled, or you must include that in your search path.
 


### PR DESCRIPTION
Added missing 'ltree' extension to the list of extensions required for the self-hosted PostgreSQL setup.