### PR TITLE
Add available exportable fields to bulk export

### DIFF
--- a/src/langsmith/data-export.mdx
+++ b/src/langsmith/data-export.mdx
@@ -242,6 +242,66 @@ The `session_id` is also known as the Tracing Project ID, which can be copied fr
 
 Use the returned `id` to reference this export in subsequent bulk export operations.
 
+#### Exportable fields
+
+By default, bulk exports include the following fields for each run. You can optionally specify a subset of these fields when creating an export to reduce file size and export time. For more details, refer to [Limiting exported fields](#limiting-exported-fields).
+
+The following fields are available for export:
+
+**Identifiers & hierarchy:**
+
+| Field | Description |
+|-------|-------------|
+| `id` | Run ID |
+| `tenant_id` | Workspace/tenant ID |
+| `session_id` | Project/session ID |
+| `trace_id` | Trace ID |
+| `parent_run_id` | Parent run ID |
+| `parent_run_ids` | List of all parent run IDs |
+| `reference_example_id` | Reference to example if part of a dataset |
+
+**Basic metadata:**
+
+| Field | Description |
+|-------|-------------|
+| `name` | Run name |
+| `run_type` | Type of run (e.g., "chain", "llm", "tool") |
+| `start_time` | Start timestamp (UTC) |
+| `end_time` | End timestamp (UTC) |
+| `status` | Run status (e.g., "success", "error") |
+| `is_root` | Whether this is a root-level run |
+| `dotted_order` | Hierarchical ordering string |
+| `trace_tier` | Trace tier/retention level |
+
+**Run data:**
+
+| Field | Description |
+|-------|-------------|
+| `inputs` | Run inputs (JSON) |
+| `outputs` | Run outputs (JSON) |
+| `error` | Error message if failed |
+| `extra` | Extra metadata (JSON) |
+| `events` | Run events (JSON) |
+
+**Tags & feedback:**
+
+| Field | Description |
+|-------|-------------|
+| `tags` | List of tags |
+| `feedback_stats` | Feedback statistics (JSON) |
+
+**Token usage & costs:**
+
+| Field | Description |
+|-------|-------------|
+| `total_tokens` | Total token count |
+| `prompt_tokens` | Prompt token count |
+| `completion_tokens` | Completion token count |
+| `total_cost` | Total cost |
+| `prompt_cost` | Prompt cost |
+| `completion_cost` | Completion cost |
+| `first_token_time` | Time to first token |
+
 #### Limiting exported fields
 
 <Note>


### PR DESCRIPTION
Fixes DOC-463

## Preview

https://langchain-5e9cc07a-preview-export-1767976498-81c8aa9.mintlify.app/langsmith/data-export#exportable-fields