### PR TITLE
Update pip install commands for langchain packages

### DIFF
--- a/src/oss/python/integrations/vectorstores/index.mdx
+++ b/src/oss/python/integrations/vectorstores/index.mdx
@@ -130,7 +130,7 @@ embeddings = OpenAIEmbeddings(model="text-embedding-3-large")
 </Accordion>
 <Accordion title="Azure">
 ```bash
-pip install -qU langchain-openai
+pip install -qU langchain-azure-ai
 ```
 ```python
 import getpass


### PR DESCRIPTION
`pip install -qU "langchain[langchain-deepseek]"`  cannot be used: 
WARNING: langchain 1.0.7 does not provide the extra 'langchain-deepseek'

## Overview
Update pip install commands for langchain packages

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
