### PR TITLE
add info on tracing to deep agents docs

### DIFF
--- a/src/oss/deepagents/cli.mdx
+++ b/src/oss/deepagents/cli.mdx
@@ -52,6 +52,29 @@ The Deep Agents CLI has the following built-in capabilities:
     </Step>
 </Steps>
 
+
+<Accordion title="Configure tracing (optional)">
+
+    Enable LangSmith tracing:
+
+    ```bash
+    export LANGCHAIN_TRACING_V2=true
+    export LANGCHAIN_API_KEY="your-api-key"
+    ```
+
+    Configure agent tracing for tool calls and agent decisions:
+
+    ```bash
+    export DEEPAGENTS_LANGSMITH_PROJECT="my-agent-project"
+    ```
+
+    Configure user code tracing for code executed with shell commands:
+
+    ```bash
+    export LANGSMITH_PROJECT="my-user-code-project"
+    ```
+</Accordion>
+
 <Accordion title="Additional installation and configuration options">
 Install locally if needed:
 


### PR DESCRIPTION
Please check if you agree with the placement of these config options. I considered putting them under configuration but since they're env variables this feels more appropriate to me