### PR TITLE
Update model in ChatGroq initialization

### DIFF
--- a/src/oss/python/integrations/chat/groq.mdx
+++ b/src/oss/python/integrations/chat/groq.mdx
@@ -76,7 +76,7 @@ If you choose to set a `reasoning_format`, you must ensure that the model you ar
 from langchain_groq import ChatGroq
 
 llm = ChatGroq(
-    model="deepseek-r1-distill-llama-70b",
+    model="qwen/qwen3-32b",
     temperature=0,
     max_tokens=None,
     reasoning_format="parsed",


### PR DESCRIPTION
### Summary

This PR updates the Groq chat integration example to use a **currently supported Groq model**, improving the reliability of the documentation for users following the example.

---

### Change Details

In `src/oss/python/integrations/chat/groq.mdx`, the example model has been updated with reference to[ Groq documentation](https://console.groq.com/docs/reasoning#supported-models):

```diff
- model="deepseek-r1-distill-llama-70b",
+ model="qwen/qwen3-32b",
