### PR TITLE
fix(docs): update import paths in docling loader to use langchain_classic

### DIFF
--- a/src/oss/python/integrations/document_loaders/docling.mdx
+++ b/src/oss/python/integrations/document_loaders/docling.mdx
@@ -239,8 +239,8 @@ vectorstore = Milvus.from_documents(
 ### RAG
 
 ```python
-from langchain.chains import create_retrieval_chain
-from langchain.chains.combine_documents import create_stuff_documents_chain
+from langchain_classic.chains import create_retrieval_chain
+from langchain_classic.chains.combine_documents import create_stuff_documents_chain
 from langchain_huggingface import HuggingFaceEndpoint
 
 retriever = vectorstore.as_retriever(search_kwargs={"k": TOP_K})


### PR DESCRIPTION
## **Description:**

Updated the import paths in `src/oss/python/integrations/document_loaders/docling.mdx` to correctly reference the `langchain_classic.chains` package instead of the outdated `langchain.chains` import paths.

This ensures that documentation examples are aligned with the current LangChain codebase structure and prevents user confusion or import errors.

## **Issue:** N/A
## **Dependencies:** None
## **Twitter handle:** N/A 