### PR TITLE
docs: Update support contact from email to support portal

### DIFF
--- a/src/langsmith/administration-overview.mdx
+++ b/src/langsmith/administration-overview.mdx
@@ -244,7 +244,7 @@ We have two reasons behind the auto-upgrade model for tracing:
 1. We think that traces that match any of these conditions are fundamentally more interesting than other traces, and therefore it is good for users to be able to keep them around longer.
 2. We philosophically want to charge customers an order of magnitude lower for traces that may not be interacted with meaningfully. We think auto-upgrades align our pricing model with the value that LangSmith brings, where only traces with meaningful interaction are charged at a higher rate.
 
-If you have questions or concerns about our pricing model, please feel free to reach out to [support@langchain.dev](mailto:support@langchain.dev) and let us know your thoughts!
+If you have questions or concerns about our pricing model, please feel free to contact support via [support.langchain.com](https://support.langchain.com) and let us know your thoughts!
 
 **How does data retention affect downstream features?**
 
@@ -356,7 +356,7 @@ For convenience, LangChain applications built with the LangSmith SDK has this ca
 <Note>
 It is important to note that if you are saturating the endpoints for extended periods of time, retries may not be effective as your application will eventually run large enough backlogs to exhaust all retries.
 
-If that is the case, we would like to discuss your needs more specifically. Please reach out to [LangSmith Support](mailto:support@langchain.dev) with details about your applications throughput needs and sample code and we can work with you to better understand whether the best approach is fixing a bug, changes to your application code, or a different LangSmith plan.
+If that is the case, we would like to discuss your needs more specifically. Please contact support via [LangSmith Support](https://support.langchain.com) with details about your applications throughput needs and sample code and we can work with you to better understand whether the best approach is fixing a bug, changes to your application code, or a different LangSmith plan.
 </Note>
 
 ### Usage Limits

--- a/src/langsmith/agent-server-scale.mdx
+++ b/src/langsmith/agent-server-scale.mdx
@@ -165,7 +165,7 @@ Autoscaling is disabled by default, but should be configured for bursty workload
 ## Example self-hosted Agent Server configurations
 
 <Note>
-The exact optimal configuration depends on your application complexity, request patterns, and data requirements. Use the following examples in combination with the information in the previous sections and your specific usage to update your deployment configuration as needed. If you have any questions, reach out to the LangChain team at [support@langchain.dev](mailto:support@langchain.dev).
+The exact optimal configuration depends on your application complexity, request patterns, and data requirements. Use the following examples in combination with the information in the previous sections and your specific usage to update your deployment configuration as needed. If you have any questions, contact support via [support.langchain.com](https://support.langchain.com).
 </Note>
 
 The following table provides an overview comparing different LangSmith Agent Server configurations for various load patterns (read requests per second / write requests per second) and standard assistant characteristics (average run execution time of 1 second, moderate CPU and memory usage):

--- a/src/langsmith/billing.mdx
+++ b/src/langsmith/billing.mdx
@@ -87,7 +87,7 @@ You may find it helpful to read the following pages, before continuing with this
 </Check>
 
 <Note>
-Some of the features mentioned in this guide are not currently available on Enterprise plan due to its custom nature of billing. If you are on the Enterprise plan and have questions about cost optimization, reach out to your sales rep or [support@langchain.dev](mailto:support@langchain.dev).
+Some of the features mentioned in this guide are not currently available on Enterprise plan due to its custom nature of billing. If you are on the Enterprise plan and have questions about cost optimization, contact your sales rep or support via [support.langchain.com](https://support.langchain.com).
 </Note>
 
 
@@ -191,5 +191,5 @@ For high-volume deployment usage, please [contact our sales team](https://www.la
 
 ### Summary
 
-If you have questions about further managing your spend, please reach out to [support@langchain.dev](mailto:support@langchain.dev).
+If you have questions about further managing your spend, please contact support via [support.langchain.com](https://support.langchain.com).
 

--- a/src/langsmith/control-plane.mdx
+++ b/src/langsmith/control-plane.mdx
@@ -73,7 +73,7 @@ Resources for [Hybrid](/langsmith/hybrid) and [Self-Hosted](/langsmith/self-host
 
 `Production` type deployments are suitable for "production" workloads. For example, select `Production` for customer-facing applications in the critical path.
 
-Resources for `Production` type deployments can be manually increased on a case-by-case basis depending on use case and capacity constraints. Contact support@langchain.dev to request an increase in resources.
+Resources for `Production` type deployments can be manually increased on a case-by-case basis depending on use case and capacity constraints. Contact support via [support.langchain.com](https://support.langchain.com) to request an increase in resources.
 
 #### Development
 
@@ -92,7 +92,7 @@ This behavior is expected. Preemptible compute infrastructure **significantly re
 `Production` type deployments are provisioned on durable compute infrastructure, not preemptible compute infrastructure.
 </Danger>
 
-Database disk size for `Development` type deployments can be manually increased on a case-by-case basis depending on use case and capacity constraints. For most use cases, [TTLs](/langsmith/configure-ttl) should be configured to manage disk usage. Contact support@langchain.dev to request an increase in resources.
+Database disk size for `Development` type deployments can be manually increased on a case-by-case basis depending on use case and capacity constraints. For most use cases, [TTLs](/langsmith/configure-ttl) should be configured to manage disk usage. Contact support via [support.langchain.com](https://support.langchain.com) to request an increase in resources.
 
 ### Database provisioning
 

--- a/src/langsmith/dataset-transformations.mdx
+++ b/src/langsmith/dataset-transformations.mdx
@@ -33,7 +33,7 @@ Users who want to iterate on their system prompts often also add the Remove Syst
 
 The LLM run collection schema is built to collect data from LangChain @[`BaseChatModel`] runs or traced runs from the [LangSmith OpenAI wrapper](/langsmith/annotate-code#wrap-the-openai-client).
 
-Please reach out to [support@langchain.dev](mailto:support@langchain.dev) if you have an LLM run you are tracing that is not compatible and we can extend support.
+Please contact support via [support.langchain.com](https://support.langchain.com) if you have an LLM run you are tracing that is not compatible and we can extend support.
 
 If you want to apply transformations to other sorts of runs (for example, representing LangGraph state with message history), please define your schema directly and manually add the relevant transformations.
 

--- a/src/langsmith/index-datasets-for-dynamic-few-shot-example-selection.mdx
+++ b/src/langsmith/index-datasets-for-dynamic-few-shot-example-selection.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Dynamic few shot example selection
 ---
 
 <Note>
-This feature is in open beta. It is only available to paid team plans. Please reach out to [support@langchain.dev](mailto:support@langchain.dev) if you have questions about enablement.
+This feature is in open beta. It is only available to paid team plans. Please contact support via [support.langchain.com](https://support.langchain.com) if you have questions about enablement.
 </Note>
 
 Configure your datasets so that you can search for few shot examples based on an incoming request.

--- a/src/langsmith/mask-inputs-outputs.mdx
+++ b/src/langsmith/mask-inputs-outputs.mdx
@@ -153,7 +153,7 @@ const main = traceable(async (inputs: any) => {
 Please note, that using the anonymizer might incur a performance hit with complex regular expressions or large payloads, as the anonymizer serializes the payload to JSON before processing.
 
 <Note>
-Improving the performance of `anonymizer` API is on our roadmap! If you are encountering performance issues, please contact us at [support@langchain.dev](mailto:support@langchain.dev).
+Improving the performance of `anonymizer` API is on our roadmap! If you are encountering performance issues, please contact support via [support.langchain.com](https://support.langchain.com).
 </Note>
 
 ![](/langsmith/images/hide-inputs-outputs.png)

--- a/src/langsmith/observability-concepts.mdx
+++ b/src/langsmith/observability-concepts.mdx
@@ -118,4 +118,4 @@ You can delete a project with one of the following ways:
 
 LangSmith does not support self-service deletion of individual traces.
 
-If you have a need to delete a single trace (or set of traces) from LangSmith project before its expiration date, the account owner should reach out to [LangSmith Support](mailto:support@langchain.dev) with the organization ID and trace IDs.
+If you have a need to delete a single trace (or set of traces) from LangSmith project before its expiration date, the account owner should contact support via [LangSmith Support](https://support.langchain.com) with the organization ID and trace IDs.

--- a/src/langsmith/pricing-faq.mdx
+++ b/src/langsmith/pricing-faq.mdx
@@ -43,7 +43,7 @@ An ingested event is any distinct, trace-related data sent to LangSmith. This in
 
 When you first sign up for a LangSmith account, you get a Personal organization that is limited to 5000 monthly traces. To continue sending traces after reaching this limit, upgrade to the Developer or Plus plans by adding a credit card. Head to [Plans and Billing](https://smith.langchain.com/settings/payments) to upgrade.
 
-Similarly, if you've hit the rate limits on your current plan, you can upgrade to a higher plan to get higher limits, or reach out to [support@langchain.dev](mailto:support@langchain.dev) with questions.
+Similarly, if you've hit the rate limits on your current plan, you can upgrade to a higher plan to get higher limits, or contact support via [support.langchain.com](https://support.langchain.com) with questions.
 
 ### I have a developer account, can I upgrade my account to the Plus or Enterprise plan?
 
@@ -75,7 +75,7 @@ Under the Settings section for your Organization you will see subsection for **U
 
 ### I have a question about my bill...
 
-Customers on the Developer and Plus plan tiers should email [support@langchain.dev](mailto:support@langchain.dev). Customers on the Enterprise plan should contact their sales representative directly.
+Customers on the Developer and Plus plan tiers should contact support via [support.langchain.com](https://support.langchain.com). Customers on the Enterprise plan should contact their sales representative directly.
 
 Enterprise plan customers are billed annually by invoice.
 
@@ -83,7 +83,7 @@ Enterprise plan customers are billed annually by invoice.
 
 On the Developer plan, community-based support is available on [LangChain community Slack](https://www.langchain.com/join-community).
 
-On the Plus plan, you will also receive preferential, email support at [support@langchain.dev](mailto:support@langchain.dev) for LangSmith-related questions only and we'll do our best to respond within the next business day.
+On the Plus plan, you will also receive preferential support via [support.langchain.com](https://support.langchain.com) for LangSmith-related questions only and we'll do our best to respond within the next business day.
 
 On the Enterprise plan, you'll get white-glove support with a Slack channel, a dedicated customer success manager, and monthly check-ins to go over LangSmith and LangChain questions. We can help with anything from debugging, agent and RAG techniques, evaluation approaches, and cognitive architecture reviews. If you purchase the add-on to run LangSmith in your environment, we'll also support deployments and new releases with our infra engineering team on-call.
 

--- a/src/langsmith/regions-faq.mdx
+++ b/src/langsmith/regions-faq.mdx
@@ -11,7 +11,7 @@ See the [cloud architecture reference](/langsmith/cloud#architecture) for additi
 
 #### *What privacy and data protection frameworks does LangSmith, including its EU instance, comply with?*
 
-LangSmith complies with the General Data Protection Regulation (GDPR) and other laws and regulations applicable to the LangSmith service. We are also SOC 2 Type 2 certified and are HIPAA compliant. You can request more information about our security policies and posture at [trust.langchain.com](https://trust.langchain.com). If you would like to sign a Data Processing Addendum (DPA) with us, please reach out to [support@langchain.dev](mailto:support@langchain.dev). Please note we only enter into Business Associate Agreements (BAAs) with customers on our Enterprise plan.
+LangSmith complies with the General Data Protection Regulation (GDPR) and other laws and regulations applicable to the LangSmith service. We are also SOC 2 Type 2 certified and are HIPAA compliant. You can request more information about our security policies and posture at [trust.langchain.com](https://trust.langchain.com). If you would like to sign a Data Processing Addendum (DPA) with us, please contact support via [support.langchain.com](https://support.langchain.com). Please note we only enter into Business Associate Agreements (BAAs) with customers on our Enterprise plan.
 
 #### *My company isn't based in the EU, can I still have my data hosted there?*
 
@@ -37,11 +37,11 @@ There may be a small delay between launches to each region depending on the feat
 
 #### *Can an organization have workspaces in different regions?*
 
-LangSmith does not support this at the moment, but if you are interested, please contact [support@langchain.dev](mailto:support@langchain.dev) and share your use case.
+LangSmith does not support this at the moment, but if you are interested, please contact support via [support.langchain.com](https://support.langchain.com) and share your use case.
 
 #### *Can I connect an EU organization to a US organization and share billing?*
 
-LangSmith does not support this at the moment, but if you are interested, please contact [support@langchain.dev](mailto:support@langchain.dev) and share your use case.
+LangSmith does not support this at the moment, but if you are interested, please contact support via [support.langchain.com](https://support.langchain.com) and share your use case.
 
 #### *What data will be stored in my selected region?*
 
@@ -53,7 +53,7 @@ Check your URL - any organizations on [https://eu.smith.langchain.com](https://e
 
 #### *Can I switch my organization from the US to EU or vice versa?*
 
-We do not support migration between regions at this time, but if you are interested in this feature, please reach out to [support@langchain.dev](mailto:support@langchain.dev).
+We do not support migration between regions at this time, but if you are interested in this feature, please contact support via [support.langchain.com](https://support.langchain.com).
 
 ## Plans and pricing
 

--- a/src/langsmith/self-host-external-clickhouse.mdx
+++ b/src/langsmith/self-host-external-clickhouse.mdx
@@ -22,7 +22,7 @@ However, you can configure LangSmith to use an external ClickHouse database for 
 <Note>
 Using the first two options (LangSmith-managed ClickHouse or ClickHouse Cloud) will provision a Clickhouse service OUTSIDE of your VPC. However, both options support private endpoints, meaning that you can direct traffic to the ClickHouse service without exposing it to the public internet (eg via AWS PrivateLink, or GCP Private Service Connect).
 
-Additionally, sensitive information can be configured to be not stored in Clickhouse. Please reach out to [support@langchain.dev](mailto:support@langchain.dev) for more information.
+Additionally, sensitive information can be configured to be not stored in Clickhouse. Please contact support via [support.langchain.com](https://support.langchain.com) for more information.
 </Note>
 
 ## Requirements
@@ -75,7 +75,7 @@ For an example setup of a replicated ClickHouse cluster, refer to the [replicate
 
 ## LangSmith-managed ClickHouse
 
-* If using LangSmith-managed ClickHouse, you will need to set up a VPC peering connection between the LangSmith VPC and the ClickHouse VPC. Please reach out to [support@langchain.dev](mailto:support@langchain.dev) for more information.
+* If using LangSmith-managed ClickHouse, you will need to set up a VPC peering connection between the LangSmith VPC and the ClickHouse VPC. Please contact support via [support.langchain.com](https://support.langchain.com) for more information.
 * You will also need to set up Blob Storage. You can read more about Blob Storage in the [Blob Storage documentation](/langsmith/self-host-blob-storage).
 
 <Note>

--- a/src/langsmith/self-host-sso.mdx
+++ b/src/langsmith/self-host-sso.mdx
@@ -148,7 +148,7 @@ You must have administrator-level access to your organization's Google Cloud Pla
 #### Configuration steps
 
 For additional information, see Okta's [documentation](https://help.okta.com/en-us/content/topics/apps/apps_app_integration_wizard_oidc.htm).
-If you have any questions or issues, please reach out to [support@langchain.dev](mailto:support@langchain.dev).
+If you have any questions or issues, please contact support via [support.langchain.com](https://support.langchain.com).
 
 <div id="via-okta-integration-network">
     <b>Via Okta Integration Network (recommended)</b>

--- a/src/langsmith/user-management.mdx
+++ b/src/langsmith/user-management.mdx
@@ -94,7 +94,7 @@ To ensure users can only access the organization when logged in using SAML SSO a
 You must be logged in via SAML SSO in order to update this setting to `Only SAML SSO`. This is to ensure the SAML settings are valid and avoid locking users out of your organization.
 </Note>
 
-For troubleshooting, refer to the [SAML SSO FAQs](/langsmith/faq#saml-sso-faqs). If you have issues setting up SAML SSO, reach out to the LangChain support team at [support@langchain.dev](mailto:support@langchain.dev).
+For troubleshooting, refer to the [SAML SSO FAQs](/langsmith/faq#saml-sso-faqs). If you have issues setting up SAML SSO, contact the LangChain support team via [support.langchain.com](https://support.langchain.com).
 
 ### Prerequisites
 
@@ -628,7 +628,7 @@ Set **Target Object Actions** to `Create` and `Update` only (start with `Delete`
 2. Monitor the initial sync to ensure users and groups are provisioned correctly.
 3. Once verified, enable `Delete` actions for both User and Group mappings.
 
-For troubleshooting, refer to the [SAML SSO FAQs](/langsmith/faq#saml-sso-faqs). If you have issues setting up SCIM, reach out to the LangChain support team at [support@langchain.dev](mailto:support@langchain.dev).
+For troubleshooting, refer to the [SAML SSO FAQs](/langsmith/faq#saml-sso-faqs). If you have issues setting up SCIM, contact the LangChain support team via [support.langchain.com](https://support.langchain.com).
 
 #### Okta configuration steps
 


### PR DESCRIPTION
## Summary

This PR updates all references from the support email address (`support@langchain.dev`) to the support portal (`support.langchain.com`) across LangSmith documentation.

## Why

- Provides users with a better, centralized support experience through the support portal
- Ensures consistency in how users access support resources
- Aligns with the current support infrastructure

## What Changed

Replaced all instances of `support@langchain.dev` with links to `support.langchain.com` in the following documentation files:

- `administration-overview.mdx` (2 changes)
- `agent-server-scale.mdx` (1 change)
- `billing.mdx` (2 changes)
- `control-plane.mdx` (2 changes)
- `dataset-transformations.mdx` (1 change)
- `index-datasets-for-dynamic-few-shot-example-selection.mdx` (1 change)
- `mask-inputs-outputs.mdx` (1 change)
- `observability-concepts.mdx` (1 change)
- `pricing-faq.mdx` (3 changes)
- `regions-faq.mdx` (4 changes)
- `self-host-external-clickhouse.mdx` (2 changes)
- `self-host-sso.mdx` (1 change)
- `user-management.mdx` (2 changes)

**Total: 23 replacements across 13 files**

## Review Notes

- All changes are simple text replacements
- No functional changes to the documentation content
- All links point to `https://support.langchain.com`