### PR TITLE
fix: Broken Link Reference for RunnableLambda Class

### DIFF
--- a/pipeline/preprocessors/link_map.py
+++ b/pipeline/preprocessors/link_map.py
@@ -184,6 +184,7 @@ LINK_MAPS: list[LinkMap] = [
             # Runnables
             "Runnable": "langchain_core/runnables/#langchain_core.runnables.Runnable",
             "RunnableConfig": "langchain_core/runnables/#langchain_core.runnables.RunnableConfig",
+            "RunnableLambda": "langchain_core/runnables/#langchain_core.runnables.base.RunnableLambda",
             "RunnableConfig(max_concurrency)": "langchain_core/runnables/#langchain_core.runnables.RunnableConfig.max_concurrency",
             # Retrievers
             "Retrievers": "langchain_core/retrievers/#langchain_core.retrievers.BaseRetriever",

--- a/src/oss/langgraph/graph-api.mdx
+++ b/src/oss/langgraph/graph-api.mdx
@@ -702,7 +702,7 @@ const builder = new StateGraph(State)
 
 :::
 
-Behind the scenes, functions are converted to [`RunnableLambda`](https://reference.langchain.com/python/langchain_core/runnables/#langchain_core.runnables.base.RunnableLambda), which add batch and async support to your function, along with native tracing and debugging.
+Behind the scenes, functions are converted to @[`RunnableLambda`], which add batch and async support to your function, along with native tracing and debugging.
 
 If you add a node to a graph without specifying a name, it will be given a default name equivalent to the function name.
 


### PR DESCRIPTION
## Overview
In `Graph API Overview` docs, We have broken link for `RunnableLambda` class reference. Currently It points to main docs page of langchain-core package instead of `RunnableLambda` Definition.

## Type of change

Broken Link Fix

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
