### PR TITLE
fix: install mintlify CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,7 @@ test:
 install:
 	@echo "Installing all dependencies"
 	uv sync --all-groups
+	npm install -g mint@latest
 
 clean:
 	@echo "Cleaning build artifacts..."


### PR DESCRIPTION
I got an error running the docs page due to the fact that I didn't had the latest Mintlify CLI package installed. Should we add it to the `make install` command?