### PR TITLE
Add callout and short steps for auth to private registry

### DIFF
--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -75,49 +75,49 @@ As of v0.12.0, the `langgraphPlatform` option is deprecated. Use `config.deploym
       enabled: true
       langgraphPlatformLicenseKey: "YOUR_LANGGRAPH_PLATFORM_LICENSE_KEY"
 ```
-4. In your `values.yaml` file, configure the `hostBackendImage` and `operatorImage` options (if you need to mirror images). If you are using a private container registry that requires authentication, you must also configure `imagePullSecrets`:
-
-   <Accordion title="Configure authentication for private registries (optional)">
-
-   If your user deployments will use images from private container registries (e.g., AWS ECR, Azure ACR, private Docker registry), configure image pull secrets. This is a one-time infrastructure configuration that allows all deployments to automatically authenticate with your private registry.
-
-   **Step 1: Create a Kubernetes image pull secret**
-
-   ```bash
-   kubectl create secret docker-registry langsmith-registry-secret \
-     --docker-server=myregistry.com \
-     --docker-username=your-username \
-     --docker-password=your-password \
-     --docker-email=your-email@example.com \
-     -n langsmith
-   ```
-
-   Replace the values with your registry credentials:
-   - `myregistry.com`: Your registry URL
-   - `your-username`: Your registry username
-   - `your-password`: Your registry password or access token
-   - `langsmith`: The namespace where LangSmith is installed
-
-   **Step 2: Configure the secret in your `values.yaml`**
-
-   ```yaml
-   images:
-     imagePullSecrets:
-       - name: langsmith-registry-secret
-   ```
-
-   **Step 3: Apply during Helm installation/upgrade**
-
-   When you deploy or upgrade your LangSmith instance using Helm, this configuration will be applied. All user deployments created through the LangSmith UI will automatically inherit these registry credentials.
-
-   For registry-specific authentication methods (AWS ECR, Azure ACR, GCP Artifact Registry, etc.), refer to the [Kubernetes documentation on pulling images from private registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
-
-   </Accordion>
+4. In your `values.yaml` file, configure the `hostBackendImage` and `operatorImage` options (if you need to mirror images). If you are using a private container registry that requires authentication, you must also configure `imagePullSecrets`, refer to [Configure authentication for private registries](#optional-configure-authentication-for-private-registries).
 
 5. You can also configure base templates for your agents by overriding the base templates [here](https://github.com/langchain-ai/helm/blob/main/charts/langsmith/values.yaml#L898).
 
     Your self-hosted infrastructure is now ready to create deployments.
 
+## (Optional) Configure authentication for private registries
+
+If your [Agent Server deployments](/langsmith/agent-server) will use images from private container registries (e.g., AWS ECR, Azure ACR, GCP Artifact Registry, private Docker registry), configure image pull secrets. This is a one-time infrastructure configuration that allows all deployments to automatically authenticate with your private registry.
+
+**Step 1: Create a Kubernetes image pull secret**
+
+```bash
+kubectl create secret docker-registry langsmith-registry-secret \
+    --docker-server=myregistry.com \
+    --docker-username=your-username \
+    --docker-password=your-password \
+    --docker-email=your-email@example.com \
+    -n langsmith
+```
+
+Replace the values with your registry credentials:
+- `myregistry.com`: Your registry URL
+- `your-username`: Your registry username
+- `your-password`: Your registry password or access token
+- `langsmith`: The Kubernetes namespace where LangSmith is installed
+
+**Step 2: Configure the secret in your `values.yaml`**
+
+```yaml
+images:
+    imagePullSecrets:
+    - name: langsmith-registry-secret
+```
+
+**Step 3: Apply during Helm installation/upgrade**
+
+When you deploy or upgrade your LangSmith instance using Helm, this configuration will be applied. All user deployments created through the LangSmith UI will automatically inherit these registry credentials.
+
+For registry-specific authentication methods (AWS ECR, Azure ACR, GCP Artifact Registry, etc.), refer to the [Kubernetes documentation on pulling images from private registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
+
 ## Next steps
 
 Once your infrastructure is set up, you're ready to deploy applications. See the deployment guides in the [Deployment tab](/langsmith/deployments) for instructions on building and deploying your applications.
+
+

--- a/src/langsmith/deploy-with-control-plane.mdx
+++ b/src/langsmith/deploy-with-control-plane.mdx
@@ -119,7 +119,7 @@ Starting from the LangSmith UI:
 
 ## Private registry authentication
 
-If your container registry requires authentication (e.g., AWS ECR, Azure ACR, private Docker registry), you must configure Kubernetes image pull secrets before deploying applications. This is a one-time infrastructure configuration.
+If your container registry requires authentication (e.g., AWS ECR, Azure ACR, GCP Artifact Registry, private Docker registry), you must configure Kubernetes image pull secrets before deploying applications. This is a one-time infrastructure configuration.
 
 <Note>
 **This configuration is done at the infrastructure level, not per-deployment.** Once configured, all deployments automatically inherit the registry credentials.


### PR DESCRIPTION
Fixes DOC-413

## Preview

Deploy with control plane: https://langchain-5e9cc07a-preview-contro-1762189117-6d9ff6a.mintlify.app/langsmith/deploy-with-control-plane#private-registry-authentication
Deploy full self-hosted platform: https://langchain-5e9cc07a-preview-contro-1762189117-6d9ff6a.mintlify.app/langsmith/deploy-self-hosted-full-platform (See accordion)