### PR TITLE
Fix environment variable name for Google Scholar API

### DIFF
--- a/src/oss/javascript/integrations/tools/google_scholar.mdx
+++ b/src/oss/javascript/integrations/tools/google_scholar.mdx
@@ -31,7 +31,7 @@ npm install @langchain/community
 Ensure you have the appropriate API key to access Google Scholar. Set it in your environment variables:
 
 ```typescript
-process.env.GOOGLE_SCHOLAR_API_KEY="your-serp-api-key"
+SERPAPI_API_KEY="your-serp-api-key"
 ```
 
 It's also helpful to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:


### PR DESCRIPTION
Update API key environment variable reference , 

In credentials  , environmental variable is defined like this :
process.env.GOOGLE_SCHOLAR_API_KEY="your-serp-api-key"
 to  : SERPAPI_API_KEY="your-serp-api-key" 

