### PR TITLE
fix(docs): provider name (google_genai) wrong

### DIFF
--- a/src/snippets/chat-model-tabs-js.mdx
+++ b/src/snippets/chat-model-tabs-js.mdx
@@ -137,7 +137,7 @@
 
             process.env.GOOGLE_API_KEY = "your-api-key";
 
-            const model = await initChatModel("google_genai:gemini-2.5-flash-lite");
+            const model = await initChatModel("google-genai:gemini-2.5-flash-lite");
             ```
             ```typescript Model Class
             import { ChatGoogleGenerativeAI } from "@langchain/google-genai";


### PR DESCRIPTION
## Overview
Fixed provider name from google_genai to google-genai

## Type of change
Fix existing documentation

## Checklist
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers

