### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.6.35

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -4040,8 +4040,7 @@
                 "user_id",
                 "payload",
                 "next_run_date",
-                "metadata",
-                "now"
+                "metadata"
               ]
             },
             "title": "Select",


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.6.35**

This update was automatically generated by the sync workflow in the langgraph-api repository.