### PR TITLE
Change out deprecated chat dataset type

### DIFF
--- a/src/langsmith/manage-datasets-programmatically.mdx
+++ b/src/langsmith/manage-datasets-programmatically.mdx
@@ -311,17 +311,17 @@ const datasets = await client.listDatasets({
 
 ### List datasets by type
 
-You can filter datasets by type. Below is an example querying for chat datasets.
+You can filter datasets by type:
 
 <CodeGroup>
 
 ```python Python
-datasets = client.list_datasets(data_type="chat")
+datasets = client.list_datasets(data_type="kv")
 ```
 
 ```typescript TypeScript
 const datasets = await client.listDatasets({
-  dataType: "chat"
+  dataType: "kv"
 });
 ```
 


### PR DESCRIPTION
Fixes DOC-492

Switched out the `chat` dataset type for `kv` in this example.