### PR TITLE
Add link from obs concepts data retention to full details on admin page

### DIFF
--- a/src/langsmith/observability-concepts.mdx
+++ b/src/langsmith/observability-concepts.mdx
@@ -106,7 +106,7 @@ For traces ingested on or after Wednesday, May 22, 2024, LangSmith (SaaS) retain
 
 After 400 days, the traces are permanently deleted from LangSmith, with a limited amount of metadata retained for the purpose of showing accurate statistics, such as historic usage and cost.
 
-For more information on data retention tiers, pricing, and auto-upgrade scenarios, refer to [Usage and Billing: Data Retention](/langsmith/administration-overview#data-retention).
+For more information on data retention tiers, pricing, and auto-upgrade scenarios, refer to [Usage and billing: Data retention](/langsmith/administration-overview#data-retention).
 
 <Note>
 If you wish to keep tracing data longer than the data retention period, you can add it to a dataset. A [dataset](/langsmith/manage-datasets) allows you to store the trace inputs and outputs (e.g., as a key-value dataset), and will persist indefinitely, even after the trace gets deleted.


### PR DESCRIPTION
Fixes DOC-41

Small PR to fix a connection from the obs concept page high-level description of data retention to the detailed section on the usage and billing page. Details requested in the issue were added as a result of a more recent issue around auto-upgrading data retention policies. This link completes these issues to provide the necessary information.