### PR TITLE
Update short-term-memory.mdx

### DIFF
--- a/src/oss/langchain/short-term-memory.mdx
+++ b/src/oss/langchain/short-term-memory.mdx
@@ -678,7 +678,7 @@ class CustomContext(BaseModel):
 def update_user_info(
     runtime: ToolRuntime[CustomContext, CustomState],
 ) -> Command:
-    """Look up and update user info."""
+    """Look up, get and update current user info."""
     user_id = runtime.context.user_id 
     name = "John Smith" if user_id == "user_123" else "Unknown user"
     return Command(update={  # [!code highlight]
@@ -697,7 +697,16 @@ def greet(
     runtime: ToolRuntime[CustomContext, CustomState]
 ) -> str:
     """Use this to greet the user once you found their info."""
-    user_name = runtime.state["user_name"]
+    user_name = runtime.state.get("user_name", None)
+    if user_name is None:
+       return Command(update={
+            "messages": [
+                ToolMessage(
+                    "Please call the 'update_user_info' tool it will get and update the user's name.",
+                    tool_call_id=runtime.tool_call_id
+                )
+            ]
+        })
     return f"Hello {user_name}!"
 
 agent = create_agent(


### PR DESCRIPTION
## Overview
Hi!
I found unsafe TypedDict operation on LangChain "Memory - Tools - Write short-term memory from tools" docs code example. Some small models run the code example with `KeyError: user_name`.

## Type of change
I propose more robust decision in the code example to prevent users confusion who try to reuse and run code examples with small models.

