### PR TITLE
Fix formatting of edge additions in `Thinking in LangGraph`

### DIFF
--- a/src/oss/langgraph/thinking-in-langgraph.mdx
+++ b/src/oss/langgraph/thinking-in-langgraph.mdx
@@ -931,8 +931,8 @@ const workflow = new StateGraph(EmailAgentState)
   .addNode("humanReview", humanReview)
   .addNode("sendReply", sendReply)
   // Add only the essential edges
-  .addEdge(START, "readEmail");
-  .addEdge("readEmail", "classifyIntent");
+  .addEdge(START, "readEmail")
+  .addEdge("readEmail", "classifyIntent")
   .addEdge("sendReply", END);
 
 // Compile with checkpointer for persistence


### PR DESCRIPTION


## Overview
Remove the exta semicolan which are causing the compilation error while copy pasting the code so to avoid that we should fix this formatting issue

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [X] I have read the [contributing guidelines](README.md)
- [X] I have tested my changes locally using `docs dev`
- [X] All code examples have been tested and work correctly
- [X] I have used **root relative** paths for internal links
- [X] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
