### PR TITLE
oss(langgraph): clarify `baseUrl` use

### DIFF
--- a/src/oss/langgraph/local-server.mdx
+++ b/src/oss/langgraph/local-server.mdx
@@ -129,7 +129,11 @@ The `langgraph dev` command starts Agent Server in an in-memory mode. This mode 
 >    - LangGraph Studio Web UI: https://smith.langchain.com/studio/?baseUrl=http://127.0.0.1:2024
 ```
 
-For an Agent Server running on a custom host/port, update the `baseURL` parameter.
+For an Agent Server running on a custom host/port, update the `baseUrl` query parameter in the URL. For example, if your server is running on `http://myhost:3000`:
+
+```
+https://smith.langchain.com/studio/?baseUrl=http://myhost:3000
+```
 
 <Accordion title="Safari compatibility">
     Use the `--tunnel` flag with your command to create a secure tunnel, as Safari has limitations when connecting to localhost servers:


### PR DESCRIPTION
- Clarify how to update the `baseUrl` parameter for custom host/port configurations in Studio
- Add concrete example showing the URL format
- Fix casing from `baseURL` to `baseUrl` to match actual query parameter