### PR TITLE
fix(docs): update humanInTheLoopMiddleware example to new decision-ba…

### DIFF
--- a/src/oss/langchain/middleware/built-in.mdx
+++ b/src/oss/langchain/middleware/built-in.mdx
@@ -419,9 +419,7 @@ const agent = createAgent({
     humanInTheLoopMiddleware({
       interruptOn: {
         sendEmailTool: {
-          allowAccept: true,
-          allowEdit: true,
-          allowRespond: true,
+          allowedDecisions: ["approve", "edit", "reject"],
         },
         readEmailTool: false,
       }


### PR DESCRIPTION
## Overview

Updates the `humanInTheLoopMiddleware` documentation example to use the current decision-based API (allowedDecisions) instead of the removed boolean flags. This ensures the example reflects the latest middleware behavior and avoids confusion for users following the docs.

## Type of change

**Type:** Fix typo/bug/link/formatting

Related issues/PRs

GitHub issue: N/A

Feature PR: N/A

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)
