### PR TITLE
Mention that subagent-created files outlive the subagent in the LangGraph State

### DIFF
--- a/src/oss/deepagents/backends.mdx
+++ b/src/oss/deepagents/backends.mdx
@@ -75,6 +75,9 @@ const agent2 = createDeepAgent({
 - A scratch pad for the agent to write intermediate results.
 - Automatic eviction of large tool outputs which the agent can then read back in piece by piece.
 
+Note that this backend is shared between the supervisor agent and subagents, and any files a subagent writes will remain in the LangGraph agent state
+even after that subagent's execution is complete. Those files will continue to be available to the supervisor agent and other subagents.
+
 ### FilesystemBackend (local disk)
 
 :::python


### PR DESCRIPTION

## Overview
This is an important detail for developers to keep in mind while thinking about subagent context isolation.

## Type of change

**Type:** Update existing documentation

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed