### PR TITLE
chore: clarify that we index up to 100 keys per run for input/output kv

### DIFF
--- a/src/langsmith/filter-traces-in-application.mdx
+++ b/src/langsmith/filter-traces-in-application.mdx
@@ -80,7 +80,7 @@ Based on the filters above, the system will search for `python` and `tensorflow`
 In addition to full-text search, you can filter runs based on specific key-value pairs in the inputs and outputs. This allows for more precise filtering, especially when dealing with structured data.
 
 <Note>
-We index up to 100 unique keys to keep your data organized and searchable. Each key also has a character limit of 250 characters per value. If your data exceeds either of these limits, the text won't be indexed. This helps us ensure fast, reliable performance.
+We index up to 100 unique keys per run to keep your data organized and searchable. Each key also has a character limit of 250 characters per value. If your data exceeds either of these limits, the text won't be indexed. This helps us ensure fast, reliable performance.
 </Note>
 
 To filter based on key-value pairs, select the `Input Key` or `Output Key` filter from the filters dropdown.


### PR DESCRIPTION
## Overview
People were confused by what this "100 key limit" meant - is it per project? per deployment? etc. Its actually per run.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
N/A
- GitHub issue: N/A
- Feature PR: N/A

<!-- For LangChain employees, if applicable: -->
- Linear issue: N/A
- Slack thread: https://langchain.slack.com/archives/C075MG11VJB/p1767387619024319?thread_ts=1766002332.074219&cid=C075MG11VJB

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
Confirmed with Suraj that this is true
