### PR TITLE
fix(subagents.mdx): remove unsupported CompiledSubAgent from JS docs

### DIFF
--- a/src/oss/deepagents/subagents.mdx
+++ b/src/oss/deepagents/subagents.mdx
@@ -54,6 +54,7 @@ For most use cases, define subagents as dictionaries:
 - **middleware** (`List[Middleware]`): Additional middleware for custom behavior, logging, or rate limiting.
 - **interrupt_on** (`Dict[str, bool]`): Configure human-in-the-loop for specific tools. Requires a checkpointer.
 
+:::python
 ### CompiledSubAgent
 
 For complex workflows, use a pre-built LangGraph graph:
@@ -62,6 +63,7 @@ For complex workflows, use a pre-built LangGraph graph:
 - **name** (`str`): Unique identifier
 - **description** (`str`): What this subagent does
 - **runnable** (`Runnable`): A compiled LangGraph graph (must call `.compile()` first)
+:::
 
 ## Using SubAgent
 
@@ -163,11 +165,11 @@ const agent = createDeepAgent({
 ```
 :::
 
+:::python
 ## Using CompiledSubAgent
 
 For more complex use cases, you can provide your own pre-built LangGraph graph as a subagent:
 
-:::python
 ```python
 from deepagents import create_deep_agent, CompiledSubAgent
 from langchain.agents import create_agent
@@ -194,36 +196,6 @@ agent = create_deep_agent(
     system_prompt=research_instructions,
     subagents=subagents
 )
-```
-:::
-
-:::js
-```typescript
-import { createDeepAgent, CompiledSubAgent } from "deepagents";
-import { createAgent } from "langchain";
-
-// Create a custom agent graph
-const customGraph = createAgent({
-  model: yourModel,
-  tools: specializedTools,
-  prompt: "You are a specialized agent for data analysis...",
-});
-
-// Use it as a custom subagent
-const customSubagent: CompiledSubAgent = {
-  name: "data-analyzer",
-  description: "Specialized agent for complex data analysis tasks",
-  runnable: customGraph,
-};
-
-const subagents = [customSubagent];
-
-const agent = createDeepAgent({
-  model: "claude-sonnet-4-5-20250929",
-  tools: [internetSearch],
-  systemPrompt: researchInstructions,
-  subagents: subagents,
-});
 ```
 :::
 


### PR DESCRIPTION
## Summary

- Remove `CompiledSubAgent` TypeScript example from JS docs as it's not supported in the JavaScript SDK
- Add `:::python` tabs to properly scope Python-only `CompiledSubAgent` documentation sections

## Problem

The JavaScript/TypeScript SDK does not currently support `CompiledSubAgent`. The existing documentation included JS examples for this feature, which could mislead users.

## Changes

- Removed the unsupported JS/TS code block for `CompiledSubAgent` usage
- Added proper `:::python` and `:::` markers to clearly indicate Python-only sections
- Kept all Python documentation intact

## Test Plan

- [x] `make lint` - Python lint passed
- [x] `make lint_md` - No new markdown errors introduced  
- [x] `make test` - 101 tests passed
- [x] `make build` - Documentation build successful
- [x] `make broken-links` - Broken links check passed (≤5)