### PR TITLE
chore: function not method

### DIFF
--- a/src/oss/langgraph/interrupts.mdx
+++ b/src/oss/langgraph/interrupts.mdx
@@ -1432,7 +1432,7 @@ To debug and test a graph, you can use static interrupts as breakpoints to step 
 :::
 
 <Note>
-    Static interrupts are **not** recommended for human-in-the-loop workflows. Use the @[`interrupt`] method instead.
+    Static interrupts are **not** recommended for human-in-the-loop workflows. Use the @[`interrupt`] function instead.
 </Note>
 
 <Tabs>


### PR DESCRIPTION
Low value pedantry