### PR TITLE
fix: short-term-memory doc

### DIFF
--- a/src/oss/langchain/short-term-memory.mdx
+++ b/src/oss/langchain/short-term-memory.mdx
@@ -1134,7 +1134,6 @@ const validateResponse = createMiddleware({
       return {
         messages: [
           new RemoveMessage({ id: REMOVE_ALL_MESSAGES }),
-          ...state.messages,
         ],
       };
     }


### PR DESCRIPTION
messages are added back after REMOVE_ALL_MESSAGES
