### PR TITLE
integrations cleanup

### DIFF
--- a/src/oss/javascript/integrations/chat/anthropic.mdx
+++ b/src/oss/javascript/integrations/chat/anthropic.mdx
@@ -45,16 +45,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain `ChatAnthropic` integration lives in the `@langchain/anthropic` package:
 
-```{=mdx}
-
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/anthropic @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/anthropic @langchain/core
 ```
+```bash yarn
+yarn add @langchain/anthropic @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/anthropic @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 
@@ -301,15 +302,9 @@ AIMessage {
 
 ## Prompt caching
 
-```{=mdx}
-
 <Warning>
-**Compatibility**
-
-This feature is currently in beta.
+**Compatibility**: This feature is currently in beta.
 </Warning>
-
-```
 
 Anthropic supports [caching parts of your prompt](https://docs.claude.com/en/docs/build-with-claude/prompt-caching) in order to reduce costs for use-cases that require long context. You can cache tools and both entire messages and individual blocks.
 

--- a/src/oss/javascript/integrations/chat/arcjet.mdx
+++ b/src/oss/javascript/integrations/chat/arcjet.mdx
@@ -20,28 +20,33 @@ The Arcjet Redact object is not a chat model itself, instead it wraps an LLM. It
 
 Install the Arcjet Redaction Library:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @arcjet/redact
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @arcjet/redact
 ```
+```bash yarn
+yarn add @arcjet/redact
+```
+```bash pnpm
+pnpm add @arcjet/redact
+```
+</CodeGroup>
 
 And install LangChain Community:
 
-```{=mdx}
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
+```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 And now you're ready to start protecting your chat model calls with Arcjet Redaction!
-
-```
 
 ## Usage
 

--- a/src/oss/javascript/integrations/chat/azure.mdx
+++ b/src/oss/javascript/integrations/chat/azure.mdx
@@ -56,16 +56,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain AzureChatOpenAI integration lives in the `@langchain/openai` package:
 
-```{=mdx}
-
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/openai @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/openai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/openai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/openai @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 
@@ -206,13 +207,17 @@ If you are using the deprecated Azure OpenAI SDK with the `@langchain/azure-open
 
 1. Install the new `@langchain/openai` package and remove the previous `@langchain/azure-openai` package:
 
-```{=mdx}
-
-<Npm2Yarn>
-  @langchain/openai
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/openai
 ```
+```bash yarn
+yarn add @langchain/openai
+```
+```bash pnpm
+pnpm add @langchain/openai
+```
+</CodeGroup>
 
 ```bash
 npm uninstall @langchain/azure-openai

