### PR TITLE
fix(docs): Typo in markdown_header_metadata_splitter.mdx

### DIFF
--- a/src/oss/python/integrations/splitters/markdown_header_metadata_splitter.mdx
+++ b/src/oss/python/integrations/splitters/markdown_header_metadata_splitter.mdx
@@ -154,5 +154,5 @@ splits
 - After header-based splitting (e.g., `MarkdownHeaderTextSplitter`), use **`split_documents(docs)`** (not `split_text`) so that overlap is applied **within each section** and per-section metadata (headers) is preserved on chunks.
 - Overlap appears only when a **single section** exceeds `chunk_size` and is split into multiple chunks.
 - Overlap **does not cross** section/document boundaries (e.g., `# H1` → `## H2`).
-- If the header becomes a tiny first chunk, consider settubg `strip_headers` to `True` so the header line doesn't become a standalone chunk.
+- If the header becomes a tiny first chunk, consider setting `strip_headers` to `True` so the header line doesn't become a standalone chunk.
 - If your text lacks newlines/spaces, keep a fallback `""` in `separators` so the splitter can still split and apply overlap.


### PR DESCRIPTION
## Overview
Fixed a typo in markdown_header_metadata_splitter.mdx

## Type of change

**Type:** Fix typo

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
