### PR TITLE
Emphasize auto project creation on trace ingestion

### DIFF
--- a/src/langsmith/observability-concepts.mdx
+++ b/src/langsmith/observability-concepts.mdx
@@ -65,6 +65,8 @@ A _project_ is a collection of traces. You can think of a project as a container
 
 ![Project](/langsmith/images/project.png)
 
+For more details on project setup and traces, refer to [Log traces to a project](/langsmith/log-traces-to-a-project).
+
 ## Feedback
 
 _Feedback_ allows you to score an individual run based on certain criteria. Each feedback entry consists of a feedback tag and feedback score, and is bound to a run by a unique run ID. Feedback can be continuous or discrete (categorical), and you can reuse feedback tags across different runs within an organization.

--- a/src/langsmith/observability-llm-tutorial.mdx
+++ b/src/langsmith/observability-llm-tutorial.mdx
@@ -3,6 +3,8 @@ title: Trace a RAG application tutorial
 sidebarTitle: Trace a RAG application
 ---
 
+import project from '/snippets/langsmith/trace-ingestion-project.mdx';
+
 In this tutorial, we'll build a simple RAG application using the OpenAI SDK. We'll add observability to the application at each stage of development, from prototyping to production.
 
 <CodeGroup>
@@ -94,6 +96,8 @@ export LANGSMITH_API_KEY=<your-api-key>
 export LANGSMITH_WORKSPACE_ID=<your-workspace-id>
 export LANGSMITH_PROJECT=default
 ```
+
+<project />
 
 <Note>
 You may see these variables referenced as `LANGCHAIN_*` in other places. These are all equivalent, however the best practice is to use `LANGSMITH_TRACING`, `LANGSMITH_API_KEY`, `LANGSMITH_PROJECT`.

--- a/src/langsmith/observability-quickstart.mdx
+++ b/src/langsmith/observability-quickstart.mdx
@@ -3,6 +3,8 @@ title: Tracing quickstart
 sidebarTitle: Quickstart
 ---
 
+import project from '/snippets/langsmith/trace-ingestion-project.mdx';
+
 [_Observability_](/langsmith/observability-concepts) is a critical requirement for applications built with Large Language Models (LLMs). LLMs are non-deterministic, which means that the same prompt can produce different responses. This behavior makes debugging and monitoring more challenging than with traditional software.
 
 LangSmith addresses this by providing end-to-end visibility into how your application handles a request. Each request generates a [_trace_](/langsmith/observability-concepts#traces), which captures the full record of what happened. Within a trace are individual [_runs_](/langsmith/observability-concepts#runs), the specific operations your application performed, such as an LLM call or a retrieval step. Tracing runs allows you to inspect, debug, and validate your application’s behavior.
@@ -71,6 +73,10 @@ export LANGSMITH_WORKSPACE_ID="<your-workspace-id>"
 ```
 
 If you're using Anthropic, use the [Anthropic wrapper](/langsmith/annotate-code#wrap-the-anthropic-client-python-only) to trace your calls. For other providers, use [the traceable wrapper](/langsmith/annotate-code#use-%40traceable-%2F-traceable).
+
+<Note>
+<project />
+</Note>
 
 ## 3. Define your application
 

--- a/src/snippets/langsmith/trace-ingestion-project.mdx
+++ b/src/snippets/langsmith/trace-ingestion-project.mdx
@@ -1,0 +1,1 @@
+To send traces to a specific project, use the [`LANGSMITH_PROJECT` environment variable](/langsmith/log-traces-to-project). If this is not set, LangSmith will create a default tracing project automatically on trace ingestion.


### PR DESCRIPTION
Fixes DOC-361

Small PR to add a couple more notes and links to make it clearer that projects will be auto-created in LangSmith if the `LANGSMITH_PROJECT` env var is not set

## Preview 

https://langchain-5e9cc07a-preview-autopr-1768252693-f5d8bd4.mintlify.app/langsmith/observability-quickstart#2-set-up-environment-variables