### PR TITLE
Fix troubleshooting link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The Mintlify docs pipeline is structured with `.mdx` source files in `/src` and 
 
 The `/src/docs.json` file is used to configure the Mintlify site navigation and settings. Refer to the [Mintlify documentation](https://www.mintlify.com/docs/organize/navigation) for detailed syntax and component usage.
 
-Documentation changes follow a PR workflow where all tests must pass before merging. See the [contributing guidelines](/oss/contributing/documentation) for more details.
+Documentation changes follow a PR workflow where all tests must pass before merging. See the [contributing guidelines](https://docs.langchain.com/oss/python/contributing/documentation) for more details.
 
 #### `reference.langchain.com`
 


### PR DESCRIPTION
## Overview

Updated the troubleshooting link to point to the correct documentation. Issue caused by https://github.com/langchain-ai/docs/pull/1363

<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** Fix link

Slack thread: https://langchain.slack.com/archives/C09G1T60QV9/p1767639068051019

## Checklist
- [x] I have read the [contributing guidelines](README.md)