### PR TITLE
Correct typos and wrong information found in SummarizationMiddleware docs according to its reference for Python

### DIFF
--- a/src/oss/langchain/middleware/built-in.mdx
+++ b/src/oss/langchain/middleware/built-in.mdx
@@ -134,7 +134,7 @@ const agent = createAgent({
     See the API reference for @[`ContextSize`] for more information.
 </ParamField>
 
-<ParamField body="keep" type="ContextSize" default=("messages", 20)>
+<ParamField body="keep" type="ContextSize" default="('messages', 20)">
     How much context to preserve after summarization. Specify exactly one of:
 
     - `fraction` (float): Fraction of model's context size to keep (0-1)
@@ -152,7 +152,7 @@ const agent = createAgent({
     Custom prompt template for summarization. Uses built-in template if not specified. The template should include `{messages}` placeholder where conversation history will be inserted.
 </ParamField>
 
-<ParamField body="trim_tokens_to_summarize" type="number" default=4000>
+<ParamField body="trim_tokens_to_summarize" type="number" default="4000">
     Maximum number of tokens to include when generating the summary. Messages will be trimmed to fit this limit before summarization.
 </ParamField>
 


### PR DESCRIPTION
## Overview
Update SummarizationMiddleware docs according to SummarizationMiddleware reference

## Type of change

Update existing documentation and Fix typo


## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed


## Additional notes
Please read my changes and compare original docs with API reference carefully. Feel free to change wording.

Some images might help:

from the ref:
<img width="959" height="446" alt="image" src="https://github.com/user-attachments/assets/196859cb-b481-42f0-8841-adeab36cd044" />

from the docs:
<img width="594" height="297" alt="image" src="https://github.com/user-attachments/assets/442c8fd9-62f9-4ffc-9006-c65642a5d530" />
