### PR TITLE
fix(docs): spelling branding name

### DIFF
--- a/src/oss/javascript/integrations/document_loaders/index.mdx
+++ b/src/oss/javascript/integrations/document_loaders/index.mdx
@@ -111,7 +111,7 @@ LangChain.js categorizes document loaders in two different ways:
 | Document Loader | Description | Web Support | Package/API |
 |----------------|-------------|:-----------:|-------------|
 | [SearchAPI](/oss/integrations/document_loaders/web_loaders/searchapi) | Load web search results from SearchAPI (Google, YouTube, etc.) | ✅ | API |
-| [SerpAPI](/oss/integrations/document_loaders/web_loaders/serpapi) | Load web search results from SerpAPI | ✅ | API |
+| [SerpApi](/oss/integrations/document_loaders/web_loaders/serpapi) | Load web search results from SerpApi | ✅ | API |
 | [Apify Dataset](/oss/integrations/document_loaders/web_loaders/apify_dataset) | Load scraped data from Apify platform | ✅ | API |
 
 #### Audio & Video
@@ -175,7 +175,7 @@ LangChain.js categorizes document loaders in two different ways:
 <Card title="RecursiveUrlLoader" icon="link" href="/oss/integrations/document_loaders/web_loaders/recursive_url_loader" arrow="true" cta="View guide" />
 <Card title="S3" icon="link" href="/oss/integrations/document_loaders/web_loaders/s3" arrow="true" cta="View guide" />
 <Card title="SearchAPI" icon="link" href="/oss/integrations/document_loaders/web_loaders/searchapi" arrow="true" cta="View guide" />
-<Card title="SerpAPI" icon="link" href="/oss/integrations/document_loaders/web_loaders/serpapi" arrow="true" cta="View guide" />
+<Card title="SerpApi" icon="link" href="/oss/integrations/document_loaders/web_loaders/serpapi" arrow="true" cta="View guide" />
 <Card title="Sitemap" icon="link" href="/oss/integrations/document_loaders/web_loaders/sitemap" arrow="true" cta="View guide" />
 <Card title="Sonix Audio" icon="link" href="/oss/integrations/document_loaders/web_loaders/sonix_audio_transcription" arrow="true" cta="View guide" />
 <Card title="Spider" icon="link" href="/oss/integrations/document_loaders/web_loaders/spider" arrow="true" cta="View guide" />

--- a/src/oss/javascript/integrations/document_loaders/web_loaders/index.mdx
+++ b/src/oss/javascript/integrations/document_loaders/web_loaders/index.mdx
@@ -183,7 +183,7 @@ These loaders are used to load web resources. They do not involve the local file
     cta="View guide"
   />
   <Card
-    title="SerpAPI Loader"
+    title="SerpApi Loader"
     icon="link"
     href="/oss/integrations/document_loaders/web_loaders/serpapi"
     arrow="true"

--- a/src/oss/javascript/integrations/document_loaders/web_loaders/serpapi.mdx
+++ b/src/oss/javascript/integrations/document_loaders/web_loaders/serpapi.mdx
@@ -2,17 +2,17 @@
 title: SerpAPI Loader
 ---
 
-This guide shows how to use SerpAPI with LangChain to load web search results.
+This guide shows how to use SerpApi with LangChain to load web search results.
 
 ## Overview
 
