### PR TITLE
Add `ToolRuntime` migration section to tools documentation

### DIFF
--- a/src/oss/langchain/tools.mdx
+++ b/src/oss/langchain/tools.mdx
@@ -168,7 +168,7 @@ The following parameter names are reserved and cannot be used as tool arguments.
 
 To access runtime information, use the @[`ToolRuntime`] parameter instead of naming your own arguments `config` or `runtime`.
 
-If you used `InjectedState`, `InjectedStore`, `get_runtime()`, or `InjectedToolCallId`, see [Migrate from older injection patterns](#migrate-from-older-injection-patterns).
+If you use `InjectedState`, `InjectedStore`, `get_runtime()`, or `InjectedToolCallId`, see [Migrate from older injection patterns](#migrate-from-older-injection-patterns).
 :::
 
 ## Access context

--- a/src/oss/langchain/tools.mdx
+++ b/src/oss/langchain/tools.mdx
@@ -766,7 +766,15 @@ Handle tool errors using LangChain agent [middleware](/oss/langchain/middleware)
 Tools access graph state through @[`ToolRuntime`]. See [Access context](#access-context) for state, context, store, and streaming APIs.
 
 :::python
-If you used `InjectedState`, `InjectedStore`, `get_runtime()`, or `InjectedToolCallId`, see [Migrate from older injection patterns](#migrate-from-older-injection-patterns).
+```python
+from langchain.tools import tool, ToolRuntime
+
+@tool
+def get_message_count(runtime: ToolRuntime) -> str:
+    """Get the number of messages in the conversation."""
+    messages = runtime.state["messages"]
+    return f"There are {len(messages)} messages."
+```
 :::
 
 ## Dynamic tool selection

--- a/src/oss/langchain/tools.mdx
+++ b/src/oss/langchain/tools.mdx
@@ -167,6 +167,8 @@ The following parameter names are reserved and cannot be used as tool arguments.
 | `runtime` | Reserved for `ToolRuntime` parameter (accessing state, context, store) |
 
 To access runtime information, use the @[`ToolRuntime`] parameter instead of naming your own arguments `config` or `runtime`.
+
+If you used `InjectedState`, `InjectedStore`, `get_runtime()`, or `InjectedToolCallId`, see [Migrate from older injection patterns](#migrate-from-older-injection-patterns).
 :::
 
 ## Access context
@@ -621,6 +623,40 @@ Requires `deepagents>=1.9.0` (or `@langchain/langgraph>=1.2.8`).
 </Note>
 :::
 
+:::python
+<Accordion title="Migrate from older injection patterns" id="migrate-from-older-injection-patterns">
+
+Older examples used `InjectedState`, `InjectedStore`, `get_runtime()`, or `InjectedToolCallId`. Use @[`ToolRuntime`] instead for one explicit interface to state, context, store, and execution metadata.
+
+#### Previous pattern
+
+```python
+from langchain.tools import tool, InjectedState
+
+@tool
+def summarize(state: InjectedState) -> str:
+    """Summarize the conversation."""
+    messages = state["messages"]
+    return f"Conversation length: {len(messages)} messages."
+```
+
+#### Recommended pattern
+
+```python
+from langchain.tools import tool, ToolRuntime
+
+@tool
+def summarize(runtime: ToolRuntime) -> str:
+    """Summarize the conversation."""
+    messages = runtime.state["messages"]
+    return f"Conversation length: {len(messages)} messages."
+```
+
+For agent-level migrations (for example `create_react_agent` and custom state), see the [LangChain v1 migration guide](/oss/migrate/langchain-v1).
+
+</Accordion>
+:::
+
 ## Tool execution
 
 In LangChain, tools are used by agents (for example via @[`create_agent`]) and tool error handling is configured through [middleware](/oss/langchain/middleware).
@@ -727,24 +763,11 @@ Handle tool errors using LangChain agent [middleware](/oss/langchain/middleware)
 
 ### State injection
 
-Tools can access the current graph state through @[`ToolRuntime`]:
+Tools access graph state through @[`ToolRuntime`]. See [Access context](#access-context) for state, context, store, and streaming APIs.
 
 :::python
-
-```python
-from langchain.tools import tool, ToolRuntime
-
-@tool
-def get_message_count(runtime: ToolRuntime) -> str:
-    """Get the number of messages in the conversation."""
-    messages = runtime.state["messages"]
-    return f"There are {len(messages)} messages."
-```
-
+If you used `InjectedState`, `InjectedStore`, `get_runtime()`, or `InjectedToolCallId`, see [Migrate from older injection patterns](#migrate-from-older-injection-patterns).
 :::
-
-For more details on accessing state, context, and long-term memory from tools, see [Access context](#access-context).
-
 
 ## Dynamic tool selection
 


### PR DESCRIPTION
Adds a migration section explaining how older injection helpers (InjectedState, InjectedStore, get_runtime, etc.) map to the unified ToolRuntime API.

## Overview
This PR updates the Tools documentation by adding a migration section that explains how legacy injection helpers map to the new ToolRuntime API. It includes before/after examples and clarifies why the unified approach should be used going forward.

## Type of change

Type: Update existing documentation

## Related issues/PRs

Not applicable


## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [X] I have read the [contributing guidelines](README.md)
- [X] I have tested my changes locally using `docs dev`
- [X] All code examples have been tested and work correctly
- [X] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
Adds clarity around transitioning to ToolRuntime and consolidates several previously undocumented patterns into one unified section.