### PR TITLE
Revert "fix(docs): use thread level vars instead of run level (#1096)"

### DIFF
--- a/src/langsmith/insights.mdx
+++ b/src/langsmith/insights.mdx
@@ -113,12 +113,9 @@ The Insights Agent analyzes [threads](https://docs.langchain.com/langsmith/threa
 
 | Variable | Best for | Example |
 | --- | --- | --- |
-| `{{thread.last_inputs}}` | Access input data from the most recent trace (i.e. final turn) in a thread |
-| `{{thread.last_outputs}}` | Access output data from the most recent trace (i.e. final turn) in a thread |
-| `{{thread.last_error}}` | Access error data from the most recent trace (i.e. final turn) in a thread |
-| `{{thread.all_messages}}` | All messages across all traces in the thread, formatted as a conversation |
+| run.* | Access data from the most recent root run (i.e. final turn) in a thread | `{{run.inputs}}` `{{run.outputs}}` `{{run.error}}`|
 
-You can also access nested fields using dot notation. For example, the prompt `"Summarize this: {{thread.last_inputs.foo.bar}}"` will include only the "bar" value within the "foo" value of the last trace's inputs.
+You can also access nested fields using dot notation. For example, the prompt `"Summarize this: {{run.inputs.foo.bar}}"` will include only the "bar" value within the "foo" value of the last run's inputs.
 
 #### Attributes
 Along with a summary, you can define additional categorical, numerical, and boolean attributes to be extracted from each trace.


### PR DESCRIPTION
Reverting because #1096 was merged into main after review but fe/be changes are not complete yet