### PR TITLE
clarify chat model usage and add info on return types

### DIFF
--- a/src/oss/langchain/models.mdx
+++ b/src/oss/langchain/models.mdx
@@ -172,7 +172,7 @@ console.log(response);
 ```
 :::
 
-A list of messages can be provided to a model to represent conversation history. Each message has a role that models use to indicate who sent the message in the conversation. See the [messages](/oss/langchain/messages) guide for more detail on roles, types, and content.
+A list of messages can be provided to a chat model to represent conversation history. Each message has a role that models use to indicate who sent the message in the conversation. See the [messages](/oss/langchain/messages) guide for more detail on roles, types, and content.
 
 :::python
 ```python Dictionary format
@@ -229,6 +229,10 @@ const response = await model.invoke(conversation);
 console.log(response);  // AIMessage("J'adore créer des applications.")
 ```
 :::
+
+<Info>
+    If the return type of your invocation is a string, ensure that you are using a chat model as opposed to a LLM. Legacy, text-completion LLMs return strings directly. LangChain chat models are prefixed with "Chat", e.g., @[`ChatOpenAI`](/oss/integrations/chat/openai).
+</Info>
 
 ### Stream
 


### PR DESCRIPTION
Will defer for approval; torn between adding the callout (and potentially interrupting flow) versus not having it, and new users being confused why their model is returning a different type and getting frustrated.