### PR TITLE
Added Antigravity MCP serverUrl instead of url as key

### DIFF
--- a/src/use-these-docs.mdx
+++ b/src/use-these-docs.mdx
@@ -81,6 +81,20 @@ Add the following to your MCP settings configuration file:
 }
 ```
 
+### Connect with Antigravity
+
+Add the following to your MCP settings configuration file:
+
+```json
+{
+  "mcpServers": {
+    "docs-langchain": {
+      "serverUrl": "https://docs.langchain.com/mcp"
+    }
+  }
+}
+```
+
 ## Learn more
 
 For more information about using Mintlify's MCP servers, see the [official Mintlify documentation](https://www.mintlify.com/docs/ai/model-context-protocol).


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
Antigravity requires a serverUrl key instead of url for its mcp json config.

## Type of change

**Type:** Update existing documentation

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ x ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed


