### PR TITLE
Fix typo in backends.mdx documentation

### DIFF
--- a/src/oss/deepagents/backends.mdx
+++ b/src/oss/deepagents/backends.mdx
@@ -43,7 +43,7 @@ agent = create_deep_agent(
 
 **Best for:**
 - A scratch pad for the agent to write intermediate results.
-- Aautomatic eviction of large tool outputs which the agent can then read back in piece by piece.
+- Automatic eviction of large tool outputs which the agent can then read back in piece by piece.
 
 ### FilesystemBackend (local disk)
 


### PR DESCRIPTION
## Overview
Changed Aautomatic to Automatic and matched the sentences context

## Type of change

**Type:** Fix typo

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
Its my first PR for langchain, I love the framework and wanted to give back in any way possible!
