### PR TITLE
Eval techniques nav changes

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -1141,24 +1141,44 @@
                     {
                       "group": "Evaluation techniques",
                       "pages": [
-                        "langsmith/experiment-configuration",
-                        "langsmith/evaluate-with-retry",
-                        "langsmith/define-target-function",
-                        "langsmith/evaluate-on-intermediate-steps",
-                        "langsmith/multiple-scores",
-                        "langsmith/metric-type",
-                        "langsmith/bind-evaluator-to-dataset",
-                        "langsmith/evaluation-async",
-                        "langsmith/repetition",
-                        "langsmith/rate-limiting",
-                        "langsmith/local",
-                        "langsmith/read-local-experiment-results",
-                        "langsmith/langchain-runnable",
-                        "langsmith/evaluate-graph",
-                        "langsmith/evaluate-existing-experiment",
-                        "langsmith/evaluate-with-attachments",
-                        "langsmith/multi-turn-simulation",
-                        "langsmith/trajectory-evals"
+                        {
+                          "group": "Define evaluation target",
+                          "pages": [
+                            "langsmith/define-target-function",
+                            "langsmith/evaluate-on-intermediate-steps",
+                            "langsmith/langchain-runnable",
+                            "langsmith/evaluate-graph",
+                            "langsmith/multi-turn-simulation",
+                            "langsmith/trajectory-evals"
+                          ]
+                        },
+                        {
+                          "group": "Scoring methods",
+                          "pages": [
+                            "langsmith/multiple-scores",
+                            "langsmith/metric-type"
+                          ]
+                        },
+                        {
+                          "group": "Experiment configuration",
+                          "pages": [
+                            "langsmith/experiment-configuration",
+                            "langsmith/evaluation-async",
+                            "langsmith/repetition",
+                            "langsmith/rate-limiting",
+                            "langsmith/bind-evaluator-to-dataset",
+                            "langsmith/evaluate-existing-experiment",
+                            "langsmith/local",
+                            "langsmith/read-local-experiment-results",
+                            "langsmith/evaluate-with-retry"
+                          ]
+                        },
+                        {
+                          "group": "Multimodal evaluations",
+                          "pages": [
+                            "langsmith/evaluate-with-attachments"
+                          ]
+                        }
                       ]
                     },
                     {


### PR DESCRIPTION
Fixes DOC-611

This PR restructures the long dropdown of pages under Evaluation techniques.

## Preview

https://langchain-5e9cc07a-preview-improv-1769100537-6cffc34.mintlify.app/langsmith/define-target-function