### PR TITLE
oss(models): some nits

### DIFF
--- a/src/oss/langchain/models.mdx
+++ b/src/oss/langchain/models.mdx
@@ -36,7 +36,7 @@ The same model interface works in both contexts, which gives you the flexibility
 ### Initialize a model
 
 :::python
-The easiest way to get started with a standalone model in LangChain is to use @[`init_chat_model`] to initialize one from a [chat model provider](/oss/integrations/chat) of your choice (examples below):
+The easiest way to get started with a standalone model in LangChain is to use @[`init_chat_model`] to initialize one from a chat model provider of your choice (examples below):
 
 <ChatModelTabsPy />
 ```python
@@ -55,6 +55,9 @@ const response = await model.invoke("Why do parrots talk?");
 See @[`initChatModel`][initChatModel] for more detail, including information on how to pass model [parameters](#parameters).
 :::
 
+### Supported models
+
+LangChain supports all major model providers, including OpenAI, Anthropic, Google, Azure, AWS Bedrock, and more. Each provider offers a variety of models with different capabilities. For a full list of supported models in LangChain, see the [integrations page](/oss/integrations/providers/overview).
 
 ### Key methods
 
@@ -902,6 +905,10 @@ Below, we show some common ways you can use tool calling.
 
 Models can be requested to provide their response in a format matching a given schema. This is useful for ensuring the output can be easily parsed and used in subsequent processing. LangChain supports multiple schema types and methods for enforcing structured output.
 
+<Tip>
+    To learn about structured output, see [Structured output](/oss/langchain/structured-output).
+</Tip>
+
 :::python
 <Tabs>
     <Tab title="Pydantic">
@@ -923,7 +930,7 @@ Models can be requested to provide their response in a format matching a given s
         ```
     </Tab>
     <Tab title="TypedDict">
-        `TypedDict` provides a simpler alternative using Python's built-in typing, ideal when you don't need runtime validation.
+        Python's `TypedDict` provides a simpler alternative to Pydantic models, ideal when you don't need runtime validation.
 
         ```python
         from typing_extensions import TypedDict, Annotated
@@ -941,7 +948,7 @@ Models can be requested to provide their response in a format matching a given s
         ```
     </Tab>
     <Tab title="JSON Schema">
-        For maximum control or interoperability, you can provide a raw JSON Schema.
+        Provide a [JSON Schema](https://json-schema.org/understanding-json-schema/about) for maximum control and interoperability.
 
         ```python
         import json
@@ -1052,14 +1059,16 @@ Models can be requested to provide their response in a format matching a given s
 
 :::python
 <Note>
-    **Key considerations for structured output:**
+    **Key considerations for structured output**
 
-    - **Method parameter**: Some providers support different methods (`'json_schema'`, `'function_calling'`, `'json_mode'`)
-        - `'json_schema'` typically refers to dedicated structured output features offered by a provider
-        - `'function_calling'` derives structured output by forcing a [tool call](#tool-calling) following the given schema
-        - `'json_mode'` is a precursor to `'json_schema'` offered by some providers - it generates valid json, but the schema must be described in the prompt
-    - **Include raw**: Use `include_raw=True` to get both the parsed output and the raw AI message
-    - **Validation**: Pydantic models provide automatic validation, while `TypedDict` and JSON Schema require manual validation
+    - **Method parameter**: Some providers support different methods for structured output:
+        - `'json_schema'`: Uses dedicated structured output features offered by the provider.
+        - `'function_calling'`: Derives structured output by forcing a [tool call](#tool-calling) that follows the given schema.
+        - `'json_mode'`: A precursor to `'json_schema'` offered by some providers. Generates valid JSON, but the schema must be described in the prompt.
+    - **Include raw**: Set `include_raw=True` to get both the parsed output and the raw AI message.
+    - **Validation**: Pydantic models provide automatic validation. `TypedDict` and JSON Schema require manual validation.
+
+    See your [provider's integration page](/oss/integrations/providers/overview) for supported methods and configuration options.
 </Note>
 :::
 
@@ -1070,6 +1079,8 @@ Models can be requested to provide their response in a format matching a given s
     - **Method parameter**: Some providers support different methods (`'jsonSchema'`, `'functionCalling'`, `'jsonMode'`)
     - **Include raw**: Use @[`includeRaw: true`][BaseChatModel.with_structured_output(include_raw)] to get both the parsed output and the raw @[`AIMessage`]
     - **Validation**: Zod models provide automatic validation, while JSON Schema requires manual validation
+
+    See your [provider's integration page](/oss/integrations/providers/overview) for supported methods and configuration options.
 </Note>
 :::
 
@@ -1189,19 +1200,13 @@ It can be useful to return the raw @[`AIMessage`] object alongside the parsed re
 
 ---
 
-## Supported models
-
-LangChain supports all major model providers, including OpenAI, Anthropic, Google, Azure, AWS Bedrock, and more. Each provider offers a variety of models with different capabilities. For a full list of supported models in LangChain, see the [integrations page](/oss/integrations/providers/overview).
-
----
-
 ## Advanced topics
 
 ### Model profiles
 
-<Warning> This is a beta feature. The format of model profiles is subject to change. </Warning>
-
-<Info> Model profiles require `langchain>=1.1`. </Info>
+<Info>
+    Model profiles require `langchain>=1.1`.
+</Info>
 
 :::python
 LangChain chat models can expose a dictionary of supported features and capabilities through a `.profile` attribute:
@@ -1336,6 +1341,10 @@ Model profile data allow applications to work around model capabilities dynamica
 
 :::
 
+<Warning>
+    Model profiles are a beta feature. The format of a profile is subject to change.
+</Warning>
+
 ### Multimodal
 
 Certain models can process and return non-textual data such as images, audio, and video. You can pass non-textual data to a model by providing [content blocks](/oss/langchain/messages#message-content).
@@ -1425,7 +1434,9 @@ For details, see the [integrations page](/oss/integrations/providers/overview) o
 
 LangChain supports running models locally on your own hardware. This is useful for scenarios where either data privacy is critical, you want to invoke a custom model, or when you want to avoid the costs incurred when using a cloud-based model.
 
-[Ollama](/oss/integrations/chat/ollama) is one of the easiest ways to run models locally. See the full list of local integrations on the [integrations page](/oss/integrations/providers/overview).
+[Ollama](/oss/integrations/chat/ollama) is one of the easiest ways to run chat and embedding models locally.
+
+{/* TODO: whenever we have a better integrations directory, x-ref to that page with a local query filter */}
 
 ### Prompt caching
 


### PR DESCRIPTION
* mode `Supported models` header to a more sensible location
* x-ref dedicated `Structured output` page in section
* minor wording improvements under `Structured output` section
* x-ref provider index, note location for method params supported
* move model profile beta warning. not a good look if a beta warning is the first thing you see under advanced topics header
* local tweaks following #2070