### PR TITLE
docs: wrap JSON schema example in ProviderStrategy to fix bug

### DIFF
--- a/src/oss/langchain/structured-output.mdx
+++ b/src/oss/langchain/structured-output.mdx
@@ -187,7 +187,7 @@ LangChain automatically uses `ProviderStrategy` when you pass a schema type dire
     agent = create_agent(
         model="gpt-5",
         tools=tools,
-        response_format=contact_info_schema  # Auto-selects ProviderStrategy
+        response_format=ProviderStrategy(contact_info_schema)
     )
 
     result = agent.invoke({


### PR DESCRIPTION
## Overview
Previously, the documentation showed passing a raw JSON schema to `response_format` in `create_agent`, which could trigger a ValueError when LangChain auto-selected ToolStrategy instead of ProviderStrategy.

This update wraps the `contact_info_schema` in `ProviderStrategy` to ensure provider-native structured output is used and the example runs correctly with models that support JSON schema output (e.g. gpt-5).

## Type of change
**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
Examples:
- GitHub issue: https://github.com/langchain-ai/docs/issues/1420#issuecomment-3528899265


## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x ] I have read the [contributing guidelines](README.md)
- [N/A ] I have tested my changes locally using `docs dev`
- [x ] All code examples have been tested and work correctly
- [ N/A] I have used **root relative** paths for internal links
- [N/A ] I have updated navigation in `src/docs.json` if needed
- I have gotten approval from the relevant reviewers
- (Internal team members only / optional) I have created a preview deployment using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
The original docs say it should auto select the strategy. If that's true, then I think there's a bug in the python code that needs to be addressed. This change just updates the documentation so the example works.