### PR TITLE
fix: wrap_model_call return type error

### DIFF
--- a/src/oss/langchain/multi-agent/skills-sql-assistant.mdx
+++ b/src/oss/langchain/multi-agent/skills-sql-assistant.mdx
@@ -387,7 +387,8 @@ class SkillMiddleware(AgentMiddleware):  # [!code highlight]
             {"type": "text", "text": skills_addendum}
         ]
         new_system_message = SystemMessage(content=new_content)
-        return request.override(system_message=new_system_message)
+        modified_request = request.override(system_message=new_system_message)
+        return handler(modified_request)
 ```
 
 The middleware appends skill descriptions to the system prompt, making the agent aware of available skills without loading their full content. The `load_skill` tool is registered as a class variable, making it available to the agent.
@@ -872,7 +873,8 @@ class SkillMiddleware(AgentMiddleware):
             {"type": "text", "text": skills_addendum}
         ]
         new_system_message = SystemMessage(content=new_content)
-        return request.override(system_message=new_system_message)
+        modified_request = request.override(system_message=new_system_message)
+        return handler(modified_request)
 
 # Initialize your chat model (replace with your model)
 # Example: from langchain_anthropic import ChatAnthropic


### PR DESCRIPTION
wrap_model_call need ModelResponse

state_updates = {"messages": response.result}
^^^^^^^^^^^^^^^
AttributeError: 'ModelRequest' object has no attribute 'result'

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
