### PR TITLE
Fix PostgresStore initialization in CompositeBackend

### DIFF
--- a/src/oss/deepagents/long-term-memory.mdx
+++ b/src/oss/deepagents/long-term-memory.mdx
@@ -357,7 +357,11 @@ For production, use a persistent store:
 from langgraph.store.postgres import PostgresStore
 import os
 
-store = PostgresStore(connection_string=os.environ["DATABASE_URL"])
+# Use PostgresStore.from_conn_string as a context manager
+store_ctx = PostgresStore.from_conn_string(os.environ["DATABASE_URL"])
+store = store_ctx.__enter__()
+store.setup()
+
 agent = create_deep_agent(
     store=store,
     backend=lambda rt: CompositeBackend(


### PR DESCRIPTION
The current documentation reference a `connection_string` argument that does not exist on PostgresStore. This change updates the documentation to use the supported context manager pattern via `PostgresStore.from_conn_string(...)`, retrieving the store through `__enter__()`.

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

- Update existing documentation: The current documentation reference a `connection_string` argument that does not exist on PostgresStore.

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally
- [x] All code examples have been tested and work correctly
