### PR TITLE
Update DigitalOcean Gradient references to include 'AI Platform' in t…

### DIFF
--- a/reference/packages.yml
+++ b/reference/packages.yml
@@ -717,7 +717,7 @@ packages:
   downloads: 236
   downloads_updated_at: "2025-11-10T00:06:22.543193+00:00"
 - name: langchain-gradient
-  name_title: DigitalOcean Gradient
+  name_title: DigitalOcean Gradient AI Platform
   repo: digitalocean/langchain-gradient
   provider_page: gradientai
   downloads: 338

--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -1218,11 +1218,11 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
-        title="GradientAI"
+        title="DigitalOcean Gradient AI Platform"
         href="/oss/integrations/providers/gradientai"
         icon="link"
     >
-        Private AI model training platform.
+        Single endpoint to multiple LLMs via serverless inference.
     </Card>
 
     <Card

--- a/src/oss/python/integrations/providers/gradientai.mdx
+++ b/src/oss/python/integrations/providers/gradientai.mdx
@@ -1,5 +1,5 @@
 ---
-title: DigitalOcean Gradient
+title: DigitalOcean Gradient AI Platform
 ---
 
 This will help you getting started with DigitalOcean Gradient [chat models](/oss/langchain/models).


### PR DESCRIPTION
## Overview

Update DigitalOcean Gradient references across documentation to include 'AI Platform' in titles and improve the product description to better reflect its serverless inference capabilities.

## Type of change

**Type:** Update existing documentation