### PR TITLE
langsmith: include info on fetching a single run

### DIFF
--- a/src/langsmith/export-traces.mdx
+++ b/src/langsmith/export-traces.mdx
@@ -172,6 +172,40 @@ for await (const run of client.listRuns({
 
 </CodeGroup>
 
+### Fetch a single run by ID
+
+To fetch a single run (trace) by its ID, use the `read_run` method. This is useful when you have a specific trace ID (for example, from a LangSmith share link like `https://smith.langchain.com/public/<trace-id>/r`) and want to retrieve its full data.
+
+<CodeGroup>
+
+```python Python
+run_id = "a36092d2-4ad5-4fb4-9c0d-0dba9a2ed836"
+run = client.read_run(run_id)
+
+# Access run data
+print(run.inputs)
+print(run.outputs)
+print(run.name)
+```
+
+```typescript TypeScript
+const runId = "a36092d2-4ad5-4fb4-9c0d-0dba9a2ed836";
+const run = await client.readRun(runId);
+
+// Access run data
+console.log(run.inputs);
+console.log(run.outputs);
+console.log(run.name);
+```
+
+</CodeGroup>
+
+<Tip>
+    **Replay traces locally with LangGraph**
+
+    If you're using LangGraph with checkpointing, you can fetch a trace from LangSmith and replay it locally for debugging. See [LangGraph's time travel and replay documentation](/oss/langgraph/use-time-travel) for details on resuming execution from checkpoints.
+</Tip>
+
 ## Use filter query language
 
 For more complex queries, you can use the query language described in the [filter query language reference](/langsmith/trace-query-syntax#filter-query-language).

--- a/src/oss/langgraph/use-time-travel.mdx
+++ b/src/oss/langgraph/use-time-travel.mdx
@@ -80,7 +80,7 @@ process.env.ANTHROPIC_API_KEY = "YOUR_API_KEY";
 :::
 
 <Tip>
-Sign up for [LangSmith](https://smith.langchain.com) to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph.
+    Sign up for [LangSmith](https://smith.langchain.com) to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph. You can also [fetch traces from LangSmith](/langsmith/export-traces#fetch-a-single-run-by-id) to replay and debug production issues locally.
 </Tip>
 
 :::python


### PR DESCRIPTION
this wasn't documented super well IMO