### PR TITLE
fix: correct broken link to dynamically-selecting-tools in context-engineering

### DIFF
--- a/src/oss/langchain/context-engineering.mdx
+++ b/src/oss/langchain/context-engineering.mdx
@@ -941,7 +941,7 @@ Not every tool is appropriate for every situation. Too many tools may overwhelm 
   </Tab>
 </Tabs>
 
-See [Dynamically selecting tools](/oss/langchain/middleware#dynamically-selecting-tools) for more examples.
+See [Dynamically selecting tools](/oss/langchain/middleware/custom#dynamically-selecting-tools) for more examples.
 
 ### Model
 


### PR DESCRIPTION
## Overview
Fix broken link in context-engineering.mdx

## Type of change

**Type:** Fix typo/bug/link/formatting

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
Attached a screen recording demonstrating the fix works correctly.
https://github.com/user-attachments/assets/dcb44132-fa26-467a-ab62-4217f2ed7bf2
