### PR TITLE
fix(doc): Refactor middleware hooks for content filtering

### DIFF
--- a/src/oss/langchain/guardrails.mdx
+++ b/src/oss/langchain/guardrails.mdx
@@ -390,36 +390,39 @@ const contentFilterMiddleware = (bannedKeywords: string[]) => {
 
   return createMiddleware({
     name: "ContentFilterMiddleware",
-    beforeAgent: (state) => {
-      // Get the first user message
-      if (!state.messages || state.messages.length === 0) {
-        return;
-      }
-
-      const firstMessage = state.messages[0];
-      if (firstMessage._getType() !== "human") {
-        return;
-      }
-
-      const content = firstMessage.content.toString().toLowerCase();
-
-      // Check for banned keywords
-      for (const keyword of keywords) {
-        if (content.includes(keyword)) {
-          // Block execution before any processing
-          return {
-            messages: [
-              new AIMessage(
-                "I cannot process requests containing inappropriate content. Please rephrase your request."
-              )
-            ],
-            jumpTo: "end",
-          };
+    beforeAgent: {
+      hook: (state) => {
+        // Get the first user message
+        if (!state.messages || state.messages.length === 0) {
+          return;
         }
-      }
 
-      return;
-    },
+        const firstMessage = state.messages[0];
+        if (firstMessage._getType() !== "human") {
+          return;
+        }
+
+        const content = firstMessage.content.toString().toLowerCase();
+
+        // Check for banned keywords
+        for (const keyword of keywords) {
+          if (content.includes(keyword)) {
+            // Block execution before any processing
+            return {
+              messages: [
+                new AIMessage(
+                  "I cannot process requests containing inappropriate content. Please rephrase your request."
+                )
+              ],
+              jumpTo: "end",
+            };
+          }
+        }
+
+        return;
+      },
+      canJumpTo: ['end']
+    }
   });
 };
 
@@ -560,40 +563,43 @@ const safetyGuardrailMiddleware = () => {
 
   return createMiddleware({
     name: "SafetyGuardrailMiddleware",
-    afterAgent: async (state) => {
-      // Get the final AI response
-      if (!state.messages || state.messages.length === 0) {
+    afterAgent: {
+      hook: async (state) => {
+        // Get the final AI response
+        if (!state.messages || state.messages.length === 0) {
+          return;
+        }
+
+        const lastMessage = state.messages[state.messages.length - 1];
+        if (lastMessage._getType() !== "ai") {
+          return;
+        }
+
+        // Use a model to evaluate safety
+        const safetyPrompt = `Evaluate if this response is safe and appropriate.
+        Respond with only 'SAFE' or 'UNSAFE'.
+
+        Response: ${lastMessage.content.toString()}`;
+
+        const result = await safetyModel.invoke([
+          { role: "user", content: safetyPrompt }
+        ]);
+
+        if (result.content.toString().includes("UNSAFE")) {
+          return {
+            messages: [
+              new AIMessage(
+                "I cannot provide that response. Please rephrase your request."
+              )
+            ],
+            jumpTo: "end",
+          };
+        }
+
         return;
-      }
-
-      const lastMessage = state.messages[state.messages.length - 1];
-      if (lastMessage._getType() !== "ai") {
-        return;
-      }
-
-      // Use a model to evaluate safety
-      const safetyPrompt = `Evaluate if this response is safe and appropriate.
-      Respond with only 'SAFE' or 'UNSAFE'.
-
-      Response: ${lastMessage.content.toString()}`;
-
-      const result = await safetyModel.invoke([
-        { role: "user", content: safetyPrompt }
-      ]);
-
-      if (result.content.toString().includes("UNSAFE")) {
-        return {
-          messages: [
-            new AIMessage(
-              "I cannot provide that response. Please rephrase your request."
-            )
-          ],
-          jumpTo: "end",
-        };
-      }
-
-      return;
-    },
+      },
+      canJumpTo: ['end']
+    }
   });
 };
 


### PR DESCRIPTION
If don't add `canJumpTo: ['end']`, it will cause an error: 'Invalid jump target: end, no afterAgent.canJumpTo defined in middleware customerMiddleware.'

langchain version: 1.1.1

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
