### PR TITLE
Remove wrong decision type from inline comment of HITL docs

### DIFF
--- a/src/oss/langchain/human-in-the-loop.mdx
+++ b/src/oss/langchain/human-in-the-loop.mdx
@@ -203,7 +203,7 @@ print(result['__interrupt__'])
 # Resume with approval decision
 agent.invoke(
     Command( # [!code highlight]
-        resume={"decisions": [{"type": "approve"}]}  # or "edit", "reject" [!code highlight]
+        resume={"decisions": [{"type": "approve"}]}  # or "reject" [!code highlight]
     ), # [!code highlight]
     config=config # Same thread ID to resume the paused conversation
 )
@@ -253,7 +253,7 @@ console.log(result.__interrupt__);
 // Resume with approval decision
 await agent.invoke(
     new Command({ // [!code highlight]
-        resume: { decisions: [{ type: "approve" }] }, // or "edit", "reject" [!code highlight]
+        resume: { decisions: [{ type: "approve" }] }, // or "reject" [!code highlight]
     }), // [!code highlight]
     config // Same thread ID to resume the paused conversation
 );


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

This PR removes decision type "edit" from an inline comment located in HITL docs. In the scenario described in the code snippet, only "approve" and "reject" are allowed but the inline comment includes "edit", which contradicts interrupt config.
## Type of change

**Type:** Update existing documentation


## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
to make it clear:
<img width="647" height="439" alt="langchain_docs_pr" src="https://github.com/user-attachments/assets/7be38aee-bed5-4f0b-868f-f7b9e189d743" />

