### PR TITLE
Clear the confusion on Command with dynamic and static edges

### DIFF
--- a/src/oss/langgraph/graph-api.mdx
+++ b/src/oss/langgraph/graph-api.mdx
@@ -1058,6 +1058,21 @@ def my_node(state: State) -> Command[Literal["my_other_node"]]:
         return Command(update={"foo": "baz"}, goto="my_other_node")
 ```
 
+Note that @[`Command`] only adds dynamic edges, while static edges will still execute. In other words, @[`Command`] doesn't override static edges.
+
+```python
+def node_a(state: State) -> Command[Literal["my_other_node"]]:
+   if state["foo"] == "bar":
+       return Command(update={"foo": "baz"}, goto="my_other_node")
+
+# Add a static edge from "node_a" to "node_b"
+graph.add_edge("node_a", "node_b")
+
+# Command will NOT prevent "node_a" from going to "node_b"
+```
+
+In the example above, **"node_a"** will go to both **"node_b"** and **"my_other_node"**.
+
 <Note>
 
 When returning @[`Command`] in your node functions, you must add return type annotations with the list of node names the node is routing to, e.g. `Command[Literal["my_other_node"]]`. This is necessary for the graph rendering and tells LangGraph that `my_node` can navigate to `my_other_node`.
@@ -1094,6 +1109,26 @@ graph.addNode("myNode", (state) => {
   }
 });
 ```
+
+Note that @[Command] only adds dynamic edges, while static edges will still execute. In other words, @[Command] doesn't override static edges.
+
+```typescript
+graph.addNode("nodeA", (state) => {
+ if (state.foo === "bar") {
+   return new Command({
+     update: { foo: "baz" },
+     goto: "myOtherNode",
+   });
+ }
+});
+
+// Add a static edge from "nodeA" to "nodeB"
+graph.addEdge("nodeA", "nodeB")
+
+// Command will NOT prevent "nodeA" from going to "nodeB"
+```
+
+In the example above, **"nodeA"** will go to both **"nodeB"** and **"myOtherNode"**.
 
 When using @[`Command`] in your node functions, you must add the `ends` parameter when adding the node to specify which nodes it can route to:
 


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
I added an explanation on Command to the graph-api.mdx in LangGraph docs.
## Type of change
Update existing documentation

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue: [#5829](https://github.com/langchain-ai/langgraph/issues/5829), [#6571](https://github.com/langchain-ai/langgraph/issues/6571)

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
Command does not override static edges. This can be confusing, because otherwise could be expected as well. So I documented Command's behavior to make things clear.
