### PR TITLE
Refactor MCP client code to use async main function

### DIFF
--- a/src/oss/langchain/mcp.mdx
+++ b/src/oss/langchain/mcp.mdx
@@ -63,37 +63,43 @@ MCP supports different transport mechanisms for client-server communication:
 `langchain-mcp-adapters` enables agents to use tools defined across one or more MCP server.
 
 ```python Accessing multiple MCP servers icon="server"
+
+# This code will work when the math and weather servers are running
 from langchain_mcp_adapters.client import MultiServerMCPClient  # [!code highlight]
 from langchain.agents import create_agent
+import asyncio
 
-
-client = MultiServerMCPClient(  # [!code highlight]
-    {
-        "math": {
-            "transport": "stdio",  # Local subprocess communication
-            "command": "python",
-            # Absolute path to your math_server.py file
-            "args": ["/path/to/math_server.py"],
-        },
-        "weather": {
-            "transport": "streamable_http",  # HTTP-based remote server
-            # Ensure you start your weather server on port 8000
-            "url": "http://localhost:8000/mcp",
+async def main():
+    client = MultiServerMCPClient(  # [!code highlight]
+        {
+            "math": {
+                "transport": "stdio",  # Local subprocess communication
+                "command": "python",
+                # Absolute path to your math_server.py file
+                "args": ["/path/to/math_server.py"],
+            },
+            "weather": {
+                "transport": "streamable_http",  # HTTP-based remote server
+                # Ensure you start your weather server on port 8000
+                "url": "http://localhost:8000/mcp",
+            }
         }
-    }
-)
+    )
+    
+    tools = await client.get_tools()  # [!code highlight]
+    agent = create_agent(
+        "claude-sonnet-4-5-20250929",
+        tools  # [!code highlight]
+    )
+    math_response = await agent.ainvoke(
+        {"messages": [{"role": "user", "content": "what's (3 + 5) x 12?"}]}
+    )
+    weather_response = await agent.ainvoke(
+        {"messages": [{"role": "user", "content": "what is the weather in nyc?"}]}
+    )
 
-tools = await client.get_tools()  # [!code highlight]
-agent = create_agent(
-    "claude-sonnet-4-5-20250929",
-    tools  # [!code highlight]
-)
-math_response = await agent.ainvoke(
-    {"messages": [{"role": "user", "content": "what's (3 + 5) x 12?"}]}
-)
-weather_response = await agent.ainvoke(
-    {"messages": [{"role": "user", "content": "what is the weather in nyc?"}]}
-)
+if __name__ == "__main__":
+    asyncio.run(main())
 ```
 
 :::


### PR DESCRIPTION
Original code would fail because the await is outside of a function

    tools = await client.get_tools()  
            ^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: 'await' outside function

fixed this issue.

Also, this code won't work without the servers running, mentioned the same in the comment

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
