### PR TITLE
Update localai.mdx - fix link to LocalAI reranker

### DIFF
--- a/src/oss/python/integrations/providers/localai.mdx
+++ b/src/oss/python/integrations/providers/localai.mdx
@@ -32,4 +32,4 @@ See a [usage example](/oss/integrations/text_embedding/localai).
 
 ## Reranker
 
-See a [usage example](/oss/integrations/document_transformers/localai).
+See a [usage example](/oss/integrations/document_transformers/localai_rerank).


### PR DESCRIPTION

## Overview
Fixing the link
https://docs.langchain.com/oss/python/integrations/providers/localai -> https://docs.langchain.com/oss/python/integrations/document_transformers/localai_rerank
## Type of change

Update existing documentation 

## Related issues/PRs

fix the link broken in #1897

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes
I beg your pardon!