### PR TITLE
Fix joke output on quality gate pass

### DIFF
--- a/src/oss/langgraph/workflows-agents.mdx
+++ b/src/oss/langgraph/workflows-agents.mdx
@@ -252,7 +252,8 @@ if "improved_joke" in state:
     print("Final joke:")
     print(state["final_joke"])
 else:
-    print("Joke failed quality gate - no punchline detected!")
+    print("Final joke:")
+    print(state["joke"])
 ```
 ```python Functional API
 from langgraph.func import entrypoint, task


### PR DESCRIPTION
## Overview
The current logic doesn’t work properly: the 'else' branch executes when there’s no quality issue (i.e., when check_punchline returns 'Pass'), so the joke doesn’t get improved. But the old print statement was wrong: `print("Joke failed quality gate - no punchline detected!")`.

## Type of change

**Type:** [Update existing documentation /bug]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
