### PR TITLE
docs(retrievers): document BM25Plus variant for BM25Retriever

### DIFF
--- a/src/oss/python/integrations/retrievers/bm25.mdx
+++ b/src/oss/python/integrations/retrievers/bm25.mdx
@@ -92,7 +92,7 @@ result
 ```
 
 
-## BM25Plus Variant
+## BM25Plus variant
 
 - `BM25Retriever` also supports the **BM25Plus variant**, which is designed to reduce the bias against short documents present in standard BM25.
 


### PR DESCRIPTION
## Overview
Documents the optional **BM25Plus** variant supported by `BM25Retriever`.

Adds a short explanation of when BM25Plus may be useful and a minimal example showing how to enable it. The default behavior of `BM25Retriever` remains unchanged.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue: N/A
- Feature PR: langchain-ai/langchain-community#488


## Checklist
<!-- Put an 'x' in all boxes that apply -->
- ✅ I have read the [contributing guidelines](README.md)
- ✅ I have tested my changes locally using `docs dev`
- ✅ All code examples have been tested and work correctly
- ✅ I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
   _(Not needed — existing page updated only)_

## Additional notes
This documentation corresponds to an opt-in feature added in the linked code PR. No existing behavior is changed.
