### PR TITLE
update home page and links to old content

### DIFF
--- a/src/index.mdx
+++ b/src/index.mdx
@@ -28,11 +28,12 @@ mode: "custom"
 
         <h2 class="flex whitespace-pre-wrap group font-semibold">Get started</h2>
 
-        <CardGroup cols={4}>
+        <CardGroup cols={3}>
             <Card title="Build your first agent" icon="gear" href="/oss/python/langchain/quickstart" cta="Get started" />
             <Card title="Sign up for LangSmith" icon="screwdriver-wrench" href="https://smith.langchain.com/" cta="Try LangSmith" />
             <Card title="Send your first trace" icon="monitor-waveform" href="/langsmith/integrations" cta="Get started" />
             <Card title="Build an advanced agent" icon="robot" href="/oss/python/langgraph/quickstart" cta="Get started"/>
+            <Card title="Enroll in LangChain Academy" icon="graduation-cap" href="https://academy.langchain.com/" cta="Get started"/>
         </CardGroup>
 
         <h2 class="flex whitespace-pre-wrap group font-semibold">Open source agent frameworks</h2>

--- a/src/oss/langchain/overview.mdx
+++ b/src/oss/langchain/overview.mdx
@@ -9,7 +9,7 @@ sidebarTitle: Overview
 
     For a complete list of changes and instructions on how to upgrade your code, see the [release notes](/oss/releases/langchain-v1) and [migration guide](/oss/migrate/langchain-v1).
 
-    If you encounter any issues or have feedback, please [open an issue](https://github.com/langchain-ai/docs/issues/new?template=01-langchain.yml) so we can improve. To view v0.x documentation, [go to the archived site](https://python.langchain.com/docs/introduction/).
+    If you encounter any issues or have feedback, please [open an issue](https://github.com/langchain-ai/docs/issues/new?template=01-langchain.yml) so we can improve. To view v0.x documentation, [go to the archived content](https://github.com/langchain-ai/langchain/tree/v0.3/docs/docs).
 </Callout>
 :::
 
@@ -19,7 +19,7 @@ sidebarTitle: Overview
 
     For a complete list of changes and instructions on how to upgrade your code, see the [release notes](/oss/releases/langchain-v1) and [migration guide](/oss/migrate/langchain-v1).
 
-    If you encounter any issues or have feedback, please [open an issue](https://github.com/langchain-ai/docs/issues/new?template=01-langchain.yml) so we can improve. To view v0.x documentation, [go to the archived site](https://js.langchain.com/docs/introduction/).
+    If you encounter any issues or have feedback, please [open an issue](https://github.com/langchain-ai/docs/issues/new?template=01-langchain.yml) so we can improve. To view v0.x documentation, [go to the archived content](https://github.com/langchain-ai/langchainjs/tree/v0.3/docs/core_docs/docs).
 </Callout>
 :::
 

--- a/src/oss/langgraph/overview.mdx
+++ b/src/oss/langgraph/overview.mdx
@@ -9,7 +9,7 @@ sidebarTitle: Overview
 
     For a complete list of changes and instructions on how to upgrade your code, see the [release notes](/oss/releases/langgraph-v1) and [migration guide](/oss/migrate/langgraph-v1).
 
-    If you encounter any issues or have feedback, please [open an issue](https://github.com/langchain-ai/docs/issues/new?template=02-langgraph.yml&labels=langgraph,python) so we can improve. To view v0.x documentation, [go to the archived site](https://langchain-ai.github.io/langgraph/).
+    If you encounter any issues or have feedback, please [open an issue](https://github.com/langchain-ai/docs/issues/new?template=02-langgraph.yml&labels=langgraph,python) so we can improve. To view v0.x documentation, [go to the archived content](https://github.com/langchain-ai/langgraph/tree/main/docs/docs).
 </Callout>
 :::
 
@@ -20,7 +20,7 @@ sidebarTitle: Overview
 
     For a complete list of changes and instructions on how to upgrade your code, see the [release notes](/oss/releases/langgraph-v1) and [migration guide](/oss/migrate/langgraph-v1).
 
-    If you encounter any issues or have feedback, please [open an issue](https://github.com/langchain-ai/docs/issues/new?template=02-langgraph.yml&labels=langgraph,js/ts) so we can improve. To view v0.x documentation, [go to the archived site](https://langchain-ai.github.io/langgraphjs/).
+    If you encounter any issues or have feedback, please [open an issue](https://github.com/langchain-ai/docs/issues/new?template=02-langgraph.yml&labels=langgraph,js/ts) so we can improve. To view v0.x documentation, [go to the archived content](https://github.com/langchain-ai/langgraphjs/tree/main/docs/docs).
 </Callout>
 :::
 


### PR DESCRIPTION
## Overview
- Add link to LC Academy on main landing page
- Update callouts on LC / LG overviews to point to md pages in old content

## Type of change

**Type:** Update



## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
