### PR TITLE
fix(docs): Use @tool decorator for retriever in agentic RAG tutorial

### DIFF
--- a/src/oss/langgraph/agentic-rag.mdx
+++ b/src/oss/langgraph/agentic-rag.mdx
@@ -150,15 +150,17 @@ Now that we have our split documents, we can index them into a vector store that
   )
   retriever = vectorstore.as_retriever()
   ```
-2. Create a retriever tool using LangChain's prebuilt `create_retriever_tool`:
+2. Create a retriever tool using the `@tool` decorator:
   ```python
-  from langchain_classic.tools.retriever import create_retriever_tool
-
-  retriever_tool = create_retriever_tool(
-      retriever,
-      "retrieve_blog_posts",
-      "Search and return information about Lilian Weng blog posts.",
-  )
+  from langchain_core.tools import tool
+  
+  @tool
+  def retrieve_blog_posts(query: str) -> str:
+      """Search and return information about Lilian Weng blog posts."""
+      docs = retriever.invoke(query)
+      return "\n\n".join([doc.page_content for doc in docs])
+  
+  retriever_tool = retrieve_blog_posts
   ```
 3. Test the tool:
   ```python


### PR DESCRIPTION
The current tutorial uses create_retriever_tool which internally uses functools.partial. When LangGraph's ToolNode tries to inspect the tool with typing.get_type_hints(), it fails because get_type_hints() doesn't work with partial objects. @tool decorator approach creates a proper StructuredTool with inspectable type hints.

## Overview
Fixed the agentic RAG tutorial to use the `@tool` decorator instead of `create_retriever_tool`, which causes a TypeError when used with LangGraph's ToolNode due to functools.partial incompatibility.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue: N/A (discovered while following the tutorial)
- Feature PR: N/A

## Checklist
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes
The current tutorial code causes a `TypeError: functools.partial(...) is not a module, class, method, or function` when following the steps. The `@tool` decorator approach has been tested and works correctly with LangGraph's ToolNode. This is a breaking issue that prevents users from completing the tutorial successfully.