### PR TITLE
docs: Update Bright Data to reflect v0.2.0 changes

### DIFF
--- a/src/oss/python/integrations/providers/brightdata.mdx
+++ b/src/oss/python/integrations/providers/brightdata.mdx
@@ -16,11 +16,12 @@ pip install langchain-brightdata
 ```bash uv
 uv add langchain-brightdata
 ```
+
 </CodeGroup>
 
 You'll need to set up your Bright Data API key:
 
-Sign up at [Bright Data](https://brightdata.com/?utm_source=tech-partner&utm_medium=link&utm_campaign=langchain&hs_signup=1) and retrieve your API key from your account settings. Replace `"your-api-key"` with your actual API key in the examples below: 
+Sign up at [Bright Data](https://brightdata.com/?utm_source=tech-partner&utm_medium=link&utm_campaign=langchain&hs_signup=1) and retrieve your API key from your account settings. Replace `"your-api-key"` with your actual API key in the examples below:
 
 ```python
 import os
@@ -30,7 +31,7 @@ os.environ["BRIGHT_DATA_API_KEY"] = "your-api-key"
 Or you can pass it directly when initializing tools:
 
 ```python
-from langchain_bright_data import BrightDataSERP
+from langchain_brightdata import BrightDataSERP
 
 tool = BrightDataSERP(bright_data_api_key="your-api-key")
 ```
@@ -39,6 +40,6 @@ tool = BrightDataSERP(bright_data_api_key="your-api-key")
 
 The Bright Data integration provides several tools:
 
-- [BrightDataSERP](/oss/integrations/tools/brightdata_serp) - Search engine results collection with geo-targeting
-- [BrightDataUnblocker](/oss/integrations/tools/brightdata_unlocker) - Access ANY public website that might be geo-restricted or bot-protected
-- [BrightDataWebScraperAPI](/oss/integrations/tools/brightdata-webscraperapi) - Extract structured data from 100+ ppoular domains, e.g. Amazon product details and LinkedIn profiles
+- [BrightDataSERP](/oss/integrations/tools/brightdata_serp) - Search engine results collection with geo-targeting and custom zone support
+- [BrightDataUnlocker](/oss/integrations/tools/brightdata_unlocker) - Access any public website that might be geo-restricted or bot-protected
+- [BrightDataWebScraperAPI](/oss/integrations/tools/brightdata-webscraperapi) - Extract structured data from 44 popular domains including Amazon, LinkedIn, Instagram, TikTok, and more

--- a/src/oss/python/integrations/tools/brightdata-webscraperapi.mdx
+++ b/src/oss/python/integrations/tools/brightdata-webscraperapi.mdx
@@ -1,8 +1,9 @@
 ---
 title: BrightDataWebScraperAPI
+description: Extract structured data from 44 popular domains using Bright Data's Web Scraper API
 ---
 
-[Bright Data](https://brightdata.com/) provides a powerful Web Scraper API that allows you to extract structured data from 100+ ppular domains, including Amazon product details, LinkedIn profiles, and more, making it particularly useful for AI agents requiring reliable structured web data feeds.
+[Bright Data](https://brightdata.com/) provides a powerful Web Scraper API that allows you to extract structured data from 44 popular domains, including e-commerce sites (Amazon, Walmart, eBay), social media (LinkedIn, Instagram, TikTok, Facebook), and more, making it particularly useful for AI agents requiring reliable structured web data feeds.
 
 ## Overview
 
@@ -46,14 +47,9 @@ scraper_tool = BrightDataWebScraperAPI(bright_data_api_key="your-api-key")
 
 Here we show how to instantiate an instance of the BrightDataWebScraperAPI tool. This tool allows you to extract structured data from various websites including Amazon product details, LinkedIn profiles, and more using Bright Data's Dataset API.
 
-The tool accepts various parameters during instantiation:
+The tool accepts the following parameter during instantiation:
 
 - `bright_data_api_key` (required, str): Your Bright Data API key for authentication.
-- `dataset_mapping` (optional, Dict[str, str]): A dictionary mapping dataset types to their corresponding Bright Data dataset IDs. The default mapping includes:
-  - "amazon_product": "gd_l7q7dkf244hwjntr0"
-  - "amazon_product_reviews": "gd_le8e811kzy4ggddlq"
-  - "linkedin_person_profile": "gd_l1viktl72bvl7bjuj0"
-  - "linkedin_company_profile": "gd_l1vikfnt1wgvvqz95w"
 
 ## Invocation
 
@@ -112,19 +108,104 @@ The BrightDataWebScraperAPI tool accepts several parameters for customization:
 |Parameter|Type|Description|
 |:--|:--|:--|
 |`url`|str|The URL to extract data from|
-|`dataset_type`|str|Type of dataset to use (e.g., "amazon_product")|
+|`dataset_type`|str|Type of dataset to use (see available types below)|
 |`zipcode`|str|Optional zipcode for location-specific data|
+|`keyword`|str|Search keyword (required for `amazon_product_search`)|
+|`first_name`|str|First name (required for `linkedin_people_search`)|
+|`last_name`|str|Last name (required for `linkedin_people_search`)|
+|`num_of_reviews`|str|Number of reviews (required for `facebook_company_reviews`)|
+|`num_of_comments`|str|Number of comments (for `youtube_comments`, default: 10)|
+|`days_limit`|str|Days to limit results (for `google_maps_reviews`, default: 3)|
 
-## Available Dataset Types
+## Available dataset types (44 datasets)
 
-The tool supports the following dataset types for structured data extraction:
+### E-commerce (10 datasets)
 
-|Dataset Type|Description|
-|:--|:--|
-|`amazon_product`|Extract detailed Amazon product data|
-|`amazon_product_reviews`|Extract Amazon product reviews|
-|`linkedin_person_profile`|Extract LinkedIn person profile data|
-|`linkedin_company_profile`|Extract LinkedIn company profile data|
+|Dataset Type|Description|Required Inputs|
+|:--|:--|:--|
+|`amazon_product`|Product details, pricing, specs|`url` (with /dp/)|
+|`amazon_product_reviews`|Customer reviews and ratings|`url` (with /dp/)|
+|`amazon_product_search`|Search results from Amazon|`keyword`, `url`|
+|`walmart_product`|Walmart product data|`url` (with /ip/)|
+|`walmart_seller`|Walmart seller information|`url`|
+|`ebay_product`|eBay product data|`url`|
+|`homedepot_products`|Home Depot product data|`url`|
+|`zara_products`|Zara product data|`url`|
+|`etsy_products`|Etsy product data|`url`|
+|`bestbuy_products`|Best Buy product data|`url`|
+
+### LinkedIn (5 datasets)
+
+|Dataset Type|Description|Required Inputs|
+|:--|:--|:--|
+|`linkedin_person_profile`|Professional profile data|`url`|
+|`linkedin_company_profile`|Company information|`url`|
+|`linkedin_job_listings`|Job listing details|`url`|
+|`linkedin_posts`|Post content and engagement|`url`|
+|`linkedin_people_search`|Search for people|`url`, `first_name`, `last_name`|
+
+### Business intelligence (2 datasets)
+
+|Dataset Type|Description|Required Inputs|
+|:--|:--|:--|
+|`crunchbase_company`|Company funding, investors, metrics|`url`|
+|`zoominfo_company_profile`|B2B company intelligence|`url`|
+
+### Instagram (4 datasets)
+
+|Dataset Type|Description|Required Inputs|
+|:--|:--|:--|
+|`instagram_profiles`|Profile data and stats|`url`|
+|`instagram_posts`|Post content and engagement|`url`|
+|`instagram_reels`|Reel content and metrics|`url`|
+|`instagram_comments`|Comments on posts|`url`|
+
+### Facebook (4 datasets)
+
+|Dataset Type|Description|Required Inputs|
+|:--|:--|:--|
+|`facebook_posts`|Post content and engagement|`url`|
+|`facebook_marketplace_listings`|Marketplace listing data|`url`|
+|`facebook_company_reviews`|Company reviews|`url`, `num_of_reviews`|
+|`facebook_events`|Event details|`url`|
+
+### TikTok (4 datasets)
+
+|Dataset Type|Description|Required Inputs|
+|:--|:--|:--|
+|`tiktok_profiles`|Profile data and stats|`url`|
+|`tiktok_posts`|Video content and metrics|`url`|
+|`tiktok_shop`|Shop product data|`url`|
+|`tiktok_comments`|Comments on videos|`url`|
+
+### YouTube (3 datasets)
+
+|Dataset Type|Description|Required Inputs|
+|:--|:--|:--|
+|`youtube_profiles`|Channel profile data|`url`|
+|`youtube_videos`|Video content and metrics|`url`|
+|`youtube_comments`|Comments on videos|`url`, `num_of_comments` (default: 10)|
+
+### Google (3 datasets)
+
+|Dataset Type|Description|Required Inputs|
+|:--|:--|:--|
+|`google_maps_reviews`|Business reviews from Maps|`url`, `days_limit` (default: 3)|
+|`google_shopping`|Shopping product data|`url`|
+|`google_play_store`|App store data|`url`|
+
+### Other platforms (9 datasets)
+
+|Dataset Type|Description|Required Inputs|
+|:--|:--|:--|
+|`apple_app_store`|iOS app data|`url`|
+|`x_posts`|X (Twitter) post data|`url`|
+|`reddit_posts`|Reddit post data|`url`|
+|`github_repository_file`|GitHub file content|`url`|
+|`yahoo_finance_business`|Financial business data|`url`|
+|`reuter_news`|News article data|`url`|
+|`zillow_properties_listing`|Real estate listing data|`url`|
+|`booking_hotel_listings`|Hotel listing data|`url`|
 
 ## Use within an agent
 

--- a/src/oss/python/integrations/tools/brightdata_serp.mdx
+++ b/src/oss/python/integrations/tools/brightdata_serp.mdx
@@ -1,8 +1,9 @@
 ---
 title: BrightDataSERP
+description: Query search engines with geo-targeting using Bright Data's SERP API
 ---
 
-[Bright Data](https://brightdata.com/) provides a powerful SERP API that allows you to query search engines (Google,Bing.DuckDuckGo,Yandex) with geo-targeting and advanced customization options, particularly useful for AI agents requiring real-time web information.
+[Bright Data](https://brightdata.com/) provides a powerful SERP API that allows you to query search engines (Google, Bing, DuckDuckGo, Yandex) with geo-targeting and advanced customization options, particularly useful for AI agents requiring real-time web information.
 
 ## Overview
 
@@ -48,7 +49,8 @@ Here we show how to instantiate an instance of the BrightDataSERP tool. This too
 The tool accepts various parameters during instantiation:
 
 - `bright_data_api_key` (required, str): Your Bright Data API key for authentication.
-- `search_engine` (optional, str): Search engine to use for queries. Default is "google". Other options include "bing", "yahoo", "yandex", "DuckDuckGo" etc.
+- `zone` (optional, str): Bright Data zone name for the SERP API. Default is "serp". You can configure custom zones in your [Bright Data dashboard](https://brightdata.com/cp/zones).
+- `search_engine` (optional, str): Search engine to use for queries. Default is "google". Other options include "bing", "yahoo", "yandex", "duckduckgo", etc.
 - `country` (optional, str): Two-letter country code for localized search results (e.g., "us", "gb", "de", "jp"). Default is "us".
 - `language` (optional, str): Two-letter language code for the search results (e.g., "en", "es", "fr", "de"). Default is "en".
 - `results_count` (optional, int): Number of search results to return. Default is 10. Maximum value is typically 100.
@@ -120,6 +122,7 @@ The BrightDataSERP tool accepts several parameters for customization:
 |Parameter|Type|Description|
 |:--|:--|:--|
 |`query`|str|The search query to perform|
+|`zone`|str|Bright Data zone name (default: "serp")|
 |`search_engine`|str|Search engine to use (default: "google")|
 |`country`|str|Two-letter country code for localized results (default: "us")|
 |`language`|str|Two-letter language code (default: "en")|
@@ -127,6 +130,34 @@ The BrightDataSERP tool accepts several parameters for customization:
 |`search_type`|str|Type of search: None (web), "isch" (images), "shop", "nws" (news), "jobs"|
 |`device_type`|str|Device type: None (desktop), "mobile", "ios", "android"|
 |`parse_results`|bool|Whether to return structured JSON (default: False)|
+
+## Zone configuration
+
+Bright Data uses "zones" to manage different API configurations. You can set the zone at initialization or override it per-request.
+
+### Setting zone at initialization
+
+```python
+from langchain_brightdata import BrightDataSERP
+
+# Initialize with a custom zone
+serp_tool = BrightDataSERP(
+    bright_data_api_key="your-api-key",
+    zone="my_custom_serp_zone"
+)
+```
+
+### Overriding zone per-request
+
+```python
+# Override zone for a specific request
+results = serp_tool.invoke({
+    "query": "AI news",
+    "zone": "different_zone"
+})
+```
+
+Zone names must match the zones configured in your [Bright Data dashboard](https://brightdata.com/cp/zones).
 
 ## Use within an agent
 


### PR DESCRIPTION
## Overview

Update Bright Data integration documentation to reflect v0.2.0 changes: expanded Web Scraper API with 44 supported datasets (up from 4), added zone configuration support for SERP API, and fixed import typo.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: N/A
- Feature PR: https://github.com/luminati-io/langchain-brightdata/releases/tag/v0.2.0

## Checklist

- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes

### Changes made:

**brightdata.mdx (provider page)**

- Fixed import typo: `langchain_bright_data` → `langchain_brightdata`
- Updated BrightDataWebScraperAPI description to reflect 44 supported datasets
- Added zone configuration mention for SERP tool

**brightdata-webscraperapi.mdx**

- Added frontmatter `description` field
- Expanded documentation from 4 to 44 supported datasets organized by category:
  - E-commerce (10): Amazon, Walmart, eBay, Home Depot, Zara, Etsy, Best Buy
  - LinkedIn (5): profiles, companies, jobs, posts, people search
  - Business Intelligence (2): Crunchbase, ZoomInfo
  - Instagram (4): profiles, posts, reels, comments
  - Facebook (4): posts, marketplace, reviews, events
  - TikTok (4): profiles, posts, shop, comments
  - YouTube (3): profiles, videos, comments
  - Google (3): Maps reviews, shopping, Play Store
  - Other (9): Apple App Store, X/Twitter, Reddit, GitHub, Yahoo Finance, Reuters, Zillow, Booking.com
- Added new parameters: `keyword`, `first_name`, `last_name`, `num_of_reviews`, `num_of_comments`, `days_limit`

**brightdata_serp.mdx**

- Added frontmatter `description` field
- Added `zone` parameter documentation
- Added new "Zone configuration" section with examples for initialization and per-request overrides
- Fixed spacing in search engine list