### PR TITLE
clarify that exit handles HIL

### DIFF
--- a/src/oss/langgraph/durable-execution.mdx
+++ b/src/oss/langgraph/durable-execution.mdx
@@ -74,9 +74,9 @@ graph.stream(
 
 The durability modes, from least to most durable, are as follows:
 
-* `"exit"`: Changes are persisted only when graph execution exits (either successfully, with an error, or due to an interrupt). This provides the best performance for long-running graphs but means intermediate state is not saved, so you cannot recover from system failures (e.g., process crashes) that occur mid-execution.
-* `"async"`: Changes are persisted asynchronously while the next step executes. This provides good performance and durability, but there's a small risk that checkpoints might not be written if the process crashes during execution.
-* `"sync"`: Changes are persisted synchronously before the next step starts. This ensures that every checkpoint is written before continuing execution, providing high durability at the cost of some performance overhead.
+* `"exit"`: LangGraph persists changes only when graph execution exits either successfully, with an error, or due to a human in the loop interrupt. This provides the best performance for long-running graphs but means intermediate state is not saved, so you cannot recover from system failures (like process crashes) that occur mid-execution.
+* `"async"`: LangGraph persists changes asynchronously while the next step executes. This provides good performance and durability, but there's a small risk that LangGraph does not write checkpoints if the process crashes during execution.
+* `"sync"`: LangGraph persists changes synchronously before the next step starts. This ensures that LangGraph writes every checkpoint before continuing execution, providing high durability at the cost of some performance overhead.
 
 ## Using tasks in nodes
 


### PR DESCRIPTION
Eugene suggested we update the tools page [here](https://langchain.slack.com/archives/C09G1T60QV9/p1763655296575339). Maybe the context has moved - I think covering it on durability modes is better. 

Fixing up some passive voice as well - let me know if you would prefer they stayed