### PR TITLE
Call out Claude system prompts exclusion

### DIFF
--- a/src/langsmith/trace-claude-code.mdx
+++ b/src/langsmith/trace-claude-code.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Claude Code
 
 This guide shows you how to automatically send conversations from the [Claude Code CLI](https://code.claude.com/docs/en/overview) to LangSmith.
 
-Once configured, you can opt-in to sending traces from Claude Code projects to LangSmith. Traces will include user messages, tool calls and assistant responses.
+Once configured, you can opt-in to sending traces from Claude Code projects to LangSmith. Traces will include user messages, tool calls and assistant responses. As system prompts aren't returned in Claude Code's conversation transcripts, these are not included in the trace.
 
 <div style={{ textAlign: 'center' }}>
 <img


### PR DESCRIPTION
Customer Request: Clarify that Claude's system prompts are not included in traces.

## Overview
Customer request to explicitly call out that Claude Code system prompts aren't included in the traces.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- Slack thread: https://langchain.slack.com/archives/C07HR2D217C/p1767080584864589

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
