### PR TITLE
docs(langsmith): update HAR file generation link

### DIFF
--- a/src/langsmith/troubleshooting.mdx
+++ b/src/langsmith/troubleshooting.mdx
@@ -41,7 +41,7 @@ docker compose logs >> logs.txt
 
 #### Browser Errors
 
-If you are experiencing an issue that surfaces as a browser error, it may also be helpful to inspect a HAR file which may include key information. To get the HAR file, you can follow [this guide](https://support.zendesk.com/hc/en-us/articles/4408828867098-Generating-a-HAR-file-for-troubleshooting) which explains the short process for various browsers.
+If you are experiencing an issue that surfaces as a browser error, it may also be helpful to inspect a HAR file which may include key information. To get the HAR file, you can follow [this guide](https://support.langchain.com/articles/9042697994-how-to-generate-a-har-file-for-troubleshooting) which explains the short process for various browsers.
 
 You can then use [Google's HAR analyzer](https://toolbox.googleapps.com/apps/har_analyzer/) to investigate. You can also send your HAR file to the LangSmith team to help with debugging.
 


### PR DESCRIPTION
## Summary
- Update HAR file generation link in LangSmith troubleshooting documentation from Zendesk support article to LangChain-specific support article

## Changes
- Changed link from `https://support.zendesk.com/hc/en-us/articles/4408828867098-Generating-a-HAR-file-for-troubleshooting` to `https://support.langchain.com/articles/9042697994-how-to-generate-a-har-file-for-troubleshooting` in `src/langsmith/troubleshooting.mdx`

## Test plan
- [x] Verified the link change is correct
- [x] Confirmed the new URL points to LangChain-specific HAR file generation guide