### PR TITLE
Fix error message formatting in custom_error_handler

### DIFF
--- a/src/oss/langchain/structured-output.mdx
+++ b/src/oss/langchain/structured-output.mdx
@@ -971,7 +971,7 @@ from langchain.agents.structured_output import MultipleStructuredOutputsError
 
 def custom_error_handler(error: Exception) -> str:
     if isinstance(error, StructuredOutputValidationError):
-        return "There was an issue with the format. Try again.
+        return "There was an issue with the format. Try again."
     elif isinstance(error, MultipleStructuredOutputsError):
         return "Multiple structured outputs were returned. Pick the most relevant one."
     else:


### PR DESCRIPTION
line 974 
A missing closing double quote (") at the end of a string

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
