### PR TITLE
Add RSS feed subscription to IP allowlist section

### DIFF
--- a/src/langsmith/cloud.mdx
+++ b/src/langsmith/cloud.mdx
@@ -106,6 +106,18 @@ Some additional GCP services we use include:
 
 ### Allowlisting IP addresses
 
+<Update
+  label="2024-12-26"
+  description="Current IP addresses"
+  tags={["Infrastructure", "Cloud"]}
+  rss={{
+    title: "December 2024 - LangSmith Cloud IP addresses",
+    description: "Current egress and ingress IP addresses for LangSmith Cloud services in US and EU regions"
+  }}
+>
+The following IP addresses are currently in use for LangSmith Cloud. Subscribe to the RSS feed to receive notifications when these IP addresses are updated.
+</Update>
+
 #### Egress from LangChain SaaS
 All traffic leaving LangSmith services will be routed through a NAT gateway. All traffic will appear to originate from the following IP addresses:
 


### PR DESCRIPTION
## Summary
Enables users to subscribe via RSS feed to receive notifications when LangSmith Cloud IP addresses are updated in the "Allowlisting IP addresses" section.

## Changes
- Added Mintlify Update component with custom RSS properties to the IP allowlist section
- Configured RSS feed with descriptive title and description for subscribers
- Added tags for categorization (Infrastructure, Cloud)