### PR TITLE
fix(docs): improve grammar and clarity

### DIFF
--- a/src/oss/langgraph/overview.mdx
+++ b/src/oss/langgraph/overview.mdx
@@ -27,7 +27,7 @@ Trusted by companies shaping the future of agents-- including Klarna, Replit, El
 
 LangGraph is very low-level, and focused entirely on agent **orchestration**. Before using LangGraph, we recommend you familiarize yourself with some of the components used to build agents, starting with [models](/oss/langchain/models) and [tools](/oss/langchain/tools).
 
-We will commonly use [LangChain](/oss/langchain/overview) components throughout the documentation to integrate models and tools, but you don't need to use LangChain to use LangGraph. If you are just getting start with agents or want a higher level abstraction, we recommend you use LangChain's [agents](/oss/langchain/agents) that provide pre-built architectures for common LLM and tool calling loops.
+We will commonly use [LangChain](/oss/langchain/overview) components throughout the documentation to integrate models and tools, but you don't need to use LangChain to use LangGraph. If you are just getting started with agents or want a higher-level abstraction, we recommend you use LangChain's [agents](/oss/langchain/agents) that provide pre-built architectures for common LLM and tool-calling loops.
 
 LangGraph is focused on the underlying capabilities important for agent orchestration: durable execution, streaming, human-in-the-loop, and more.
 


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

Improve grammar and clarity of the `oss/python/langgraph/overview` document:
- ✅ “getting start” → “getting started”
- ✅ “higher level abstraction” → “higher-level abstraction” (compound adjective needs a hyphen)
- ✅ Added hyphen in “tool-calling” for consistency and clarity.

## Type of change

**Type:** [Fix typo]

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x ] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
