### PR TITLE
fix: use 2.5-flash instead of preview variant

### DIFF
--- a/src/oss/python/integrations/retrievers/imap.mdx
+++ b/src/oss/python/integrations/retrievers/imap.mdx
@@ -173,7 +173,7 @@ from langchain_imap import ImapRetriever, ImapConfig
 
 # Setup LLM (example using OpenRouter)
 llm = ChatOpenAI(
-    model="google/gemini-2.5-flash-preview-09-2025",
+    model="google/gemini-2.5-flash",
     temperature=0,
     openai_api_key=os.getenv("OPENAI_API_KEY"),
     openai_api_base="https://openrouter.ai/api/v1"


### PR DESCRIPTION
Following removal announcement email