### PR TITLE
Update docs for new set usage limits flow

### DIFF
--- a/src/langsmith/billing.mdx
+++ b/src/langsmith/billing.mdx
@@ -15,21 +15,19 @@ This page describes how to manage billing for your LangSmith organization:
 Before using this guide, note the following:
 
 - If you are interested in the [Enterprise](https://www.langchain.com/pricing) plan, please [contact sales](https://www.langchain.com/contact-sales). This guide is only for our self-serve billing plans.
-- If you created your LangSmith organization before pricing was introduced on April 2nd, 2024, please [skip to the final section](#set-up-billing-for-accounts-created-before-pricing-was-introduced-on-april-2-2024).
 </Note>
 
 To set up billing for your LangSmith organization, navigate to the [Usage and Billing](https://smith.langchain.com/settings/payments) page under **Settings**. Depending on your organization's settings, there are different setup guides:
 
 - [Developer plan](#developer-plan%3A-set-up-billing-on-your-personal-organization)
 - [Plus plan](#plus-plan%3A-set-up-billing-on-a-shared-organization)
-- [Setup for accounts created before April 2, 2024 pricing introduction](#set-up-billing-for-accounts-created-before-pricing-introduction)
 
 ### Developer Plan: set up billing on your personal organization
 
-Personal organizations are limited to 5000 traces per month until a credit card is added. You can add a credit card on the **Plans and Billing** page as follows:
+Personal organizations are limited to 5,000 traces per month until a credit card is added. You can add a credit card on the **Plans and Billing** page as follows:
 
 1. Click **Set up Billing**.
-1. Add your credit card information. After this step, you will no longer be rate limited to 5000 traces, and you will be charged for any excess traces at rates specified on the [pricing](https://www.langchain.com/pricing-langsmith) page.
+2. Add your credit card information. After this step, you will no longer be rate limited to 5,000 traces, and you will be charged for any excess traces at rates specified on the [pricing](https://www.langchain.com/pricing-langsmith) page.
 
 ### Plus Plan: set up billing on a shared organization
 
@@ -40,27 +38,12 @@ You can't use a new organization until you enter credit card information. After 
 </Note>
 
 1. Click **Subscribe** on the **Plus** page.
-    <Note>
-    If you are a startup building with AI, instead click **Apply Now** on the Startup Plan. You may be eligible for discounted prices and a free, monthly trace allotment.
-    </Note>
-1. Review your existing members. Before subscribing, LangSmith lets you remove any added users that you do **not** want to be included in the bill.
-1. Enter your credit card information. Then, enter business information, invoice email, and tax ID. If this organization belongs to a business, check the **This is a business** checkbox and enter the information accordingly.
+2. Review your existing members. Before subscribing, LangSmith lets you remove any added users that you do **not** want to be included in the bill.
+3. Enter your credit card information. Then, enter business information, invoice email, and tax ID. If this organization belongs to a business, check the **This is a business** checkbox and enter the information accordingly.
 
 For more information, refer to the [Update your information section](#update-your-information).
 
 Once this step is complete, your organization will have access to the rest of LangSmith.
-
-### Set up billing for accounts created before pricing introduction
-
-If you joined LangSmith before pricing was introduced on April 2, 2024, you have the option to upgrade your existing account to set up billing. If you did not set up billing by July 8, 2024, then your account is now rate limited to a maximum of 5,000 traces per month.
-
-1. Navigate to the [Settings](https://smith.langchain.com/settings) page.
-2. Click **Set up Billing**.
-
-  ![](/langsmith/images/setup-billing-legacy.png)
-
-3. Enter your credit card information. If you are on a Personal organization, this will add you to the Developer plan. If you are on a shared organization, this will add you to the Plus plan. For more information, refer to the guides for the [Developer](#developer-plan%3A-set-up-billing-on-your-personal-organization) or [Plus](#plus-plan%3A-set-up-billing-on-a-shared-organization) plans respectively, starting at step 2.
-4. Claim free credits as a thank you for being an early LangSmith user.
 
 ## Update your information
 
@@ -175,9 +158,7 @@ LangSmith charges differently based on a trace's [data retention](/langsmith/adm
 
 Navigate to the **Usage configuration** tab, and look at the organization level retention settings. Modifying this setting affects all **new projects** that are created going forward in all workspaces in the organizaton.
 
-<Note>
-For backwards compatibility, older organizations may have this defaulted to **Extended**. Organizations created after June 3rd, 2024 have this defaulted to **Base**.
-</Note>
+You can checkbox if you'd like to apply your data retention setting to all existing traces in your workspace. If unchecked, your retention setting will only apply to new traces.
 
 ![](/langsmith/images/p1orgretention-v2.png)
 
@@ -224,11 +205,13 @@ In the previous section, you managed data retention settings to **optimize exist
 
 LangSmith has two usage limits: total traces and extended retention traces. These correspond to the two metrics tracked on the [usage graph](#usage-graph). You can use these in tandem to have granular control over spend.
 
-To set limits, navigate back to **Settings** -> **Usage and Billing** -> **Usage configuration**. There is a table at the bottom of the page that lets you set usage limits per workspace. For each workspace, the two limits appear, along with a cost estimate:
+To set limits, navigate back to **Settings** -> **Usage and Billing** -> **Usage configuration**. Input a spend limit, and we will imply a number of base and extended traces. Move the slider to set the trace limits to your desired numbers.
+
+Note that if you have more than one workspace, your free monthly traces are by default allocated to your first workspace.
 
 ![](/langsmith/images/p2usagelimitsempty-v2.png)
 
-Start by setting limits on production usage, since that is where the majority of spend comes from.
+Start by setting limits on production usage, since that is where the majority of spend comes from. You can drag the slider to determine the maximum limits for each trace type.
 
 #### Set a good total traces limit
 
@@ -240,26 +223,29 @@ Picking the right total traces limit depends on the expected load of traces that
 From these assumptions, you can calculate an approximate limit:
 
 ```python
-limit = current_load_per_day * expected_growth * days/month
+trace limit = current_load_per_day * expected_growth * days/month
       = 130,000 * 2 * 30
       = 7,800,000 traces / month
+spend limit = trace limit * base trace rate
+      = 7,800,000 traces / month * $0.0005
+      = $3,900
+    
 ```
 
-Click on the edit icon on the right side of the table for the **Prod** row to enter the limit.
+Click on the edit icon in the table for the **Prod** row to enter the limit. You can drag the slider to determine the maximum limits for each trace type. In the example below, we show the spend limit allocated towards only base retention traces.
+
+<Note>
+The extended data retention limit can cause features other than traces to stop working once reached. If you plan to use this feature, read more about its [functionality and side effects](/langsmith/administration-overview#side-effects-of-extended-data-retention-traces-limit).
+</Note>
 
 ![](/langsmith/images/p2alllimitonly-v2.png)
 
-<Note>
-When set without the extended data retention traces limit, the maximum cost estimator assumes that all traces are using extended data retention.
-</Note>
-
 #### Cut maximum spend with an extended data retention limit
 
-From [Optimization 1](#optimization-1-manage-data-retention), you learned that the easiest way to cut cost was through managing data retention. The same is true for limits. If you only want to keep roughly 10% of traces to be around more than 14 days, you can set a limit on the maximum high retention traces you can keep. This would result in `.10 * 7,800,000 = 780,000`.
+From [Optimization 1](#optimization-1-manage-data-retention), you learned that the easiest way to cut cost was through managing data retention. The same is true for limits. If you only want to keep a certain percentage of traces to be around more than 14 days, you can set a limit on the maximum high retention traces you can keep by dragging the slider. 
 
 ![](/langsmith/images/p2bothlimits-v2.png)
 
-The maximum cost is cut from \~40k per month to \~7.5k per month, because you no longer allow as many expensive data retention upgrades. This ensures that new users on the platform will not accidentally cause cost to balloon.
 
 <Note>
 The extended data retention limit can cause features other than traces to stop working once reached. If you plan to use this feature, read more about its [functionality and side effects](/langsmith/administration-overview#side-effects-of-extended-data-retention-traces-limit).
@@ -267,15 +253,12 @@ The extended data retention limit can cause features other than traces to stop w
 
 #### Set dev/staging limits and view total spent limit across workspaces
 
-Following a similar logic for the `dev` and `staging` environments, you can set limits at 10% of the production limit on usage for each workspace.
+Following a similar logic for the `dev` and `staging` environments, you can set trace limits for each workspace. Note that your free monthly traces are by default allocated to your first workspace.
 
-While this works with this usage pattern, setting good dev and staging limits may vary depending on your use case with LangSmith. For example, if you run evals as part of CI/CD in dev or staging, you may want to be more flexible with your usage limits to avoid test failures.
-
-With the limits set, LangSmith shows a maximum spend estimate across all workspaces:
+Setting good dev and staging limits may vary depending on your use case with LangSmith. For example, if you run evals as part of CI/CD in dev or staging, you may want to be more flexible with your usage limits to avoid test failures.
 
 ![](/langsmith/images/p2totalspendlimits-v2.png)
 
-You can use the cost estimate to plan for your invoice total.
 
 ### Summary
 


### PR DESCRIPTION
## Overview
Growth eng team work by Arjun, Hana, Jess. Jess to send new screenshots in docs channel


## Type of change

**Type:** Update existing documentation
<img width="1309" height="775" alt="p2totalspendlimits-v2" src="https://github.com/user-attachments/assets/767d06ee-9702-4ae1-ae7c-210cf77d9e0f" />
<img width="1306" height="791" alt="p2bothlimits-v2" src="https://github.com/user-attachments/assets/952463b3-0ef7-4a49-bcfa-2d3f7e9ad026" />
<img width="1306" height="795" alt="p2alllimitonly-v2" src="https://github.com/user-attachments/assets/5f2a6486-0269-41f6-8ebe-864383f77471" />
<img width="1299" height="791" alt="p2usagelimitsempty-v2" src="https://github.com/user-attachments/assets/0e219060-9d66-4468-8ace-264301c09a80" />
<img width="1308" height="779" alt="plorgretention-v2" src="https://github.com/user-attachments/assets/95072461-f202-455c-92a8-8faba5c15e10" />

