### PR TITLE
fix(docs): update claude code add mcp command with valid server name

### DIFF
--- a/src/use-these-docs.mdx
+++ b/src/use-these-docs.mdx
@@ -51,7 +51,7 @@ Our MCP server is available at: `https://docs.langchain.com/mcp`
 If you're using Claude Code, run this command in your terminal:
 
 ```bash
-claude mcp add --transport http "Docs by LangChain" https://docs.langchain.com/mcp
+claude mcp add --transport http "docs-langchain" https://docs.langchain.com/mcp
 ```
 
 #### Connect with Claude Desktop


### PR DESCRIPTION
## Description

This PR fixes the Claude Code add MCP server command in the documentation. The server name "Docs by LangChain" contained spaces which are invalid according to Claude Code's naming requirements (only letters, numbers, hyphens, and underscores are allowed).

<img width="1019" height="60" alt="image" src="https://github.com/user-attachments/assets/e83260f4-a397-4df9-8013-6dd42712cbff" />


## Changes

- Updated MCP server name from `"Docs by LangChain"` to `"docs-langchain"` in the Claude Code installation command

<img width="991" height="43" alt="image" src="https://github.com/user-attachments/assets/24dbd3b9-39da-4783-b3d1-9e1e52c2888a" />

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## Testing

- Verified the command syntax matches Claude Code's naming requirements
- No code changes required - documentation only