### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.6.28

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -4895,7 +4895,6 @@
                 "updated_at",
                 "metadata",
                 "config",
-                "context",
                 "status",
                 "values",
                 "interrupts"


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.6.28**

This update was automatically generated by the sync workflow in the langgraph-api repository.