### PR TITLE
docs: fix ChatGoogleGenerativeAI example to use `model` instead of `modelName`

### DIFF
--- a/src/oss/javascript/integrations/chat/index.mdx
+++ b/src/oss/javascript/integrations/chat/index.mdx
@@ -106,7 +106,7 @@ title: Chat models
         import { ChatGoogleGenerativeAI } from "@langchain/google-genai";
 
         const model = new ChatGoogleGenerativeAI({
-        modelName: "gemini-2.5-flash-lite",
+        model: "gemini-2.5-flash-lite",
         temperature: 0
         });
         ```


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

This PR fixes an incorrect property name in the `ChatGoogleGenerativeAI` documentation.
The example currently uses `modelName`, but the actual constructor and TypeScript types only support the `model` property.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue: None
- Feature PR: None

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->

https://docs.langchain.com/oss/javascript/integrations/chat#google-gemini

<img width="1710" height="974" alt="image" src="https://github.com/user-attachments/assets/e9b5d3e1-4b58-4e8b-93e6-a226ad26468a" />

In the latest version of `@langchain/google-genai` (`^2.1.6`), `ChatGoogleGenerativeAI` expects a `model` property. The `modelName` field does not exist in the current implementation.

<img width="1231" height="81" alt="image" src="https://github.com/user-attachments/assets/76d01285-7e4e-4d0c-9165-2c254872357d" />

<img width="1369" height="656" alt="image" src="https://github.com/user-attachments/assets/7a4e0948-a620-4217-af31-edc2cf44f600" />
