### PR TITLE
update tools.mdx to fix the unnecessary ‘Python’ contents from this doc

### DIFF
--- a/src/oss/langchain/tools.mdx
+++ b/src/oss/langchain/tools.mdx
@@ -139,7 +139,6 @@ Define complex inputs with Pydantic models or JSON schemas:
     ```
 </CodeGroup>
 
-:::python
 ### Reserved argument names
 
 The following parameter names are reserved and cannot be used as tool arguments. Using these names will cause runtime errors.


### PR DESCRIPTION
update tools.mdx to fix the unnecessary ‘Python’ contents from this doc