### PR TITLE
fix(docs): update deprecated mongodb reference links

### DIFF
--- a/src/oss/javascript/integrations/vectorstores/mongodb_atlas.mdx
+++ b/src/oss/javascript/integrations/vectorstores/mongodb_atlas.mdx
@@ -220,7 +220,7 @@ MongoDB Atlas supports pre-filtering of results on other fields. They require yo
 
 Above, the first item in `fields` is the vector index, and the second item is the metadata property you want to filter on. The name of the property is the value of the `path` key. So the above index would allow us to search on a metadata field named `source`.
 
-Then, in your code you can use [MQL Query Operators](https://www.mongodb.com/docs/manual/reference/operator/query/) for filtering.
+Then, in your code you can use [MQL Query Operators](https://www.mongodb.com/docs/manual/reference/mql/query-predicates/#alphabetical-list-of-operators) for filtering.
 
 The below example illustrates this:
 

--- a/src/oss/python/integrations/vectorstores/faiss.mdx
+++ b/src/oss/python/integrations/vectorstores/faiss.mdx
@@ -178,7 +178,7 @@ for res in results:
 * LangGraph is the best framework for building stateful, agentic applications! [{'source': 'tweet'}]
 ```
 
-Some [MongoDB query and projection operators](https://www.mongodb.com/docs/manual/reference/operator/query/) are supported for more advanced metadata filtering. The current list of supported operators are as follows:
+Some [MongoDB query and projection operators](https://www.mongodb.com/docs/manual/reference/mql/query-predicates/#alphabetical-list-of-operators) are supported for more advanced metadata filtering. The current list of supported operators are as follows:
 
 - `$eq` (equals)
 - `$neq` (not equals)

--- a/src/oss/python/integrations/vectorstores/faiss_async.mdx
+++ b/src/oss/python/integrations/vectorstores/faiss_async.mdx
@@ -204,7 +204,7 @@ for doc in results:
 Content: foo, Metadata: {'page': 1}
 ```
 
-Some [MongoDB query and projection operators](https://www.mongodb.com/docs/manual/reference/operator/query/) are supported for more advanced metadata filtering. The current list of supported operators are as follows:
+Some [MongoDB query and projection operators](https://www.mongodb.com/docs/manual/reference/mql/query-predicates/#alphabetical-list-of-operators) are supported for more advanced metadata filtering. The current list of supported operators are as follows:
 
 - `$eq` (equals)
 - `$neq` (not equals)


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

- Several parts of the documentation provides reference to the mongodb docs for "query operators". However this documentation has been migrated to a new URL in mongodb docs.
- So, this PR updates all the occurances older URLs (referring to the mongodb query opperators) to the latest one.

Old URL (shows 404 Error): https://www.mongodb.com/docs/manual/reference/operator/query/
<img width="1902" height="861" alt="Screenshot 2025-12-31 191835" src="https://github.com/user-attachments/assets/b766f557-602d-4456-b953-6486c0a78794" />

Latest URL for Query Operators: https://www.mongodb.com/docs/manual/reference/mql/query-predicates/#alphabetical-list-of-operators
<img width="1597" height="968" alt="Screenshot 2025-12-31 191943" src="https://github.com/user-attachments/assets/211956b0-b1f0-46a7-a439-016f3eec272d" />


## Type of change

**Type:** Fix link

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
N/A