### PR TITLE
fix: add include_bucket_in_prefix param to bulk exports documentation

### DIFF
--- a/src/langsmith/data-export.mdx
+++ b/src/langsmith/data-export.mdx
@@ -36,7 +36,7 @@ The following information is needed for the export:
 - **Endpoint URL**: The endpoint URL for the S3 bucket - this is needed for S3 API compatible buckets.
 - **Access Key**: The access key for the S3 bucket.
 - **Secret Key**: The secret key for the S3 bucket.
-- **Include Bucket in Prefix** (optional): Whether to include the bucket name as part of the S3 path prefix. Defaults to `false` for new destinations. Set to `true` for legacy compatibility or when using S3-compatible storage systems that require the bucket name in the path.
+- **Include Bucket in Prefix** (optional): Whether to include the bucket name as part of the path prefix. Defaults to `false` for new destinations or when the bucket name is already present in the path. Set to `true` for legacy compatibility or when using storage systems that require the bucket name in the path.
 
 We support any S3 compatible bucket, for non AWS buckets such as GCS or MinIO, you will need to provide the endpoint URL.
 


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
Add documentation for recently added `include_bucket_in_prefix` optional param when creating destinations for bulk exports
## Type of change

**Type:** Update existing documentation 

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR: https://github.com/langchain-ai/langchainplus/pull/13772

<!-- For LangChain employees, if applicable: -->
- Linear issue: https://linear.app/langchain/issue/ENT-210/avoid-none-prefix-in-bulk-export-destination-path
- Slack thread: https://langchain.slack.com/archives/C09GLF9F96D/p1764940224259009?thread_ts=1764940071.452319&cid=C09GLF9F96D

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
