### PR TITLE
Fix model identifier format in code examples to match description

### DIFF
--- a/src/oss/langchain/agents.mdx
+++ b/src/oss/langchain/agents.mdx
@@ -72,7 +72,7 @@ To initialize a static model from a <Tooltip tip="A string that follows the form
 ```python wrap
 from langchain.agents import create_agent
 
-agent = create_agent("gpt-5", tools=tools)
+agent = create_agent("openai:gpt-5", tools=tools)
 ```
 :::
 :::js
@@ -80,7 +80,7 @@ agent = create_agent("gpt-5", tools=tools)
 import { createAgent } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-5",
+  model: "openai:gpt-5",
   tools: []
 });
 ```


### PR DESCRIPTION
## Issue

The documentation describes model identifier strings with this format:

> "A string that follows the format `provider:model` (e.g. openai:gpt-5)"

However, the code examples immediately below this description don't follow this format - they use `"gpt-5"` instead of `"openai:gpt-5"`.

## Changes

Updated both code examples to use the `provider:model` format as described:
- Python: `create_agent("gpt-5", tools=tools)` → `create_agent("openai:gpt-5", tools=tools)`
- JavaScript: `model: "gpt-5"` → `model: "openai:gpt-5"`

This makes the examples consistent with the format explanation in the paragraph above them.