### PR TITLE
docs: wrap long code lines for better readability (#33742)

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -68,3 +68,22 @@ a[href] code {
     display: none;
   }
 
+/* Wrap long lines in code blocks for better readability */
+pre code,
+.md-typeset pre,
+pre[class*="language-"] {
+  white-space: pre-wrap;
+  word-wrap: break-word;
+  overflow-wrap: anywhere;
+}
+
+pre,
+.md-typeset pre {
+  padding-right: 3.5rem;
+}
+
+pre {
+  overflow-x: auto;
+}
+
+


### PR DESCRIPTION
Add styles to improve readability of code blocks

## Overview
This PR adds CSS rules to wrap long code lines for better readability on all screen sizes.


## Type of change

Fix formatting

## Related issues/PRs
fixes #33742


## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
