### PR TITLE
Auto trigger publish when pushing to main

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,6 +3,9 @@ run-name: Publish by @${{ github.actor }}
 
 on:
   workflow_dispatch:  # Allows to trigger the workflow manually in GitHub UI
+  push:
+    branches:
+      - main
 
 jobs:
   publish:


### PR DESCRIPTION
Originally when we set up this docs repo, we created a manual workflow for publishing in the event that we wanted to merge something but not release it yet. In practice, we haven't had to do that ever and it has caused issues with people merging and then forgetting to publish.

This PR automates the trigger to publish docs.