### PR TITLE
Make wrapToolCall asynchronous for error handling

### DIFF
--- a/src/oss/langchain/agents.mdx
+++ b/src/oss/langchain/agents.mdx
@@ -341,9 +341,9 @@ import { createAgent, createMiddleware, ToolMessage } from "langchain";
 
 const handleToolErrors = createMiddleware({
   name: "HandleToolErrors",
-  wrapToolCall: (request, handler) => {
+  wrapToolCall: async (request, handler) => {
     try {
-      return handler(request);
+      return await handler(request);
     } catch (error) {
       // Return a custom error message to the model
       return new ToolMessage({


### PR DESCRIPTION
## Overview
Make wrapToolCall asynchronous for error handling

## Type of change

Fix bug

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
