### PR TITLE
chore: document adding config to existing project

### DIFF
--- a/src/oss/langgraph/local-server.mdx
+++ b/src/oss/langgraph/local-server.mdx
@@ -31,7 +31,7 @@ uv add "langgraph-cli[inmem]"
 
 :::js
 ```shell
-npx @langchain/langgraph-cli
+npm install --save-dev @langchain/langgraph-cli
 ```
 :::
 
@@ -56,6 +56,33 @@ Create a new app from the [`new-langgraph-project-js` template](https://github.c
 ```shell
 npm create langgraph
 ```
+
+<Accordion title="Adding LangGraph to an existing project">
+If you have an existing project with LangGraph agents, you can automatically generate a `langgraph.json` configuration file using the `config` command:
+
+```shell
+npm create langgraph config
+```
+
+This command scans your project for LangGraph agents (such as `createAgent()`, `StateGraph.compile()`, or `workflow.compile()` patterns) and generates a configuration file with all exported agents.
+
+Example output:
+
+```json
+{
+  "node_version": "24",
+  "graphs": {
+    "agent": "./src/agent.ts:agent",
+    "searchAgent": "./src/search.ts:searchAgent"
+  },
+  "env": ".env"
+}
+```
+
+<Tip>
+Only **exported** agents are included in the configuration. If an agent is not exported, the command will warn you so you can add the `export` keyword.
+</Tip>
+</Accordion>
 :::
 
 ## 3. Install dependencies


### PR DESCRIPTION
For the `create-langgraph` package I've added a command that allows to generate a config if the user doesn't have one. This is JS only.

<img width="730" height="802" alt="Screenshot 2026-01-05 at 11 45 21 AM" src="https://github.com/user-attachments/assets/d75d8700-4fe8-4a99-9cca-2f98a1d56c84" />
