### PR TITLE
docs: fix ToolRuntime parameter naming in short-term memory docs

### DIFF
--- a/src/oss/langchain/short-term-memory.mdx
+++ b/src/oss/langchain/short-term-memory.mdx
@@ -585,9 +585,9 @@ You can access and modify the short-term memory (state) of an agent in several w
 
 #### Read short-term memory in a tool
 
-Access short term memory (state) in a tool using the `ToolRuntime` parameter.
+Access short term memory (state) in a tool using the `runtime` parameter (typed as `ToolRuntime`).
 
-The `tool_runtime` parameter is hidden from the tool signature (so the model doesn't see it), but the tool can access the state through it.
+The `runtime` parameter is hidden from the tool signature (so the model doesn't see it), but the tool can access the state through it.
 
 :::python
 ```python


### PR DESCRIPTION
## Overview
Fix inconsistent parameter naming in the short-term memory documentation where `ToolRuntime` and `tool_runtime` were used inconsistently. The correct parameter name is `runtime` (typed as `ToolRuntime`).

## Type of change
**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue: fixes langchain-ai/docs#2042

## Checklist
- [x] I have read the contributing guidelines
- [x] I have tested my changes locally using `make build`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
Changed:
- `ToolRuntime` → `runtime` (the actual parameter name used in code examples)
- `tool_runtime` → `runtime` (matching the code examples)

The parameter is named `runtime` and typed as `ToolRuntime`.

AI-assisted contribution using Claude.