### PR TITLE
chore: document 25mb payload limit

### DIFF
--- a/src/langsmith/data-plane.mdx
+++ b/src/langsmith/data-plane.mdx
@@ -103,6 +103,13 @@ All traffic from deployments created after January 6th 2025 will come through a 
 | 34.121.166.52  |                |
 | 34.31.121.70   |                |
 
+### Payload size
+<Info>
+**Only for Cloud**
+Payload size restrictions are only applicable to [Cloud](/langsmith/cloud) deployments.
+</Info>
+The maximum payload size for all requests sent to [Cloud](/langsmith/cloud) deployments is 25 MB. Attempting to send a request with a payload larger than 25 MB will result in a `413 Payload Too Large` error.
+
 ### Custom PostgreSQL
 
 <Info>


### PR DESCRIPTION
## Overview
document 25mb payload limit for cloud deployments

- Slack thread: https://langchain.slack.com/archives/C089RDWTKU4/p1762545462042289

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
