### PR TITLE
docs: add Chrome 142+ Private Network Access troubleshooting

### DIFF
--- a/src/langsmith/troubleshooting-studio.mdx
+++ b/src/langsmith/troubleshooting-studio.mdx
@@ -36,52 +36,52 @@ Use this URL in Safari to load Studio. Here, the `baseUrl` parameter specifies y
 
 Chrome and other Chromium browsers allow HTTP on localhost. Use `langgraph dev` without additional configuration.
 
-## Chrome Connection Issues
+## Chrome connection issues
 
-Starting with Chrome version 142, you may experience "Failed to initialize Studio" errors with "TypeError: Failed to fetch" when trying to connect LangSmith Studio to your local development server via `langgraph dev`. This occurs even when the API server at `http://127.0.0.1:2024/docs` loads successfully.
+Starting with Chrome version 142, you may experience "Failed to initialize Studio" errors with "TypeError: Failed to fetch" when trying to connect [LangSmith Studio](/langsmith/studio) to your local development server via [`langgraph dev`](/langsmith/cli). This occurs even when the API server at `http://127.0.0.1:2024/docs` loads successfully.
 
 **Root Cause:** Chrome 142 fully enforces the Private Network Access (PNA) specification with no fallback, which blocks HTTPS sites (like `https://smith.langchain.com`) from accessing HTTP localhost servers by default.
 
 ### Symptoms
 
-- Running `langgraph dev` starts the server successfully
-- Navigating to `http://127.0.0.1:2024/docs` shows the API documentation correctly
-- LangSmith Studio at `https://smith.langchain.com` shows: "Failed to initialize Studio - Please verify if the API server is running or accessible from the browser. TypeError: Failed to fetch"
-- Browser console shows errors like: `Permission was denied for this request to access the 'unknown' address space`
+- Running `langgraph dev` starts the server successfully.
+- Navigating to `http://127.0.0.1:2024/docs` shows the API documentation correctly.
+- LangSmith Studio at `https://smith.langchain.com` shows: "Failed to initialize Studio - Please verify if the API server is running or accessible from the browser. TypeError: Failed to fetch".
+- Browser console shows errors like: `Permission was denied for this request to access the 'unknown' address space`.
 
-### Solution: Allow Local Network Access in Chrome
+### Solution: Allow local network access in Chrome
 
-1. Open LangSmith Studio at `https://smith.langchain.com` in Chrome
-2. Click the **lock icon** (or site information icon) to the left of the address bar
-3. Look for the **"Local network access"** option in the dropdown
-4. Change the setting from **"Ask (default)"** or **"Block"** to **"Allow"**
-5. Reload the page
+1. Open LangSmith Studio at `https://smith.langchain.com` in Chrome.
+2. Click the **lock icon** (or site information icon) to the left of the address bar.
+3. Look for the **"Local network access"** option in the dropdown.
+4. Change the setting from **"Ask (default)"** or **"Block"** to **"Allow"**.
+5. Reload the page.
 
-The Studio should now connect to your local development server successfully.
+Studio should now connect to your local development server successfully.
 
-### Additional Troubleshooting
+### Additional troubleshooting
 
-**Check for Browser Extension Conflicts**
+**Check for browser extension conflicts**
 
 Browser extensions (especially Ollama Chrome extension or AI model extensions) can interfere with localhost connections:
 
-1. Disable all browser extensions temporarily
-2. Restart Chrome
-3. Try connecting to Studio again
-4. If it works, re-enable extensions one by one to identify the culprit
+1. Disable all browser extensions temporarily.
+2. Restart Chrome.
+3. Try connecting to Studio again.
+4. If it works, re-enable extensions one by one to identify the culprit.
 
-**Verify Dependencies Are Up to Date**
+**Verify dependencies are up to date**
 
 ```shell
 pip install -U "langgraph-cli[inmem]"
 ```
 
-**Clear Browser Cache and Site Data**
+**Clear browser cache and site data**
 
-1. In Chrome, go to Settings > Privacy and Security > Site Settings
-2. Find `https://smith.langchain.com` in the list
-3. Click "Clear data"
-4. Restart Chrome and try again
+1. In Chrome, go to **Settings** > **Privacy and Security** > **Site Settings**.
+2. Find `https://smith.langchain.com` in the list.
+3. Click **Clear data**.
+4. Restart Chrome and try again.
 
 ## Brave Connection Issues
 


### PR DESCRIPTION
## Description

Adds troubleshooting documentation for Chrome 142+ blocking localhost connections to LangSmith Studio.

## Problem

Starting with Chrome version 142, users are experiencing "Failed to initialize Studio" errors when trying to connect LangSmith Studio to their local development server via `langgraph dev`. This is due to Chrome's full enforcement of the Private Network Access (PNA) specification, which blocks HTTPS sites from accessing HTTP localhost servers by default.

## Changes

- Added new "Chrome Connection Issues" section to `src/langsmith/troubleshooting-studio.mdx`
- Documented symptoms users will encounter
- Provided step-by-step solution to allow local network access in Chrome settings
- Added additional troubleshooting steps for browser extensions, dependency updates, and cache clearing

## Testing

- [x] Verified markdown syntax is correct
- [x] Confirmed no linting errors
- [x] Tested that links and formatting render correctly

## References

- [Support article](https://support.langchain.com/articles/1897181200-private-network-access-blocking-langsmith-studio-connection)