### PR TITLE
add missing print statements

### DIFF
--- a/src/oss/langchain/models.mdx
+++ b/src/oss/langchain/models.mdx
@@ -1471,7 +1471,7 @@ tool = {"type": "web_search"}
 model_with_tools = model.bind_tools([tool])
 
 response = model_with_tools.invoke("What was a positive news story from today?")
-response.content_blocks
+print(response.content_blocks)
 ```
 ```python Result expandable
 [
@@ -1663,7 +1663,7 @@ You can track aggregate token counts across models in an application using eithe
         callback = UsageMetadataCallbackHandler()
         result_1 = model_1.invoke("Hello", config={"callbacks": [callback]})
         result_2 = model_2.invoke("Hello", config={"callbacks": [callback]})
-        callback.usage_metadata
+        print(callback.usage_metadata)
         ```
         ```python
         {


### PR DESCRIPTION
## Overview
Updated code examples to include print statements for response content and usage metadata, matching the format of other documentation examples.
While Jupyter notebooks automatically display the last returned object, running these examples as standard Python scripts requires explicit print statements to show the information described in the docs.


## Type of change

**Type:** Update existing documentation

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
