### PR TITLE
Edits to make API ref titles clearer + links

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -798,8 +798,13 @@
                   "langsmith/langgraph-python-sdk",
                   "langsmith/langgraph-js-ts-sdk",
                   "langsmith/smith-api-ref",
-                  "langsmith/server-api-ref",
-                  "langsmith/api-ref-control-plane"
+                  {
+                    "group": "API reference for LangSmith Deployment",
+                    "pages": [
+                      "langsmith/server-api-ref",
+                      "langsmith/api-ref-control-plane"
+                    ]
+                  }
                 ]
               },
               {

--- a/src/langsmith/api-ref-control-plane.mdx
+++ b/src/langsmith/api-ref-control-plane.mdx
@@ -1,11 +1,13 @@
 ---
-title: Control Plane API reference
-sidebarTitle: Control Plane API for LangSmith Deployment
+title: Control plane API reference for LangSmith Deployment
+sidebarTitle: Control plane API
 ---
 
-The control plane API is part of [LangSmith Deployment](/langsmith/deployments). It lets you programmatically create, manage, and automate your [LangGraph Server](/langsmith/langgraph-server) deployments—for example, as part of a custom CI/CD workflow.
+The control plane API is part of [LangSmith Deployment](/langsmith/deployments). With the control plane API, you can programmatically create, manage, and automate your [LangGraph Server](/langsmith/langgraph-server) deployments—for example, as part of a custom CI/CD workflow.
 
-Click <a href="https://api.host.langchain.com/docs" target="_blank">here</a> to view the API reference.
+<Card title="API Reference" href="https://api.host.langchain.com/docs" icon="book">
+  View the full Control Plane API reference documentation
+</Card>
 
 ## Host
 

--- a/src/langsmith/langgraph-server.mdx
+++ b/src/langsmith/langgraph-server.mdx
@@ -13,11 +13,11 @@ For detailed information on the API endpoints and data models, refer to the [API
 
 To use the `Enterprise` version of the LangGraph Server, you must acquire a license key that you will need to specify when running the Docker image. To acquire a license key, [contact our sales team](https://www.langchain.com/contact-sales).
 
-You can run the `Enterprise` version of the LangGraph Server on the following deployment options:
+You can run the `Enterprise` version of the LangGraph Server on the following LangSmith [hosting](/langsmith/hosting) options:
 
-- Cloud
-- Hybrid
-- Self-hosted
+- [Cloud](/langsmith/cloud)
+- [Hybrid](/langsmith/hybrid)
+- [Self-hosted](/langsmith/self-hosted)
 
 ## Application structure
 

--- a/src/langsmith/server-api-ref.mdx
+++ b/src/langsmith/server-api-ref.mdx
@@ -1,11 +1,13 @@
 ---
-title: LangGraph Server API reference
+title: LangGraph Server API reference for LangSmith Deployment
 sidebarTitle: LangGraph Server API
 ---
 
-The LangGraph Server API reference is available within each deployment at the `/docs` endpoint (e.g. `http://localhost:8124/docs`).
+The LangGraph Server API reference is available within each [deployment](/langsmith/deployments) at the `/docs` endpoint (e.g. `http://localhost:8124/docs`).
 
-View the [API reference](https://langchain-ai.github.io/langgraph/cloud/reference/api/api_ref.html).
+<Card title="API Reference" href="https://langchain-ai.github.io/langgraph/cloud/reference/api/api_ref.html" icon="book">
+  View the full LangGraph Server API reference documentation
+</Card>
 
 ## Authentication
 


### PR DESCRIPTION
## Preview 
https://langchain-5e9cc07a-preview-langgr-1760976599-114e688.mintlify.app/langsmith/api-ref-control-plane