### PR TITLE
fix(langchain): remove empty accordion in middleware docs

### DIFF
--- a/src/oss/langchain/middleware/built-in.mdx
+++ b/src/oss/langchain/middleware/built-in.mdx
@@ -1939,11 +1939,9 @@ agent = create_agent(
     ],
 )
 ```
-:::
 
 <Accordion title="Configuration options">
 
-:::python
 <ParamField body="root_path" type="str" required>
     Root directory to search. All file operations are relative to this path.
 </ParamField>
@@ -1998,9 +1996,9 @@ result = agent.invoke({
 # 1. glob_search(pattern="**/*.py") to find Python files
 # 2. grep_search(pattern="async def", include="*.py") to find async functions
 ```
-:::
-
 </Accordion>
+
+:::
 
 ## Provider-specific middleware
 


### PR DESCRIPTION
The Context editing middleware docs have an additional Configuration options accordion. This patch fixes.

<img width="657" height="106" alt="Screenshot 2025-11-20 at 9 14 43 AM" src="https://github.com/user-attachments/assets/76784621-a16a-4a7b-bd14-560009ba85b9" />