--- a/src/oss/javascript/integrations/chat/bedrock.mdx
+++ b/src/oss/javascript/integrations/chat/bedrock.mdx
@@ -6,11 +6,9 @@ title: BedrockChat
 
 This will help you getting started with Amazon Bedrock [chat models](/oss/langchain/models). For detailed documentation of all `BedrockChat` features and configurations head to the [API reference](https://api.js.langchain.com/classes/langchain_community_chat_models_bedrock.BedrockChat.html).
 
-```{=mdx}
 <Tip>
 The newer [`ChatBedrockConverse` chat model is now available via the dedicated `@langchain/aws`](/oss/integrations/chat/bedrock_converse) integration package. Use [tool calling](/oss/langchain/tools) with more models with this package.
 </Tip>
-```
 
 ## Overview
 
@@ -47,25 +45,31 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain `BedrockChat` integration lives in the `@langchain/community` package. You'll also need to install several official AWS packages as peer dependencies:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+</CodeGroup>
 
 You can also use BedrockChat in web environments such as Edge functions or Cloudflare Workers by omitting the @aws-sdk/credential-provider-node dependency and using the web entrypoint:
 
-```{=mdx}
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core @aws-crypto/sha256-js @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core @aws-crypto/sha256-js @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core @aws-crypto/sha256-js @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core @aws-crypto/sha256-js @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/bedrock_converse.mdx
+++ b/src/oss/javascript/integrations/chat/bedrock_converse.mdx
@@ -41,15 +41,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain `ChatBedrockConverse` integration lives in the `@langchain/aws` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/aws @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/aws @langchain/core
 ```
+```bash yarn
+yarn add @langchain/aws @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/aws @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/cerebras.mdx
+++ b/src/oss/javascript/integrations/chat/cerebras.mdx
@@ -53,16 +53,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain ChatCerebras integration lives in the `@langchain/cerebras` package:
 
-```{=mdx}
-
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/cerebras @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/cerebras @langchain/core
 ```
+```bash yarn
+yarn add @langchain/cerebras @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/cerebras @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/cloudflare_workersai.mdx
+++ b/src/oss/javascript/integrations/chat/cloudflare_workersai.mdx
@@ -36,15 +36,17 @@ Passing a binding within a Cloudflare Worker is not yet supported.
 
 The LangChain ChatCloudflareWorkersAI integration lives in the `@langchain/cloudflare` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/cloudflare @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/cloudflare @langchain/core
 ```
+```bash yarn
+yarn add @langchain/cloudflare @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/cloudflare @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/cohere.mdx
+++ b/src/oss/javascript/integrations/chat/cohere.mdx
@@ -48,16 +48,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain ChatCohere integration lives in the `@langchain/cohere` package:
 
-```{=mdx}
-
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/cohere @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/cohere @langchain/core
 ```
+```bash yarn
+yarn add @langchain/cohere @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/cohere @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/deepseek.mdx
+++ b/src/oss/javascript/integrations/chat/deepseek.mdx
@@ -47,15 +47,18 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain ChatDeepSeek integration lives in the `@langchain/deepseek` package:
 
+<CodeGroup>
+```bash npm
+npm install @langchain/deepseek @langchain/core
 ```
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/deepseek @langchain/core
-</Npm2Yarn>
-
+```bash yarn
+yarn add @langchain/deepseek @langchain/core
 ```
+```bash pnpm
+pnpm add @langchain/deepseek @langchain/core
+```
+</CodeGroup>
+
 ## Instantiation
 
 Now we can instantiate our model object and generate chat completions:

--- a/src/oss/javascript/integrations/chat/fireworks.mdx
+++ b/src/oss/javascript/integrations/chat/fireworks.mdx
@@ -45,16 +45,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain `ChatFireworks` integration lives in the `@langchain/community` package:
 
-```{=mdx}
-
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/google_generative_ai.mdx
+++ b/src/oss/javascript/integrations/chat/google_generative_ai.mdx
@@ -28,16 +28,10 @@ You can access Google's `gemini` and `gemini-vision` models, as well as other
 generative models in LangChain through `ChatGoogleGenerativeAI` class in the
 `@langchain/google-genai` integration package.
 
-```{=mdx}
 
 <Tip>
-**You can also access Google's `gemini` family of models via the LangChain VertexAI and VertexAI-web integrations.**
-
-
-Click [here](/oss/integrations/chat/google_vertex_ai) to read the docs.
+You can also access Google's `gemini` family of models via the LangChain VertexAI and VertexAI-web integrations. Click [here](/oss/integrations/chat/google_vertex_ai) to read the docs.
 </Tip>
-
-```
 
 ### Credentials
 
@@ -60,15 +54,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain `ChatGoogleGenerativeAI` integration lives in the `@langchain/google-genai` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/google-genai @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/google-genai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/google-genai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/google-genai @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/google_vertex_ai.mdx
+++ b/src/oss/javascript/integrations/chat/google_vertex_ai.mdx
@@ -65,21 +65,31 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain `ChatVertexAI` integration lives in the `@langchain/google-vertexai` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/google-vertexai @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/google-vertexai @langchain/core
+```
+```bash yarn
+yarn add @langchain/google-vertexai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/google-vertexai @langchain/core
+```
+</CodeGroup>
 
 Or if using in a web environment like a [Vercel Edge function](https://vercel.com/blog/edge-functions-generally-available):
 
-<Npm2Yarn>
-  @langchain/google-vertexai-web @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/google-vertexai-web @langchain/core
 ```
+```bash yarn
+yarn add @langchain/google-vertexai-web @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/google-vertexai-web @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/groq.mdx
+++ b/src/oss/javascript/integrations/chat/groq.mdx
@@ -46,16 +46,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain ChatGroq integration lives in the `@langchain/groq` package:
 
-```{=mdx}
-
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/groq @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/groq @langchain/core
 ```
+```bash yarn
+yarn add @langchain/groq @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/groq @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/ibm.mdx
+++ b/src/oss/javascript/integrations/chat/ibm.mdx
@@ -111,15 +111,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain IBM watsonx.ai integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/mistral.mdx
+++ b/src/oss/javascript/integrations/chat/mistral.mdx
@@ -45,15 +45,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain ChatMistralAI integration lives in the `@langchain/mistralai` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-@langchain/mistralai @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/mistralai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/mistralai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/mistralai @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/novita.mdx
+++ b/src/oss/javascript/integrations/chat/novita.mdx
@@ -32,14 +32,17 @@ export NOVITA_API_KEY="your-api-key"
 
 The LangChain Novita integration lives in the `@langchain-community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/ollama.mdx
+++ b/src/oss/javascript/integrations/chat/ollama.mdx
@@ -45,15 +45,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain ChatOllama integration lives in the `@langchain/ollama` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/ollama @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/ollama @langchain/core
 ```
+```bash yarn
+yarn add @langchain/ollama @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/ollama @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/openai.mdx
+++ b/src/oss/javascript/integrations/chat/openai.mdx
@@ -45,16 +45,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain @[`ChatOpenAI`] integration lives in the `@langchain/openai` package:
 
-```{=mdx}
-
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/openai @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/openai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/openai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/openai @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 
@@ -752,15 +753,11 @@ const response = await llmWithImageGeneration.invoke(
 
 ### Reasoning models
 
-```{=mdx}
+
 <Warning>
-**Compatibility**
-
-
-The below points apply to `@langchain/openai>=0.4.0`.
-
+**Compatibility**: The below points apply to `@langchain/openai>=0.4.0`.
 </Warning>
-```
+
 
 When using reasoning models like `o1`, the default method for `withStructuredOutput` is OpenAI's built-in method for structured output (equivalent to passing `method: "jsonSchema"` as an option into `withStructuredOutput`). JSON schema mostly works the same as other models, but with one important caveat: when defining schema, `z.optional()` is not respected, and you should instead use `z.nullable()`.
 

--- a/src/oss/javascript/integrations/chat/perplexity.mdx
+++ b/src/oss/javascript/integrations/chat/perplexity.mdx
@@ -45,15 +45,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain Perplexity integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/togetherai.mdx
+++ b/src/oss/javascript/integrations/chat/togetherai.mdx
@@ -45,15 +45,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain ChatTogetherAI integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/chat/xai.mdx
+++ b/src/oss/javascript/integrations/chat/xai.mdx
@@ -45,16 +45,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain `ChatXAI` integration lives in the `@langchain/xai` package:
 
-```{=mdx}
-
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/xai @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/xai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/xai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/xai @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/document_compressors/ibm.mdx
+++ b/src/oss/javascript/integrations/document_compressors/ibm.mdx
@@ -105,14 +105,17 @@ If you want to get automated tracing from individual queries, you can also set y
 
 This document compressor lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/document_loaders/file_loaders/csv.mdx
+++ b/src/oss/javascript/integrations/document_loaders/file_loaders/csv.mdx
@@ -2,18 +2,9 @@
 title: CSV
 ---
 
-
-```{=mdx}
-
 <Tip>
-**Compatibility**
-
-
-Only available on Node.js.
-
+**Compatibility**: Only available on Node.js.
 </Tip>
-
-```
 
 This notebook provides a quick overview for getting started with `CSVLoader` [document loaders](/oss/integrations/document_loaders). For detailed documentation of all `CSVLoader` features and configurations head to the [API reference](https://api.js.langchain.com/classes/langchain_community_document_loaders_fs_csv.CSVLoader.html).
 
@@ -35,15 +26,17 @@ To access `CSVLoader` document loader you'll need to install the `@langchain/com
 
 The LangChain CSVLoader integration lives in the `@langchain/community` integration package.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core d3-dsv@2
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core d3-dsv@2
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core d3-dsv@2
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core d3-dsv@2
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/document_loaders/file_loaders/directory.mdx
+++ b/src/oss/javascript/integrations/document_loaders/file_loaders/directory.mdx
@@ -2,17 +2,10 @@
 title: DirectoryLoader
 ---
 
-```{=mdx}
 
 <Tip>
-**Compatibility**
-
-
-Only available on Node.js.
-
+**Compatibility**: Only available on Node.js.
 </Tip>
-
-```
 
 This notebook provides a quick overview for getting started with `DirectoryLoader` [document loaders](/oss/integrations/document_loaders). For detailed documentation of all `DirectoryLoader` features and configurations head to the [API reference](https://api.js.langchain.com/classes/langchain.document_loaders_fs_directory.DirectoryLoader.html).
 
@@ -44,15 +37,17 @@ To access `DirectoryLoader` document loader you'll need to install the `langchai
 
 The LangChain DirectoryLoader integration lives in the `langchain` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  langchain @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install langchain @langchain/core
 ```
+```bash yarn
+yarn add langchain @langchain/core
+```
+```bash pnpm
+pnpm add langchain @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/document_loaders/file_loaders/pdf.mdx
+++ b/src/oss/javascript/integrations/document_loaders/file_loaders/pdf.mdx
@@ -2,17 +2,9 @@
 title: PDFLoader
 ---
 
-```{=mdx}
-
 <Tip>
-**Compatibility**
-
-
-Only available on Node.js.
-
+**Compatibility**: Only available on Node.js.
 </Tip>
-
-```
 
 This notebook provides a quick overview for getting started with `PDFLoader` [document loaders](/oss/integrations/document_loaders). For detailed documentation of all `PDFLoader` features and configurations head to the [API reference](https://api.js.langchain.com/classes/langchain_community_document_loaders_fs_pdf.PDFLoader.html).
 
@@ -34,15 +26,17 @@ To access `PDFLoader` document loader you'll need to install the `@langchain/com
 
 The LangChain PDFLoader integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core pdf-parse
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core pdf-parse
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core pdf-parse
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core pdf-parse
+```
+</CodeGroup>
 
 ## Instantiation
 
@@ -192,12 +186,19 @@ By default we use the `pdfjs` build bundled with `pdf-parse`, which is compatibl
 
 In the following example we use the "legacy" (see [pdfjs docs](https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#which-browsersenvironments-are-supported)) build of `pdfjs-dist`, which includes several polyfills not included in the default build.
 
-```{=mdx}
-<Npm2Yarn>
-  pdfjs-dist
-</Npm2Yarn>
 
+<CodeGroup>
+```bash npm
+npm install pdfjs-dist
 ```
+```bash yarn
+yarn add pdfjs-dist
+```
+```bash pnpm
+pnpm add pdfjs-dist
+```
+</CodeGroup>
+
 
 ```typescript
 import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf";

--- a/src/oss/javascript/integrations/document_loaders/file_loaders/text.mdx
+++ b/src/oss/javascript/integrations/document_loaders/file_loaders/text.mdx
@@ -2,17 +2,9 @@
 title: TextLoader
 ---
 
-```{=mdx}
-
 <Tip>
-**Compatibility**
-
-
-Only available on Node.js.
-
+**Compatibility**: Only available on Node.js.
 </Tip>
-
-```
 
 This notebook provides a quick overview for getting started with `TextLoader` [document loaders](/oss/integrations/document_loaders). For detailed documentation of all `TextLoader` features and configurations head to the [API reference](https://api.js.langchain.com/classes/langchain.document_loaders_fs_text.TextLoader.html).
 
@@ -32,15 +24,17 @@ To access `TextLoader` document loader you'll need to install the `langchain` pa
 
 The LangChain TextLoader integration lives in the `langchain` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  langchain
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install langchain
 ```
+```bash yarn
+yarn add langchain
+```
+```bash pnpm
+pnpm add langchain
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/document_loaders/file_loaders/unstructured.mdx
+++ b/src/oss/javascript/integrations/document_loaders/file_loaders/unstructured.mdx
@@ -2,17 +2,9 @@
 title: UnstructuredLoader
 ---
 
-```{=mdx}
-
 <Tip>
-**Compatibility**
-
-
-Only available on Node.js.
-
+**Compatibility**: Only available on Node.js.
 </Tip>
-
-```
 
 This notebook provides a quick overview for getting started with `UnstructuredLoader` [document loaders](/oss/integrations/document_loaders). For detailed documentation of all `UnstructuredLoader` features and configurations head to the [API reference](https://api.js.langchain.com/classes/langchain_community_document_loaders_fs_unstructured.UnstructuredLoader.html).
 
@@ -48,15 +40,17 @@ export UNSTRUCTURED_API_KEY="your-api-key"
 
 The LangChain UnstructuredLoader integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/document_loaders/web_loaders/firecrawl.mdx
+++ b/src/oss/javascript/integrations/document_loaders/web_loaders/firecrawl.mdx
@@ -50,15 +50,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain FireCrawlLoader integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core @mendable/firecrawl-js@0.0.36
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core @mendable/firecrawl-js@0.0.36
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core @mendable/firecrawl-js@0.0.36
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core @mendable/firecrawl-js@0.0.36
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/document_loaders/web_loaders/langsmith.mdx
+++ b/src/oss/javascript/integrations/document_loaders/web_loaders/langsmith.mdx
@@ -35,15 +35,17 @@ export LANGSMITH_API_KEY="your-api-key"
 
 The `LangSmithLoader` integration lives in the `@langchain/core` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/core
 ```
+```bash yarn
+yarn add @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/core
+```
+</CodeGroup>
 
 ## Create example dataset
 

--- a/src/oss/javascript/integrations/document_loaders/web_loaders/pdf.mdx
+++ b/src/oss/javascript/integrations/document_loaders/web_loaders/pdf.mdx
@@ -39,15 +39,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain WebPDFLoader integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core pdf-parse
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core pdf-parse
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core pdf-parse
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core pdf-parse
+```
+</CodeGroup>
 
 ## Instantiation
 
@@ -184,12 +186,18 @@ By default we use the `pdfjs` build bundled with `pdf-parse`, which is compatibl
 
 In the following example we use the "legacy" (see [pdfjs docs](https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#which-browsersenvironments-are-supported)) build of `pdfjs-dist`, which includes several polyfills not included in the default build.
 
-```{=mdx}
-<Npm2Yarn>
-  pdfjs-dist
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install pdfjs-dist
 ```
+```bash yarn
+yarn add pdfjs-dist
+```
+```bash pnpm
+pnpm add pdfjs-dist
+```
+</CodeGroup>
+
 
 ```typescript
 import { WebPDFLoader } from "@langchain/community/document_loaders/web/pdf";

--- a/src/oss/javascript/integrations/document_loaders/web_loaders/recursive_url_loader.mdx
+++ b/src/oss/javascript/integrations/document_loaders/web_loaders/recursive_url_loader.mdx
@@ -2,17 +2,9 @@
 title: RecursiveUrlLoader
 ---
 
-```{=mdx}
-
 <Tip>
-**Compatibility**
-
-
-Only available on Node.js.
-
+**Compatibility**: Only available on Node.js.
 </Tip>
-
-```
 
 This notebook provides a quick overview for getting started with [RecursiveUrlLoader](/oss/integrations/document_loaders/). For detailed documentation of all RecursiveUrlLoader features and configurations head to the [API reference](https://api.js.langchain.com/classes/langchain_community_document_loaders_web_recursive_url.RecursiveUrlLoader.html).
 
@@ -59,22 +51,66 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain RecursiveUrlLoader integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core jsdom
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core jsdom
 </Npm2Yarn>
+
+We also suggest adding a package like [`html-to-text`](https://www.npmjs.com/package/html-to-text) or
+[`@mozilla/readability`](https://www.npmjs.com/package/@mozilla/readability) for extracting the raw text from the page.
+
+<CodeGroup>
+```bash npm
+npm install html-to-text
+```
+```bash yarn
+yarn add @langchain/community @langchain/core jsdom
+```
+```bash yarn
+yarn add html-to-text
+```
+```bash yarn
+yarn add @langchain/community @langchain/core jsdom
+```
+```bash pnpm
+pnpm add html-to-text
+```
+```bash yarn
+yarn add @langchain/community @langchain/core jsdom
+```
+</CodeGroup>
+
+We also suggest adding a package like [`html-to-text`](https://www.npmjs.com/package/html-to-text) or
+[`@mozilla/readability`](https://www.npmjs.com/package/@mozilla/readability) for extracting the raw text from the page.
+
+<CodeGroup>
+```bash npm
+npm install html-to-text
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core jsdom
+```
+```bash yarn
+yarn add html-to-text
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core jsdom
+```
+```bash pnpm
+pnpm add html-to-text
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core jsdom
+```
+</CodeGroup>
 
 We also suggest adding a package like [`html-to-text`](https://www.npmjs.com/package/html-to-text) or
 [`@mozilla/readability`](https://www.npmjs.com/package/@mozilla/readability) for extracting the raw text from the page.
 
 <Npm2Yarn>
   html-to-text
-</Npm2Yarn>
-
 ```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/document_loaders/web_loaders/web_cheerio.mdx
+++ b/src/oss/javascript/integrations/document_loaders/web_loaders/web_cheerio.mdx
@@ -42,15 +42,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain CheerioWebBaseLoader integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core cheerio
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core cheerio
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core cheerio
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core cheerio
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/document_loaders/web_loaders/web_puppeteer.mdx
+++ b/src/oss/javascript/integrations/document_loaders/web_loaders/web_puppeteer.mdx
@@ -2,15 +2,9 @@
 title: PuppeteerWebBaseLoader
 ---
 
-```{=mdx}
 <Tip>
-**Compatibility**
-
-
-Only available on Node.js.
-
+**Compatibility**: Only available on Node.js.
 </Tip>
-```
 
 This notebook provides a quick overview for getting started with [PuppeteerWebBaseLoader](/oss/integrations/document_loaders/). For detailed documentation of all PuppeteerWebBaseLoader features and configurations head to the [API reference](https://api.js.langchain.com/classes/langchain_community_document_loaders_web_puppeteer.PuppeteerWebBaseLoader.html).
 
@@ -49,15 +43,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain PuppeteerWebBaseLoader integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core puppeteer
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core puppeteer
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core puppeteer
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core puppeteer
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/llms/arcjet.mdx
+++ b/src/oss/javascript/integrations/llms/arcjet.mdx
@@ -20,28 +20,34 @@ The Arcjet Redact object is not an LLM itself, instead it wraps an LLM. It redac
 
 Install the Arcjet Redaction Library:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @arcjet/redact
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @arcjet/redact
 ```
+```bash yarn
+yarn add @arcjet/redact
+```
+```bash pnpm
+pnpm add @arcjet/redact
+```
+</CodeGroup>
 
 And install LangChain Community:
 
-```{=mdx}
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
+```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 And now you're ready to start protecting your LLM calls with Arcjet Redaction!
 
-```
 
 ## Usage
 

--- a/src/oss/javascript/integrations/llms/azure.mdx
+++ b/src/oss/javascript/integrations/llms/azure.mdx
@@ -2,8 +2,6 @@
 title: Azure OpenAI
 ---
 
-```{=mdx}
-
 <Warning>
 **You are currently on a page documenting the use of Azure OpenAI text completion models. The latest and most popular Azure OpenAI models are [chat completion models](/oss/langchain/models).**
 
@@ -19,7 +17,6 @@ If you are using Azure OpenAI with the deprecated SDK, see the [migration guide]
 
 </Info>
 
-```
 
 [Azure OpenAI](https://learn.microsoft.com/en-us/azure/ai-services/openai/) is a Microsoft Azure service that provides powerful language models from OpenAI.
 
@@ -67,15 +64,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain AzureOpenAI integration lives in the `@langchain/openai` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/openai @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/openai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/openai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/openai @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/llms/bedrock.mdx
+++ b/src/oss/javascript/integrations/llms/bedrock.mdx
@@ -4,7 +4,7 @@ title: Bedrock
 
 # Bedrock
 
-```{=mdx}
+
 
 <Warning>
 **You are currently on a page documenting the use of Amazon Bedrock models as text completion models. Many popular models available on Bedrock are [chat completion models](/oss/langchain/models).**
@@ -13,7 +13,6 @@ title: Bedrock
 You may be looking for [this page instead](/oss/integrations/chat/bedrock/).
 </Warning>
 
-```
 
 > [Amazon Bedrock](https://aws.amazon.com/bedrock/) is a fully managed service that makes Foundation Models (FMs)
 > from leading AI startups and Amazon available via an API. You can choose from a wide range of FMs to find the model that is best suited for your use case.
@@ -53,28 +52,108 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain Bedrock integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 </Npm2Yarn>
 
 And install the peer dependencies:
 
-<Npm2Yarn>
-  @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+```bash yarn
+yarn add @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+```bash pnpm
+pnpm add @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+</CodeGroup>
+
+You can also use Bedrock in web environments such as Edge functions or Cloudflare Workers by omitting the `@aws-sdk/credential-provider-node` dependency
+and using the `web` entrypoint:
+
+<CodeGroup>
+```bash npm
+npm install @aws-crypto/sha256-js @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash yarn
+yarn add @aws-crypto/sha256-js @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @aws-crypto/sha256-js @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+</CodeGroup>
+
+And install the peer dependencies:
+
+<CodeGroup>
+```bash npm
+npm install @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+```bash yarn
+yarn add @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+```bash pnpm
+pnpm add @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+</CodeGroup>
+
+You can also use Bedrock in web environments such as Edge functions or Cloudflare Workers by omitting the `@aws-sdk/credential-provider-node` dependency
+and using the `web` entrypoint:
+
+<CodeGroup>
+```bash npm
+npm install @aws-crypto/sha256-js @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+```bash yarn
+yarn add @aws-crypto/sha256-js @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @aws-crypto/sha256-js @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
+
+And install the peer dependencies:
+
+<CodeGroup>
+```bash npm
+npm install @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+```bash yarn
+yarn add @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+```bash pnpm
+pnpm add @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+</CodeGroup>
 
 You can also use Bedrock in web environments such as Edge functions or Cloudflare Workers by omitting the `@aws-sdk/credential-provider-node` dependency
 and using the `web` entrypoint:
 
 <Npm2Yarn>
   @aws-crypto/sha256-js @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
-</Npm2Yarn>
-
 ```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/llms/cloudflare_workersai.mdx
+++ b/src/oss/javascript/integrations/llms/cloudflare_workersai.mdx
@@ -24,15 +24,17 @@ Head [to this page](https://developers.cloudflare.com/workers-ai/) to sign up to
 
 The LangChain Cloudflare integration lives in the `@langchain/cloudflare` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/cloudflare @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/cloudflare @langchain/core
 ```
+```bash yarn
+yarn add @langchain/cloudflare @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/cloudflare @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/llms/cohere.mdx
+++ b/src/oss/javascript/integrations/llms/cohere.mdx
@@ -47,15 +47,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain Cohere integration lives in the `@langchain/cohere` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/cohere @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/cohere @langchain/core
 ```
+```bash yarn
+yarn add @langchain/cohere @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/cohere @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/llms/fireworks.mdx
+++ b/src/oss/javascript/integrations/llms/fireworks.mdx
@@ -2,7 +2,6 @@
 title: Fireworks
 ---
 
-```{=mdx}
 
 <Warning>
 **You are currently on a page documenting the use of Fireworks models as text completion models. Many popular models available on Fireworks are [chat completion models](/oss/langchain/models).**
@@ -11,7 +10,6 @@ title: Fireworks
 You may be looking for [this page instead](/oss/integrations/chat/fireworks/).
 </Warning>
 
-```
 
 [Fireworks AI](https://fireworks.ai/) is an AI inference platform to run and customize models. For a list of all models served by Fireworks see the [Fireworks docs](https://fireworks.ai/models).
 
@@ -48,15 +46,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain Fireworks integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/llms/google_vertex_ai.mdx
+++ b/src/oss/javascript/integrations/llms/google_vertex_ai.mdx
@@ -2,7 +2,6 @@
 title: Google Vertex AI
 ---
 
-```{=mdx}
 
 <Warning>
 **You are currently on a page documenting the use of Google Vertex models as text completion models. Many popular models available on Google Vertex are [chat completion models](/oss/langchain/models).**
@@ -11,7 +10,6 @@ title: Google Vertex AI
 You may be looking for [this page instead](/oss/integrations/chat/google_vertex_ai/).
 </Warning>
 
-```
 
 [Google Vertex](https://cloud.google.com/vertex-ai) is a service that exposes all foundation models available in Google Cloud, like `gemini-1.5-pro`, `gemini-1.5-flash`, etc.
 
@@ -86,21 +84,31 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain VertexAI integration lives in the `@langchain/google-vertexai` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/google-vertexai @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/google-vertexai @langchain/core
+```
+```bash yarn
+yarn add @langchain/google-vertexai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/google-vertexai @langchain/core
+```
+</CodeGroup>
 
 or for web environments:
 
-<Npm2Yarn>
-  @langchain/google-vertexai-web @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/google-vertexai-web @langchain/core
 ```
+```bash yarn
+yarn add @langchain/google-vertexai-web @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/google-vertexai-web @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/llms/ibm.mdx
+++ b/src/oss/javascript/integrations/llms/ibm.mdx
@@ -105,15 +105,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain IBM watsonx.ai integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/llms/mistral.mdx
+++ b/src/oss/javascript/integrations/llms/mistral.mdx
@@ -2,20 +2,15 @@
 title: MistralAI
 ---
 
-```{=mdx}
-
 <Tip>
 **Want to run Mistral's models locally? Check out our [Ollama integration](/oss/integrations/chat/ollama).**
-
-:::
-
-</Tip>caution
+</Tip>
+<Warning>
 You are currently on a page documenting the use of Mistral models as text completion models. Many popular models available on Mistral are [chat completion models](/oss/langchain/models).
 
 You may be looking for [this page instead](/oss/integrations/chat/mistral/).
-:::
+</Warning>
 
-```
 
 [Mistral AI](https://mistral.ai/) is a platform that offers hosting for their powerful [open source models](https://docs.mistral.ai/getting-started/models/).
 
@@ -52,15 +47,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain MistralAI integration lives in the `@langchain/mistralai` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/mistralai @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/mistralai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/mistralai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/mistralai @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/llms/ollama.mdx
+++ b/src/oss/javascript/integrations/llms/ollama.mdx
@@ -2,7 +2,6 @@
 title: Ollama
 ---
 
-```{=mdx}
 
 <Warning>
 **You are currently on a page documenting the use of Ollama models as text completion models. Many popular models available on Ollama are [chat completion models](/oss/langchain/models).**
@@ -11,7 +10,6 @@ title: Ollama
 You may be looking for [this page instead](/oss/integrations/chat/ollama/).
 </Warning>
 
-```
 
 This will help you get started with Ollama text completion models (LLMs) using LangChain. For detailed documentation on `Ollama` features and configuration options, please refer to the [API reference](https://api.js.langchain.com/classes/langchain_ollama.Ollama.html).
 
@@ -47,15 +45,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain Ollama integration lives in the `@langchain/ollama` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/ollama @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/ollama @langchain/core
 ```
+```bash yarn
+yarn add @langchain/ollama @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/ollama @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/llms/openai.mdx
+++ b/src/oss/javascript/integrations/llms/openai.mdx
@@ -2,7 +2,6 @@
 title: OpenAI
 ---
 
-```{=mdx}
 
 <Warning>
 **You are currently on a page documenting the use of OpenAI text completion models. The latest and most popular OpenAI models are [chat completion models](/oss/langchain/models).**
@@ -11,7 +10,6 @@ title: OpenAI
 Unless you are specifically using `gpt-3.5-turbo-instruct`, you are probably looking for [this page instead](/oss/integrations/chat/openai/).
 </Warning>
 
-```
 
 [OpenAI](https://en.wikipedia.org/wiki/OpenAI) is an artificial intelligence (AI) research laboratory.
 
@@ -48,15 +46,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain OpenAI integration lives in the `@langchain/openai` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/openai @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/openai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/openai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/openai @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/llms/together.mdx
+++ b/src/oss/javascript/integrations/llms/together.mdx
@@ -43,15 +43,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain TogetherAI integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/providers/google.mdx
+++ b/src/oss/javascript/integrations/providers/google.mdx
@@ -77,7 +77,6 @@ const res = await visionModel.invoke(input2);
 </Tab>
 
 <Tab title="VertexAI">
-<IntegrationInstallTooltip/>
 
 ```bash npm
 npm install @langchain/google-vertexai @langchain/core

--- a/src/oss/javascript/integrations/providers/microsoft.mdx
+++ b/src/oss/javascript/integrations/providers/microsoft.mdx
@@ -97,7 +97,6 @@ const model = new AzureOpenAIEmbeddings({
 
 > [Azure AI Search](https://azure.microsoft.com/products/ai-services/ai-search) (formerly known as Azure Search and Azure Cognitive Search) is a distributed, RESTful search engine optimized for speed and relevance on production-scale workloads on Azure. It supports also vector search using the [k-nearest neighbor](https://en.wikipedia.org/wiki/Nearest_neighbor_search) (kNN) algorithm and also [semantic search](https://learn.microsoft.com/azure/search/semantic-search-overview).
 
-<IntegrationInstallTooltip/>
 
 ```bash npm
 npm install -S @langchain/community @langchain/core @azure/search-documents
@@ -111,8 +110,6 @@ import { AzureAISearchVectorStore } from "@langchain/community/vectorstores/azur
 
 > [Azure Cosmos DB for NoSQL](https://learn.microsoft.com/azure/cosmos-db/nosql/) provides support for querying items with flexible schemas and native support for JSON. It now offers vector indexing and search. This feature is designed to handle high-dimensional vectors, enabling efficient and accurate vector search at any scale. You can now store vectors directly in the documents alongside your data. Each document in your database can contain not only traditional schema-free data, but also high-dimensional vectors as other properties of the documents.
 
-<IntegrationInstallTooltip/>
-
 ```bash npm
 npm install @langchain/azure-cosmosdb @langchain/core
 ```
@@ -123,9 +120,7 @@ import { AzureCosmosDBNoSQLVectorStore } from "@langchain/azure-cosmosdb";
 ```
 ### Azure Cosmos DB for MongoDB vCore
 
-> [Azure Cosmos DB for MongoDB vCore](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore/) makes it easy to create a database with full native MongoDB support. You can apply your MongoDB experience and continue to use your favorite MongoDB drivers, SDKs, and tools by pointing your application to the API for MongoDB vCore account’s connection string. Use vector search in Azure Cosmos DB for MongoDB vCore to seamlessly integrate your AI-based applications with your data that’s stored in Azure Cosmos DB.
-
-<IntegrationInstallTooltip/>
+> [Azure Cosmos DB for MongoDB vCore](https://learn.microsoft.com/azure/cosmos-db/mongodb/vcore/) makes it easy to create a database with full native MongoDB support. You can apply your MongoDB experience and continue to use your favorite MongoDB drivers, SDKs, and tools by pointing your application to the API for MongoDB vCore account's connection string. Use vector search in Azure Cosmos DB for MongoDB vCore to seamlessly integrate your AI-based applications with your data that's stored in Azure Cosmos DB.
 
 ```bash npm
 npm install @langchain/azure-cosmosdb @langchain/core
@@ -140,8 +135,6 @@ import { AzureCosmosDBMongoDBVectorStore } from "@langchain/azure-cosmosdb";
 ### Azure Cosmos DB NoSQL Semantic Cache
 
 > The Semantic Cache feature is supported with Azure Cosmos DB for NoSQL integration, enabling users to retrieve cached responses based on semantic similarity between the user input and previously cached results. It leverages [AzureCosmosDBNoSQLVectorStore](/oss/integrations/vectorstores/azure_cosmosdb_nosql), which stores vector embeddings of cached prompts. These embeddings enable similarity-based searches, allowing the system to retrieve relevant cached results.
-
-<IntegrationInstallTooltip/>
 
 ```bash npm
 npm install @langchain/azure-cosmosdb @langchain/core
@@ -171,8 +164,6 @@ import { AzureCosmosDBNoSQLSemanticCache } from "@langchain/azure-cosmosdb";
 - Storing data for backup and restore, disaster recovery, and archiving.
 - Storing data for analysis by an on-premises or Azure-hosted service.
 
-<IntegrationInstallTooltip/>
-
 ```bash npm
 npm install @langchain/community @langchain/core @azure/storage-blob
 ```
@@ -191,8 +182,6 @@ import { AzureBlobStorageFileLoader } from "@langchain/community/document_loader
 ### Azure Container Apps Dynamic Sessions
 
 > [Azure Container Apps dynamic sessions](https://learn.microsoft.com/azure/container-apps/sessions) provide fast access to secure sandboxed environments that are ideal for running code or applications that require strong isolation from other workloads.
-
-<IntegrationInstallTooltip/>
 
 ```bash npm
 npm install @langchain/azure-dynamic-sessions @langchain/core

--- a/src/oss/javascript/integrations/retrievers/azion-edgesql.mdx
+++ b/src/oss/javascript/integrations/retrievers/azion-edgesql.mdx
@@ -37,14 +37,17 @@ If you want to get automated tracing from individual queries, you can also set y
 
 This retriever lives in the `@langchain/community/retrievers/azion_edgesql` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  azion @langchain/openai @langchain/community
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install azion @langchain/openai @langchain/community
 ```
+```bash yarn
+yarn add azion @langchain/openai @langchain/community
+```
+```bash pnpm
+pnpm add azion @langchain/openai @langchain/community
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/retrievers/bedrock-knowledge-bases.mdx
+++ b/src/oss/javascript/integrations/retrievers/bedrock-knowledge-bases.mdx
@@ -39,14 +39,17 @@ If you want to get automated tracing from individual queries, you can also set y
 
 This retriever lives in the `@langchain/aws` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/aws @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/aws @langchain/core
 ```
+```bash yarn
+yarn add @langchain/aws @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/aws @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/retrievers/bm25.mdx
+++ b/src/oss/javascript/integrations/retrievers/bm25.mdx
@@ -10,14 +10,17 @@ You can use it as part of your retrieval pipeline as a to rerank documents as a 
 
 The `BM25Retriever` is exported from `@langchain/community`. You'll need to install it like this:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 This retriever uses code from [`this implementation`](https://github.com/FurkanToprak/OkapiBM25) of Okapi BM25.
 

--- a/src/oss/javascript/integrations/retrievers/exa.mdx
+++ b/src/oss/javascript/integrations/retrievers/exa.mdx
@@ -35,14 +35,17 @@ If you want to get automated tracing from individual queries, you can also set y
 
 This retriever lives in the `@langchain/exa` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/exa @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/exa @langchain/core
 ```
+```bash yarn
+yarn add @langchain/exa @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/exa @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/retrievers/kendra-retriever.mdx
+++ b/src/oss/javascript/integrations/retrievers/kendra-retriever.mdx
@@ -34,14 +34,17 @@ If you want to get automated tracing from individual queries, you can also set y
 
 This retriever lives in the `@langchain/aws` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/aws @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/aws @langchain/core
 ```
+```bash yarn
+yarn add @langchain/aws @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/aws @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/retrievers/tavily.mdx
+++ b/src/oss/javascript/integrations/retrievers/tavily.mdx
@@ -29,14 +29,17 @@ If you want to get automated tracing from individual queries, you can also set y
 
 This retriever lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/stores/file_system.mdx
+++ b/src/oss/javascript/integrations/stores/file_system.mdx
@@ -2,17 +2,10 @@
 title: LocalFileStore
 ---
 
-```{=mdx}
-
 <Tip>
-**Compatibility**
-
-
-Only available on Node.js.
-
+**Compatibility**: Only available on Node.js.
 </Tip>
 
-```
 
 This will help you get started with [LocalFileStore](/oss/integrations/stores). For detailed documentation of all LocalFileStore features and configurations head to the [API reference](https://api.js.langchain.com/classes/langchain.storage_file_system.LocalFileStore.html).
 
@@ -22,12 +15,9 @@ The `LocalFileStore` is a wrapper around the `fs` module for storing data as key
 Each key value pair has its own file nested inside the directory passed to the `.fromPath` method.
 The file name is the key and inside contains the value of the key.
 
-```{=mdx}
 
 <Info>
 **The path passed to the `.fromPath` must be a directory, not a file.**
-
-
 </Info>
 
 <Warning>
@@ -37,7 +27,6 @@ Make sure that the path you specify when initializing the store is free of other
 
 </Warning>
 
-```
 
 ### Integration details
 
@@ -51,16 +40,17 @@ Make sure that the path you specify when initializing the store is free of other
 
 The LangChain `LocalFileStore` integration lives in the `langchain` package:
 
-```{=mdx}
-
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  langchain @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install langchain @langchain/core
 ```
+```bash yarn
+yarn add langchain @langchain/core
+```
+```bash pnpm
+pnpm add langchain @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/stores/in_memory.mdx
+++ b/src/oss/javascript/integrations/stores/in_memory.mdx
@@ -20,16 +20,17 @@ The `InMemoryStore` allows for a generic type to be assigned to the values in th
 
 The LangChain InMemoryStore integration lives in the `@langchain/core` package:
 
-```{=mdx}
-
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/core
 ```
+```bash yarn
+yarn add @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/text_embedding/azure_openai.mdx
+++ b/src/oss/javascript/integrations/text_embedding/azure_openai.mdx
@@ -10,7 +10,6 @@ You can learn more about Azure OpenAI and its difference with the OpenAI API on 
 
 This will help you get started with AzureOpenAIEmbeddings [embedding models](/oss/integrations/text_embedding) using LangChain. For detailed documentation on `AzureOpenAIEmbeddings` features and configuration options, please refer to the [API reference](https://api.js.langchain.com/classes/langchain_openai.AzureOpenAIEmbeddings.html).
 
-```{=mdx}
 
 <Info>
 **Previously, LangChain.js supported integration with Azure OpenAI using the dedicated [Azure OpenAI SDK](https://github.com/Azure/azure-sdk-for-js/tree/main/sdk/openai/openai). This SDK is now deprecated in favor of the new Azure integration in the OpenAI SDK, which allows to access the latest OpenAI models and features the same day they are released, and allows seamless transition between the OpenAI API and Azure OpenAI.**
@@ -20,7 +19,6 @@ If you are using Azure OpenAI with the deprecated SDK, see the [migration guide]
 
 </Info>
 
-```
 
 ## Overview
 
@@ -60,13 +58,18 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain AzureOpenAIEmbeddings integration lives in the `@langchain/openai` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
+<CodeGroup>
+```bash npm
+npm install @langchain/openai @langchain/core
+```
+```bash yarn
+yarn add @langchain/openai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/openai @langchain/core
+```
+</CodeGroup>
 
-<Npm2Yarn>
-  @langchain/openai @langchain/core
-</Npm2Yarn>
 
 <Info>
 **You can find the list of supported API versions in the [Azure OpenAI documentation](https://learn.microsoft.com/azure/ai-services/openai/reference).**

--- a/src/oss/javascript/integrations/text_embedding/bedrock.mdx
+++ b/src/oss/javascript/integrations/text_embedding/bedrock.mdx
@@ -34,14 +34,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain Bedrock integration lives in the `@langchain/aws` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/aws @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/aws @langchain/core
 ```
+```bash yarn
+yarn add @langchain/aws @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/aws @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/text_embedding/bytedance_doubao.mdx
+++ b/src/oss/javascript/integrations/text_embedding/bytedance_doubao.mdx
@@ -31,14 +31,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain ByteDanceDoubaoEmbeddings integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community
 ```
+```bash yarn
+yarn add @langchain/community
+```
+```bash pnpm
+pnpm add @langchain/community
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/text_embedding/cloudflare_ai.mdx
+++ b/src/oss/javascript/integrations/text_embedding/cloudflare_ai.mdx
@@ -46,14 +46,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain CloudflareWorkersAIEmbeddings integration lives in the `@langchain/cloudflare` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/cloudflare @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/cloudflare @langchain/core
 ```
+```bash yarn
+yarn add @langchain/cloudflare @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/cloudflare @langchain/core
+```
+</CodeGroup>
 
 ## Usage
 

--- a/src/oss/javascript/integrations/text_embedding/cohere.mdx
+++ b/src/oss/javascript/integrations/text_embedding/cohere.mdx
@@ -35,14 +35,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain CohereEmbeddings integration lives in the `@langchain/cohere` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/cohere @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/cohere @langchain/core
 ```
+```bash yarn
+yarn add @langchain/cohere @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/cohere @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/text_embedding/fireworks.mdx
+++ b/src/oss/javascript/integrations/text_embedding/fireworks.mdx
@@ -35,14 +35,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain `FireworksEmbeddings` integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/text_embedding/google_generativeai.mdx
+++ b/src/oss/javascript/integrations/text_embedding/google_generativeai.mdx
@@ -37,14 +37,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain `GoogleGenerativeAIEmbeddings` integration lives in the `@langchain/google-genai` package. You may also wish to install the official SDK:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/google-genai @langchain/core @google/generative-ai
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/google-genai @langchain/core @google/generative-ai
 ```
+```bash yarn
+yarn add @langchain/google-genai @langchain/core @google/generative-ai
+```
+```bash pnpm
+pnpm add @langchain/google-genai @langchain/core @google/generative-ai
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/text_embedding/google_vertex_ai.mdx
+++ b/src/oss/javascript/integrations/text_embedding/google_vertex_ai.mdx
@@ -46,14 +46,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain `VertexAIEmbeddings` integration lives in the `@langchain/google-vertexai` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/google-vertexai @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/google-vertexai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/google-vertexai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/google-vertexai @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/text_embedding/ibm.mdx
+++ b/src/oss/javascript/integrations/text_embedding/ibm.mdx
@@ -105,15 +105,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain IBM watsonx.ai integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/text_embedding/mistralai.mdx
+++ b/src/oss/javascript/integrations/text_embedding/mistralai.mdx
@@ -35,14 +35,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain MistralAIEmbeddings integration lives in the `@langchain/mistralai` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/mistralai @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/mistralai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/mistralai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/mistralai @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/text_embedding/ollama.mdx
+++ b/src/oss/javascript/integrations/text_embedding/ollama.mdx
@@ -29,14 +29,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain OllamaEmbeddings integration lives in the `@langchain/ollama` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/ollama @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/ollama @langchain/core
 ```
+```bash yarn
+yarn add @langchain/ollama @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/ollama @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/text_embedding/openai.mdx
+++ b/src/oss/javascript/integrations/text_embedding/openai.mdx
@@ -35,14 +35,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain OpenAIEmbeddings integration lives in the `@langchain/openai` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/openai @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/openai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/openai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/openai @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/text_embedding/pinecone.mdx
+++ b/src/oss/javascript/integrations/text_embedding/pinecone.mdx
@@ -35,14 +35,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain PineconeEmbeddings integration lives in the `@langchain/pinecone` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/pinecone @langchain/core @pinecone-database/pinecone@5
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/pinecone @langchain/core @pinecone-database/pinecone@5
 ```
+```bash yarn
+yarn add @langchain/pinecone @langchain/core @pinecone-database/pinecone@5
+```
+```bash pnpm
+pnpm add @langchain/pinecone @langchain/core @pinecone-database/pinecone@5
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/text_embedding/togetherai.mdx
+++ b/src/oss/javascript/integrations/text_embedding/togetherai.mdx
@@ -35,14 +35,17 @@ If you want to get automated tracing of your model calls you can also set your [
 
 The LangChain TogetherAIEmbeddings integration lives in the `@langchain/community` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 

--- a/src/oss/javascript/integrations/tools/duckduckgo_search.mdx
+++ b/src/oss/javascript/integrations/tools/duckduckgo_search.mdx
@@ -18,14 +18,17 @@ DuckDuckGoSearch offers a privacy-focused search API designed for LLM Agents. It
 
 The integration lives in the `@langchain/community` package, along with the `duck-duck-scrape` dependency:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core duck-duck-scrape
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core duck-duck-scrape
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core duck-duck-scrape
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core duck-duck-scrape
+```
+</CodeGroup>
 
 ### Credentials
 
@@ -89,9 +92,6 @@ ToolMessage {
 
 We can use our tool in a chain by first binding it to a [tool-calling model](/oss/langchain/tools/) and then calling it:
 
-```{=mdx}
-<ChatModelTabs customVarName="llm" />
-```
 
 ```typescript
 // @lc-docs-hide-cell

--- a/src/oss/javascript/integrations/tools/exa_search.mdx
+++ b/src/oss/javascript/integrations/tools/exa_search.mdx
@@ -20,16 +20,17 @@ This page goes over how to use `ExaSearchResults` with LangChain.
 
 The integration lives in the `@langchain/exa` package.
 
-```{=mdx}
-
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/exa @langchain/core
-</Npm2Yarn>
-
+<CodeGroup>
+```bash npm
+npm install @langchain/exa @langchain/core
 ```
+```bash yarn
+yarn add @langchain/exa @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/exa @langchain/core
+```
+</CodeGroup>
 
 ### Credentials
 
@@ -109,11 +110,6 @@ ToolMessage {
 
 We can use our tool in a chain by first binding it to a [tool-calling model](/oss/langchain/tools) and then calling it:
 
-```{=mdx}
-
-<ChatModelTabs customVarName="llm" />
-
-```
 
 ```typescript
 // @lc-docs-hide-cell
@@ -186,15 +182,21 @@ We can create LangChain tools which use the `ExaRetriever` and the `createRetrie
 
 We'll use LangGraph to create the agent. Make sure you have `@langchain/langgraph` installed:
 
-```{=mdx}
-<Npm2Yarn>
-  @langchain/langgraph
-</Npm2Yarn>
+
+<CodeGroup>
+```bash npm
+npm install @langchain/langgraph
+```
+```bash yarn
+yarn add @langchain/langgraph
+```
+```bash pnpm
+pnpm add @langchain/langgraph
+```
+</CodeGroup>
 
 Then, define the LLM to use with the agent
 
-<ChatModelTabs customVarName="llmForAgent" />
-```
 
 ```typescript
 // @lc-docs-hide-cell

--- a/src/oss/javascript/integrations/tools/ibm.mdx
+++ b/src/oss/javascript/integrations/tools/ibm.mdx
@@ -104,11 +104,19 @@ For detailed info about tools please visit [watsonx.ai API docs](https://cloud.i
 
 First, ensure you have LangGraph installed:
 
-```{=mdx}
-<Npm2Yarn>
- @langchain/langgraph
-</Npm2Yarn>
+
+<CodeGroup>
+```bash npm
+npm install @langchain/langgraph
 ```
+```bash yarn
+yarn add @langchain/langgraph
+```
+```bash pnpm
+pnpm add @langchain/langgraph
+```
+</CodeGroup>
+
 Then, instantiate your LLM to be used in the React agent:
 
 

--- a/src/oss/javascript/integrations/tools/openapi.mdx
+++ b/src/oss/javascript/integrations/tools/openapi.mdx
@@ -2,12 +2,8 @@
 title: OpenApi Toolkit
 ---
 
-```{=mdx}
 
 <Warning>
-**Disclaimer ⚠️**
-
-
 This agent can make requests to external APIs. Use with caution, especially when granting access to users.
 
 Be aware that this agent could theoretically send requests with provided credentials or other sensitive data to unverified or potentially malicious URLs --although it should never in theory.
@@ -18,7 +14,6 @@ In addition, consider implementing measures to validate URLs before sending requ
 
 </Warning>
 
-```
 
 This will help you getting started with the [OpenApiToolkit](/oss/langchain/tools#toolkits). For detailed documentation of all OpenApiToolkit features and configurations head to the [API reference](https://api.js.langchain.com/classes/langchain.agents.OpenApiToolkit.html).
 
@@ -45,22 +40,21 @@ process.env.LANGSMITH_API_KEY="your-api-key"
 
 This toolkit lives in the `langchain` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  langchain @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install langchain @langchain/core
 ```
+```bash yarn
+yarn add langchain @langchain/core
+```
+```bash pnpm
+pnpm add langchain @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 
 Now we can instantiate our toolkit. First, we need to define the LLM we would like to use in the toolkit.
-
-```{=mdx}
-<ChatModelTabs customVarName="llm" />
-```
 
 ```typescript
 // @lc-docs-hide-cell
@@ -139,11 +133,19 @@ console.log(tools.map((tool) => ({
 
 First, ensure you have LangGraph installed:
 
-```{=mdx}
-<Npm2Yarn>
-  @langchain/langgraph
-</Npm2Yarn>
+
+<CodeGroup>
+```bash npm
+npm install @langchain/langgraph
 ```
+```bash yarn
+yarn add @langchain/langgraph
+```
+```bash pnpm
+pnpm add @langchain/langgraph
+```
+</CodeGroup>
+
 
 ```typescript
 import { createAgent } from "@langchain/classic"

--- a/src/oss/javascript/integrations/tools/serpapi.mdx
+++ b/src/oss/javascript/integrations/tools/serpapi.mdx
@@ -18,14 +18,17 @@ This guide provides a quick overview for getting started with the SerpAPI [tool]
 
 The integration lives in the `@langchain/community` package, which you can install as shown below:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ### Credentials
 
@@ -99,10 +102,6 @@ ToolMessage {
 ## Chaining
 
 We can use our tool in a chain by first binding it to a [tool-calling model](/oss/langchain/tools/) and then calling it:
-
-```{=mdx}
-<ChatModelTabs customVarName="llm" />
-```
 
 ```typescript
 // @lc-docs-hide-cell

--- a/src/oss/javascript/integrations/tools/sql.mdx
+++ b/src/oss/javascript/integrations/tools/sql.mdx
@@ -30,22 +30,21 @@ process.env.LANGSMITH_API_KEY="your-api-key"
 
 This toolkit lives in the `langchain` package. You'll also need to install the `typeorm` peer dependency.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  langchain @langchain/core typeorm
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install langchain @langchain/core typeorm
 ```
+```bash yarn
+yarn add langchain @langchain/core typeorm
+```
+```bash pnpm
+pnpm add langchain @langchain/core typeorm
+```
+</CodeGroup>
 
 ## Instantiation
 
 First, we need to define our LLM to be used in the toolkit.
-
-```{=mdx}
-<ChatModelTabs customVarName="llm" />
-```
 
 ```typescript
 // @lc-docs-hide-cell
@@ -118,11 +117,19 @@ console.log(tools.map((tool) => ({
 
 First, ensure you have LangGraph installed:
 
-```{=mdx}
-<Npm2Yarn>
-  @langchain/langgraph
-</Npm2Yarn>
+
+<CodeGroup>
+```bash npm
+npm install @langchain/langgraph
 ```
+```bash yarn
+yarn add @langchain/langgraph
+```
+```bash pnpm
+pnpm add @langchain/langgraph
+```
+</CodeGroup>
+
 
 ```typescript
 import { createAgent } from "@langchain/classic"

--- a/src/oss/javascript/integrations/tools/tavily_crawl.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_crawl.mdx
@@ -18,14 +18,17 @@ This guide provides a quick overview for getting started with the Tavily [tool](
 
 The integration lives in the `@langchain/tavily` package, which you can install as shown below:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/tavily @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/tavily @langchain/core
 ```
+```bash yarn
+yarn add @langchain/tavily @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/tavily @langchain/core
+```
+</CodeGroup>
 
 ### Credentials
 
@@ -97,10 +100,6 @@ await tool.invoke(modelGeneratedToolCall)
 ## Chaining
 
 We can use our tool in a chain by first binding it to a [tool-calling model](/oss/langchain/tools/) and then calling it:
-
-```{=mdx}
-<ChatModelTabs customVarName="llm" />
-```
 
 ```typescript
 // @lc-docs-hide-cell

--- a/src/oss/javascript/integrations/tools/tavily_extract.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_extract.mdx
@@ -18,14 +18,17 @@ This guide provides a quick overview for getting started with the Tavily [tool](
 
 The integration lives in the `@langchain/tavily` package, which you can install as shown below:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/tavily @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/tavily @langchain/core
 ```
+```bash yarn
+yarn add @langchain/tavily @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/tavily @langchain/core
+```
+</CodeGroup>
 
 ### Credentials
 
@@ -90,10 +93,6 @@ await tool.invoke(modelGeneratedToolCall)
 ## Chaining
 
 We can use our tool in a chain by first binding it to a [tool-calling model](/oss/langchain/tools/) and then calling it:
-
-```{=mdx}
-<ChatModelTabs customVarName="llm" />
-```
 
 ```typescript
 // @lc-docs-hide-cell

--- a/src/oss/javascript/integrations/tools/tavily_map.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_map.mdx
@@ -18,14 +18,17 @@ This guide provides a quick overview for getting started with the Tavily [tool](
 
 The integration lives in the `@langchain/tavily` package, which you can install as shown below:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/tavily @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/tavily @langchain/core
 ```
+```bash yarn
+yarn add @langchain/tavily @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/tavily @langchain/core
+```
+</CodeGroup>
 
 ### Credentials
 
@@ -94,10 +97,6 @@ await tool.invoke(modelGeneratedToolCall)
 ## Chaining
 
 We can use our tool in a chain by first binding it to a [tool-calling model](/oss/langchain/tools/) and then calling it:
-
-```{=mdx}
-<ChatModelTabs customVarName="llm" />
-```
 
 ```typescript
 // @lc-docs-hide-cell

--- a/src/oss/javascript/integrations/tools/tavily_search.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_search.mdx
@@ -18,14 +18,17 @@ This guide provides a quick overview for getting started with the Tavily [tool](
 
 The integration lives in the `@langchain/tavily` package, which you can install as shown below:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/tavily @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/tavily @langchain/core
 ```
+```bash yarn
+yarn add @langchain/tavily @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/tavily @langchain/core
+```
+</CodeGroup>
 
 ### Credentials
 
@@ -102,10 +105,6 @@ await tool.invoke(modelGeneratedToolCall)
 ## Chaining
 
 We can use our tool in a chain by first binding it to a [tool-calling model](/oss/langchain/tools/) and then calling it:
-
-```{=mdx}
-<ChatModelTabs customVarName="llm" />
-```
 
 ```typescript
 // @lc-docs-hide-cell

--- a/src/oss/javascript/integrations/tools/tavily_search_community.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_search_community.mdx
@@ -25,14 +25,17 @@ This guide provides a quick overview for getting started with the Tavily [tool](
 
 The integration lives in the `@langchain/community` package, which you can install as shown below:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core
+```
+</CodeGroup>
 
 ### Credentials
 
@@ -95,10 +98,6 @@ await tool.invoke(modelGeneratedToolCall)
 ## Chaining
 
 We can use our tool in a chain by first binding it to a [tool-calling model](/oss/langchain/tools/) and then calling it:
-
-```{=mdx}
-<ChatModelTabs customVarName="llm" />
-```
 
 ```typescript
 // @lc-docs-hide-cell

--- a/src/oss/javascript/integrations/tools/vectorstore.mdx
+++ b/src/oss/javascript/integrations/tools/vectorstore.mdx
@@ -19,22 +19,21 @@ process.env.LANGSMITH_API_KEY="your-api-key"
 
 This toolkit lives in the `langchain` package:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  langchain @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install langchain @langchain/core
 ```
+```bash yarn
+yarn add langchain @langchain/core
+```
+```bash pnpm
+pnpm add langchain @langchain/core
+```
+</CodeGroup>
 
 ## Instantiation
 
 Now we can instantiate our toolkit. First, we need to define the LLM we'll use in the toolkit.
-
-```{=mdx}
-<ChatModelTabs customVarName="llm" />
-```
 
 ```typescript
 // @lc-docs-hide-cell
@@ -98,11 +97,19 @@ console.log(tools.map((tool) => ({
 
 First, ensure you have LangGraph installed:
 
-```{=mdx}
-<Npm2Yarn>
-  @langchain/langgraph
-</Npm2Yarn>
+
+<CodeGroup>
+```bash npm
+npm install @langchain/langgraph
 ```
+```bash yarn
+yarn add @langchain/langgraph
+```
+```bash pnpm
+pnpm add @langchain/langgraph
+```
+</CodeGroup>
+
 
 Then, instantiate the agent:
 

--- a/src/oss/javascript/integrations/vectorstores/azion-edgesql.mdx
+++ b/src/oss/javascript/integrations/vectorstores/azion-edgesql.mdx
@@ -20,14 +20,17 @@ To use the `AzionVectorStore` vector store, you will need to install the `@langc
 
 This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/openai), which require you to install the `@langchain/openai` integration package. You can also use [other supported embeddings models](/oss/integrations/text_embedding) if you wish.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  azion @langchain/openai @langchain/community
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install azion @langchain/openai @langchain/community
 ```
+```bash yarn
+yarn add azion @langchain/openai @langchain/community
+```
+```bash pnpm
+pnpm add azion @langchain/openai @langchain/community
+```
+</CodeGroup>
 
 ### Credentials
 

--- a/src/oss/javascript/integrations/vectorstores/chroma.mdx
+++ b/src/oss/javascript/integrations/vectorstores/chroma.mdx
@@ -29,14 +29,17 @@ To use Chroma vector stores, you'll need to install the `@langchain/community` i
 
 This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/openai), which require you to install the `@langchain/openai` integration package. You can also use [other supported embeddings models](/oss/integrations/text_embedding) if you wish.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/openai @langchain/core chromadb
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/openai @langchain/core chromadb
 ```
+```bash yarn
+yarn add @langchain/community @langchain/openai @langchain/core chromadb
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/openai @langchain/core chromadb
+```
+</CodeGroup>
 
 If you want to run Chroma locally, you can [run a local Chroma server](https://docs.trychroma.com/docs/cli/run) using the Chroma CLI, which ships with the `chromadb` package:
 

--- a/src/oss/javascript/integrations/vectorstores/elasticsearch.mdx
+++ b/src/oss/javascript/integrations/vectorstores/elasticsearch.mdx
@@ -2,15 +2,9 @@
 title: Elasticsearch
 ---
 
-```{=mdx}
-
 <Tip>
-**Compatibility**
-
-Only available on Node.js.
+**Compatibility**: Only available on Node.js.
 </Tip>
-
-```
 
 [Elasticsearch](https://github.com/elastic/elasticsearch) is a distributed, RESTful search engine optimized for speed and relevance on production-scale workloads. It supports also vector search using the [k-nearest neighbor](https://en.wikipedia.org/wiki/K-nearest_neighbors_algorithm) (kNN) algorithm and also [custom models for Natural Language Processing](https://www.elastic.co/blog/how-to-deploy-nlp-text-embeddings-and-vector-search) (NLP).
 You can read more about the support of vector search in Elasticsearch [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/knn-search.html).
@@ -33,14 +27,17 @@ LangChain.js accepts [`@elastic/elasticsearch`](https://github.com/elastic/elast
 
 This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/openai), which require you to install the `@langchain/openai` integration package. You can also use [other supported embeddings models](/oss/integrations/text_embedding) if you wish.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @elastic/elasticsearch @langchain/openai @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @elastic/elasticsearch @langchain/openai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community @elastic/elasticsearch @langchain/openai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community @elastic/elasticsearch @langchain/openai @langchain/core
+```
+</CodeGroup>
 
 ### Credentials
 

--- a/src/oss/javascript/integrations/vectorstores/faiss.mdx
+++ b/src/oss/javascript/integrations/vectorstores/faiss.mdx
@@ -2,15 +2,9 @@
 title: FaissStore
 ---
 
-```{=mdx}
-
 <Tip>
-**Compatibility**
-
-Only available on Node.js.
+**Compatibility**: Only available on Node.js.
 </Tip>
-
-```
 
 [Faiss](https://github.com/facebookresearch/faiss) is a library for efficient similarity search and clustering of dense vectors.
 
@@ -32,14 +26,17 @@ To use Faiss vector stores, you'll need to install the `@langchain/community` in
 
 This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/openai), which require you to install the `@langchain/openai` integration package. You can also use [other supported embeddings models](/oss/integrations/text_embedding) if you wish.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community faiss-node @langchain/openai @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community faiss-node @langchain/openai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community faiss-node @langchain/openai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community faiss-node @langchain/openai @langchain/core
+```
+</CodeGroup>
 
 ### Credentials
 
@@ -246,11 +243,19 @@ console.log(result);
 
 To enable the ability to read the saved file from [LangChain Python's implementation](https://python.langchain.com/docs/integrations/vectorstores/faiss#saving-and-loading), you'll need to install the [`pickleparser`](https://github.com/ewfian/pickleparser) package.
 
-```{=mdx}
-<Npm2Yarn>
-  pickleparser
-</Npm2Yarn>
+
+<CodeGroup>
+```bash npm
+npm install pickleparser
 ```
+```bash yarn
+yarn add pickleparser
+```
+```bash pnpm
+pnpm add pickleparser
+```
+</CodeGroup>
+
 
 Then you can use the `.loadFromPython` static method:
 

--- a/src/oss/javascript/integrations/vectorstores/hnswlib.mdx
+++ b/src/oss/javascript/integrations/vectorstores/hnswlib.mdx
@@ -2,13 +2,9 @@
 title: HNSWLib
 ---
 
-```{=mdx}
 <Tip>
-**Compatibility**
-
-Only available on Node.js.
+**Compatibility**: Only available on Node.js.
 </Tip>
-```
 
 HNSWLib is an in-memory vector store that can be saved to a file. It uses the [HNSWLib library](https://github.com/nmslib/hnswlib).
 
@@ -28,22 +24,23 @@ To use HNSWLib vector stores, you'll need to install the `@langchain/community` 
 
 This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/openai), which require you to install the `@langchain/openai` integration package. You can also use [other supported embeddings models](/oss/integrations/text_embedding) if you wish.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community hnswlib-node @langchain/openai @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community hnswlib-node @langchain/openai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/community hnswlib-node @langchain/openai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/community hnswlib-node @langchain/openai @langchain/core
+```
+</CodeGroup>
 
-```{=mdx}
+
 <Warning>
-****On Windows**, you might need to install [Visual Studio](https://visualstudio.microsoft.com/downloads/) first in order to properly build the `hnswlib-node` package.**
-
-
+**On Windows**, you might need to install [Visual Studio](https://visualstudio.microsoft.com/downloads/) first in order to properly build the `hnswlib-node` package.**
 </Warning>
-```
+
 
 ### Credentials
 

--- a/src/oss/javascript/integrations/vectorstores/mariadb.mdx
+++ b/src/oss/javascript/integrations/vectorstores/mariadb.mdx
@@ -2,13 +2,9 @@
 title: MariaDB
 ---
 
-```{=mdx}
 <Tip>
-**Compatibility**
-
-Only available on Node.js.
+**Compatibility**: Only available on Node.js.
 </Tip>
-```
 
 This requires MariaDB 11.7 or later version
 
@@ -30,14 +26,17 @@ This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/op
 
 We'll also use the [`uuid`](https://www.npmjs.com/package/uuid) package to generate ids in the required format.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/openai @langchain/core mariadb uuid
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/openai @langchain/core mariadb uuid
 ```
+```bash yarn
+yarn add @langchain/community @langchain/openai @langchain/core mariadb uuid
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/openai @langchain/core mariadb uuid
+```
+</CodeGroup>
 
 ### Setting up an instance
 

--- a/src/oss/javascript/integrations/vectorstores/memory.mdx
+++ b/src/oss/javascript/integrations/vectorstores/memory.mdx
@@ -22,14 +22,17 @@ To use in-memory vector stores, you'll need to install the `langchain` package:
 
 This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/openai), which require you to install the `@langchain/openai` integration package. You can also use [other supported embeddings models](/oss/integrations/text_embedding) if you wish.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  langchain @langchain/openai @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install langchain @langchain/openai @langchain/core
 ```
+```bash yarn
+yarn add langchain @langchain/openai @langchain/core
+```
+```bash pnpm
+pnpm add langchain @langchain/openai @langchain/core
+```
+</CodeGroup>
 
 ### Credentials
 

--- a/src/oss/javascript/integrations/vectorstores/mongodb_atlas.mdx
+++ b/src/oss/javascript/integrations/vectorstores/mongodb_atlas.mdx
@@ -2,11 +2,8 @@
 title: MongoDB Atlas
 ---
 
-```{=mdx}
 <Tip>
-**Compatibility**
-
-Only available on Node.js.
+**Compatibility**: Only available on Node.js.
 
 You can still create API routes that use MongoDB with Next.js by setting the `runtime` variable to `nodejs` like so:
 
@@ -71,14 +68,17 @@ This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/op
 
 Install the following packages:
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/mongodb mongodb @langchain/openai @langchain/core
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/mongodb mongodb @langchain/openai @langchain/core
 ```
+```bash yarn
+yarn add @langchain/mongodb mongodb @langchain/openai @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/mongodb mongodb @langchain/openai @langchain/core
+```
+</CodeGroup>
 
 ### Credentials
 

--- a/src/oss/javascript/integrations/vectorstores/pgvector.mdx
+++ b/src/oss/javascript/integrations/vectorstores/pgvector.mdx
@@ -2,13 +2,9 @@
 title: PGVectorStore
 ---
 
-```{=mdx}
 <Tip>
-**Compatibility**
-
-Only available on Node.js.
+**Compatibility**: Only available on Node.js.
 </Tip>
-```
 
 To enable vector search in generic PostgreSQL databases, LangChain.js supports using the [`pgvector`](https://github.com/pgvector/pgvector) Postgres extension.
 
@@ -30,14 +26,17 @@ This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/op
 
 We'll also use the [`uuid`](https://www.npmjs.com/package/uuid) package to generate ids in the required format.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/openai @langchain/core pg uuid
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/openai @langchain/core pg uuid
 ```
+```bash yarn
+yarn add @langchain/community @langchain/openai @langchain/core pg uuid
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/openai @langchain/core pg uuid
+```
+</CodeGroup>
 
 ### Setting up an instance
 
@@ -86,16 +85,10 @@ If you want to get automated tracing of your model calls you can also set your [
 
 To instantiate the vector store, call the `.initialize()` static method. This will automatically check for the presence of a table, given by `tableName` in the passed `config`. If it is not there, it will create it with the required columns.
 
-```{=mdx}
-
-:<Warning>
-**Security**
-
-User-generated data such as usernames should not be used as input for table and column names.
+<Warning>
+**Security**: User-generated data such as usernames should not be used as input for table and column names.
 **This may lead to SQL Injection!**
-</Warning>:
-
-```
+</Warning>
 
 ```typescript
 import {

--- a/src/oss/javascript/integrations/vectorstores/pinecone.mdx
+++ b/src/oss/javascript/integrations/vectorstores/pinecone.mdx
@@ -20,14 +20,17 @@ To use Pinecone vector stores, you'll need to create a Pinecone account, initial
 
 This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/openai), which require you to install the `@langchain/openai` integration package. You can also use [other supported embeddings models](/oss/integrations/text_embedding) if you wish.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/pinecone @langchain/openai @langchain/core @pinecone-database/pinecone@5
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/pinecone @langchain/openai @langchain/core @pinecone-database/pinecone@5
 ```
+```bash yarn
+yarn add @langchain/pinecone @langchain/openai @langchain/core @pinecone-database/pinecone@5
+```
+```bash pnpm
+pnpm add @langchain/pinecone @langchain/openai @langchain/core @pinecone-database/pinecone@5
+```
+</CodeGroup>
 
 ### Credentials
 

--- a/src/oss/javascript/integrations/vectorstores/qdrant.mdx
+++ b/src/oss/javascript/integrations/vectorstores/qdrant.mdx
@@ -2,13 +2,9 @@
 title: QdrantVectorStore
 ---
 
-```{=mdx}
 <Tip>
-**Compatibility**
-
-Only available on Node.js.
+**Compatibility**: Only available on Node.js.
 </Tip>
-```
 
 [Qdrant](https://qdrant.tech/) is a vector similarity search engine. It provides a production-ready service with a convenient API to store, search, and manage points - vectors with an additional payload.
 
@@ -28,14 +24,17 @@ To use Qdrant vector stores, you'll need to set up a Qdrant instance and install
 
 This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/openai), which require you to install the `@langchain/openai` integration package. You can also use [other supported embeddings models](/oss/integrations/text_embedding) if you wish.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/qdrant @langchain/core @langchain/openai
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/qdrant @langchain/core @langchain/openai
 ```
+```bash yarn
+yarn add @langchain/qdrant @langchain/core @langchain/openai
+```
+```bash pnpm
+pnpm add @langchain/qdrant @langchain/core @langchain/openai
+```
+</CodeGroup>
 
 After installing the required dependencies, run a Qdrant instance with Docker on your computer by following the [Qdrant setup instructions](https://qdrant.tech/documentation/quickstart/). Note the URL your container runs on.
 

--- a/src/oss/javascript/integrations/vectorstores/redis.mdx
+++ b/src/oss/javascript/integrations/vectorstores/redis.mdx
@@ -2,13 +2,9 @@
 title: RedisVectorStore
 ---
 
-```{=mdx}
 <Tip>
-**Compatibility**
-
-Only available on Node.js.
+**Compatibility**: Only available on Node.js.
 </Tip>
-```
 
 [Redis](https://redis.io/) is a fast open source, in-memory data store. As part of the [Redis Stack](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/), [RediSearch](https://redis.io/docs/latest/develop/interact/search-and-query/) is the module that enables vector similarity semantic search, as well as many other types of searching.
 
@@ -28,14 +24,17 @@ To use Redis vector stores, you'll need to set up a Redis instance and install t
 
 This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/openai), which require you to install the `@langchain/openai` integration package. You can also use [other supported embeddings models](/oss/integrations/text_embedding) if you wish.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/redis @langchain/core redis @langchain/openai
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/redis @langchain/core redis @langchain/openai
 ```
+```bash yarn
+yarn add @langchain/redis @langchain/core redis @langchain/openai
+```
+```bash pnpm
+pnpm add @langchain/redis @langchain/core redis @langchain/openai
+```
+</CodeGroup>
 
 You can set up a Redis instance locally with Docker by following [these instructions](https://redis.io/docs/latest/operate/oss_and_stack/install/install-stack/docker/#redisredis-stack).
 

--- a/src/oss/javascript/integrations/vectorstores/supabase.mdx
+++ b/src/oss/javascript/integrations/vectorstores/supabase.mdx
@@ -22,14 +22,17 @@ To use Supabase vector stores, you'll need to set up a Supabase database and ins
 
 This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/openai), which require you to install the `@langchain/openai` integration package. You can also use [other supported embeddings models](/oss/integrations/text_embedding) if you wish.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core @supabase/supabase-js @langchain/openai
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core @supabase/supabase-js @langchain/openai
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core @supabase/supabase-js @langchain/openai
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core @supabase/supabase-js @langchain/openai
+```
+</CodeGroup>
 
 Once you've created a database, run the following SQL to set up [`pgvector`](https://github.com/pgvector/pgvector) and create the necessary table and functions:
 

--- a/src/oss/javascript/integrations/vectorstores/upstash.mdx
+++ b/src/oss/javascript/integrations/vectorstores/upstash.mdx
@@ -20,24 +20,26 @@ To use Upstash vector stores, you'll need to create an Upstash account, create a
 
 This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/openai), which require you to install the `@langchain/openai` integration package. You can also use [other supported embeddings models](/oss/integrations/text_embedding) if you wish.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/community @langchain/core @upstash/vector @langchain/openai
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/community @langchain/core @upstash/vector @langchain/openai
 ```
+```bash yarn
+yarn add @langchain/community @langchain/core @upstash/vector @langchain/openai
+```
+```bash pnpm
+pnpm add @langchain/community @langchain/core @upstash/vector @langchain/openai
+```
+</CodeGroup>
 
 You can create an index from the [Upstash Console](https://console.upstash.com/login). For further reference, see [the official docs](https://upstash.com/docs/vector/overall/getstarted).
 
 Upstash vector also has built in embedding support. Which means you can use it directly without the need for an additional embedding model. Check the [embedding models documentation](https://upstash.com/docs/vector/features/embeddingmodels) for more details.
 
-```{=mdx}
 <Note>
 To use the built-in Upstash embeddings, you'll need to select an embedding model when creating the index.
 </Note>
-```
+
 
 ### Credentials
 

--- a/src/oss/javascript/integrations/vectorstores/weaviate.mdx
+++ b/src/oss/javascript/integrations/vectorstores/weaviate.mdx
@@ -20,14 +20,17 @@ To use Weaviate vector stores, you'll need to set up a Weaviate instance and ins
 
 This guide will also use [OpenAI embeddings](/oss/integrations/text_embedding/openai), which require you to install the `@langchain/openai` integration package. You can also use [other supported embeddings models](/oss/integrations/text_embedding) if you wish.
 
-```{=mdx}
-import IntegrationInstallTooltip from "@mdx_components/integration_install_tooltip.mdx";
-<IntegrationInstallTooltip></IntegrationInstallTooltip>
-
-<Npm2Yarn>
-  @langchain/weaviate @langchain/core weaviate-client uuid @langchain/openai
-</Npm2Yarn>
+<CodeGroup>
+```bash npm
+npm install @langchain/weaviate @langchain/core weaviate-client uuid @langchain/openai
 ```
+```bash yarn
+yarn add @langchain/weaviate @langchain/core weaviate-client uuid @langchain/openai
+```
+```bash pnpm
+pnpm add @langchain/weaviate @langchain/core weaviate-client uuid @langchain/openai
+```
+</CodeGroup>
 
 You'll need to run Weaviate either locally or on a server. See [the Weaviate documentation](https://weaviate.io/developers/weaviate/installation) for more information.
 


### PR DESCRIPTION
## Overview
Ported Brody's changes from https://github.com/langchain-ai/docs/pull/415 over:

This tooltip was removed (the callout linked to a page that's in the old docs but not the new docs, and didn't seem critical to me to have right now):

```
import IntegrationInstallTooltip from '/snippets/javascript-integrations/integration-install-tooltip.mdx';

<IntegrationInstallTooltip/>
```

Installation code blocks like this didn't migrate so well:

```
<Npm2Yarn>
  @arcjet/redact
</Npm2Yarn>
```

For now, I've replaced these with code groups (below is just an example, each code group is different based on the library getting installed)

```
<CodeGroup>
```bash npm
npm install @arcjet/redact
```
```bash yarn
yarn add @arcjet/redact
```
```bash pnpm
pnpm add @arcjet/redact
```
</CodeGroup>
```

Removed {=mdx} tags

This snippet shows up in several places:

`<ChatModelTabs customVarName="llm" />`

So I removed

## Type of change

**Type:** Fix

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
