### PR TITLE
docs: clarify run-time validation limitations in graph outputs

### DIFF
--- a/src/oss/langgraph/use-graph-api.mdx
+++ b/src/oss/langgraph/use-graph-api.mdx
@@ -750,7 +750,7 @@ Here, we'll see how a [Pydantic BaseModel](https://docs.pydantic.dev/latest/api/
 <Note>
 **Known Limitations**
 * Currently, the output of the graph will **NOT** be an instance of a pydantic model.
-* Run-time validation only occurs on inputs into nodes, not on the outputs.
+* Run-time validation only occurs on inputs to the first node in the graph, not on subsequent nodes or outputs.
 * The validation error trace from pydantic does not show which node the error arises in.
 * Pydantic's recursive validation can be slow. For performance-sensitive applications, you may want to consider using a `dataclass` instead.
 </Note>


### PR DESCRIPTION
Fixes #572