### PR TITLE
Add note to scim docs re http/1.1

### DIFF
--- a/src/langsmith/user-management.mdx
+++ b/src/langsmith/user-management.mdx
@@ -393,6 +393,10 @@ SCIM eliminates the need for manual user management and ensures that user access
   - Okta supports allow-listing IPs or domains ([details](https://help.okta.com/en-us/content/topics/security/ip-address-allow-listing.htm))
     or an agent-based solution ([details](https://help.okta.com/en-us/content/topics/provisioning/opp/opp-main.htm)) to provide connectivity.
 
+<Note>
+SCIM connections typically require HTTP/1.1 or later. If your client uses HTTP/1.0, you may encounter a `426 Upgrade Required` error.
+</Note>
+
 #### Role precedence
 
 When a user belongs to multiple groups for the same workspace, the following precedence applies:


### PR DESCRIPTION
Fixes DOC-541

Small PR for note to SCIM docs re the need for http/1.1 in order to avoid running into a 426 error.