### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.6.34

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -5592,9 +5592,16 @@
         }
       },
       "ErrorResponse": {
-        "type": "string",
+        "type": "object",
+        "required": ["detail"],
+        "properties": {
+          "detail": {
+            "type": "string",
+            "description": "Human-readable error message"
+          }
+        },
         "title": "ErrorResponse",
-        "description": "Error message returned from the server"
+        "description": "Error response returned from the server"
       },
       "ThreadCronCreate": {
         "properties": {


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.6.34**

This update was automatically generated by the sync workflow in the langgraph-api repository.