### PR TITLE
Update time travel documentation

### DIFF
--- a/src/oss/langgraph/use-time-travel.mdx
+++ b/src/oss/langgraph/use-time-travel.mdx
@@ -11,9 +11,9 @@ When working with non-deterministic systems that make model-based decisions (e.g
 2. <Icon icon="bug" size={16} /> **Debug mistakes**: Identify where and why errors occurred.
 3. <Icon icon="magnifying-glass" size={16} /> **Explore alternatives**: Test different paths to uncover better solutions.
 
-LangGraph provides [time travel](/oss/langgraph/use-time-travel) functionality to support these use cases. Specifically, you can resume execution from a prior checkpoint — either replaying the same state or modifying it to explore alternatives. In all cases, resuming past execution produces a new fork in the history.
+LangGraph provides time-travel functionality to support these use cases. Specifically, you can resume execution from a prior checkpoint — either replaying the same state or modifying it to explore alternatives. In all cases, resuming past execution produces a new fork in the history.
 
-To use [time-travel](/oss/langgraph/use-time-travel) in LangGraph:
+To use time-travel in LangGraph:
 
 :::python
 1. [Run the graph](#1-run-the-graph) with initial inputs using @[`invoke`][CompiledStateGraph.invoke] or @[`stream`][CompiledStateGraph.stream] methods.
@@ -31,38 +31,27 @@ To use [time-travel](/oss/langgraph/use-time-travel) in LangGraph:
 4. [Resume execution from the checkpoint](#4-resume-execution-from-the-checkpoint): Use the `invoke` or `stream` methods with an input of `null` and a configuration containing the appropriate `thread_id` and `checkpoint_id`.
 :::
 
-<Tip>
-For a conceptual overview of time-travel, see [Time travel](/oss/langgraph/use-time-travel).
-</Tip>
-
 ## In a workflow
 
 This example builds a simple LangGraph workflow that generates a joke topic and writes a joke using an LLM. It demonstrates how to run the graph, retrieve past execution checkpoints, optionally modify the state, and resume execution from a chosen checkpoint to explore alternate outcomes.
 
 ### Setup
 
-First we need to install the packages required
+To build this workflow in this example you need to set up the Anthropic LLM and install the required dependencies:
 
 :::python
-```python
-%%capture --no-stderr
-pip install --quiet -U langgraph langchain_anthropic
-```
-:::
-
-:::js
+1. Install dependencies:
 ```bash
-npm install @langchain/langgraph @langchain/anthropic
+pip install langchain_core langchain-anthropic langgraph
 ```
-:::
 
-Next, we need to set API keys for Anthropic (the LLM we will use)
+2. Initialize the LLM:
 
-:::python
 ```python
-import getpass
 import os
+import getpass
 
+from langchain_anthropic import ChatAnthropic
 
 def _set_env(var: str):
     if not os.environ.get(var):
@@ -70,18 +59,49 @@ def _set_env(var: str):
 
 
 _set_env("ANTHROPIC_API_KEY")
+
+llm = ChatAnthropic(model="claude-sonnet-4-5-20250929")
 ```
 :::
 
 :::js
+1. Install dependencies
+<CodeGroup>
+```bash npm
+npm install @langchain/langgraph @langchain/core
+```
+
+```bash pnpm
+pnpm add @langchain/langgraph @langchain/core
+```
+
+```bash yarn
+yarn add @langchain/langgraph @langchain/core
+```
+
+```bash bun
+bun add @langchain/langgraph @langchain/core
+```
+</CodeGroup>
+
+2. Initialize the LLM:
+
 ```typescript
-process.env.ANTHROPIC_API_KEY = "YOUR_API_KEY";
+import { ChatAnthropic } from "@langchain/anthropic";
+
+const llm = new ChatAnthropic({
+  model: "claude-sonnet-4-5-20250929",
+  apiKey: "<your_anthropic_key>"
+});
 ```
 :::
 
 <Tip>
 Sign up for [LangSmith](https://smith.langchain.com) to quickly spot issues and improve the performance of your LangGraph projects. LangSmith lets you use trace data to debug, test, and monitor your LLM apps built with LangGraph.
 </Tip>
+
+3. Implement the workflow
+The implementation of the workflow is a simple graph with two nodes, one for generating a joke topic, another for writing the joke itself and a state to storing the intermediate values.
 
 :::python
 ```python
@@ -178,6 +198,7 @@ const graph = workflow.compile({ checkpointer });
 :::
 
 ### 1. Run the graph
+To start the workflow, @[`invoke`][CompiledStateGraph.invoke] is called without any inputs. Note the `thread_id` to track this execution and retrieve its checkpoints later.
 
 :::python
 ```python
@@ -223,6 +244,7 @@ My blue argyle is now living in Bermuda with a red polka dot, posting vacation p
 ```
 
 ### 2. Identify a checkpoint
+To continue from a previous point in the graphs run, use @[`get_state_history`] to retrieve all the states and select the one where you want to resume execution.
 
 :::python
 ```python
@@ -317,7 +339,7 @@ console.log(selectedState.values);
 :::
 
 <a id="optional"></a>
-### 3. Update the state
+### 3. Update the state (optional)
 
 :::python
 @[`update_state`] will create a new checkpoint. The new checkpoint will be associated with the same thread, but a new checkpoint ID.
@@ -352,6 +374,7 @@ console.log(newConfig);
 :::
 
 ### 4. Resume execution from the checkpoint
+For resumings execution from the selected checkpoint, call @[`invoke`][CompiledStateGraph.invoke] with the config that points to the new checkpoint.
 
 :::python
 ```python


### PR DESCRIPTION
## Overview
Some small enhancements / fixes to the time travel documentation:
* Align setup of LLM with the rest of the documentation
* Removed self-referencing internal links to the time-travel page
* Fix broken link to part 3
* Add some more notes to describe what is done in the respective paragraphs

## Type of change

**Type:** Update existing documentation

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [X] I have read the [contributing guidelines](README.md)
- [X] have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [X] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes
Please not that I could not check the typescript examples because I currently have no working environment for that. Regarding the links to _time travel_ that were previously on this page and were self-referencing; I couldn't find a target where they were supposed to point at. But maybe there is a page which I didn't find.
