### PR TITLE
Add missed comma in authenticate() example

### DIFF
--- a/src/langsmith/auth.mdx
+++ b/src/langsmith/auth.mdx
@@ -106,7 +106,7 @@ async def authenticate(headers: dict) -> Auth.types.MinimalUserDict:
     return {
         "identity": "user-123",        # Required: unique user identifier
         "is_authenticated": True,      # Optional: assumed True by default
-        "permissions": ["read", "write"] # Optional: for permission-based auth
+        "permissions": ["read", "write"], # Optional: for permission-based auth
         # You can add more custom fields if you want to implement other auth patterns
         "role": "admin",
         "org_id": "org-456"


### PR DESCRIPTION
## Overview
Add missed comma in authenticate() example

## Type of change

**Type:** Fix typo/bug/link/formatting

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
