### PR TITLE
fix: unused model var and runtime type error

### DIFF
--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -541,9 +541,9 @@ const checkpointer = new MemorySaver();
 const agent = createAgent({
   model,
   systemPrompt,
-  tools: [getUserLocation, getWeather],
   responseFormat,
   checkpointer,
+  tools: [getUserLocation, getWeather],
 });
 
 // Run agent


### PR DESCRIPTION
## Overview
Fixing two issues in this section of the docs: an unused model var and type errors with tool `Runtime`

## Type of change

* In the "Full example code" section, `model` was defined but never used. Now we pass in the `model` object instead of the string.
* Fixing type errors from `Runtime` when we defined `getUserLocation`, both in "Full example code" and the earlier snippet. 
* Using object shorthand properties consistently

- [Slack thread](https://langchain.slack.com/archives/C04S2MUSHA4/p1764047118495919)

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes

