### PR TITLE
Added clarification that evaluators in UI will be automatically triggered

### DIFF
--- a/src/langsmith/evaluate-llm-application.mdx
+++ b/src/langsmith/evaluate-llm-application.mdx
@@ -205,7 +205,7 @@ function correct({
 
 ### In LangSmith UI
 
-You can also define an evaluator in LangSmith UI. You can [create evaluators in the UI](/langsmith/llm-as-judge#ui) under the `Evaluators` tab. These evaluators will be [automatically triggered with every new experiment](/langsmith/bind-evaluator-to-dataset).
+You can also define an evaluator in the [LangSmith UI](https://smith.langchain.com). You can [create evaluators in the UI](/langsmith/llm-as-judge#ui) under the **Evaluators** tab. These evaluators will be [automatically triggered with every new experiment](/langsmith/bind-evaluator-to-dataset).
 
 
 ## Run the evaluation
@@ -215,8 +215,8 @@ We'll use the [evaluate()](https://docs.smith.langchain.com/reference/python/eva
 The key arguments are:
 
 * a target function that takes an input dictionary and returns an output dictionary. The `example.inputs` field of each [Example](/langsmith/example-data-format) is what gets passed to the target function. In this case our `toxicity_classifier` is already set up to take in example inputs so we can use it directly.
-* `data` - the name OR UUID of the LangSmith dataset to evaluate on, or an iterator of examples
-* `evaluators` - a list of evaluators to score the outputs of the function; dataset evaluators in langsmith UI will also automatically get triggered
+* `data` - the name OR UUID of the LangSmith dataset to evaluate on, or an iterator of examples.
+* `evaluators` - a list of evaluators to score the outputs of the function; dataset evaluators in the [Langsmith UI](https://smith.langchain.com) will also automatically get triggered.
 
 
 Python: Requires `langsmith>=0.3.13`


### PR DESCRIPTION
## Type of change

**Type:** Update existing documentation 

## Related issues/PRs
- Linear issue: LSE-1676

## Checklist
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed