### PR TITLE
Fix link in Accordion title for MongoDB checkpointer

### DIFF
--- a/src/oss/langgraph/add-memory.mdx
+++ b/src/oss/langgraph/add-memory.mdx
@@ -235,14 +235,14 @@ const graph = builder.compile({ checkpointer });
 </Accordion>
 
 :::python
-<Accordion title="Example: using [MongoDB](https://pypi.org/project/langgraph-checkpoint-mongodb/) checkpointer">
+<Accordion title="Example: using MongoDB checkpointer">
   ```
   pip install -U pymongo langgraph langgraph-checkpoint-mongodb
   ```
 
     <Note>
     **Setup**
-    To use the MongoDB checkpointer, you will need a MongoDB cluster. Follow [this guide](https://www.mongodb.com/docs/guides/atlas/cluster/) to create a cluster if you don't already have one.
+    To use the [MongoDB checkpointer](https://pypi.org/project/langgraph-checkpoint-mongodb/), you will need a MongoDB cluster. Follow [this guide](https://www.mongodb.com/docs/guides/atlas/cluster/) to create a cluster if you don't already have one.
     </Note>
 
     <Tabs>


### PR DESCRIPTION
This doesn't render correctly
<img width="713" height="258" alt="Screenshot 2025-12-25 at 4 26 49 PM" src="https://github.com/user-attachments/assets/a5917be9-295f-46b6-8836-ff0dec0cda2e" />
