### PR TITLE
fix token syntax; fix capitalization in MotherDuck

### DIFF
--- a/src/oss/python/integrations/providers/motherduck.mdx
+++ b/src/oss/python/integrations/providers/motherduck.mdx
@@ -1,6 +1,5 @@
 ---
 title: MotherDuck
-description: Connect LangChain to MotherDuck for serverless DuckDB analytics
 ---
 
 >[MotherDuck](https://motherduck.com/) is a cloud data warehouse powered by DuckDB.
@@ -27,7 +26,8 @@ The connection string is likely in the form:
 ```
 token="..."
 
-conn_str = f"duckdb:///md:my_db?motherduck_token={token}"```
+conn_str = f"duckdb:///md:my_db?motherduck_token={token}"
+```
 
 For more authentication options, see the [MotherDuck SQLAlchemy documentation](https://motherduck.com/docs/integrations/language-apis-and-drivers/python/sqlalchemy/).
 


### PR DESCRIPTION
## Overview
This page still had workaround MotherDuck token syntax from pre-duckdb-1.0. I updated the syntax and opportunistically fixed MotherDuck capitalization.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
I noticed this when working on testing  https://github.com/langchain-ai/langchain-community/pull/487 , but it's not actually related.

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- n/a I have used **root relative** paths for internal links
- n/a I have updated navigation in `src/docs.json` if needed

AI disclosure: I normally use Claude Code, but the docs it generates continue being too verbose so I rewrote this all to be minimal.