### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.5.39

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -4411,7 +4411,7 @@
             "enum": ["cancel", "continue"],
             "title": "On Disconnect",
             "description": "The disconnect mode to use. Must be one of 'cancel' or 'continue'.",
-            "default": "cancel"
+            "default": "continue"
           },
           "feedback_keys": {
             "items": {
@@ -4630,7 +4630,7 @@
             "enum": ["cancel", "continue"],
             "title": "On Disconnect",
             "description": "The disconnect mode to use. Must be one of 'cancel' or 'continue'.",
-            "default": "cancel"
+            "default": "continue"
           },
           "after_seconds": {
             "type": "number",


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.5.39**

This update was automatically generated by the sync workflow in the langgraph-api repository.