### PR TITLE
feat: document LANGGRAPH_AES_JSON_KEYS

### DIFF
--- a/src/langsmith/encryption.mdx
+++ b/src/langsmith/encryption.mdx
@@ -9,7 +9,7 @@ Agent Server supports encryption at-rest for checkpoint data and metadata. You c
 
 | Method | What's encrypted | Use case |
 |--------|------------------|----------|
-| **Basic encryption** | Checkpoint blobs only | Single static key, automatic AES encryption |
+| **Basic encryption** | Checkpoint blobs, optionally JSON fields | Single static key, automatic AES encryption |
 | **Custom encryption** | Checkpoints, threads, runs, assistants, crons and stores | Per-tenant keys, KMS integration, selective field encryption |
 
 ## Basic encryption
@@ -28,7 +28,22 @@ For simple encryption with a single static key, set the `LANGGRAPH_AES_KEY` envi
 
 2. Set the `LANGGRAPH_AES_KEY` environment variable to a 16, 24, or 32-byte key (for AES-128, AES-192, or AES-256 respectively).
 
-Basic encryption only encrypts checkpoint blobs. Metadata fields remain unencrypted and searchable.
+### Encrypting JSON fields
+
+To also encrypt specific JSON fields, set `LANGGRAPH_AES_JSON_KEYS` to a comma-separated list of keys to encrypt:
+
+```bash
+export LANGGRAPH_AES_KEY="your-16-24-or-32-byte-key"
+export LANGGRAPH_AES_JSON_KEYS="api_key,secret_token,user_credentials"
+```
+
+These keys are encrypted wherever they appear in thread, assistant, run, cron, and store data.
+
+<Warning>
+Encrypted fields cannot be searched or filtered.
+</Warning>
+
+System fields cannot be encrypted: `langgraph_version`, `langgraph_api_version`, `langgraph_plan`, `langgraph_host`, `langgraph_api_url`, `langgraph_request_id`, `langgraph_auth_user_id`, `langgraph_auth_permissions`.
 
 ## Custom encryption
 
@@ -72,7 +87,7 @@ Add your encryption module to `langgraph.json`:
 ```
 
 <Note>
-If you're already using `LANGGRAPH_AES_KEY`, keep it configured—custom encryption replaces AES for new writes, but existing AES-encrypted data will still be readable.
+If you're migrating from basic encryption, keep `LANGGRAPH_AES_KEY` configured. Custom encryption handles new writes while existing AES-encrypted data remains readable.
 </Note>
 
 ### Defining your encryption module


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
this new environment variable allows LANGGRAPH_AES_KEY users to encrypt JSON fields like langgraph_auth_user.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: 
- Feature PR: https://github.com/langchain-ai/langgraph-api/pull/2280

<!-- For LangChain employees, if applicable: -->
- Linear issue: LSD-1023
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