-[SerpAPI](https://serpapi.com/) is a real-time API that provides access to search results from various search engines. It is commonly used for tasks like competitor analysis and rank tracking. It empowers businesses to scrape, extract, and make sense of data from all search engines' result pages.
+[SerpApi](https://serpapi.com/) is a real-time API that provides access to search results from various search engines. It is commonly used for tasks like competitor analysis and rank tracking. It empowers businesses to scrape, extract, and make sense of data from all search engines' result pages.
 
-This guide shows how to load web search results using the `SerpAPILoader` in LangChain. The `SerpAPILoader` simplifies the process of loading and processing web search results from SerpAPI.
+This guide shows how to load web search results using the `SerpAPILoader` in LangChain. The `SerpAPILoader` simplifies the process of loading and processing web search results from SerpApi.
 
 ## Setup
 
-You'll need to sign up and retrieve your [SerpAPI API key](https://serpapi.com/dashboard).
+You'll need to sign up and retrieve your [SerpApi API key](https://serpapi.com/dashboard).
 
 ## Usage
 
@@ -31,7 +31,7 @@ const llm = new ChatOpenAI({
   model: "gpt-4o-mini",
 });
 const embeddings = new OpenAIEmbeddings();
-const apiKey = "Your SerpAPI API key";
+const apiKey = "Your SerpApi API key";
 
 // Define your question and query
 const question = "Your question here";

--- a/src/oss/javascript/integrations/providers/all_providers.mdx
+++ b/src/oss/javascript/integrations/providers/all_providers.mdx
@@ -1457,10 +1457,10 @@ Connect LangGraph agents to front ends. See the [LangGraph integrations](/oss/la
   </Card>
 
   <Card
-    title="SerpAPI"
+    title="SerpApi"
     href="/oss/integrations/document_loaders/web_loaders/serpapi"
   >
-    Load search results using SerpAPI.
+    Load search results using SerpApi.
   </Card>
 
   <Card
@@ -1767,10 +1767,10 @@ Connect LangGraph agents to front ends. See the [LangGraph integrations](/oss/la
   </Card>
 
   <Card
-    title="SerpAPI"
+    title="SerpApi"
     href="/oss/integrations/tools/serpapi"
   >
-    Google Search results through SerpAPI.
+    Google Search results through SerpApi.
   </Card>
 
   <Card

--- a/src/oss/javascript/integrations/tools/index.mdx
+++ b/src/oss/javascript/integrations/tools/index.mdx
@@ -165,7 +165,7 @@ The following platforms provide access to multiple tools and services through a 
     cta="View guide"
   />
   <Card
-    title="SerpAPI"
+    title="SerpApi"
     icon="link"
     href="/oss/integrations/tools/serpapi"
     arrow="true"

--- a/src/oss/javascript/integrations/tools/serpapi.mdx
+++ b/src/oss/javascript/integrations/tools/serpapi.mdx
@@ -1,10 +1,10 @@
 ---
-title: SerpAPI
+title: SerpApi
 ---
 
-[SerpAPI](https://serpapi.com/) allows you to integrate search engine results into your LLM apps
+[SerpApi](https://serpapi.com/) allows you to integrate search engine results into your LLM apps
 
-This guide provides a quick overview for getting started with the SerpAPI [tool](/oss/integrations/tools/). For detailed documentation of all `SerpAPI` features and configurations head to the [API reference](https://api.js.langchain.com/classes/_langchain_community.tools_serpapi.SerpAPI.html).
+This guide provides a quick overview for getting started with the SerpApi [tool](/oss/integrations/tools/). For detailed documentation of all `SerpAPI` features and configurations head to the [API reference](https://api.js.langchain.com/classes/_langchain_community.tools_serpapi.SerpAPI.html).
 
 ## Overview
 

--- a/src/oss/python/integrations/chat/mlx.mdx
+++ b/src/oss/python/integrations/chat/mlx.mdx
@@ -61,7 +61,7 @@ print(res.content)
 
 Here we'll test out `gemma-2b-it` as a zero-shot `ReAct` Agent. The example below is taken from [here](https://python.langchain.com/docs/modules/agents/agent_types/react#using-chat-models).
 
-> Note: To run this section, you'll need to have a [SerpAPI Token](https://serpapi.com/) saved as an environment variable: `SERPAPI_API_KEY`
+> Note: To run this section, you'll need to have a [SerpApi Token](https://serpapi.com/) saved as an environment variable: `SERPAPI_API_KEY`
 
 ```python
 from langchain_classic import hub

--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -2464,7 +2464,7 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
-        title="SerpAPI"
+        title="SerpApi"
         href="/oss/integrations/providers/serpapi"
         icon="link"
     >

--- a/src/oss/python/integrations/providers/clearml_tracking.mdx
+++ b/src/oss/python/integrations/providers/clearml_tracking.mdx
@@ -31,7 +31,7 @@ We'll be using quite some APIs in this notebook, here is a list and where to get
 
 - ClearML: [app.clear.ml/settings/workspace-configuration](https://app.clear.ml/settings/workspace-configuration)
 - OpenAI: [platform.openai.com/account/api-keys](https://platform.openai.com/account/api-keys)
-- SerpAPI (google search): [serpapi.com/dashboard](https://serpapi.com/dashboard)
+- SerpApi (google search): [serpapi.com/dashboard](https://serpapi.com/dashboard)
 
 ```python
 import os

--- a/src/oss/python/integrations/providers/comet_tracking.mdx
+++ b/src/oss/python/integrations/providers/comet_tracking.mdx
@@ -32,9 +32,9 @@ import comet_ml
 comet_ml.init(project_name="comet-example-langchain")
 ```
 
-### Set OpenAI and SerpAPI credentials
+### Set OpenAI and SerpApi credentials
 
-You will need an [OpenAI API Key](https://platform.openai.com/account/api-keys) and a [SerpAPI API Key](https://serpapi.com/dashboard) to run the following examples
+You will need an [OpenAI API Key](https://platform.openai.com/account/api-keys) and a [SerpApi API Key](https://serpapi.com/dashboard) to run the following examples
 
 ```python
 import os


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
Updates the documentation to correct a brand name typo from SerpAPI to SerpApi

## Type of change

**Type:** [Update existing documentation / Fix typo]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue: NA
- Feature PR: NA

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
