### PR TITLE
fix(docs): Fix unused parameter from get_user_location QuickStart agent sample

### DIFF
--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -129,7 +129,7 @@ Let's walk through each step:
             user_id: str
 
         @tool
-        def get_user_location(runtime: ToolRuntime[Context, Any]) -> str:
+        def get_user_location(runtime: ToolRuntime[Context]) -> str:
             """Retrieve user information based on user ID."""
             user_id = runtime.context.user_id
             return "Florida" if user_id == "1" else "SF"


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
The parameter `Any` is not available in the full code sample but available only in this section. So, removing the unused `Any` from the sample get_user_location in the sample agent code

## Type of change

**Type:** Fix typo

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
