### PR TITLE
oss(structured output): nits

### DIFF
--- a/src/oss/langchain/structured-output.mdx
+++ b/src/oss/langchain/structured-output.mdx
@@ -4,7 +4,7 @@ title: Structured output
 
 :::python
 
-Structured output allows agents to return data in a specific, predictable format. Instead of parsing natural language responses, you get structured data in the form of JSON objects, Pydantic models, or dataclasses that your application can directly use.
+Structured output allows agents to return data in a specific, predictable format. Instead of parsing natural language responses, you get structured data in the form of JSON objects, [Pydantic models](https://docs.pydantic.dev/latest/concepts/models/#basic-model-usage), or dataclasses that your application can use directly.
 
 LangChain's @[`create_agent`] handles structured output automatically. The user sets their desired structured output schema, and when the model generates the structured data, it's captured, validated, and returned in the `'structured_response'` key of the agent's state.
 
@@ -15,32 +15,35 @@ def create_agent(
         ToolStrategy[StructuredResponseT],
         ProviderStrategy[StructuredResponseT],
         type[StructuredResponseT],
+        None,
     ]
 ```
 
 ## Response Format
-Controls how the agent returns structured data:
+
+Use `response_format` to control how the agent returns structured data:
 
 - **`ToolStrategy[StructuredResponseT]`**: Uses tool calling for structured output
 - **`ProviderStrategy[StructuredResponseT]`**: Uses provider-native structured output
 - **`type[StructuredResponseT]`**: Schema type - automatically selects best strategy based on model capabilities
-- **`None`**: No structured output
+- **`None`**: Structured output not explicitly requested
 
 When a schema type is provided directly, LangChain automatically chooses:
-- `ProviderStrategy` for models supporting native structured output (e.g. [OpenAI](/oss/integrations/providers/openai), [Anthropic](/oss/integrations/providers/anthropic), or [Grok](/oss/integrations/providers/xai)).
+
+- `ProviderStrategy` if the model and provider chosen supports native structured output (e.g. [OpenAI](/oss/integrations/providers/openai), [Anthropic (Claude)](/oss/integrations/providers/anthropic), or [xAI (Grok)](/oss/integrations/providers/xai)).
 - `ToolStrategy` for all other models.
 
-<Tip>
-Support for native structured output features is read dynamically from the model's [profile data](/oss/langchain/models#model-profiles) if using `langchain>=1.1`. If data are not available, use another condition or specify manually:
-```python
-custom_profile = {
-    "structured_output": True,
-    # ...
-}
-model = init_chat_model("...", profile=custom_profile)
-```
-If tools are specified, the model must support simultaneous use of tools and structured output.
-</Tip>
+<Note>
+    Support for native structured output features is read dynamically from the model's [profile data](/oss/langchain/models#model-profiles) if using `langchain>=1.1`. If data are not available, use another condition or specify manually:
+    ```python
+    custom_profile = {
+        "structured_output": True,
+        # ...
+    }
+    model = init_chat_model("...", profile=custom_profile)
+    ```
+    If tools are specified, the model must support simultaneous use of tools and structured output.
+</Note>
 
 The structured response is returned in the `structured_response` key of the agent's final state.
 :::
@@ -81,21 +84,21 @@ const agent = createAgent({
 The structured response is returned in the `structuredResponse` key of the agent's final state.
 
 <Tip>
-Support for native structured output features is read dynamically from the model's [profile data](/oss/langchain/models#model-profiles) if using `langchain>=1.1`. If data are not available, use another condition or specify manually:
-```typescript
-const customProfile: ModelProfile = {
-    structuredOutput: true,
-    // ...
-}
-const model = await initChatModel("...", { profile: customProfile });
-```
-If tools are specified, the model must support simultaneous use of tools and structured output.
+    Support for native structured output features is read dynamically from the model's [profile data](/oss/langchain/models#model-profiles) if using `langchain>=1.1`. If data are not available, use another condition or specify manually:
+    ```typescript
+    const customProfile: ModelProfile = {
+        structuredOutput: true,
+        // ...
+    }
+    const model = await initChatModel("...", { profile: customProfile });
+    ```
+    If tools are specified, the model must support simultaneous use of tools and structured output.
 </Tip>
 :::
 
 ## Provider strategy
 
-Some model providers support structured output natively through their APIs (e.g. OpenAI, Grok, Gemini). This is the most reliable method when available.
+Some model providers support structured output natively through their APIs (e.g. OpenAI, xAI (Grok), Gemini, Anthropic (Claude)). This is the most reliable method when available.
 
 To use this strategy, configure a `ProviderStrategy`:
 
@@ -111,10 +114,10 @@ class ProviderStrategy(Generic[SchemaT]):
 
 <ParamField path="schema" required>
     The schema defining the structured output format. Supports:
-    - **Pydantic models**: `BaseModel` subclasses with field validation
-    - **Dataclasses**: Python dataclasses with type annotations
-    - **TypedDict**: Typed dictionary classes
-    - **JSON Schema**: Dictionary with JSON schema specification
+    - **Pydantic models**: `BaseModel` subclasses with field validation. Returns validated Pydantic instance.
+    - **Dataclasses**: Python dataclasses with type annotations. Returns dict.
+    - **TypedDict**: Typed dictionary classes. Returns dict.
+    - **JSON Schema**: Dictionary with JSON schema specification. Returns dict.
 </ParamField>
 
 <ParamField path="strict">
@@ -171,7 +174,7 @@ LangChain automatically uses `ProviderStrategy` when you pass a schema type dire
     })
 
     result["structured_response"]
-    # ContactInfo(name='John Doe', email='john@example.com', phone='(555) 123-4567')
+    # {'name': 'John Doe', 'email': 'john@example.com', 'phone': '(555) 123-4567'}
     ```
 
     ```python TypedDict
@@ -303,18 +306,22 @@ Provider-native structured output provides high reliability and strict validatio
 
 :::python
 <Note>
-    If the provider natively supports structured output for your model choice, it is functionally equivalent to write `response_format=ProductReview` instead of `response_format=ProviderStrategy(ProductReview)`. In either case, if structured output is not supported, the agent will fall back to a tool calling strategy.
+    If the provider natively supports structured output for your model choice, it is functionally equivalent to write `response_format=ProductReview` instead of `response_format=ProviderStrategy(ProductReview)`.
+
+    In either case, if structured output is not supported, the agent will fall back to a tool calling strategy.
 </Note>
 :::
 :::js
 <Note>
-    If the provider natively supports structured output for your model choice, it is functionally equivalent to write `responseFormat: contactInfoSchema` instead of `responseFormat: providerStrategy(contactInfoSchema)`. In either case, if structured output is not supported, the agent will fall back to a tool calling strategy.
+    If the provider natively supports structured output for your model choice, it is functionally equivalent to write `responseFormat: contactInfoSchema` instead of `responseFormat: providerStrategy(contactInfoSchema)`.
+
+    In either case, if structured output is not supported, the agent will fall back to a tool calling strategy.
 </Note>
 :::
 
 ## Tool calling strategy
 
-For models that don't support native structured output, LangChain uses tool calling to achieve the same result. This works with all models that support tool calling, which is most modern models.
+For models that don't support native structured output, LangChain uses tool calling to achieve the same result. This works with all models that support tool calling (most modern models).
 
 To use this strategy, configure a `ToolStrategy`:
 
@@ -334,10 +341,10 @@ class ToolStrategy(Generic[SchemaT]):
 
 <ParamField path="schema" required>
     The schema defining the structured output format. Supports:
-    - **Pydantic models**: `BaseModel` subclasses with field validation
-    - **Dataclasses**: Python dataclasses with type annotations
-    - **TypedDict**: Typed dictionary classes
-    - **JSON Schema**: Dictionary with JSON schema specification
+    - **Pydantic models**: `BaseModel` subclasses with field validation. Returns validated Pydantic instance.
+    - **Dataclasses**: Python dataclasses with type annotations. Returns dict.
+    - **TypedDict**: Typed dictionary classes. Returns dict.
+    - **JSON Schema**: Dictionary with JSON schema specification. Returns dict.
     - **Union types**: Multiple schema options. The model will choose the most appropriate schema based on the context.
 </ParamField>
 
@@ -408,7 +415,7 @@ class ToolStrategy(Generic[SchemaT]):
         "messages": [{"role": "user", "content": "Analyze this review: 'Great product: 5 out of 5 stars. Fast shipping, but expensive'"}]
     })
     result["structured_response"]
-    # ProductReview(rating=5, sentiment='positive', key_points=['fast shipping', 'expensive'])
+    # {'rating': 5, 'sentiment': 'positive', 'key_points': ['fast shipping', 'expensive']}
     ```
 
     ```python TypedDict
@@ -952,6 +959,7 @@ Please provide a valid rating between 1-5 and include a comment.
 ```
 
 **Handle specific exceptions only:**
+
 ```python
 ToolStrategy(
     schema=ProductRating,
@@ -972,6 +980,7 @@ ToolStrategy(
 If `handle_errors` is a tuple of exceptions, the agent will only retry (using the default error message) if the exception raised is one of the specified types. In all other cases, the exception will be raised.
 
 **Custom error handler function:**
+
 ```python
 
 from langchain.agents.structured_output import StructuredOutputValidationError
@@ -1036,6 +1045,7 @@ Error: <error message>
 ```
 
 **No error handling:**
+
 ```python
 response_format = ToolStrategy(
     schema=ProductRating,
@@ -1089,6 +1099,7 @@ console.log(result);
 You can customize how errors are handled using the `handleErrors` parameter:
 
 **Custom error message:**
+
 ```ts
 const responseFormat = toolStrategy(ProductRating, {
     handleError: "Please provide a valid rating between 1-5 and include a comment."
@@ -1099,6 +1110,7 @@ const responseFormat = toolStrategy(ProductRating, {
 ```
 
 **Handle specific exceptions only:**
+
 ```ts
 import { ToolInputParsingException } from "@langchain/core/tools";
 
@@ -1116,6 +1128,7 @@ const responseFormat = toolStrategy(ProductRating, {
 ```
 
 **Handle multiple exception types:**
+
 ```ts
 const responseFormat = toolStrategy(ProductRating, {
     handleError: (error: ToolStrategyError) => {
@@ -1131,6 +1144,7 @@ const responseFormat = toolStrategy(ProductRating, {
 ```
 
 **No error handling:**
+
 ```ts
 const responseFormat = toolStrategy(ProductRating, {
     handleError: false  // All errors raised


### PR DESCRIPTION
- indentation fixes
- xref pydantic page
- add `None` to signature union
- wording tweaks
- add aliases `Anthropic (Claude)` `xAI (Grok)`
- clarify schema return types
- fix outputs from `result["structured_response"]`