### PR TITLE
 fix(docs): update import path to use langchain_classic

### DIFF
--- a/src/oss/python/integrations/document_loaders/youtube_audio.mdx
+++ b/src/oss/python/integrations/document_loaders/youtube_audio.mdx
@@ -96,7 +96,7 @@ docs[0].page_content[0:500]
 Given `Documents`, we can easily enable chat / question+answering.
 
 ```python
-from langchain.chains import RetrievalQA
+from langchain_classic.chains import RetrievalQA
 from langchain_community.vectorstores import FAISS
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 from langchain_text_splitters import RecursiveCharacterTextSplitter


### PR DESCRIPTION
## **Description:**

Updated the import paths in `src/oss/python/integrations/document_loaders/youtube_audio.mdx` to correctly reference the `langchain_classic.chains` package instead of the outdated `langchain.chains` import paths.

This ensures that documentation examples are aligned with the current LangChain codebase structure and prevents user confusion or import errors.

## **Issue:** N/A
## **Dependencies:** None
## **Twitter handle:** N/A 