### PR TITLE
chore: Add session id explanation to trace delete notes

### DIFF
--- a/src/langsmith/data-purging-compliance.mdx
+++ b/src/langsmith/data-purging-compliance.mdx
@@ -32,6 +32,10 @@ Trace deletions are processed during non-peak usage times and are not instant. L
 
 To delete specific traces by their trace IDs from a single session:
 
+<Note>
+The `session_id` is the project ID for the trace you are trying to delete. You can find it on the tracing project page in the LangSmith UI.
+</Note>
+
 ```bash
 curl -X POST "https://api.smith.langchain.com/api/v1/runs/delete" \
   -H "x-api-key: YOUR_API_KEY" \


### PR DESCRIPTION
## Overview
session_id can be confusing since we refer to tracing sessions as projects in the langsmith ui.