### PR TITLE
Update name of the API Key environment variable in mistralai.mdx

### DIFF
--- a/src/oss/python/integrations/text_embedding/mistralai.mdx
+++ b/src/oss/python/integrations/text_embedding/mistralai.mdx
@@ -16,14 +16,14 @@ To access MistralAI embedding models you'll need to create a/an MistralAI accoun
 
 ### Credentials
 
-Head to [https://console.mistral.ai/](https://console.mistral.ai/) to sign up to MistralAI and generate an API key. Once you've done this set the MISTRALAI_API_KEY environment variable:
+Head to [https://console.mistral.ai/](https://console.mistral.ai/) to sign up to MistralAI and generate an API key. Once you've done this set the MISTRAL_API_KEY environment variable:
 
 ```python
 import getpass
 import os
 
-if not os.getenv("MISTRALAI_API_KEY"):
-    os.environ["MISTRALAI_API_KEY"] = getpass.getpass("Enter your MistralAI API key: ")
+if not os.getenv("MISTRAL_API_KEY"):
+    os.environ["MISTRAL_API_KEY"] = getpass.getpass("Enter your MistralAI API key: ")
 ```
 
 To enable automated tracing of your model calls, set your [LangSmith](https://docs.langchain.com/langsmith/home) API key:


### PR DESCRIPTION
API Key env variable for Mistral AI embeddings should be `MISTRAL_API_KEY` and not `MISTRALAI_API_KEY`

## Overview
<!-- Brief description of what documentation is being added/updated -->
The name of the API Key environment variable is incorrect for the MistralAi embeddings docs. Replacing it from `MISTRALAI_API_KEY` to `MISTRAL_API_KEY` fixes error `httpx.LocalProtocolError: Illegal header value b'Bearer '`

## Type of change

**Type:** Fix typo

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue: [#21261](https://github.com/langchain-ai/langchain/issues/21261)
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
