### PR TITLE
Add more definition resource vs commit tags

### DIFF
--- a/src/langsmith/administration-overview.mdx
+++ b/src/langsmith/administration-overview.mdx
@@ -176,7 +176,18 @@ For more details on assigning and creating roles, see the [access control setup 
 
 ### Environment Separation
 
-Use [resource tags](#resource-tags) to organize resources by environment using the default tag key `Environment` and different values for the environment (e.g. `dev`, `staging`, `prod`). This tagging structure will allow you to organize your tracing projects today and easily enforce permissions when we release attribute based access control (ABAC). ABAC on the resource tag will provide a fine-grained way to restrict access to production tracing projects, for example. We do not recommend that you use Workspaces for environment separation as you cannot share resources across Workspaces. If you would like to promote a prompt from `staging` to `prod`, we recommend you use commit tags instead. See [docs](/langsmith/prompt-engineering-concepts#tags) for more information.
+Use [resource tags](#resource-tags) to organize resources by environment using the default tag key `Environment` and different values for the environment (e.g., `dev`, `staging`, `prod`). We do not recommend using separate workspaces for environment separation because resources cannot be shared across workspaces, which would prevent you from promoting resources (like prompts) between environments.
+
+<Note>
+**Resource tags vs. commit tags for prompt management**
+
+While both types of tags can use environment terminology like `dev`, `staging`, and `prod`, they serve different purposes:
+
+- **Resource tags** (`Environment: prod`): Use these to *organize and filter* resources across your workspace. Apply resource tags to tracing projects, datasets, and other resources (including prompts) to group them by environment, which enables filtering in the UI.
+- [Commit tags](/langsmith/manage-prompts#commit-tags) (`prod` tag): Use these to manage which [prompt version](/langsmith/prompt-engineering) your code references. Commit tags are labels that point to specific commits in a prompt's history. When your code pulls a prompt by tag name (e.g., `client.pull_prompt("prompt-name:prod")`), it retrieves whichever commit that tag currently points to. To promote a prompt from `staging` to `prod`, move the commit tag to point to the desired version.
+
+Resource tags organize **which resources** belong to an environment. Commit tags let you control **which version** of a prompt your code references without changing the code itself.
+</Note>
 
 ## Usage and Billing
 

--- a/src/langsmith/manage-prompts.mdx
+++ b/src/langsmith/manage-prompts.mdx
@@ -15,11 +15,9 @@ LangSmith provides several tools to help you manage your [_prompts_](/langsmith/
 
 Each tag references exactly one commit, though you can reassign a tag to point to a different commit.
 
-Use cases for commit tags can include:
-
-- **Environment-specific tags**: Mark commits for `production` or `staging` environments, which allows you to switch between different versions without changing your code.
-- **Version control**: Mark stable versions of your prompts, for example, `v1`, `v2`, which lets you reference specific versions in your code and track changes over time.
-- **Collaboration**: Mark versions ready for review, which enables you to share specific versions with collaborators and get feedback.
+<Note>
+**Not to be confused with resource tags**: Commit tags are specific to prompt versioning and reference individual commits in a prompt's history. [Resource tags](/langsmith/set-up-resource-tags) are key-value pairs used to organize workspace resources like projects, datasets, and prompts. While both can use similar naming conventions (like `prod` or `staging`), commit tags control **which version** of a prompt runs, while resource tags help you **organize and filter** resources across your workspace.
+</Note>
 
 ### Create a tag
 

--- a/src/langsmith/prompt-engineering-concepts.mdx
+++ b/src/langsmith/prompt-engineering-concepts.mdx
@@ -90,15 +90,32 @@ Verisioning is a key part of iterating and collaborating on your different promp
 
 ### Commits
 
-Every saved update to a prompt creates a new commit. You can view previous commits, making it easy to review earlier prompt versions or revert to a previous state if needed. In the SDK, you can access a specific commit of a prompt by specifying the commit hash along with the prompt name (e.g. `prompt_name:commit_hash`).
+Every saved update to a prompt creates a new commit with a unique commit hash. This allows you to:
 
-In the UI, you can compare a commit with its previous version by toggling the "diff" button in the top-right corner of the Commits tab.
+- View the full history of changes to a prompt.
+- Review earlier versions.
+- Revert to a previous state if needed.
+- Reference specific versions in your code using the commit hash (e.g., `client.pull_prompt("prompt_name:commit_hash")`).
 
-![](/langsmith/images/commit-diff.png)
+In the UI, you can compare a commit with its previous version by toggling **Show diff** in the top-right corner of the **Commits** tab.
+
+![The commit hashes list for a prompt with the diff of one commit.](/langsmith/images/commit-diff.png)
 
 ### Tags
 
-You may want to tag prompt commits with a human-readable tag so that you can refer to it even as new commits are added. Common use cases include tagging a prompt with `dev` or `prod` tags. This allows you to track which versions of prompts are used where.
+Commit tags are human-readable labels that point to specific commits in your prompt's history. Unlike commit hashes, tags can be moved to point to different commits, allowing you to update which version your code references without changing the code itself.
+
+Use cases for commit tags can include:
+
+- **Environment-specific tags**: Mark commits for `production` or `staging` environments, which allows you to switch between different versions without changing your code.
+- **Version control**: Mark stable versions of your prompts, for example, `v1`, `v2`, which lets you reference specific versions in your code and track changes over time.
+- **Collaboration**: Mark versions ready for review, which enables you to share specific versions with collaborators and get feedback.
+
+<Note>
+**Not to be confused with resource tags**: Commit tags reference specific prompt versions. [Resource tags](/langsmith/set-up-resource-tags) are key-value pairs used to organize workspace resources.
+</Note>
+
+For detailed information on creating and managing commit tags, see [Manage prompts](/langsmith/manage-prompts#commit-tags).
 
 ## Prompt playground
 

--- a/src/langsmith/set-up-resource-tags.mdx
+++ b/src/langsmith/set-up-resource-tags.mdx
@@ -15,6 +15,10 @@ Resource tags are available for Plus and Enterprise plans.
 
 While workspaces help separate trust boundaries and access control, tags help you organize resources within a workspace. Tags are key-value pairs that you can attach to resources.
 
+<Note>
+**Not to be confused with commit tags**: Resource tags are key-value pairs used to organize and filter workspace resources (projects, datasets, prompts, etc.). [Commit tags](/langsmith/manage-prompts#commit-tags) are labels that reference specific versions in a prompt's commit history. While both types of tags can use similar terminology (like `prod` or `staging`), resource tags help you *organize resources* across your workspace, while commit tags control *which version* of a prompt is used in your code.
+</Note>
+
 ## Create a tag
 
 To create a tag, head to the workspace settings and click on the "Resource Tags" tab. Here, you'll be able to see the existing tag values, grouped by key. Two keys `Application` and `Environment` are created by default.


### PR DESCRIPTION
Fixes DOC-364

This PR adds more description and comparison between resource and commit tags where there had been some confusion.

## Preview

https://langchain-5e9cc07a-preview-resour-1762202790-b7036c0.mintlify.app/langsmith/manage-prompts#commit-tags