### PR TITLE
docs: Add VertexAI configuration to playground environment settings

### DIFF
--- a/src/langsmith/self-host-playground-environment-settings.mdx
+++ b/src/langsmith/self-host-playground-environment-settings.mdx
@@ -51,7 +51,7 @@ langchain-playground:
 
 ## VertexAI configuration
 
-You can configure VertexAI credentials for the playground service using either environment variables with secrets or IRSA (IAM Roles for Service Accounts) with workload identity.
+You can configure VertexAI credentials for the playground service using either environment variables with secrets or workload identity (GCP Workload Identity for GKE or AWS IRSA for EKS).
 
 ### Using secrets
 
@@ -107,9 +107,13 @@ langchain-playground:
 
 </CodeGroup>
 
-### Using IRSA (workload identity)
+### Using workload identity
 
-If you're using IRSA or workload identity, you can configure the playground service account to assume a GCP role without storing credentials:
+You can configure the playground service account to use workload identity to assume a GCP service account role without storing credentials. This is the recommended approach for GKE clusters.
+
+#### GCP Workload Identity (GKE)
+
+For GKE clusters, use GCP Workload Identity:
 
 <CodeGroup>
 
@@ -128,11 +132,41 @@ playground:
   serviceAccount:
     create: true  # Enable if not exists
     annotations:
+      iam.gke.io/gcp-service-account: "vertexai-sa@your-gcp-project.iam.gserviceaccount.com"
+```
+
+</CodeGroup>
+
+<Note>
+When using GCP Workload Identity, ensure the GCP service account has the required VertexAI permissions (e.g., `roles/aiplatform.user`).
+</Note>
+
+#### AWS IRSA (EKS)
+
+For EKS clusters, you can use AWS IRSA to assume a GCP service account role:
+
+<CodeGroup>
+
+```yaml Helm
+playground:
+  deployment:
+    extraEnv:
+      # Optional: Set project/location if not in model config
+      - name: GOOGLE_CLOUD_PROJECT
+        value: "your-gcp-project-id"
+      - name: VERTEXAI_PROJECT_ID
+        value: "your-gcp-project-id"
+      - name: VERTEXAI_LOCATION
+        value: "us-central1"
+    # No credentials needed - pod assumes GCP SA role via AWS IAM role
+  serviceAccount:
+    create: true  # Enable if not exists
+    annotations:
       eks.amazonaws.com/role-arn: arn:aws:iam::<account>:role/LangSmith-VertexAI-Role
 ```
 
 </CodeGroup>
 
 <Note>
-When using IRSA, ensure your AWS IAM role has the necessary permissions to assume the GCP service account role, and that the GCP service account has the required VertexAI permissions.
+When using AWS IRSA, ensure your AWS IAM role has the necessary permissions to assume the GCP service account role, and that the GCP service account has the required VertexAI permissions.
 </Note>


### PR DESCRIPTION
## Overview

Adds documentation for configuring VertexAI credentials in the playground service using either:
- Environment variables with Kubernetes secrets (`GOOGLE_VERTEX_AI_WEB_CREDENTIALS` or `GOOGLE_APPLICATION_CREDENTIALS`)
- IRSA (IAM Roles for Service Accounts) with workload identity

Includes Helm and Docker configuration examples for both approaches.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
