### PR TITLE
fix(docs): Update installation command to include pdfplumber

### DIFF
--- a/src/oss/python/integrations/document_loaders/pdfplumber.mdx
+++ b/src/oss/python/integrations/document_loaders/pdfplumber.mdx
@@ -36,7 +36,7 @@ os.environ["LANGSMITH_TRACING"] = "true"
 Install **langchain-community**.
 
 ```python
-pip install -qU langchain-community
+pip install -qU langchain-community pdfplumber
 ```
 
 ## Initialization


### PR DESCRIPTION
Added pdfplumber to the pip install command to ensure the code examples run correctly without ImportErrors.

## Overview
<!-- Brief description of what documentation is being added/updated -->
Added pdfplumber to the pip install command in the documentation. This ensures that users have all necessary dependencies installed to run the PDF-related code examples without encountering ImportErrors.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue: None(Minor documentation improvement)
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
The existing command was missing pdfplumber, which is required for the PDF loader examples in the community package.
