### PR TITLE
Add section on retry and failure modes for bulk export

### DIFF
--- a/src/langsmith/data-export.mdx
+++ b/src/langsmith/data-export.mdx
@@ -13,7 +13,7 @@ LangSmith's bulk data export functionality allows you to export your traces into
 
 An export can be launched to target a specific LangSmith project and date range. Once a batch export is launched, the system will handle the orchestration and [resilience of the export process](#failure-modes-and-retry-policy).
 
-Exporting your data may take some time depending on the size of your data. LangSmith also has a limit on how many of your exports can run at the same time. Bulk exports have a runtime timeout of 48 hours, refer to [Automatic retry behavior](#automatic-retry-behavior) for more details.
+Exporting your data may take some time depending on the size of your data. LangSmith also has a limit on how many of your exports can run at the same time. Bulk exports have a runtime timeout of 72 hours, refer to [Automatic retry behavior](#automatic-retry-behavior) for more details.
 
 ## Destinations
 
@@ -529,21 +529,21 @@ Each run (date range) in your export has its own [failure handling](#failure-sce
 
 Export jobs automatically retry transient failures with the following behavior:
 
-- **Maximum retry attempts**: 10 retries per run.
+- **Maximum retry attempts**: 20 retries per run (subject to change).
 - **Retry delay**: 30 seconds between attempts (fixed, no exponential backoff).
 - **Run timeout**: 4 hours maximum per run.
-- **Overall workflow timeout**: 48 hours for the entire export.
+- **Overall workflow timeout**: 72 hours for the entire export.
 
 ### Failure scenarios
 
 | Failure type | Cause | Automatic retry? | Action required |
 |--------------|-------|------------------|-----------------|
 | **Infrastructure interruption** | [Deployments](/langsmith/deployments), server restarts, worker crashes | Yes, automatically requeued with remaining retries. | None, jobs resume automatically. |
-| **Run timeout** | Single run exceeds 4-hour limit | Yes, retried up to 10 times. | If persistent, narrow date range or add filters. |
-| **Workflow timeout** | Entire export exceeds 48 hours | No | Reduce export scope (date range, filters) or break into smaller exports. |
+| **Run timeout** | Single run exceeds 4-hour limit | Yes, retried up to 20 times (subject to change). | If persistent, narrow date range, add filters, or [limit the exported fields](#limiting-exported-fields). |
+| **Workflow timeout** | Entire export exceeds 72 hours | No | Reduce export scope (date range, filters) or break into smaller exports. |
 | **Storage/destination errors** | [Invalid credentials](#credentials-configuration), [missing bucket](#destinations-providing-an-s3-bucket), [permission issues](#permissions-required) | No | Fix destination configuration and create new export. |
 | **Destination deleted** | Bucket removed during export | No | Recreate destination and restart export. |
-| **Terminal processing errors** | Data serialization issues, resource exhaustion | Yes, retried up to 10 times. | Check run error details; may require investigation. |
+| **Terminal processing errors** | Data serialization issues, resource exhaustion | Yes, retried up to 20 times (subject to change). | Check run error details; may require investigation. |
 
 <Note>
 Any single run failure (after all retries are exhausted) causes the entire export to fail.
@@ -568,8 +568,8 @@ Individual runs can have the same possible statuses: `CREATED`, `RUNNING`, `COMP
 
 To ensure system stability, exports are subject to the following limits:
 
-- **Maximum concurrent runs per export**: 5
-- **Maximum concurrent exports per workspace**: 3
+- **Maximum concurrent runs per export**: 45
+- **Maximum concurrent exports per workspace**: 15
 
 If you have multiple exports running, new run jobs will queue until capacity becomes available.
 


### PR DESCRIPTION
Fixes DOC-549

Adds a section to the bulk export docs on the retry policy and failure modes. Includes the settings/behavior, common failure scenarios and whether they're retryable. 

Also some general styling updates to page just for consistency (headings).

## Preview

https://langchain-5e9cc07a-preview-retryp-1767650881-4680733.mintlify.app/langsmith/data-export#failure-modes-and-retry-policy