### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.7.4

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -3374,6 +3374,89 @@
                       "contextId": "f5bd2a40-74b6-4f7a-b649-ea3f09890003"
                     }
                   }
+                },
+                "message_stream_with_context": {
+                  "summary": "Stream multi-turn messages using the same contextId",
+                  "description": "Send a streaming message; reuse the same contextId for subsequent turns to keep conversation state.",
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "id": "1",
+                    "method": "message/stream",
+                    "params": {
+                      "message": {
+                        "role": "user",
+                        "contextId": "thread-123",
+                        "parts": [
+                          {
+                            "kind": "text",
+                            "text": "Hello!"
+                          }
+                        ],
+                        "messageId": "msg-1"
+                      }
+                    }
+                  }
+                },
+                "interrupt_resume_text": {
+                  "summary": "Resume an interrupted task with a text reply",
+                  "description": "When a task is in input-required state, send a normal text part with the same contextId and taskId to resume.",
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "id": "2",
+                    "method": "message/send",
+                    "params": {
+                      "message": {
+                        "role": "user",
+                        "contextId": "thread-123",
+                        "parts": [
+                          {
+                            "kind": "text",
+                            "text": "Here is the info you asked for."
+                          }
+                        ],
+                        "messageId": "msg-2",
+                        "taskId": "thread-123:run-456"
+                      }
+                    }
+                  }
+                },
+                "interrupt_resume_data_parallel": {
+                  "summary": "Resume parallel interrupts with a data part",
+                  "description": "Advanced: if your agent supports parallel interrupts, provide a structured resume payload in a data part with the same contextId and taskId.",
+                  "value": {
+                    "jsonrpc": "2.0",
+                    "id": "3",
+                    "method": "message/send",
+                    "params": {
+                      "message": {
+                        "role": "user",
+                        "contextId": "thread-123",
+                        "parts": [
+                          {
+                            "kind": "data",
+                            "data": {
+                              "resume": [
+                                {
+                                  "id": "interrupt-1",
+                                  "value": {
+                                    "choice": "A"
+                                  }
+                                },
+                                {
+                                  "id": "interrupt-2",
+                                  "value": {
+                                    "choice": "B"
+                                  }
+                                }
+                              ]
+                            }
+                          }
+                        ],
+                        "messageId": "msg-3",
+                        "taskId": "thread-123:run-456"
+                      }
+                    }
+                  }
                 }
               }
             }


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.7.4**

This update was automatically generated by the sync workflow in the langgraph-api repository.