### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.5.36

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -4742,6 +4742,11 @@
             "type": "string",
             "title": "Graph Id",
             "description": "The ID of the graph to filter by. The graph ID is normally set in your langgraph.json configuration."
+          },
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "description": "Name of the assistant to filter by. The filtering logic will match (case insensitive) assistants where 'name' is a substring of the assistant name."
           }
         },
         "type": "object",


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.5.36**

This update was automatically generated by the sync workflow in the langgraph-api repository.