### PR TITLE
fix a2a docs

### DIFF
--- a/src/langsmith/server-a2a.mdx
+++ b/src/langsmith/server-a2a.mdx
@@ -59,7 +59,7 @@ On the first message, omit `contextId` and `taskId` - the agent will generate an
 
 **LangSmith Tracing:** The Langsmith Deployment A2A endpoint automatically converts the A2A `contextId` to `thread_id` for LangSmith tracing, grouping all messages in the conversation under a single thread.
 
-Here's an example:
+For example:
 
 ```python
 """LangGraph A2A conversational agent.


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread: [Slack thread about incorrect A2A documentation causing customer confusion](https://langchain.slack.com/archives/C089RDWTKU4/p1768250313385539)


## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [ N/A ] I have used **root relative** paths for internal links 
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
This PR is to fix A2A Deployments Endpoint to reflect correct A2A protocol usage- namely including `contextId` and `taskId` fields for A2A  `messages` continuity, as well as removing `"thread": {"threadId": ""}` since this is unused, instead mentioning that the LangSmith Deployment endpoint converts `contextId` to `thread_id`
