### PR TITLE
fix(docs): correct typos in TypeScript examples in structured-output.mdx

### DIFF
--- a/src/oss/langchain/structured-output.mdx
+++ b/src/oss/langchain/structured-output.mdx
@@ -235,7 +235,7 @@ LangChain automatically uses `ProviderStrategy` when you pass a schema type dire
         messages: [{"role": "user", "content": "Extract contact info from: John Doe, john@example.com, (555) 123-4567"}]
     });
 
-    result.structuredResponse;
+    console.log(result.structuredResponse);
     // { name: "John Doe", email: "john@example.com", phone: "(555) 123-4567" }
     ```
 
@@ -263,7 +263,7 @@ LangChain automatically uses `ProviderStrategy` when you pass a schema type dire
         messages: [{"role": "user", "content": "Extract contact info from: John Doe, john@example.com, (555) 123-4567"}]
     });
 
-    result.structuredResponse;
+    console.log(result.structuredResponse);
     // { name: "John Doe", email: "john@example.com", phone: "(555) 123-4567" }
     ```
 </CodeGroup>
@@ -586,7 +586,7 @@ function toolStrategy<StructuredResponseT>(
         responseFormat: toolStrategy(ProductReview)
     })
 
-    result = agent.invoke({
+    const result = await agent.invoke({
         "messages": [{"role": "user", "content": "Analyze this review: 'Great product: 5 out of 5 stars. Fast shipping, but expensive'"}]
     })
 


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
