### PR TITLE
Update installation commands for deepagents package

### DIFF
--- a/src/oss/deepagents/quickstart.mdx
+++ b/src/oss/deepagents/quickstart.mdx
@@ -32,15 +32,15 @@ Before you begin, make sure you have an API key from a model provider (e.g., Ant
 :::js
 <CodeGroup>
     ```bash npm
-    npm install deepagents @langchain/tavily
+    npm install deepagents langchain @langchain/core @langchain/tavily
     ```
 
     ```bash yarn
-    yarn add deepagents @langchain/tavily
+    yarn add deepagents langchain @langchain/core @langchain/tavily
     ```
 
     ```bash pnpm
-    pnpm add deepagents @langchain/tavily
+    pnpm add deepagents langchain @langchain/core @langchain/tavily
     ```
 </CodeGroup>
 :::


### PR DESCRIPTION
## Overview
Additional dependencies needed for the quickstart. Without installing `langchain` and `@langchain/core`, LSPs like the typescript language server has to resolve dependencies transitively rather than directly.

In my case, I was getting the following error for the `tool` and `createDeepAgent` type inference:

```
Type instantiation is excessively deep and possibly infinite
```

Installing `langchain` and `@langchain/core` as direct dependencies resolves this LSP error

## Type of change

**Type:** Update existing documentation

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
N/A
