### PR TITLE
oss(deepagents): refine `deepagents-cli` provider selection logic and model usage instructions

### DIFF
--- a/src/oss/deepagents/cli.mdx
+++ b/src/oss/deepagents/cli.mdx
@@ -95,10 +95,18 @@ uv add deepagents-cli
 ```
 </CodeGroup>
 
-The CLI uses Anthropic Claude Sonnet 4 by default. To use OpenAI:
+The CLI automatically selects a provider based on which API keys are available. If multiple keys are set, it uses the first match in this order:
+
+| Priority | API key | Default model |
+|----------|---------|---------------|
+| 1st | `OPENAI_API_KEY` | `gpt-5-mini` |
+| 2nd | `ANTHROPIC_API_KEY` | `claude-sonnet-4-5-20250929` |
+| 3rd | `GOOGLE_API_KEY` | `gemini-3-pro-preview` |
+
+To use a different model, pass the `--model` flag explicitly. For example, to use Claude Opus 4.5:
 
 ```bash
-export OPENAI_API_KEY="your-key"
+deepagents --model claude-opus-4-5-20251101
 ```
 
 Enable web search (optional):


### PR DESCRIPTION
Port: https://github.com/langchain-ai/deepagents/pull/772