### PR TITLE
docs: update import for LLMChain from langchain_classic

### DIFF
--- a/src/oss/python/integrations/retrievers/re_phrase.mdx
+++ b/src/oss/python/integrations/retrievers/re_phrase.mdx
@@ -78,7 +78,7 @@ INFO:langchain.retrievers.re_phraser:Re-phrased question: Query for vectorstore:
 ### Custom prompt
 
 ```python
-from langchain.chains import LLMChain
+from langchain_classic.chains import LLMChain
 from langchain_core.prompts import PromptTemplate
 
 QUERY_PROMPT = PromptTemplate(


### PR DESCRIPTION
## Overview
This PR updates the documentation for python retriever integrations. Specifically, it corrects the import statement for LLMChain, updating it to import from langchain_classic.

## Type of change
Type: Update existing documentation / Fix typo/bug/link/formatting

## Related issues/PRs
GitHub issue:

Feature PR:

Linear issue:

Slack thread:

## Checklist
[x] I have read the contributing guidelines

[x] I have tested my changes locally using docs dev

[x] All code examples have been tested and work correctly

[ ] I have used root relative paths for internal links

[ ] I have updated navigation in src/docs.json if needed

## Additional notes
The change specifically affects the documentation located in: docs/src/oss/python/integrations/retrievers