### PR TITLE
Update cron jobs documentation to clarify timezone

### DIFF
--- a/src/langsmith/cron-jobs.mdx
+++ b/src/langsmith/cron-jobs.mdx
@@ -19,6 +19,10 @@ The LangSmith Deployment API provides several endpoints for creating and managin
 
 Sometimes you don't want to run your graph based on user interaction, but rather you would like to schedule your graph to run on a schedule - for example if you wish for your graph to compose and send out a weekly email of to-dos for your team. LangSmith Deployment allows you to do this without having to write your own script by using the `Crons` client. To schedule a graph job, you need to pass a [cron expression](https://crontab.cronhub.io/) to inform the client when you want to run the graph. `Cron` jobs are run in the background and do not interfere with normal invocations of the graph.
 
+<Note>
+All cron schedules are interpreted in **UTC**. Make sure to convert your desired execution time to UTC when specifying the schedule.
+</Note>
+
 ## Setup
 
 First, let's set up our SDK client, assistant, and thread:
@@ -86,7 +90,7 @@ To create a cron job associated with a specific thread, you can write:
 <Tabs>
     <Tab title="Python">
     ```python
-    # This schedules a job to run at 15:27 (3:27PM) every day
+    # This schedules a job to run at 15:27 (3:27PM) UTC every day
     cron_job = await client.crons.create_for_thread(
         thread["thread_id"],
         assistant_id,
@@ -97,7 +101,7 @@ To create a cron job associated with a specific thread, you can write:
     </Tab>
     <Tab title="Javascript">
     ```js
-    // This schedules a job to run at 15:27 (3:27PM) every day
+    // This schedules a job to run at 15:27 (3:27PM) UTC every day
     const cronJob = await client.crons.create_for_thread(
       thread["thread_id"],
       assistantId,
@@ -148,7 +152,7 @@ You can also create stateless cron jobs by using the following code. Stateless c
 <Tabs>
     <Tab title="Python">
     ```python
-    # This schedules a job to run at 15:27 (3:27PM) every day
+    # This schedules a job to run at 15:27 (3:27PM) UTC every day
     cron_job_stateless = await client.crons.create(
         assistant_id,
         schedule="27 15 * * *",
@@ -158,7 +162,7 @@ You can also create stateless cron jobs by using the following code. Stateless c
     </Tab>
     <Tab title="Javascript">
     ```js
-    // This schedules a job to run at 15:27 (3:27PM) every day
+    // This schedules a job to run at 15:27 (3:27PM) UTC every day
     const cronJobStateless = await client.crons.create(
       assistantId,
       {


### PR DESCRIPTION
## Overview

Clarifies that all cron job schedules are interpreted in UTC timezone.