### PR TITLE
fix(docs): SummarizationMiddleware tuple syntax and deprecated params

### DIFF
--- a/src/oss/langchain/middleware/built-in.mdx
+++ b/src/oss/langchain/middleware/built-in.mdx
@@ -277,8 +277,8 @@ agent2 = create_agent(
         SummarizationMiddleware(
             model="gpt-4o-mini",
             trigger=[
-                [("tokens", 5000), ("messages", 3)],
-                [("tokens", 3000), ("messages", 6)],
+                ("tokens", 3000),
+                ("messages", 6),
             ],
             keep=("messages", 20),
         ),


### PR DESCRIPTION
- Correct trigger/keep parameters from dict to tuple syntax
- Update type annotations in ParamField
- Mark summary_prefix as deprecated

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** Update existing documentation

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [✅] I have read the [contributing guidelines](README.md)
- [✅] I have tested my changes locally using `docs dev`
- [✅] All code examples have been tested and work correctly
- [✅] I have used **root relative** paths for internal links
- [✅] I have updated navigation in `src/docs.json` if needed

