### PR TITLE
Update environment variable assignments in faiss.mdx

### DIFF
--- a/src/oss/javascript/integrations/vectorstores/faiss.mdx
+++ b/src/oss/javascript/integrations/vectorstores/faiss.mdx
@@ -45,14 +45,14 @@ Because Faiss runs locally, you do not need any credentials to use it.
 If you are using OpenAI embeddings for this guide, you'll need to set your OpenAI key as well:
 
 ```typescript
-process.env.OPENAI_API_KEY = "YOUR_API_KEY";
+OPENAI_API_KEY = "YOUR_API_KEY";
 ```
 
 If you want to get automated tracing of your model calls you can also set your [LangSmith](https://docs.smith.langchain.com/) API key by uncommenting below:
 
 ```typescript
-// process.env.LANGSMITH_TRACING="true"
-// process.env.LANGSMITH_API_KEY="your-api-key"
+// LANGSMITH_TRACING="true"
+// LANGSMITH_API_KEY="your-api-key"
 ```
 
 ## Instantiation


### PR DESCRIPTION
In the credentials section, 
in the .env file, we don’t write process.env.API_KEY_NAME; we only define the key name and its value.