### PR TITLE
oss(py): make anthropic middleware examples work e2e

### DIFF
--- a/src/oss/python/integrations/middleware/anthropic.mdx
+++ b/src/oss/python/integrations/middleware/anthropic.mdx
@@ -37,7 +37,7 @@ from langchain.agents import create_agent
 agent = create_agent(
     model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
     system_prompt="<Your long system prompt here>",
-    middleware=[AnthropicPromptCachingMiddleware(ttl="5m")],
+    middleware=[AnthropicPromptCachingMiddleware(ttl="5m")], # [!code highlight]
 )
 ```
 
@@ -78,7 +78,7 @@ The middleware caches content up to and including the latest message in each req
 from langchain_anthropic import ChatAnthropic
 from langchain_anthropic.middleware import AnthropicPromptCachingMiddleware
 from langchain.agents import create_agent
-from langchain_core.messages import HumanMessage
+from langchain.messages import HumanMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.memory import MemorySaver
 
@@ -92,7 +92,7 @@ Please be a helpful assistant.
 agent = create_agent(
     model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
     system_prompt=LONG_PROMPT,
-    middleware=[AnthropicPromptCachingMiddleware(ttl="5m")],
+    middleware=[AnthropicPromptCachingMiddleware(ttl="5m")], # [!code highlight]
     checkpointer=MemorySaver(),  # Persists conversation history
 )
 
@@ -138,11 +138,11 @@ from langchain.agents import create_agent
 agent = create_agent(
     model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
     tools=[],
-    middleware=[
-        ClaudeBashToolMiddleware(
-            workspace_root="/workspace",
-        ),
-    ],
+    middleware=[ # [!code highlight]
+        ClaudeBashToolMiddleware( # [!code highlight]
+            workspace_root="/workspace", # [!code highlight]
+        ), # [!code highlight]
+    ], # [!code highlight]
 )
 ```
 
@@ -187,15 +187,15 @@ workspace = tempfile.mkdtemp(prefix="agent-workspace-")
 agent = create_agent(
     model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
     tools=[],
-    middleware=[
-        ClaudeBashToolMiddleware(
-            workspace_root=workspace,
-            startup_commands=["echo 'Session initialized'"],
-            execution_policy=DockerExecutionPolicy(
-                image="python:3.11-slim",
-            ),
-        ),
-    ],
+    middleware=[ # [!code highlight]
+        ClaudeBashToolMiddleware( # [!code highlight]
+            workspace_root=workspace, # [!code highlight]
+            startup_commands=["echo 'Session initialized'"], # [!code highlight]
+            execution_policy=DockerExecutionPolicy( # [!code highlight]
+                image="python:3.11-slim", # [!code highlight]
+            ), # [!code highlight]
+        ), # [!code highlight]
+    ], # [!code highlight]
 )
 
 # Claude can now use its native bash tool
@@ -231,20 +231,42 @@ The text editor middleware is useful for the following:
 - @[`StateClaudeTextEditorMiddleware`]
 - @[`FilesystemClaudeTextEditorMiddleware`]
 
-```python
+```python State-based text editor
 from langchain_anthropic import ChatAnthropic
 from langchain_anthropic.middleware import StateClaudeTextEditorMiddleware
 from langchain.agents import create_agent
 
-# State-based (files in LangGraph state)
 agent = create_agent(
     model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
     tools=[],
-    middleware=[
-        StateClaudeTextEditorMiddleware(),
-    ],
+    middleware=[StateClaudeTextEditorMiddleware()], # [!code highlight]
 )
 ```
+
+```python Filesystem-based text editor
+from langchain_anthropic import ChatAnthropic
+from langchain_anthropic.middleware import FilesystemClaudeTextEditorMiddleware
+from langchain.agents import create_agent
+
+agent = create_agent(
+    model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
+    tools=[],
+    middleware=[ # [!code highlight]
+        FilesystemClaudeTextEditorMiddleware( # [!code highlight]
+            root_path="/workspace", # [!code highlight]
+        ), # [!code highlight]
+    ], # [!code highlight]
+)
+```
+
+Claude's text editor tool supports the following commands:
+
+- `view` - View file contents or list directory
+- `create` - Create a new file
+- `str_replace` - Replace string in file
+- `insert` - Insert text at line number
+- `delete` - Delete a file
+- `rename` - Rename/move a file
 
 <Accordion title="Configuration options">
 
@@ -270,57 +292,74 @@ agent = create_agent(
 
 </Accordion>
 
-<Accordion title="Full example">
+<AccordionGroup>
 
-Claude's text editor tool supports the following commands:
-- `view` - View file contents or list directory
-- `create` - Create a new file
-- `str_replace` - Replace string in file
-- `insert` - Insert text at line number
-- `delete` - Delete a file
-- `rename` - Rename/move a file
+<Accordion title="Full example: State-based text editor">
+
+```python
+from langchain_anthropic import ChatAnthropic
+from langchain_anthropic.middleware import StateClaudeTextEditorMiddleware
+from langchain.agents import create_agent
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.memory import MemorySaver
+
+
+agent = create_agent(
+    model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
+    tools=[],
+    middleware=[
+        StateClaudeTextEditorMiddleware( # [!code highlight]
+            allowed_path_prefixes=["/project"], # [!code highlight]
+        ), # [!code highlight]
+    ],
+    checkpointer=MemorySaver(),
+)
+
+# Use a thread_id to persist state across invocations
+config: RunnableConfig = {"configurable": {"thread_id": "my-session"}}
+
+# Claude can now create and edit files (stored in LangGraph state)
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "Create a file at /project/hello.py with a simple hello world program"}]},
+    config=config,
+)
+print(result["messages"][-1].content)
+```
+
+```output
+I've created a simple "Hello, World!" program at `/project/hello.py`. The program uses Python's `print()` function to display "Hello, World!" to the console when executed.
+```
+
+</Accordion>
+
+<Accordion title="Full example: Filesystem-based text editor">
 
 ```python
 import tempfile
 
 from langchain_anthropic import ChatAnthropic
