### PR TITLE
docs: move MCP section to top and clarify langchain-mcp-adapters usage

### DIFF
--- a/reference/python/docs/integrations/index.md
+++ b/reference/python/docs/integrations/index.md
@@ -8,8 +8,16 @@ Welcome! These pages include reference documentation for all `langchain-*` Pytho
 
 To learn more about integrations in LangChain, visit the [Integrations overview](https://docs.langchain.com/oss/python/integrations/providers/overview).
 
-!!! tip "Model Context Protocol (MCP) support"
-    To use MCP tools within LangChain and LangGraph applications, refer to [`langchain-mcp-adapters`](../langchain_mcp_adapters/index.md).
+## Model Context Protocol (MCP)
+
+LangChain supports the Model Context Protocol (MCP). This lets external tools work with LangChain and LangGraph applications through a standard interface.
+
+To begin using MCP tools in your project, see the [`langchain-mcp-adapters`](../langchain_mcp_adapters/index.md) documentation.
+
+!!! tip "Why MCP matters"
+    MCP allows LangChain apps to connect easily to tools and workflows outside of LangChain. This improves how well they work together and their reliability.
+
+---
 
 ## Popular providers
 


### PR DESCRIPTION
Added section on Model Context Protocol (MCP) support and its benefits.

## Overview
This PR makes the langchain-mcp-adapters package easier to find. It adds a new “Model Context Protocol (MCP)” section at the top of the Integrations Overview page.
MCP support was only previously mentioned in a tip block. This made it hard for developers to find when looking for integration options. This update shows that MCP is an important integration. It also explains its purpose and value for users of LangChain and LangGraph.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
Fixes #32395


## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

