### PR TITLE
fix(langchain): don't show docs on selecting formats for JS

### DIFF
--- a/src/oss/langchain/context-engineering.mdx
+++ b/src/oss/langchain/context-engineering.mdx
@@ -1278,6 +1278,7 @@ const customerSupportTicket = z.object({
 ```
 :::
 
+:::python
 #### Selecting formats
 
 Dynamic response format selection adapts schemas based on user preferences, conversation stage, or role—returning simple formats early and detailed formats as complexity increases.
@@ -1564,6 +1565,7 @@ Dynamic response format selection adapts schemas based on user preferences, conv
     :::
   </Tab>
 </Tabs>
+:::
 
 ## Tool Context
 


### PR DESCRIPTION
This feature has not be ported to JS and is currently unclear how to implement.

cc @sydney-runkle 