### PR TITLE
fix(langchain): correct createAgent parameter name in quickstart

### DIFF
--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -337,7 +337,7 @@ Let's walk through each step:
 
         const agent = createAgent({
           model: "anthropic:claude-sonnet-4-5",
-          prompt: systemPrompt,
+          systemPrompt: systemPrompt,
           tools: [getUserLocation, getWeather],
           responseFormat,
           checkpointer,
@@ -532,7 +532,7 @@ const checkpointer = new MemorySaver();
 // Create agent
 const agent = createAgent({
   model: "anthropic:claude-sonnet-4-5",
-  prompt: systemPrompt,
+  systemPrompt: systemPrompt,
   tools: [getUserLocation, getWeather],
   responseFormat,
   checkpointer,


### PR DESCRIPTION
The createAgent function in JavaScript/TypeScript uses systemPrompt as the parameter name, not prompt. This updates the documentation to reflect the correct API signature.

Changes:
- Updated remaining instance in full example code section (line 535)
- Ensures consistency with the correct createAgent API

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
