### PR TITLE
docs: Add explicit test timeout to Vitest and Jest docs

### DIFF
--- a/src/langsmith/test-react-agent-pytest.mdx
+++ b/src/langsmith/test-react-agent-pytest.mdx
@@ -682,6 +682,7 @@ Once you have setup your config files (if you are using Vitest or Jest), you can
       include: ["**/*.eval.?(c|m)[jt]s"],
       reporters: ["langsmith/vitest/reporter"],
       setupFiles: ["dotenv/config"],
+      testTimeout: 30000,
     },
   });
   ```
@@ -701,6 +702,7 @@ Once you have setup your config files (if you are using Vitest or Jest), you can
       '<rootDir>/tests/vitest/.*.vitest.eval.ts$'
     ],
     reporters: ["langsmith/jest/reporter"],
+    testTimeout: 30000,
   };
   ```
 
@@ -1201,5 +1203,3 @@ Remember to also add the config files for [Vitest](#config-files-for-vitestjest)
 
     </CodeGroup>
 </Accordion>
-
-

--- a/src/langsmith/vitest-jest.mdx
+++ b/src/langsmith/vitest-jest.mdx
@@ -79,6 +79,7 @@ export default defineConfig({
     include: ["**/*.eval.?(c|m)[jt]s"],
     reporters: ["langsmith/vitest/reporter"],
     setupFiles: ["dotenv/config"],
+    testTimeout: 30000,
   },
 });
 ```
@@ -86,6 +87,7 @@ export default defineConfig({
 * `include` ensures that only files ending with some variation of `eval.ts` in your project are run
 * `reporters` is responsible for nicely formatting your output as shown above
 * `setupFiles` runs `dotenv` to load environment variables before running your evals
+* `testTimeout` sets a global default timeout for each test. Because LLM calls can be slow, we increase this from the Vitest default
 
 <Warning>
 JSDom environments are not supported at this time. You should either omit the `"environment"` field from your config or set it to `"node"`.
@@ -159,12 +161,14 @@ module.exports = {
   testMatch: ["**/*.eval.?(c|m)[jt]s"],
   reporters: ["langsmith/jest/reporter"],
   setupFiles: ["dotenv/config"],
+  testTimeout: 30000,
 };
 ```
 
 * `testMatch` ensures that only files ending with some variation of `eval.js` in your project are run
 * `reporters` is responsible for nicely formatting your output as shown above
 * `setupFiles` runs `dotenv` to load environment variables before running your evals
+* `testTimeout` sets a global default timeout for each test. Because LLM calls can be slow, we increase this from the Jest default
 
 <Warning>
 JSDom environments are not supported at this time. You should either omit the `"testEnvironment"` field from your config or set it to `"node"`.


### PR DESCRIPTION
## Overview
I've fixed a longstanding bug around global test integration timeouts here: https://github.com/langchain-ai/langsmith-sdk/pull/2243

This updates docs with new instructions

Only the newest LangSmith JS SDK versions will respect this field, but it is important that it is present for those new versions - worth some kind of callout?

## Type of change

https://github.com/langchain-ai/langsmith-sdk/pull/2243

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
