### PR TITLE
fix: capitalize RAG acronym in middleware docs

### DIFF
--- a/src/oss/deepagents/middleware.mdx
+++ b/src/oss/deepagents/middleware.mdx
@@ -72,7 +72,7 @@ const agent = createAgent({
 
 ## Filesystem middleware
 
-Context engineering is a main challenge in building effective agents. This is particularly difficult when using tools that return variable-length results (for example, web_search and rag), as long tool results can quickly fill your context window.
+Context engineering is a main challenge in building effective agents. This is particularly difficult when using tools that return variable-length results (for example, web_search and RAG), as long tool results can quickly fill your context window.
 
 `FilesystemMiddleware` provides four tools for interacting with both short-term and long-term memory:
 


### PR DESCRIPTION
## Summary

- Capitalizes "rag" to "RAG" in the filesystem middleware documentation where it refers to Retrieval Augmented Generation