### PR TITLE
Revert "Add sync components to langchain_elasticsearch docs"

### DIFF
--- a/reference/python/docs/integrations/langchain_elasticsearch.md
+++ b/reference/python/docs/integrations/langchain_elasticsearch.md
@@ -14,9 +14,3 @@ title: Elasticsearch
 ::: langchain_elasticsearch._async.cache.AsyncElasticsearchCache
 ::: langchain_elasticsearch._async.cache.AsyncElasticsearchEmbeddingsCache
 ::: langchain_elasticsearch._async.chat_history.AsyncElasticsearchChatMessageHistory
-::: langchain_elasticsearch._sync.embeddings.AsyncElasticsearchEmbeddings
-::: langchain_elasticsearch._sync.vectorstores.AsyncElasticsearchStore
-::: langchain_elasticsearch._sync.retrievers.AsyncElasticsearchRetriever
-::: langchain_elasticsearch._sync.cache.AsyncElasticsearchCache
-::: langchain_elasticsearch._sync.cache.AsyncElasticsearchEmbeddingsCache
-::: langchain_elasticsearch._sync.chat_history.AsyncElasticsearchChatMessageHistory


### PR DESCRIPTION
Reverts langchain-ai/docs#1960

```txt
[1] ERROR   -  mkdocstrings: langchain_elasticsearch._sync.embeddings.AsyncElasticsearchEmbeddings could not be found
[1] ERROR   -  Error reading page 'integrations/langchain_elasticsearch.md':
[1] ERROR   -  Could not collect 'langchain_elasticsearch._sync.embeddings.AsyncElasticsearchEmbeddings'
```