### PR TITLE
add wrap_tool_call example to v1 migration guide

### DIFF
--- a/src/oss/python/migrate/langchain-v1.mdx
+++ b/src/oss/python/migrate/langchain-v1.mdx
@@ -592,7 +592,16 @@ You can now configure the handling of tool errors with middleware implementing t
 
 <CodeGroup>
 ```python v1 (new)
-# Example coming soon
+
+@wrap_tool_call
+def retry_on_error(request, handler):
+    max_retries = 3
+    for attempt in range(max_retries):
+        try:
+            return handler(request)
+        except Exception:
+            if attempt == max_retries - 1:
+                raise
 ```
 ```python v0 (old)
 # Example coming soon


### PR DESCRIPTION
The v1 migration guide was missing documentation for the wrap_tool_call  function. Added a practical example demonstrating its usage to help  developers understand how to properly wrap tool calls during migration.

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
