### PR TITLE
fix(docs): Update keyboard newline shortcut in cli.mdx

### DIFF
--- a/src/oss/deepagents/cli.mdx
+++ b/src/oss/deepagents/cli.mdx
@@ -151,7 +151,7 @@ API keys can be set as environment variables or in a `.env` file.
         | Shortcut | Action |
         |-|-|
         | `Enter` | Submit |
-        | `Option+Enter` (Mac) or `Alt+Enter` (Windows) | Newline |
+        | `Ctrl+J` | Newline |
         | `Ctrl+E` | External editor |
         | `Ctrl+T` | Toggle auto-approve |
         | `Ctrl+C` | Interrupt |


### PR DESCRIPTION
## Overview

Update CLI docs to reflect `Ctrl+J` as the primary newline shortcut across platforms.

See the following issue on the deepagents repo for more information: [/help should localize to current device #652 ](https://github.com/langchain-ai/deepagents/issues/652).

  ## Type of change

  Type: Update existing documentation

  ## Related issues/PRs

  - GitHub issue: See [langchain-ai/deepagents#652](https://github.com/langchain-ai/deepagents/issues/652)
  - Feature PR: N/A
  - Linear issue: N/A
  - Slack thread: N/A

  ## Checklist

  - [x] I have read the contributing guidelines (README.md)
  - [x] I have tested my changes locally using docs dev
  - [x] All code examples have been tested and work correctly
  - [x] I have used root relative paths for internal links
  - [x] I have updated navigation in src/docs.json if needed

  ## Additional notes

  No navigation changes needed; documentation update only.