### PR TITLE
Update language for version release

### DIFF
--- a/src/langsmith/agent-server-changelog.mdx
+++ b/src/langsmith/agent-server-changelog.mdx
@@ -8,8 +8,7 @@ sidebarTitle: Agent Server changelog
 <a id="2025-11-26"></a>
 ## v0.5.27
 - Ensured `runs.list` with filters returns only run fields, preventing incorrect status data from being included.
-- Updated `uuid` from version 10.0.0 to 13.0.0 with significant breaking changes including defaulting to browser exports and dropping Node.js 16 support.
-- Upgraded the `exit-hook` package from version 4.0.0 to 5.0.1 to improve compatibility and functionality.
+- (JS) Updated `uuid` from version 10.0.0 to 13.0.0. and `exit-hook` from version 4.0.0 to 5.0.1.
 
 <a id="2025-11-24"></a>
 ## v0.5.26


### PR DESCRIPTION
These were just regular dependabot updates that the autodoc workflow incorrectly communicated as breaking changes.