### PR TITLE
Update service descriptions per arch overview page

### DIFF
--- a/src/langsmith/troubleshooting.mdx
+++ b/src/langsmith/troubleshooting.mdx
@@ -9,13 +9,15 @@ While running LangSmith, you may encounter unexpected 500 errors, slow performan
 
 ## Getting helpful information
 
-To diagnose and resolve an issue, you will first need to retrieve some relevant information. Below, we explain how to do this for a kubernetes setup, a docker setup, as well as how to pull helpful browser info.
+To diagnose and resolve an issue, you will first need to retrieve some relevant information. The following sections explain how to do this for a Kubernetes or a Docker setup, and how to pull helpful browser information.
 
-Generally, the main services you will want to analyze are:
+Generally, the main services you will want to analyze are the:
 
-* `langsmith-backend`: The main backend service.
-* `langsmith-platform-backend`: Another important backend service.
-* `langsmith-queue`: The queue service.
+- `langsmith-backend`: Handles CRUD API requests, business logic, requests from the frontend and SDK, trace preparation for ingestion, and the hub API.
+- `langsmith-platform-backend`: Handles authentication, run ingestion, and other high-volume tasks.
+- `langsmith-queue`: Handles incoming traces and feedback, asynchronous ingestion and persistence into the datastore, data integrity checks, and retries during database errors or connection issues.
+
+For more details on these services, refer to the [Architectural overview](/langsmith/architectural-overview).
 
 #### Kubernetes
 


### PR DESCRIPTION
updates the service descriptions mentioned on the troubleshooting page — uses the descriptions from the architectural overview and then links to that page