### PR TITLE
oss: generalize versioning policy

### DIFF
--- a/src/oss/versioning.mdx
+++ b/src/oss/versioning.mdx
@@ -2,7 +2,7 @@
 title: Versioning
 ---
 
-LangChain OSS version numbers follow the format: `MAJOR.MINOR.PATCH`, as defined by [Semantic Versioning](https://semver.org/).
+Our OSS version numbers follow the format: `MAJOR.MINOR.PATCH`, as defined by [Semantic Versioning](https://semver.org/).
 
 - **Major**: Breaking API updates that require code changes.
 - **Minor**: New features and improvements that maintain backward compatibility.


### PR DESCRIPTION
I think we should potentially also explicitly state where `deepagents` falls?