### PR TITLE
fix(docs): update node references in subgraph example

### DIFF
--- a/src/oss/langgraph/use-subgraphs.mdx
+++ b/src/oss/langgraph/use-subgraphs.mdx
@@ -172,8 +172,8 @@ const graph = builder.compile();
 
   ```
   ((), {'node_1': {'foo': 'hi! foo'}})
-  (('node_2:9c36dd0f-151a-cb42-cbad-fa2f851f9ab7',), {'grandchild_1': {'my_grandchild_key': 'hi Bob, how are you'}})
-  (('node_2:9c36dd0f-151a-cb42-cbad-fa2f851f9ab7',), {'grandchild_2': {'bar': 'hi! foobaz'}})
+  (('node_2:577b710b-64ae-31fb-9455-6a4d4cc2b0b9',), {'subgraph_node_1': {'baz': 'baz'}})
+  (('node_2:577b710b-64ae-31fb-9455-6a4d4cc2b0b9',), {'subgraph_node_2': {'bar': 'hi! foobaz'}})
   ((), {'node_2': {'foo': 'hi! foobaz'}})
   ```
   :::


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
- This PR fixes the incorrect output shown in the example [Full example: different state schemas](https://docs.langchain.com/oss/python/langgraph/use-subgraphs#full-example-different-state-schemas), inside Subgraphs topic.
- As shown in the below screenshot from the documentation page, the output contains nodes `grandchild_1` and `grandchild_2`, which are not present inside the subgraph. Instead, the output should show the subgraph nodes as `subgraph_node_1` and `subgraph_node_2`.
<img width="396" height="817" alt="image" src="https://github.com/user-attachments/assets/2be847e4-02c6-4c91-9bf9-0c5b5c19f9c3" />

## Type of change

**Fix typo/bug**

## Related issues/PRs
N/A

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
- The below given screenshot shows the output obtained after executing the example in Jupyter Notebook:
<img width="761" height="884" alt="image" src="https://github.com/user-attachments/assets/82d50b11-d5f7-4d64-a72e-1d2be2ebfba6" />