### PR TITLE
docs: add max time for bg_job_shutdown_grace_period_secs

### DIFF
--- a/src/langsmith/env-var.mdx
+++ b/src/langsmith/env-var.mdx
@@ -14,7 +14,7 @@ Defaults to `False`.
 
 ## `BG_JOB_SHUTDOWN_GRACE_PERIOD_SECS`
 
-Specifies, in seconds, how long the server will wait for background jobs to finish after the queue receives a shutdown signal. After this period, the server will force termination. Defaults to `180` seconds. Set this to ensure jobs have enough time to complete cleanly during shutdown. Added in `langgraph-api==0.2.16`.
+Specifies, in seconds, how long the server will wait for background jobs to finish after the queue receives a shutdown signal. After this period, the server will force termination. Defaults to `180` seconds. The maximum value is `3600` seconds. Set this to ensure jobs have enough time to complete cleanly during shutdown. Added in `langgraph-api==0.2.16`.
 
 ## `BG_JOB_TIMEOUT_SECS`
 


### PR DESCRIPTION
## Overview
Adding the max default value allowed for BG_JOB_SHUTDOWN_GRACE_PERIOD_SECS.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
N/A

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [X] I have read the [contributing guidelines](README.md)
- [X] I have tested my changes locally using `docs dev`
- [X] All code examples have been tested and work correctly
- [X] I have used **root relative** paths for internal links
- [X] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
