### PR TITLE
add callout around OpenAI requiring a filename for PDFs

### DIFF
--- a/src/oss/langchain/messages.mdx
+++ b/src/oss/langchain/messages.mdx
@@ -847,7 +847,15 @@ forms, such as text, audio, images, and video. LangChain includes standard types
 for these data that can be used across providers.
 
 [Chat models](/oss/langchain/models) can accept multimodal data as input and generate
-it as output. Below we show short examples of input messages featuring multimodal data:
+it as output. Below we show short examples of input messages featuring multimodal data.
+
+<Note>
+Extra keys can be included top-level in the content block or nested in `"extras": {"key": value}`.
+
+[OpenAI](/oss/integrations/chat/openai#pdfs) and [AWS Bedrock Converse](/oss/integrations/chat/bedrock),
+for example, require a filename for PDFs. See the [provider page](/oss/integrations/providers/overview)
+for your chosen model for specifics.
+</Note>
 
 :::python
 <CodeGroup>


### PR DESCRIPTION
<img width="744" height="646" alt="Screenshot 2025-10-21 at 3 29 09 PM" src="https://github.com/user-attachments/assets/8c5fe77b-c1ef-4692-b797-ba19248e94e2" />
