### PR TITLE
Fix typo in embedding service parameter

### DIFF
--- a/src/snippets/vectorstore-tabs-py.mdx
+++ b/src/snippets/vectorstore-tabs-py.mdx
@@ -162,7 +162,7 @@
     vector_store = PGVectorStore.create_sync(
         engine=pg_engine,
         table_name='test_table',
-        embedding_service=embedding
+        embedding_service=embeddings
     )
     ```
     </Tab>


### PR DESCRIPTION
## Overview
Solves small typo in PGVectorStore snippet, as discusses in Issue https://github.com/langchain-ai/docs/issues/2038

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- closes #2038 

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed


