### PR TITLE
Fix print statement to show d_embeddings shape

### DIFF
--- a/src/oss/python/integrations/text_embedding/nvidia_ai_endpoints.mdx
+++ b/src/oss/python/integrations/text_embedding/nvidia_ai_endpoints.mdx
@@ -138,7 +138,7 @@ d_embeddings = embedder.embed_documents(
         "Enjoying life's moments is indeed a wonderful approach.",
     ]
 )
-print("Shape:", (len(q_embeddings), len(q_embeddings[0])))
+print("Shape:", (len(d_embeddings), len(d_embeddings[0])))
 ```
 
 Now that we've generated our embeddings, we can do a simple similarity check on the results to see which documents would have triggered as reasonable answers in a retrieval task:


### PR DESCRIPTION
## Overview
Print statement of Document embedding was mistakenly provided as q_embeddings so its corrected to d_embeddings

## Type of change

 Update existing documentation 

## Related issues/PRs
<!-- 
Link to related issues, feature PRs, or discussions (if applicable)


-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [X] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
