### PR TITLE
chore: make preview env comment give a link instead of an id

### DIFF
--- a/.github/workflows/create-preview-branch.yml
+++ b/.github/workflows/create-preview-branch.yml
@@ -226,12 +226,10 @@ jobs:
     steps:
       - name: Comment on PR
         uses: actions/github-script@v8
-        env:
-          MINTLIFY_PROJECT_ID: ${{ vars.MINTLIFY_PROJECT_ID }}
         with:
           script: |
             const preview = `${{ needs.create-preview.outputs.preview_branch }}`;
-            const projectId = process.env.MINTLIFY_PROJECT_ID;
+            const projectId = `${{ vars.MINTLIFY_PROJECT_ID }}`;
             const previewUrl = `https://${projectId}-${preview}.mintlify.app`;
             await github.rest.issues.createComment({
               owner: context.repo.owner,


### PR DESCRIPTION
This PR updates the preview-environment commenter to give a link instead of an ID.

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed


