### PR TITLE
feat(agent-auth): enhance documentation with multi-language support 

### DIFF
--- a/src/langsmith/agent-auth.mdx
+++ b/src/langsmith/agent-auth.mdx
@@ -167,11 +167,11 @@ auth_result = await client.authenticate(
 
 During execution, if authentication is required, the SDK will throw an [interrupt](https://langchain-ai.github.io/langgraph/how-tos/human_in_the_loop/add-human-in-the-loop/#pause-using-interrupt). The agent execution pauses and presents the OAuth URL to the user:
 
-![Studio interrupt showing OAuth URL](/images/langgraph-auth-interrupt.png)
+<Frame caption="Studio interrupt showing OAuth URL"><img src="/images/langgraph-auth-interrupt.png" /></Frame>
 
 After the user completes OAuth authentication and we receive the callback from the provider, they will see the auth success page.
 
-![GitHub OAuth success page](/images/github-auth-success.png)
+<Frame caption="GitHub OAuth success page"><img src="/images/github-auth-success.png" /></Frame>
 
 The agent then resumes execution from the point it left off at, and the token can be used for any API calls. We store and refresh OAuth tokens so that future uses of the service by either the user or agent do not require an OAuth flow.
 


### PR DESCRIPTION
## Overview

Adds JavaScript/TypeScript code examples throughout the Agent Auth documentation, alongside existing Python examples. Also adds a troubleshooting section for common self-hosted deployment issues.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue:
- Feature PR:

- Linear issue:
- Slack thread:

## Checklist

- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

- Added `<Tabs>` components for Python/JavaScript language switching in installation, client initialization, OAuth provider setup, and authentication flow sections
- Added self-hosted configuration examples (environment variable and explicit config for both languages)
- Added troubleshooting section covering 405 errors and callback URL issues