### PR TITLE
Add hyperlinks to homepage for obs evals deployment

### DIFF
--- a/src/index.mdx
+++ b/src/index.mdx
@@ -66,10 +66,6 @@ mode: "custom"
 
         <h2 class="flex whitespace-pre-wrap group font-semibold">LangSmith</h2>
 
-        <Callout icon="bullhorn" color="#DFC5FE" iconType="regular">
-        LangGraph Platform is now [LangSmith Deployment](/langsmith/deployments). For more information, check out the [Changelog](https://changelog.langchain.com/announcements/product-naming-changes-langsmith-deployment-and-langsmith-studio).
-        </Callout>
-
         [**LangSmith**](/langsmith/home) is a platform that helps AI teams use live production data for continuous testing and improvement. LangSmith provides:
 
         <CardGroup cols={4}>


### PR DESCRIPTION
Fixes DOC-417

## Preview

https://langchain-5e9cc07a-preview-obseva-1762365271-fdf1325.mintlify.app/