### PR TITLE
Revamp Self-hosted redis docs to have cluster + MTLS info

### DIFF
--- a/src/langsmith/self-host-external-redis.mdx
+++ b/src/langsmith/self-host-external-redis.mdx
@@ -199,6 +199,10 @@ To validate the Redis server certificate:
 - For Standalone Redis, use `rediss://` in the connection URL.
 - For Redis Cluster, set `redis.external.cluster.tlsEnabled: true`.
 
+<Warning>
+Mount a custom CA only when your Redis server uses an internal or private CA. Publicly trusted CAs do not require this configuration.
+</Warning>
+
 <CodeGroup>
 
 ```yaml Helm (Standalone - server TLS)
@@ -248,7 +252,8 @@ stringData:
 
 ### Mutual TLS with Client Auth (mTLS)
 
-As of LangSmith helm chart version **0.12.26**, we support mTLS for Redis clients.
+As of LangSmith helm chart version **0.12.26**, we support mTLS for Redis clients. For server-side authentication in mTLS, use the Server TLS steps above (custom CA) in addition to the client certificate configuration below.
+
 If your Redis server requires client certificate authentication:
 
 - Provide a Secret with your client certificate and key.
@@ -258,11 +263,7 @@ If your Redis server requires client certificate authentication:
 
 <CodeGroup>
 
-```yaml Helm (mTLS)
-config:
-  customCa:
-    secretName: "langsmith-custom-ca"  # Secret containing your CA bundle
-    secretKey: "ca.crt"    # Key in the Secret with the CA bundle
+```yaml Helm (client Auth)
 redis:
   external:
     enabled: true
@@ -298,19 +299,6 @@ stringData:
     -----BEGIN PRIVATE KEY-----
     <CLIENT_KEY>
     -----END PRIVATE KEY-----
-```
-
-```yaml Kubernetes Secret (CA bundle)
-apiVersion: v1
-kind: Secret
-metadata:
-  name: langsmith-custom-ca
-type: Opaque
-stringData:
-  ca.crt: |
-    -----BEGIN CERTIFICATE-----
-    <ROOT_OR_INTERMEDIATE_CA_CERT_CHAIN>
-    -----END CERTIFICATE-----
 ```
 
 </CodeGroup>


### PR DESCRIPTION
## Overview
3 distinct sections now, for standalone, redis cluster, and setting up TLS

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
Closes INF-1239

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [X] I have read the [contributing guidelines](README.md)
- [X] I have tested my changes locally using `docs dev`
- [X] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes
