### PR TITLE
fix(deployment): remove body param from auth handler

### DIFF
--- a/src/langsmith/auth.mdx
+++ b/src/langsmith/auth.mdx
@@ -123,7 +123,6 @@ The returned user information is available:
   The [`@auth.authenticate`](https://langchain-ai.github.io/langgraph/cloud/reference/sdk/python_sdk_ref/#langgraph_sdk.auth.Auth.authenticate) handler can accept any of the following parameters by name:
 
   * request (Request): The raw ASGI request object
-  * body (dict): The parsed request body
   * path (str): The request path, e.g., `"/threads/abcd-1234-abcd-1234/runs/abcd-1234-abcd-1234/stream"`
   * method (str): The HTTP method, e.g., `"GET"`
   * path_params (dict[str, str]): URL path parameters, e.g., `{"thread_id": "abcd-1234-abcd-1234", "run_id": "abcd-1234-abcd-1234"}`


### PR DESCRIPTION
This was never actually implemented, and we've decided to not support it for now. See https://github.com/langchain-ai/langgraph/pull/6322.