### PR TITLE
docs: clarify Bright Data API key setup instructions

### DIFF
--- a/src/oss/python/integrations/providers/brightdata.mdx
+++ b/src/oss/python/integrations/providers/brightdata.mdx
@@ -20,6 +20,8 @@ uv add langchain-brightdata
 
 You'll need to set up your Bright Data API key:
 
+Sign up at [Bright Data](https://brightdata.com/?utm_source=tech-partner&utm_medium=link&utm_campaign=langchain&hs_signup=1) and retrieve your API key from your account settings. Replace `"your-api-key"` with your actual API key in the examples below: 
+
 ```python
 import os
 os.environ["BRIGHT_DATA_API_KEY"] = "your-api-key"


### PR DESCRIPTION
## Overview
Added clearer instructions on how to get API key's from Bright Data.

## Type of change
**Type:** Update existing documentation

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)
To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"
For regular references without auto-closing, just use:
- "#123" or "See issue #123"
Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue: N/A
- Feature PR: N/A
<!-- For LangChain employees, if applicable: -->
- Linear issue: N/A
- Slack thread: N/A

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [X] I have read the [[contributing guidelines](README.md)
- [X] I have tested my changes locally using `docs dev`
- [X] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- [ ] I have gotten approval from the relevant reviewers
- [ ] (Internal team members only / optional) I have created a preview deployment using the [[Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
This change improves the setup instructions by providing a concrete Python code example for setting the API key environment variable, making it easier for users to get started with langchain-brightdata.