### PR TITLE
docs: add KEDA explanation and fix prerequisites numbering

### DIFF
--- a/src/langsmith/deploy-hybrid.mdx
+++ b/src/langsmith/deploy-hybrid.mdx
@@ -22,6 +22,11 @@ The following steps describe how to connect your self-hosted data plane to the m
       helm repo add kedacore https://kedacore.github.io/charts
       helm install keda kedacore/keda --namespace keda --create-namespace
     ```
+
+    <Info>
+    KEDA is used to automatically scale the deployment system based on queue size.
+    </Info>
+
 2. A valid `Ingress` controller is installed on your cluster. For more information about configuring ingress for your deployment, refer to [Create an ingress for installations](/langsmith/self-host-ingress). We highly recommend using the modern [Gateway API](/langsmith/self-host-ingress#option-2%3A-gateway-api) in a production setup.
 3. If you plan to have the listener watch multiple namespaces, you **MUST** use the [Gateway API](/langsmith/self-host-ingress#option-2%3A-gateway-api) or an [Istio Gateway](/langsmith/self-host-ingress#option-3%3A-istio-gateway) instead of the [standard ingress](/langsmith/self-host-ingress#option-1%3A-standard-ingress) resource. A standard ingress resource can only route traffic to services in the same namespace, whereas a Gateway or Istio Gateway can route traffic to services across multiple namespaces.
 4. You have slack space in your cluster for multiple deployments. `Cluster-Autoscaler` is recommended to automatically provision new nodes.
@@ -93,7 +98,7 @@ The following steps describe how to connect your self-hosted data plane to the m
 To create a data plane in a different namespace in the same cluster, repeat the above steps and pass a `-n` option to `helm upgrade` to specify a different namespace.
 
 **When installing multiple data planes in the same cluster, it is very important to follow the rules below:**
-1. The `config.watchNamespaces` list should never intersect with other installations `config.watchNamespaces`. For example, if installation A is watching namespaces `foo,bar`, installation B cannot watch either `foo` or `bar`. Multiple operators or listeners watching the same namespace will lead to unexpected behavior. This means that multiple LangSmith workspaces cannot deploy to the same namespace! Please review the [cluster organization](/langsmith/hybrid#kubernetes-cluster-organization) section to understand this better. 
+1. The `config.watchNamespaces` list should never intersect with other installations `config.watchNamespaces`. For example, if installation A is watching namespaces `foo,bar`, installation B cannot watch either `foo` or `bar`. Multiple operators or listeners watching the same namespace will lead to unexpected behavior. This means that multiple LangSmith workspaces cannot deploy to the same namespace! Please review the [cluster organization](/langsmith/hybrid#kubernetes-cluster-organization) section to understand this better.
 2. It is required to use the [Gateway API](/langsmith/self-host-ingress#option-2%3A-gateway-api) or an [Istio Gateway](/langsmith/self-host-ingress#option-3%3A-istio-gateway). Relying on the [standard ingress](/langsmith/self-host-ingress#option-1%3A-standard-ingress) resource can cause conflicts with Ingress objects created by other data planes in the same cluster. Because behavior in these cases depends on the specific ingress controller, this may result in unpredictable or undesired outcomes.
 
 

--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -35,14 +35,19 @@ This guide builds on top of the [Kubernetes installation guide](/langsmith/kuber
   helm repo add kedacore https://kedacore.github.io/charts
   helm install keda kedacore/keda --namespace keda --create-namespace
 ```
-6. Ingress Configuration
+
+<Info>
+KEDA is used to automatically scale the deployment system based on queue size.
+</Info>
+
+4. Ingress Configuration
     1. You must set up an ingress, gateway, or use Istio for your LangSmith instance. All agents will be deployed as Kubernetes services behind this ingress. Use this guide to [set up an ingress](/langsmith/self-host-ingress) for your instance.
-7. You must have slack space in your cluster for multiple deployments. `Cluster-Autoscaler` is recommended to automatically provision new nodes.
-8. A valid Dynamic PV provisioner or PVs available on your cluster. You can verify this by running:
+5. You must have slack space in your cluster for multiple deployments. `Cluster-Autoscaler` is recommended to automatically provision new nodes.
+6. A valid Dynamic PV provisioner or PVs available on your cluster. You can verify this by running:
 ```bash
   kubectl get storageclass
 ```
-9. Egress to `https://beacon.langchain.com` from your network. This is required for license verification and usage reporting if not running in air-gapped mode. See the [Egress documentation](/langsmith/self-host-egress) for more details.
+7. Egress to `https://beacon.langchain.com` from your network. This is required for license verification and usage reporting if not running in air-gapped mode. See the [Egress documentation](/langsmith/self-host-egress) for more details.
 
 ## Setup
 


### PR DESCRIPTION
## Overview
Adds Info boxes explaining why KEDA is required in both the hybrid and self-hosted deployment guides, and fixes sequential numbering in the self-hosted full platform prerequisites section.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- GitHub issue:
- Feature PR:

## Changes made

1. **Added KEDA explanation**: Added Info boxes in both `deploy-hybrid.mdx` and `deploy-self-hosted-full-platform.mdx` that explain KEDA is used to automatically scale the deployment system based on queue size. This provides context for why KEDA is listed as a prerequisite.

2. **Fixed prerequisites numbering**: Corrected the sequential numbering in `deploy-self-hosted-full-platform.mdx` prerequisites section (was incorrectly numbered 3, 6, 7, 8, 9; now correctly numbered 3, 4, 5, 6, 7).

## Checklist
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
This is a documentation improvement to clarify the purpose of KEDA as a prerequisite and fix a numbering issue that could cause confusion for users following the setup guide.

**Note:** This contribution was created with assistance from AI agents.