-from langchain_anthropic.middleware import (
-    StateClaudeTextEditorMiddleware,
-    FilesystemClaudeTextEditorMiddleware,
-)
+from langchain_anthropic.middleware import FilesystemClaudeTextEditorMiddleware
 from langchain.agents import create_agent
 
 
-# State-based: Files persist in LangGraph state
-agent_state = create_agent(
-    model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
-    tools=[],
-    middleware=[
-        StateClaudeTextEditorMiddleware(
-            allowed_path_prefixes=["/project"],
-        ),
-    ],
-)
-
-# Filesystem-based: Files persist on disk
 # Create a temporary workspace directory for this demo.
 # In production, use a persistent directory path.
 workspace = tempfile.mkdtemp(prefix="editor-workspace-")
 
-agent_fs = create_agent(
+agent = create_agent(
     model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
     tools=[],
     middleware=[
-        FilesystemClaudeTextEditorMiddleware(
-            root_path=workspace,
-            allowed_prefixes=["/src"],
-            max_file_size_mb=10,
-        ),
+        FilesystemClaudeTextEditorMiddleware( # [!code highlight]
+            root_path=workspace, # [!code highlight]
+            allowed_prefixes=["/src"], # [!code highlight]
+            max_file_size_mb=10, # [!code highlight]
+        ), # [!code highlight]
     ],
 )
 
-# Claude can now create and edit files
-result = agent_fs.invoke(
+# Claude can now create and edit files (stored on disk)
+result = agent.invoke(
     {"messages": [{"role": "user", "content": "Create a file at /src/hello.py with a simple hello world program"}]}
 )
 print(result["messages"][-1].content)
@@ -331,6 +370,8 @@ I've created a simple "Hello, World!" program at `/src/hello.py`. The program us
 ```
 
 </Accordion>
+
+</AccordionGroup>
 
 
 ## Memory
@@ -350,18 +391,31 @@ The memory middleware is useful for the following:
 
 **API reference:** @[`StateClaudeMemoryMiddleware`], @[`FilesystemClaudeMemoryMiddleware`]
 
-```python
+```python State-based memory
 from langchain_anthropic import ChatAnthropic
 from langchain_anthropic.middleware import StateClaudeMemoryMiddleware
 from langchain.agents import create_agent
 
-# State-based memory
 agent = create_agent(
     model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
     tools=[],
-    middleware=[
-        StateClaudeMemoryMiddleware(),
-    ],
+    middleware=[StateClaudeMemoryMiddleware()], # [!code highlight]
+)
+```
+
+```python Filesystem-based memory
+from langchain_anthropic import ChatAnthropic
+from langchain_anthropic.middleware import FilesystemClaudeMemoryMiddleware
+from langchain.agents import create_agent
+
+agent_fs = create_agent(
+    model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
+    tools=[],
+    middleware=[ # [!code highlight]
+        FilesystemClaudeMemoryMiddleware( # [!code highlight]
+            root_path="/workspace", # [!code highlight]
+        ), # [!code highlight]
+    ], # [!code highlight]
 )
 ```
 
@@ -397,50 +451,78 @@ agent = create_agent(
 
 </Accordion>
 
-<Accordion title="Full example">
+<AccordionGroup>
+
+<Accordion title="Full example: State-based memory">
+
+The agent will automatically:
+1. Check `/memories` directory at start
+2. Record progress and thoughts during execution
+3. Update memory files as work progresses
+
+```python
+from langchain_anthropic import ChatAnthropic
+from langchain_anthropic.middleware import StateClaudeMemoryMiddleware
+from langchain.agents import create_agent
+from langchain_core.runnables import RunnableConfig
+from langgraph.checkpoint.memory import MemorySaver
+
+
+agent = create_agent(
+    model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
+    tools=[],
+    middleware=[StateClaudeMemoryMiddleware()], # [!code highlight]
+    checkpointer=MemorySaver(),
+)
+
+# Use a thread_id to persist state across invocations
+config: RunnableConfig = {"configurable": {"thread_id": "my-session"}}
+
+# Claude can now use memory to track progress (stored in LangGraph state)
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "Remember that my favorite color is blue, then confirm what you stored."}]},
+    config=config,
+)
+print(result["messages"][-1].content)
+```
+
+```output
+Perfect! I've stored your favorite color as **blue** in my memory system. The information is saved in my user preferences file where I can access it in future conversations.
+```
+
+</Accordion>
+
+<Accordion title="Full example: Filesystem-based memory">
+
+The agent will automatically:
+1. Check `/memories` directory at start
+2. Record progress and thoughts during execution
+3. Update memory files as work progresses
 
 ```python
 import tempfile
 
 from langchain_anthropic import ChatAnthropic
-from langchain_anthropic.middleware import (
-    StateClaudeMemoryMiddleware,
-    FilesystemClaudeMemoryMiddleware,
-)
+from langchain_anthropic.middleware import FilesystemClaudeMemoryMiddleware
 from langchain.agents import create_agent
 
 
-# State-based: Memory persists in LangGraph state
-agent_state = create_agent(
-    model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
-    tools=[],
-    middleware=[
-        StateClaudeMemoryMiddleware(),
-    ],
-)
-
-# Filesystem-based: Memory persists on disk
 # Create a temporary workspace directory for this demo.
 # In production, use a persistent directory path.
 workspace = tempfile.mkdtemp(prefix="memory-workspace-")
 
-agent_fs = create_agent(
+agent = create_agent(
     model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
     tools=[],
     middleware=[
-        FilesystemClaudeMemoryMiddleware(
-            root_path=workspace,
-        ),
+        FilesystemClaudeMemoryMiddleware( # [!code highlight]
+            root_path=workspace, # [!code highlight]
+        ), # [!code highlight]
     ],
 )
 
-# The agent will automatically:
-# 1. Check /memories directory at start
-# 2. Record progress and thoughts during execution
-# 3. Update memory files as work progresses
-
-# Claude can now use memory to track progress
-result = agent_fs.invoke(
+# Claude can now use memory to track progress (stored on disk)
+result = agent.invoke(
     {"messages": [{"role": "user", "content": "Remember that my favorite color is blue, then confirm what you stored."}]}
 )
 print(result["messages"][-1].content)
@@ -451,6 +533,8 @@ Perfect! I've stored your favorite color as **blue** in my memory system. The in
 ```
 
 </Accordion>
+
+</AccordionGroup>
 
 
 ## File search
@@ -475,10 +559,10 @@ from langchain.agents import create_agent
 agent = create_agent(
     model=ChatAnthropic(model="claude-sonnet-4-5-20250929"),
     tools=[],
-    middleware=[
-        StateClaudeTextEditorMiddleware(),
-        StateFileSearchMiddleware(),  # Search text editor files
-    ],
+    middleware=[ # [!code highlight]
+        StateClaudeTextEditorMiddleware(), # [!code highlight]
+        StateFileSearchMiddleware(),  # Search text editor files [!code highlight]
+    ], # [!code highlight]
 )
 ```
 
@@ -490,11 +574,11 @@ agent = create_agent(
 
 </Accordion>
 
-<Accordion title="Full example">
+<AccordionGroup>
+
+<Accordion title="Full example: Search text editor files">
 
 The middleware adds Glob and Grep search tools that work with state-based files.
-
-**End-to-end: Create files with text editor, then search:**
 
 ```python
 from langchain_anthropic import ChatAnthropic
@@ -503,7 +587,7 @@ from langchain_anthropic.middleware import (
     StateFileSearchMiddleware,
 )
 from langchain.agents import create_agent
-from langchain_core.messages import HumanMessage
+from langchain.messages import HumanMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.memory import MemorySaver
 
@@ -555,7 +639,9 @@ I found 5 Python files in the project:
 Would you like me to view the contents of any of these files?
 ```
 
-**End-to-end: Record memories, then search:**
+</Accordion>
+
+<Accordion title="Full example: Search memory files">
 
 ```python
 from langchain_anthropic import ChatAnthropic
@@ -564,7 +650,7 @@ from langchain_anthropic.middleware import (
     StateFileSearchMiddleware,
 )
 from langchain.agents import create_agent
-from langchain_core.messages import HumanMessage
+from langchain.messages import HumanMessage
 from langchain_core.runnables import RunnableConfig
 from langgraph.checkpoint.memory import MemorySaver
 
@@ -619,3 +705,5 @@ Is there anything specific about these deadlines you'd like to know or update?
 ```
 
 </Accordion>
+
+</AccordionGroup>


### PR DESCRIPTION
4/5 of the listed examples did not run successfully. Hydrated examples to work e2e when copy / pasting