### PR TITLE
docs(studio): allowed origins instructions for langgraph dev --tunnel

### DIFF
--- a/src/langsmith/quick-start-studio.mdx
+++ b/src/langsmith/quick-start-studio.mdx
@@ -47,7 +47,7 @@ To test your application locally using Studio:
 
     <Warning>
     **Browser Compatibility**
-    Safari blocks `localhost` connections to Studio. To work around this, run the command with `--tunnel` to access Studio via a secure tunnel.
+    Safari blocks `localhost` connections to Studio. To work around this, run the command with `--tunnel` to access Studio via a secure tunnel. You'll need to manually add the tunnel URL to allowed origins by clicking **Connect to a local server** in the Studio UI. See the [troubleshooting guide](/langsmith/troubleshooting-studio#safari-connection-issues) for steps.
     </Warning>
 
     This will start the Agent Server locally, running in-memory. The server will run in watch mode, listening for and automatically restarting on code changes. Read this [reference](/langsmith/cli#dev) to learn about all the options for starting the API server.

--- a/src/langsmith/troubleshooting-studio.mdx
+++ b/src/langsmith/troubleshooting-studio.mdx
@@ -24,13 +24,19 @@ Safari blocks plain-HTTP traffic on localhost. When running Studio with `langgra
     </Tab>
 </Tabs>
 
-The command outputs a URL in this format:
+The command outputs a tunnel URL. To connect Studio:
 
-```shell
-https://smith.langchain.com/studio/?baseUrl=https://hamilton-praise-heart-costumes.trycloudflare.com
-```
+1. Copy the tunnel URL (e.g., `https://hamilton-praise-heart-costumes.trycloudflare.com`)
+2. Open Studio at `https://smith.langchain.com/studio/`
+3. Click **Connect to a local server**
+4. Paste the tunnel URL and add it to **Allowed Origins**
+5. Click **Connect**
 
-Use this URL in Safari to load Studio. Here, the `baseUrl` parameter specifies your agent server endpoint.
+This manual step is required for security - Studio requires explicit user confirmation before connecting to external URLs.
+
+<Note>
+Cloudflare tunnels can be unreliable and may intermittently disconnect.
+</Note>
 
 ### Solution 2: Use Chromium browser
 
@@ -108,13 +114,15 @@ Disable Brave Shields for LangSmith using the Brave icon in the URL bar.
     </Tab>
 </Tabs>
 
-The command outputs a URL in this format:
+The command outputs a tunnel URL. To connect Studio:
 
-```shell
-https://smith.langchain.com/studio/?baseUrl=https://hamilton-praise-heart-costumes.trycloudflare.com
-```
+1. Copy the tunnel URL (e.g., `https://hamilton-praise-heart-costumes.trycloudflare.com`)
+2. Open Studio at `https://smith.langchain.com/studio/`
+3. Click **Connect to a local server**
+4. Paste the tunnel URL and add it to **Allowed Origins**
+5. Click **Connect**
 
-Use this URL in Brave to load Studio. Here, the `baseUrl` parameter specifies your agent server endpoint.
+This manual step is required for security - Studio requires explicit user confirmation before connecting to external URLs.
 
 ## Graph edge issues
 

--- a/src/oss/langgraph/studio.mdx
+++ b/src/oss/langgraph/studio.mdx
@@ -201,7 +201,7 @@ npx @langchain/langgraph-cli dev
 :::
 
 <Warning>
-Safari blocks `localhost` connections to Studio. To work around this, run the above command with `--tunnel` to access Studio via a secure tunnel.
+Safari blocks `localhost` connections to Studio. To work around this, run the above command with `--tunnel` to access Studio via a secure tunnel. You'll need to manually add the tunnel URL to allowed origins by clicking **Connect to a local server** in the Studio UI. See the [troubleshooting guide](/langsmith/troubleshooting-studio#safari-connection-issues) for steps.
 </Warning>
 
 Once the server is running, your agent is accessible both via API at `http://127.0.0.1:2024` and through the Studio UI at `https://smith.langchain.com/studio/?baseUrl=http://127.0.0.1:2024`:


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

since allowed origins configuration was added to the UI, there are extra steps needed to get `langgraph dev --tunnel` working in safari and implicitly brave. this PR documents those steps. see slack thread linked below.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Slack thread: https://langchain.slack.com/archives/C089RDWTKU4/p1759800742196309

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
