### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.6.30

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -268,6 +268,17 @@
             },
             "name": "assistant_id",
             "in": "path"
+          },
+          {
+            "description": "If true, delete all threads with metadata.assistant_id matching this assistant, along with runs and checkpoints belonging to those threads. Auth filters are applied, so threads not visible to the user will not be deleted.",
+            "required": false,
+            "schema": {
+              "type": "boolean",
+              "default": false,
+              "title": "Delete Threads"
+            },
+            "name": "delete_threads",
+            "in": "query"
           }
         ],
         "responses": {


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.6.30**

This update was automatically generated by the sync workflow in the langgraph-api repository.