### PR TITLE
docs: improve link text and add missing alt text in LangSmith docs

### DIFF
--- a/src/langsmith/insights.mdx
+++ b/src/langsmith/insights.mdx
@@ -13,7 +13,7 @@ Insights uses hierarchical categorization to make sense of your data and highlig
 
 ## Prerequisites
 
-- An OpenAI API key (generate one [here](https://platform.openai.com/account/api-keys)) or an Anthropic API key (generate one [here](https://console.anthropic.com/settings/keys))
+- An OpenAI API key (generate one [on the OpenAI platform](https://platform.openai.com/account/api-keys)) or an Anthropic API key (generate one [on the Anthropic console](https://console.anthropic.com/settings/keys))
 - Permissions to create rules in LangSmith (required to generate new Insights Reports)
 - Permissions to view tracing projects LangSmith (required to view existing Insights Reports)
 

--- a/src/langsmith/observability-studio.mdx
+++ b/src/langsmith/observability-studio.mdx
@@ -149,7 +149,7 @@ This guide shows you how to run a full end-to-end experiment directly from Studi
 
 Before running an experiment, ensure you have the following:
 
-- **A LangSmith dataset**: Your dataset should contain the inputs you want to test and optionally, reference outputs for comparison. The schema for the inputs must match the required input schema for the assistant. For more information on schemas, see [here](/oss/langgraph/use-graph-api#schema). For more on creating datasets, refer to [How to Manage Datasets](/langsmith/manage-datasets-in-application#set-up-your-dataset).
+- **A LangSmith dataset**: Your dataset should contain the inputs you want to test and optionally, reference outputs for comparison. The schema for the inputs must match the required input schema for the assistant. For more information on schemas, see the [graph API schema documentation](/oss/langgraph/use-graph-api#schema). For more on creating datasets, refer to [How to Manage Datasets](/langsmith/manage-datasets-in-application#set-up-your-dataset).
 - **(Optional) Evaluators**: You can attach evaluators (e.g., LLM-as-a-Judge, heuristics, or custom functions) to your dataset in LangSmith. These will run automatically after the graph has processed all inputs.
 - **A running application**: The experiment can be run against:
   - An application deployed on [LangSmith](/langsmith/deployments).

--- a/src/langsmith/online-evaluations-code.mdx
+++ b/src/langsmith/online-evaluations-code.mdx
@@ -82,7 +82,7 @@ Code evaluators must be written inline. We recommend testing locally before sett
 
 In the UI, you will see a panel that lets you write your code inline, with some starter code:
 
-![](/langsmith/images/online-eval-custom-code.png)
+![Code evaluator panel in LangSmith showing the inline code editor](/langsmith/images/online-eval-custom-code.png)
 
 Code evaluators take in one argument:
 

--- a/src/langsmith/regions-faq.mdx
+++ b/src/langsmith/regions-faq.mdx
@@ -29,7 +29,7 @@ The terms are the same for the EU and US regions.
 
 #### *How do I use the EU instance?*
 
-Follow the instructions [here](/langsmith/create-account-api-key) to create an account and an API key (make sure to change the region to EU in the dropdown)
+Follow the [account and API key setup guide](/langsmith/create-account-api-key) to create an account and an API key (make sure to change the region to EU in the dropdown)
 
 #### *Are there any functional differences between US and EU cloud-managed LangSmith?*
 


### PR DESCRIPTION
## Summary

- Added descriptive alt text to an image missing alt text
- Replaced generic "here" link text with descriptive link text per Google Developer Style Guide

## Changes

### Alt text
- `online-evaluations-code.mdx`: Added alt text "Code evaluator panel in LangSmith showing the inline code editor"

### Link text improvements
- `insights.mdx`: Changed `[here]` to `[on the OpenAI platform]` and `[on the Anthropic console]`
- `observability-studio.mdx`: Changed `[here]` to `[graph API schema documentation]`
- `regions-faq.mdx`: Changed `[here]` to `[account and API key setup guide]`

## Test plan

- [ ] Verify Mintlify build succeeds
- [ ] Confirm pages render correctly with updated link text
- [ ] Verify image alt text displays properly for accessibility