### PR TITLE
chore(lsd): update dependency ranges

### DIFF
--- a/src/langsmith/setup-app-requirements-txt.mdx
+++ b/src/langsmith/setup-app-requirements-txt.mdx
@@ -45,11 +45,11 @@ Dependencies can optionally be specified in one of the following files: `pyproje
 The dependencies below will be included in the image, you can also use them in your code, as long as with a compatible version range:
 
 ```
-langgraph>=0.6.0
-langgraph-sdk>=0.1.66
-langgraph-checkpoint>=2.0.23
-langchain-core>=0.2.38
-langsmith>=0.1.63
+langgraph>=0.4.10,<2
+langgraph-sdk>=0.2.0
+langgraph-checkpoint>=3.0.1,<5
+langchain-core>=0.3.64
+langsmith>=0.3.45
 orjson>=3.9.7,<3.10.17
 httpx>=0.25.0
 tenacity>=8.0.0
@@ -60,6 +60,11 @@ httptools>=0.5.0
 jsonschema-rs>=0.20.0
 structlog>=24.1.0
 cloudpickle>=3.0.0
+truststore>=0.1
+protobuf>=6.32.1,<7.0.0
+grpcio>=1.75.0,<2.0.0
+grpcio-tools>=1.75.0,<2.0.0
+grpcio-health-checking>=1.75.0,<2.0.0
 ```
 
 Example `requirements.txt` file:

--- a/src/langsmith/setup-pyproject.mdx
+++ b/src/langsmith/setup-pyproject.mdx
@@ -44,11 +44,11 @@ Dependencies can optionally be specified in one of the following files: `pyproje
 The dependencies below will be included in the image, you can also use them in your code, as long as with a compatible version range:
 
 ```
-langgraph>=0.6.0
-langgraph-sdk>=0.1.66
-langgraph-checkpoint>=2.0.23
-langchain-core>=0.2.38
-langsmith>=0.1.63
+langgraph>=0.4.10,<2
+langgraph-sdk>=0.2.0
+langgraph-checkpoint>=3.0.1,<5
+langchain-core>=0.3.64
+langsmith>=0.3.45
 orjson>=3.9.7,<3.10.17
 httpx>=0.25.0
 tenacity>=8.0.0
@@ -59,6 +59,11 @@ httptools>=0.5.0
 jsonschema-rs>=0.20.0
 structlog>=24.1.0
 cloudpickle>=3.0.0
+truststore>=0.1
+protobuf>=6.32.1,<7.0.0
+grpcio>=1.75.0,<2.0.0
+grpcio-tools>=1.75.0,<2.0.0
+grpcio-health-checking>=1.75.0,<2.0.0
 ```
 
 Example `pyproject.toml` file:


### PR DESCRIPTION
## Overview
The dependency ranges listed in the docs are a few months out of date with respect to the latest LangSmith Deployment base image release. This brings them up to date.