### PR TITLE
docs: add SSL troubleshooting to delete traces script

### DIFF
--- a/src/langsmith/script-delete-traces.mdx
+++ b/src/langsmith/script-delete-traces.mdx
@@ -69,9 +69,9 @@ If you visit the LangSmith UI, you should now see all the specified traces have 
 
 ## Troubleshooting
 
-### *"Could not find trace IDs"* error
+### "Could not find trace IDs" error
 
-If you receive an error message stating that trace IDs could not be found, you may need to add the `--ssl` flag to your command. Without this flag, the script may not be able to properly connect to ClickHouse, resulting in false "trace ID not found" errors.
+If you receive an error message stating that trace IDs could not be found, add the `--ssl` flag to your command. Without this flag, the script may not be able to properly connect to ClickHouse, resulting in false "trace ID not found" errors.
 
 Example with SSL flag:
 


### PR DESCRIPTION
Add troubleshooting section to the delete traces script documentation to help users resolve SSL connection issues when attempting to delete traces from ClickHouse.

## Type of change

**Type:** Update existing documentation

## Additional notes
Users encountering "Could not find trace IDs" errors when running the delete_trace_by_id script often need to add the `--ssl` flag to properly connect to ClickHouse. This troubleshooting entry documents the solution and provides an alternative verification method using `clickhouse-cli`.