### PR TITLE
Fix AIMessage class path in Python example

### DIFF
--- a/src/oss/langchain/messages.mdx
+++ b/src/oss/langchain/messages.mdx
@@ -275,7 +275,7 @@ An @[`AIMessage`] represents the output of a model invocation. They can include 
 :::python
 ```python
 response = model.invoke("Explain AI")
-print(type(response))  # <class 'langchain_core.messages.AIMessage'>
+print(type(response))  # <class 'langchain_core.messages.ai.AIMessage'>
 ```
 :::
 


### PR DESCRIPTION
## Overview
That's where the class is actually defined, even though we imported it from the top-level package.

## Type of change

**Type:** [Update existing documentation / Fix typo/bug]

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
