### PR TITLE
Add API rate limits to the LangSmith Deploy Cloud docs

### DIFF
--- a/src/langsmith/cloud.mdx
+++ b/src/langsmith/cloud.mdx
@@ -134,9 +134,7 @@ You may need to allowlist these to enable traffic from your private network to L
 
 ### API rate limits
 
-LangSmith enforces rate limits on API endpoints to ensure service stability and fair usage. The following table shows the rate limits for different endpoints in both US and EU regions.
-
-**Understand the table:**
+LangSmith enforces rate limits on API endpoints to ensure service stability and fair usage. The following table shows the rate limits for different endpoints in both US and EU regions. Note that:
 
 - Rate limits are expressed as `count / interval` where count is the number of requests allowed within the interval (in seconds). For example, `2000 / 10` means 2000 requests per 10 seconds.
 - When no HTTP method is specified in the endpoint column, the rate limit applies to all HTTP methods for that endpoint.
@@ -144,37 +142,37 @@ LangSmith enforces rate limits on API endpoints to ensure service stability and 
 
 | Match / Endpoint (method) | Identity key | US prod limit | EU prod limit | Category |
 | --- | --- | --- | --- | --- |
-| OPTIONS, `/info`, `*/v1/metadata/submit` | IP | 2000 / 10 | 2000 / 10 | High throughput |
-| `/auth` | `x-api-key` | 2000 / 10 | 2000 / 10 | High throughput |
-| `/auth` | `x-user-id` + IP | 2000 / 10 | 2000 / 10 | High throughput |
-| `/v1/beacon` | IP | 2000 / 10 | 2000 / 10 | High throughput |
-| `/repos` | `x-api-key` | 100 / 60 | 100 / 60 | Repository |
-| `/repos` | `x-user-id` + IP | 100 / 60 | 100 / 60 | Repository |
-| `POST /runs/batch` | `x-api-key` | 2000 / 10 | 2000 / 10 | High throughput |
-| `POST /otel/v1/traces` | `x-api-key` | 2000 / 10 | 2000 / 10 | Run ingest |
-| `POST` containing `/charts` | `x-api-key` | 750 / 600 | 750 / 600 | Charts |
-| `POST` containing `/charts` | `x-user-id` + IP | 750 / 600 | 750 / 600 | Charts |
-| `POST /runs/multipart` | `x-api-key` | 6000 / 10 | 6000 / 10 | Multipart ingest |
-| `POST /runs/query` | `x-api-key` | 15 / 10 | 15 / 10 | Run query (API) |
-| `POST /runs/query` | `x-user-id` + IP | 300 / 10 | 300 / 10 | Run query (User) |
-| `/generate` | `x-api-key` | 30 / 3600 | 30 / 3600 | Generation |
-| `/generate` | `x-user-id` + IP | 30 / 3600 | 30 / 3600 | Generation |
-| `/commits` | `x-api-key` | 10000 / 60 | 2000 / 60 | Commits |
-| `/commits` | `x-user-id` + IP | 10000 / 60 | 2000 / 60 | Commits |
-| `DELETE /sessions` or `*/trigger` | `x-api-key` | 10 / 60 | 10 / 60 | Deletion |
-| `DELETE /sessions` or `*/trigger` | `x-user-id` + IP | 30 / 60 | 30 / 60 | Deletion |
-| `POST /runs` (single run ingest) | `x-api-key` | 2000 / 10 | 2000 / 10 | Run ingest |
-| `PATCH` containing `/runs` | `x-api-key` | 2000 / 10 | 2000 / 10 | Run ingest |
-| `POST /feedback` | `x-api-key` | 2000 / 10 | 2000 / 10 | High throughput |
-| `GET /runs/{uuid}` or `/api/v1/runs/{uuid}` | `x-api-key` | 30 / 60 | 30 / 60 | Run lookup |
-| `GET` containing `/examples` | `x-api-key` | 5000 / 60 | 5000 / 60 | Examples |
-| Any request with `x-api-key` | `x-api-key` | 1000 / 10 | 1000 / 10 | Default (API key) |
-| Any request with `x-user-id` | `x-user-id` + IP | 1000 / 10 | 1000 / 10 | Default (User) |
-| `/public/download` | IP | 5000 / 60 | 5000 / 60 | Public download |
-| `/runs/stats` | `x-api-key` | 1 / 10 | 20 / 10 | Stats |
-| All other IPs (catch-all) | IP | 100 / 60 | 100 / 60 | Public (catch-all) |
+| OPTIONS, `/info`, `*/v1/metadata/submit` | IP | 2000 / 10 | 2000 / 10 | [High throughput](#rate-limit-categories) |
+| `/auth` | `x-api-key` | 2000 / 10 | 2000 / 10 | [High throughput](#rate-limit-categories) |
+| `/auth` | `x-user-id` + IP | 2000 / 10 | 2000 / 10 | [High throughput](#rate-limit-categories) |
+| `/v1/beacon` | IP | 2000 / 10 | 2000 / 10 | [High throughput](#rate-limit-categories) |
+| `/repos` | `x-api-key` | 100 / 60 | 100 / 60 | [Repository](#rate-limit-categories) |
+| `/repos` | `x-user-id` + IP | 100 / 60 | 100 / 60 | [Repository](#rate-limit-categories) |
+| `POST /runs/batch` | `x-api-key` | 2000 / 10 | 2000 / 10 | [High throughput](#rate-limit-categories) |
+| `POST /otel/v1/traces` | `x-api-key` | 2000 / 10 | 2000 / 10 | [Run ingest](#rate-limit-categories) |
+| `POST` containing `/charts` | `x-api-key` | 750 / 600 | 750 / 600 | [Charts](#rate-limit-categories) |
+| `POST` containing `/charts` | `x-user-id` + IP | 750 / 600 | 750 / 600 | [Charts](#rate-limit-categories) |
+| `POST /runs/multipart` | `x-api-key` | 6000 / 10 | 6000 / 10 | [Multipart ingest](#rate-limit-categories) |
+| `POST /runs/query` | `x-api-key` | 15 / 10 | 15 / 10 | [Run query (API)](#rate-limit-categories) |
+| `POST /runs/query` | `x-user-id` + IP | 300 / 10 | 300 / 10 | [Run query (User)](#rate-limit-categories) |
+| `/generate` | `x-api-key` | 30 / 3600 | 30 / 3600 | [Generation](#rate-limit-categories) |
+| `/generate` | `x-user-id` + IP | 30 / 3600 | 30 / 3600 | [Generation](#rate-limit-categories) |
+| `/commits` | `x-api-key` | 10000 / 60 | 2000 / 60 | [Commits](#rate-limit-categories) |
+| `/commits` | `x-user-id` + IP | 10000 / 60 | 2000 / 60 | [Commits](#rate-limit-categories) |
+| `DELETE /sessions` or `*/trigger` | `x-api-key` | 10 / 60 | 10 / 60 | [Deletion](#rate-limit-categories) |
+| `DELETE /sessions` or `*/trigger` | `x-user-id` + IP | 30 / 60 | 30 / 60 | [Deletion](#rate-limit-categories) |
+| `POST /runs` (single run ingest) | `x-api-key` | 2000 / 10 | 2000 / 10 | [Run ingest](#rate-limit-categories) |
+| `PATCH` containing `/runs` | `x-api-key` | 2000 / 10 | 2000 / 10 | [Run ingest](#rate-limit-categories) |
+| `POST /feedback` | `x-api-key` | 2000 / 10 | 2000 / 10 | [High throughput](#rate-limit-categories) |
+| `GET /runs/{uuid}` or `/api/v1/runs/{uuid}` | `x-api-key` | 30 / 60 | 30 / 60 | [Run lookup](#rate-limit-categories) |
+| `GET` containing `/examples` | `x-api-key` | 5000 / 60 | 5000 / 60 | [Examples](#rate-limit-categories) |
+| Any request with `x-api-key` | `x-api-key` | 1000 / 10 | 1000 / 10 | [Default (API key)](#rate-limit-categories) |
+| Any request with `x-user-id` | `x-user-id` + IP | 1000 / 10 | 1000 / 10 | [Default (User)](#rate-limit-categories) |
+| `/public/download` | IP | 5000 / 60 | 5000 / 60 | [Public download](#rate-limit-categories) |
+| `/runs/stats` | `x-api-key` | 1 / 10 | 20 / 10 | [Stats](#rate-limit-categories) |
+| All other IPs (catch-all) | IP | 100 / 60 | 100 / 60 | [Public (catch-all)](#rate-limit-categories) |
 
-**Rate limit categories:**
+#### Rate limit categories
 
 - **High throughput**: General high-volume endpoints for core operations like authentication, metadata, and feedback.
 - **Repository**: Repository and prompt management operations.
@@ -194,4 +192,4 @@ LangSmith enforces rate limits on API endpoints to ensure service stability and 
 - **Stats**: Run statistics and analytics endpoints (region-specific limits apply).
 - **Public (catch-all)**: Default rate limit for unauthenticated public access.
 
-For more information on rate limits and other service limits, refer to the [administration overview](/langsmith/administration-overview#rate-limits).
+For more information on rate limits and other service limits, refer to the [Administration overview](/langsmith/administration-overview#rate-limits).


### PR DESCRIPTION
Fixes DOC-498

## Preview

https://langchain-5e9cc07a-preview-apirat-1764626578-896151a.mintlify.app/langsmith/cloud#api-rate-limits