### PR TITLE
chore: document redis max connections

### DIFF
--- a/src/langsmith/env-var.mdx
+++ b/src/langsmith/env-var.mdx
@@ -158,6 +158,14 @@ Custom Redis instances are only available for [Hybrid](/langsmith/hybrid) and [S
 
 Specify `REDIS_URI_CUSTOM` to use a custom Redis instance. The value of `REDIS_URI_CUSTOM` must be a valid [Redis connection URI](https://redis-py.readthedocs.io/en/stable/connections.html#redis.Redis.from_url).
 
+## `REDIS_MAX_CONNECTIONS`
+
+The maximum size of the Redis connection pool (per replica) can be controlled using the `REDIS_MAX_CONNECTIONS` environment variable. By setting this variable, you can determine the upper bound on the number of simultaneous connections the server will establish with the Redis instance.
+
+For example, if a deployment is scaled up to 10 replicas and `REDIS_MAX_CONNECTIONS` is configured to `150`, then up to `1500` connections to Redis can be established.
+
+Defaults to `2000`.
+
 ## `RESUMABLE_STREAM_TTL_SECONDS`
 
 Time-to-live in seconds for resumable stream data in Redis.


### PR DESCRIPTION
## Overview
Documenting the `REDIS_MAX_CONNECTIONS` env variable in langsmith deployments env var section.

Slack thread: documenting in response to [this thread](https://langchain.slack.com/archives/C09BJFQD77G/p1760985687471129)

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
