### PR TITLE
Correct 'tool_runtime' to 'runtime' in note

### DIFF
--- a/src/oss/langchain/tools.mdx
+++ b/src/oss/langchain/tools.mdx
@@ -258,7 +258,7 @@ def get_user_preference(
 ```
 
 <Warning>
-The `ToolRuntime` parameter is hidden from the model. For the example above, the model only sees `pref_name` in the tool schema - `ToolRuntime` is *not* included in the request.
+The `runtime` parameter is hidden from the model. For the example above, the model only sees `pref_name` in the tool schema - `runtime` is *not* included in the request.
 </Warning>
 
 **Updating state:**


### PR DESCRIPTION
## Overview
Updating the note in the Tools > ToolRuntime section to refer to the `ToolRuntime` parameter used in the code snippet, rather than the older `tool_runtime` parameter

## Type of change

**Type:** Fix typo

## Related issues/PRs

- Pylon ticket: 12761

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
