### PR TITLE
fix(langchain): document ClearToolUsesEdit for JS

### DIFF
--- a/pipeline/preprocessors/link_map.py
+++ b/pipeline/preprocessors/link_map.py
@@ -364,6 +364,8 @@ LINK_MAPS: list[LinkMap] = [
             "AssistantsClient.search": "classes/_langchain_langgraph-sdk.client.AssistantsClient.html#search",
             "RunsClient": "classes/_langchain_langgraph-sdk.client.RunsClient.html",
             "RunsClient.stream": "classes/_langchain_langgraph-sdk.client.RunsClient.html#stream",
+            "ClearToolUsesEdit": "classes/langchain.index.ClearToolUsesEdit.html",
+            "ContextEdit": "interfaces/langchain.index.ContextEdit.html",
         },
     },
 ]

--- a/src/oss/langchain/middleware.mdx
+++ b/src/oss/langchain/middleware.mdx
@@ -1265,7 +1265,13 @@ agent = create_agent(
     middleware=[
         ContextEditingMiddleware(
             edits=[
-                ClearToolUsesEdit(trigger=1000),  # Clear old tool uses
+                ClearToolUsesEdit(
+                    trigger=2000,        # Lower threshold for demo (default is 100K)
+                    keep=3,              # Keep 3 most recent tool results
+                    clear_tool_inputs=False,  # Keep tool call arguments for context
+                    exclude_tools=[],    # No tools excluded from clearing
+                    placeholder="[cleared]",  # Placeholder for cleared results
+                ),
             ],
         ),
     ],
@@ -1283,7 +1289,13 @@ const agent = createAgent({
   middleware: [
     contextEditingMiddleware({
       edits: [
-        new ClearToolUsesEdit({ maxTokens: 1000 }), // Clear old tool uses
+        new ClearToolUsesEdit({
+          triggerTokens: 2000,      // Lower threshold for demo (default is 100K)
+          keep: 3,                  // Keep 3 most recent tool results
+          clearToolInputs: false,   // Keep tool call arguments for context
+          excludeTools: [],         // No tools excluded from clearing
+          placeholder: "[cleared]", // Placeholder for cleared results
+        }),
       ],
     }),
   ],
@@ -1295,7 +1307,7 @@ const agent = createAgent({
 
 :::python
 <ParamField body="edits" type="list[ContextEdit]" default="[ClearToolUsesEdit()]">
-    List of `ContextEdit` strategies to apply
+    List of @[`ContextEdit`] strategies to apply
 </ParamField>
 
 <ParamField body="token_count_method" type="string" default="approximate">
@@ -1305,39 +1317,59 @@ const agent = createAgent({
 **@[`ClearToolUsesEdit`] options:**
 
 <ParamField body="trigger" type="number" default="100000">
-    Token count that triggers the edit
+    Token count that triggers the edit. When the conversation exceeds this token count, older tool outputs will be cleared.
 </ParamField>
 
 <ParamField body="clear_at_least" type="number" default="0">
-    Minimum tokens to reclaim
+    Minimum number of tokens to reclaim when the edit runs. If set to 0, clears as much as needed.
 </ParamField>
 
 <ParamField body="keep" type="number" default="3">
-    Number of recent tool results to preserve
+    Number of most recent tool results that must be preserved. These will never be cleared.
 </ParamField>
 
 <ParamField body="clear_tool_inputs" type="boolean" default="False">
-    Whether to clear tool call parameters
+    Whether to clear the originating tool call parameters on the AI message. When `True`, tool call arguments are replaced with empty objects.
 </ParamField>
 
 <ParamField body="exclude_tools" type="list[string]" default="()">
-    List of tool names to exclude from clearing
+    List of tool names to exclude from clearing. These tools will never have their outputs cleared.
 </ParamField>
 
 <ParamField body="placeholder" type="string" default="[cleared]">
-    Placeholder text for cleared outputs
+    Placeholder text inserted for cleared tool outputs. This replaces the original tool message content.
 </ParamField>
 :::
 
 :::js
 <ParamField body="edits" type="ContextEdit[]" default="[new ClearToolUsesEdit()]">
-    Array of `ContextEdit` strategies to apply
+    Array of @[`ContextEdit`] strategies to apply
 </ParamField>
 
 **@[`ClearToolUsesEdit`] options:**
 
-<ParamField body="maxTokens" type="number" default="1000">
-    Token count that triggers the edit
+<ParamField body="triggerTokens" type="number" default="100000">
+    Token count that triggers the edit. When the conversation exceeds this token count, older tool outputs will be cleared.
+</ParamField>
+
+<ParamField body="clearAtLeast" type="number" default="0">
+    Minimum number of tokens to reclaim when the edit runs. If set to 0, clears as much as needed.
+</ParamField>
+
+<ParamField body="keep" type="number" default="3">
+    Number of most recent tool results that must be preserved. These will never be cleared.
+</ParamField>
+
+<ParamField body="clearToolInputs" type="boolean" default="false">
+    Whether to clear the originating tool call parameters on the AI message. When `true`, tool call arguments are replaced with empty objects.
+</ParamField>
+
+<ParamField body="excludeTools" type="string[]" default="[]">
+    List of tool names to exclude from clearing. These tools will never have their outputs cleared.
+</ParamField>
+
+<ParamField body="placeholder" type="string" default="[cleared]">
+    Placeholder text inserted for cleared tool outputs. This replaces the original tool message content.
 </ParamField>
 :::
 


### PR DESCRIPTION
Documentation for `ClearToolUsesEdit` was missing in JS.