### PR TITLE
fix(docs): broken links in LangGraph - Graph API page

### DIFF
--- a/src/oss/langgraph/graph-api.mdx
+++ b/src/oss/langgraph/graph-api.mdx
@@ -68,9 +68,9 @@ The first thing you do when you define a graph is define the `State` of the grap
 ### Schema
 
 :::python
-The main documented way to specify the schema of a graph is by using a [`TypedDict`](https://docs.python.org/3/library/typing.html#typing.TypedDict). If you want to provide default values in your state, use a [`dataclass`](https://docs.python.org/3/library/dataclasses.html). We also support using a Pydantic [BaseModel](/oss/langgraph/graph-api.md#use-pydantic-models-for-graph-state) as your graph state if you want recursive data validation (though note that pydantic is less performant than a `TypedDict` or `dataclass`).
+The main documented way to specify the schema of a graph is by using a [`TypedDict`](https://docs.python.org/3/library/typing.html#typing.TypedDict). If you want to provide default values in your state, use a [`dataclass`](https://docs.python.org/3/library/dataclasses.html). We also support using a Pydantic [BaseModel](/oss/langgraph/use-graph-api#use-pydantic-models-for-graph-state) as your graph state if you want recursive data validation (though note that pydantic is less performant than a `TypedDict` or `dataclass`).
 
-By default, the graph will have the same input and output schemas. If you want to change this, you can also specify explicit input and output schemas directly. This is useful when you have a lot of keys, and some are explicitly for input and others for output. See the [guide here](/oss/langgraph/graph-api.md#define-input-and-output-schemas) for how to use.
+By default, the graph will have the same input and output schemas. If you want to change this, you can also specify explicit input and output schemas directly. This is useful when you have a lot of keys, and some are explicitly for input and others for output. See the [guide here](/oss/langgraph/use-graph-api#define-input-and-output-schemas) for how to use.
 :::
 
 :::js
@@ -887,7 +887,7 @@ When returning @[`Command`] in your node functions, you must add return type ann
 
 </Note>
 
-Check out this [how-to guide](/oss/langgraph/graph-api.md#combine-control-flow-and-state-updates-with-command) for an end-to-end example of how to use @[`Command`].
+Check out this [how-to guide](/oss/langgraph/use-graph-api#combine-control-flow-and-state-updates-with-command) for an end-to-end example of how to use @[`Command`].
 
 ### When should I use Command instead of conditional edges?
 
@@ -913,7 +913,7 @@ def my_node(state: State) -> Command[Literal["other_subgraph"]]:
 Setting `graph` to `Command.PARENT` will navigate to the closest parent graph.
 
 
-When you send updates from a subgraph node to a parent graph node for a key that's shared by both parent and subgraph [state schemas](#schema), you **must** define a [reducer](#reducers) for the key you're updating in the parent graph state. See this [example](/oss/langgraph/graph-api.md#navigate-to-a-node-in-a-parent-graph).
+When you send updates from a subgraph node to a parent graph node for a key that's shared by both parent and subgraph [state schemas](#schema), you **must** define a [reducer](#reducers) for the key you're updating in the parent graph state. See this [example](/oss/langgraph/use-graph-api#navigate-to-a-node-in-a-parent-graph).
 
 </Note>
 
@@ -971,13 +971,13 @@ When you send updates from a subgraph node to a parent graph node for a key that
 
 This is particularly useful when implementing [multi-agent handoffs](/oss/langchain/multi-agent#handoffs).
 
-Check out [this guide](/oss/langgraph/graph-api.md#navigate-to-a-node-in-a-parent-graph) for detail.
+Check out [this guide](/oss/langgraph/use-graph-api#navigate-to-a-node-in-a-parent-graph) for detail.
 
 ### Using inside tools
 
 A common use case is updating graph state from inside a tool. For example, in a customer support application you might want to look up customer information based on their account number or ID in the beginning of the conversation.
 
-Refer to [this guide](/oss/langgraph/graph-api.md#use-inside-tools) for detail.
+Refer to [this guide](/oss/langgraph/use-graph-api#use-inside-tools) for detail.
 
 ### Human-in-the-loop
 
@@ -1116,4 +1116,4 @@ await graph.invoke(inputs, {
 
 ## Visualization
 
-It's often nice to be able to visualize graphs, especially as they get more complex. LangGraph comes with several built-in ways to visualize graphs. See [this how-to guide](/oss/langgraph/graph-api.md#visualize-your-graph) for more info.
+It's often nice to be able to visualize graphs, especially as they get more complex. LangGraph comes with several built-in ways to visualize graphs. See [this how-to guide](/oss/langgraph/use-graph-api#visualize-your-graph) for more info.


### PR DESCRIPTION
## Overview
There broken links in LangGraph - Graph API page due to wrong file name. 
- `graph_api.md` -> `use-graph-api`

## Type of change

**Type:** Fix link

## Related issues/PRs
## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
