### PR TITLE
docs: add Ampersend toolkit integration documentation

### DIFF
--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -130,6 +130,14 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
+        title="Ampersend"
+        href="/oss/integrations/providers/ampersend"
+        icon="link"
+    >
+        Payment infrastructure for AI agent services via x402 protocol.
+    </Card>
+
+    <Card
         title="AnalyticDB"
         href="/oss/integrations/providers/analyticdb"
         icon="link"

--- a/src/oss/python/integrations/providers/ampersend.mdx
+++ b/src/oss/python/integrations/providers/ampersend.mdx
@@ -1,0 +1,22 @@
+---
+title: Ampersend
+---
+
+[Ampersend](https://ampersend.ai) enables LangChain agents to pay for and use remote AI agent services.
+
+Give agents tools to:
+
+- Pay for remote agent services automatically
+- Interact with remote A2A agents
+
+### How it works
+
+Ampersend provides transparent payment handling via the x402 protocol:
+
+1. Connect your agent to a wallet with spend controls
+2. Call remote agents via the A2A protocol
+3. Payments are handled automatically when required
+
+## Installation and setup
+
+Check out the [tool documentation](/oss/integrations/tools/ampersend) to see how to set up and install Ampersend.

--- a/src/oss/python/integrations/tools/ampersend.mdx
+++ b/src/oss/python/integrations/tools/ampersend.mdx
@@ -1,0 +1,157 @@
+---
+title: Ampersend
+description: Enable LangChain agents to pay for and use remote AI agent services.
+---
+
+[Ampersend](https://ampersend.ai) enables LangChain agents to pay for and use remote AI agent services. Payments are handled transparently via the [x402](https://www.x402.org/) protocol, with [A2A](https://google.github.io/A2A/) as the communication layer.
+
+## Overview
+
+### Integration details
+
+| Class | Package | Serializable | JS support | Version |
+| :--- | :--- | :---: | :---: | :---: |
+| A2AToolkit | `langchain-ampersend` | ❌ | ❌ | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-ampersend?style=flat-square&label=%20) |
+
+### Tool features
+
+1. **a2a_get_agent_details** - Get capabilities of the remote agent
+2. **a2a_send_message** - Send messages to the remote agent (payments handled automatically)
+
+### Key features
+
+- **Spend controls**: Pluggable payment authorization with limits and policies
+- **Transparent payments**: x402 protocol handles payment negotiation automatically
+
+---
+
+## Setup
+
+### Installation
+
+Install the `langchain-ampersend` package:
+
+<CodeGroup>
+    ```python pip
+    pip install -U langchain-ampersend
+    ```
+    ```python uv
+    uv add langchain-ampersend
+    ```
+</CodeGroup>
+
+### Credentials
+
+The toolkit requires a session key and smart account address, which you can obtain from the [Ampersend dashboard](https://app.ampersend.ai).
+
+```python Set up credentials icon="key"
+import os
+
+SESSION_KEY = os.environ.get("AMPERSEND_SESSION_KEY")  # 0x...
+SMART_ACCOUNT_ADDRESS = os.environ.get("AMPERSEND_SMART_ACCOUNT_ADDRESS")  # 0x...
+```
+
+---
+
+## Instantiation
+
+```python Initialize toolkit icon="robot"
+from langchain_ampersend import (
+    A2AToolkit,
+    AmpersendTreasurer,
+    ApiClient,
+    ApiClientOptions,
+    SmartAccountConfig,
+    SmartAccountWallet,
+)
+
+# Setup wallet
+wallet = SmartAccountWallet(
+    config=SmartAccountConfig(
+        session_key=SESSION_KEY,
+        smart_account_address=SMART_ACCOUNT_ADDRESS,
+    )
+)
+
+# Setup treasurer
+treasurer = AmpersendTreasurer(
+    api_client=ApiClient(
+        options=ApiClientOptions(
+            base_url="https://api.ampersend.ai",
+            session_key_private_key=SESSION_KEY,
+        )
+    ),
+    wallet=wallet,
+)
+
+# Create toolkit
+toolkit = A2AToolkit(
+    remote_agent_url="https://agent.example.com",
+    treasurer=treasurer,
+)
+
+await toolkit.initialize()
+```
+
+---
+
+## Invocation
+
+Send a message to the remote agent:
+
+```python Send message icon="message"
+tools = toolkit.get_tools()
+send_tool = tools[1]  # a2a_send_message
+response = await send_tool.ainvoke({"message": "Analyze the sales trends in Q4"})
+print(response)
+```
+
+---
+
+## Use within an agent
+
+```python Create agent icon="robot"
+from langchain.agents import create_agent
+from langchain_anthropic import ChatAnthropic
+
+# Initialize the LLM
+llm = ChatAnthropic(model="claude-sonnet-4-20250514")
+
+# Get tools from the toolkit
+tools = toolkit.get_tools()
+
+# Create the agent
+agent = create_agent(llm, tools)
+```
+
+Example usage:
+
+```python Run agent icon="rocket"
+result = await agent.ainvoke({
+    "messages": [("user", "What can this agent do, and then ask it to analyze recent trends")]
+})
+
+# The agent will call the remote agent and handle payments automatically
+```
+
+---
+
+## How payments work
+
+When the remote agent requires payment (HTTP 402), the toolkit:
+
+1. Receives the payment requirement
+2. Calls the treasurer to authorize the payment
+3. Signs the payment with the configured wallet
+4. Retries the request with the payment attached
+
+This is transparent to your LangChain agent.
+
+The `AmpersendTreasurer` provides managed payment sessions with spend limits and analytics. Alternative treasurer implementations are available in `ampersend_sdk`.
+
+---
+
+## API reference
+
+- [Ampersend Documentation](https://docs.ampersend.ai)
+- [x402 Protocol Specification](https://www.x402.org/)

--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -86,6 +86,7 @@ The following table shows tools that can be used to execute financial transactio
 
 | Tool/Toolkit | Pricing | Capabilities |
 |-------------|---------|--------------|
+| [Ampersend](/oss/integrations/tools/ampersend) | Paid | Pay for and use remote AI agent services with automatic x402 payment handling. |
 | [GOAT](/oss/integrations/tools/goat) | Free | Create and receive payments, purchase physical goods, make investments, and more. |
 | [Privy](/oss/integrations/tools/privy) | Free | Create wallets with configurable permissions and execute transactions with speed. |
 
@@ -104,6 +105,7 @@ The following platforms provide access to multiple tools and services through a 
 <Card title="AgentQL" icon="link" href="/oss/integrations/tools/agentql" arrow="true" cta="View guide" />
 <Card title="AINetwork Toolkit" icon="link" href="/oss/integrations/tools/ainetwork" arrow="true" cta="View guide" />
 <Card title="Alpha Vantage" icon="link" href="/oss/integrations/tools/alpha_vantage" arrow="true" cta="View guide" />
+<Card title="Ampersend" icon="link" href="/oss/integrations/tools/ampersend" arrow="true" cta="View guide" />
 <Card title="Amadeus Toolkit" icon="link" href="/oss/integrations/tools/amadeus" arrow="true" cta="View guide" />
 <Card title="Amazon Bedrock AgentCore Browser" icon="link" href="/oss/python/integrations/tools/bedrock_agentcore_browser" arrow="true" cta="View guide" />
 <Card title="Amazon Bedrock AgentCore Code Interpreter" icon="link" href="/oss/python/integrations/tools/bedrock_agentcore_code_interpreter" arrow="true" cta="View guide" />


### PR DESCRIPTION
## Overview

Add documentation for the `langchain-ampersend` integration, which enables LangChain agents to pay for and use remote AI agent services. Payments are handled transparently via the x402 protocol, with A2A as the communication layer.

## Type of change

**Type:** New documentation page

## Related issues/PRs

- GitHub issue: N/A
- Feature PR: N/A

## Checklist

- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

- Added new file: `src/oss/python/integrations/tools/ampersend.mdx`
- Updated `src/oss/python/integrations/tools/index.mdx`:
  - Added Ampersend to the Finance category table
  - Added Ampersend card to the "All tools and toolkits" section (alphabetically)
- No changes needed to `docs.json` - tool pages are linked from the index

---

**AI Disclosure:** This documentation was drafted with assistance from Claude Code (claude.ai/code). The content has been reviewed for accuracy against the actual SDK implementation.