### PR TITLE
Update support contact method in FAQ

### DIFF
--- a/src/langsmith/faq.mdx
+++ b/src/langsmith/faq.mdx
@@ -64,7 +64,7 @@ Changing email address via SCIM or otherwise is not currently supported for user
 
 #### *Can I change identity providers?*
 
-Reach out to the LangChain support team at [support@langchain.dev](mailto:support@langchain.dev) for support on migration.
+Reach out to the LangChain support team through our portal at [https://support.langchain.com](https://support.langchain.com) for support on migration.
 
 #### *How do I fix "405 method not allowed"?*
 


### PR DESCRIPTION
Updated to point to our support portal instead of E-Mail.