### PR TITLE
chore: explicitly state group renaming in SCIM is not supported

### DIFF
--- a/src/langsmith/user-management.mdx
+++ b/src/langsmith/user-management.mdx
@@ -414,6 +414,10 @@ The link expires in 24 hours, and can be resent if needed by removing and re-add
 
 #### Group Naming Convention
 
+<Warning>
+Renaming groups is **not** supported via SCIM. Group names are persistent because they must match role names and/or workspace names in LangSmith.
+</Warning>
+
 Group membership maps to LangSmith workspace membership and workspace roles with a specific naming convention:
 
 **Organization Admin Groups**
@@ -637,7 +641,7 @@ You must use the [Okta Lifecycle Management](https://www.okta.com/products/lifec
 - Create users
 - Update user attributes
 - Deactivate users
-- Group push
+- Group push (**without group renaming**)
 - Import users
 - Import groups
 


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
* our SCIM integration does not support renaming groups due to the group naming convention requirements, so make this clear in the docs

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue: part of ent-100
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
