### PR TITLE
JS: update typescript custom middleware beforeModel examples t…

### DIFF
--- a/src/oss/langchain/middleware/custom.mdx
+++ b/src/oss/langchain/middleware/custom.mdx
@@ -108,14 +108,17 @@ import { createMiddleware, AIMessage } from "langchain";
 const createMessageLimitMiddleware = (maxMessages: number = 50) => {
   return createMiddleware({
     name: "MessageLimitMiddleware",
-    beforeModel: (state) => {
-      if (state.messages.length === maxMessages) {
-        return {
-          messages: [new AIMessage("Conversation limit reached.")],
-          jumpTo: "end",
-        };
+    beforeModel: {
+      canJumpTo: ["end"],
+      hook: (state) => {
+        if (state.messages.length === maxMessages) {
+          return {
+            messages: [new AIMessage("Conversation limit reached.")],
+            jumpTo: "end",
+          };
+        }
+        return;
       }
-      return;
     },
     afterModel: (state) => {
       const lastMessage = state.messages[state.messages.length - 1];
@@ -494,11 +497,15 @@ const callCounterMiddleware = createMiddleware({
     modelCallCount: z.number().default(0),
     userId: z.string().optional(),
   }),
-  beforeModel: (state) => {
-    if (state.modelCallCount > 10) {
-      return { jumpTo: "end" };
-    }
-    return;
+  beforeModel: {
+    canJumpTo: ["end"],
+    hook: (state) => {
+      if (state.modelCallCount > 10) {
+        return { jumpTo: "end" };
+      }
+
+      return;
+    },
   },
   afterModel: (state) => {
     return { modelCallCount: state.modelCallCount + 1 };


### PR DESCRIPTION
## Overview

Updates the TypeScript custom middleware documentation to correctly include the `canJumpTo` configuration when using `jumpTo` inside `beforeModel`. Without declaring `canJumpTo`, the documented examples would throw an error at runtime when a jump was attempted. This change aligns the examples with the current middleware API and prevents both runtime and TypeScript typing errors when conditionally terminating execution.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs

GitHub issue: N/A
Feature PR: N/A

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes

This change updates the same fix in multiple locations to ensure consistency across the documentation and reduce confusion for users implementing custom middleware in TypeScript.
