### PR TITLE
fix(ref/js): point to new langgraph module dir

### DIFF
--- a/reference/javascript/build.ts
+++ b/reference/javascript/build.ts
@@ -220,7 +220,7 @@ const SOURCES: Source[] = [
       },
       {
         package: "@langchain/langgraph",
-        path: "libs/langgraph",
+        path: "libs/langgraph-core",
         repo: "langchain-ai/langgraphjs",
         branch: "main",
       },


### PR DESCRIPTION
needs an update after this PR got merged:
https://github.com/langchain-ai/langgraphjs/pull/1742