### PR TITLE
Document HITL interrupts and streaming implementation

### DIFF
--- a/src/oss/langgraph/interrupts.mdx
+++ b/src/oss/langgraph/interrupts.mdx
@@ -131,7 +131,6 @@ The key thing that interrupts unlock is the ability to pause execution and wait 
 
 When building interactive agents with human-in-the-loop workflows, you can stream both message chunks and node updates simultaneously to provide real-time feedback while handling interrupts.
 
-
 Use multiple stream modes (`"messages"` and `"updates"`) with `subgraphs=True` (if subgraphs are present) to:
 - Stream AI responses in real-time as they're generated
 - Detect when the graph encounters an interrupt
@@ -169,12 +168,10 @@ async for metadata, mode, chunk in graph.astream(
             current_node = list(chunk.keys())[0]
 ```
 
-
 - **`stream_mode=["messages", "updates"]`**: Enables dual streaming of both message chunks and graph state updates
 - **`subgraphs=True`**: Required for interrupt detection in nested graphs
 - **`"__interrupt__"` detection**: Signals when human input is needed
 - **`Command(resume=...)`**: Resumes graph execution with user-provided data
-
 
 ### Approve or reject
 


### PR DESCRIPTION
Added section on Streaming with Human-in-the-Loop (HITL) Interrupts, including implementation details and key points.

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
