### PR TITLE
docs: fix style guide violations in integration docs

### DIFF
--- a/src/oss/javascript/integrations/chat/ollama_functions.mdx
+++ b/src/oss/javascript/integrations/chat/ollama_functions.mdx
@@ -3,7 +3,7 @@ title: Ollama Functions
 ---
 
 <Warning>
-**The LangChain Ollama integration package has official support for tool calling. [Click here to view the documentation](/oss/integrations/chat/ollama#tools).**
+**The LangChain Ollama integration package has official support for tool calling. [View the Ollama tool calling documentation](/oss/integrations/chat/ollama#tools).**
 
 
 </Warning>

--- a/src/oss/python/integrations/callbacks/google_bigquery.mdx
+++ b/src/oss/python/integrations/callbacks/google_bigquery.mdx
@@ -1,3 +1,8 @@
+---
+title: BigQuery Callback Handler
+description: Log events from LangChain to Google BigQuery for monitoring, auditing, and analyzing your LLM applications.
+---
+
 # BigQuery Callback Handler
 
 <div class="language-support-tag">

--- a/src/oss/python/integrations/vectorstores/analyticdb.mdx
+++ b/src/oss/python/integrations/vectorstores/analyticdb.mdx
@@ -11,7 +11,7 @@ You'll need to install `langchain-community` with `pip install -qU langchain-com
 This notebook shows how to use functionality related to the `AnalyticDB` vector database.
 To run, you should have an [AnalyticDB](https://www.alibabacloud.com/help/en/analyticdb-for-postgresql/latest/product-introduction-overview) instance up and running:
 
-- Using [AnalyticDB Cloud Vector Database](https://www.alibabacloud.com/product/hybriddb-postgresql). Click here to fast deploy it.
+- Using [AnalyticDB Cloud Vector Database](https://www.alibabacloud.com/product/hybriddb-postgresql) for fast deployment.
 
 ```python
 from langchain_community.vectorstores import AnalyticDB
@@ -34,7 +34,7 @@ embeddings = OpenAIEmbeddings()
 
 Connect to AnalyticDB by setting related ENVIRONMENTS.
 
-```
+```bash
 export PG_HOST={your_analyticdb_hostname}
 export PG_PORT={your_analyticdb_port} # Optional, default is 5432
 export PG_DATABASE={your_database} # Optional, default is postgres

--- a/src/oss/python/integrations/vectorstores/relyt.mdx
+++ b/src/oss/python/integrations/vectorstores/relyt.mdx
@@ -9,7 +9,7 @@ title: Relyt
 This notebook shows how to use functionality related to the `Relyt` vector database.
 To run, you should have an [Relyt](https://docs.relyt.cn/) instance up and running:
 
-- Using [Relyt Vector Database](https://docs.relyt.cn/docs/vector-engine/use/). Click here to fast deploy it.
+- Using [Relyt Vector Database](https://docs.relyt.cn/docs/vector-engine/use/) for fast deployment.
 
 ```python
 pip install "pgvecto_rs[sdk]" langchain-community
@@ -35,7 +35,7 @@ embeddings = FakeEmbeddings(size=1536)
 
 Connect to Relyt by setting related ENVIRONMENTS.
 
-```
+```bash
 export PG_HOST={your_relyt_hostname}
 export PG_PORT={your_relyt_port} # Optional, default is 5432
 export PG_DATABASE={your_database} # Optional, default is postgres


### PR DESCRIPTION
## Summary

- Fixed "Click here" link text violations in three integration docs to use descriptive link text
- Added missing language tags (`bash`) to code blocks
- Added required frontmatter (title and description) to BigQuery callback handler page

## Changes

### Link text improvements (Google Developer Style Guide compliance)
- `ollama_functions.mdx`: Changed "Click here to view the documentation" → "View the Ollama tool calling documentation"
- `analyticdb.mdx`: Changed "Click here to fast deploy it" → "for fast deployment"
- `relyt.mdx`: Changed "Click here to fast deploy it" → "for fast deployment"

### Code block language tags
- `analyticdb.mdx`: Added `bash` language tag to environment variables code block
- `relyt.mdx`: Added `bash` language tag to environment variables code block

### Frontmatter
- `google_bigquery.mdx`: Added missing title and description frontmatter

## Test plan

- [ ] Verify Mintlify build succeeds
- [ ] Confirm pages render correctly with link text changes
- [ ] Check code blocks have proper syntax highlighting