### PR TITLE
fix(docs): fix typo in example (Middleware → AgentMiddleware)

### DIFF
--- a/src/oss/python/releases/langchain-v1.mdx
+++ b/src/oss/python/releases/langchain-v1.mdx
@@ -146,7 +146,7 @@ from langchain.messages import AIMessage
 class Context:
     user_expertise: str = "beginner"
 
-class ExpertiseBasedToolMiddleware(Middleware):
+class ExpertiseBasedToolMiddleware(AgentMiddleware):
     def wrap_model_call(
         self,
         request: ModelRequest,


### PR DESCRIPTION
## Overview
Fixes a small typo in the LangChain documentation where `Middleware` was used instead of `AgentMiddleware` in an example for `ExpertiseBasedToolMiddleware`.

## Type of change
**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- None

## Checklist
- [x] I have read the [contributing guidelines](README.md)
- [x] I have verified the class name in the current LangChain API
- [x] All code examples have been tested and work correctly
- [x] Root relative paths verified
- [x] N/A — no navigation updates needed
- [x] I have gotten approval from the relevant reviewers

## Additional notes
This change aligns the example with the current LangChain API (`AgentMiddleware` is the correct base class).