### PR TITLE
docs: fix typo in README - remove duplicate 'o' in contribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ make install
 make dev
 ```
 
-For more information on how to o contribute to LangChain documentation, follow the steps outlined in the [contributing guide](https://docs.langchain.com/oss/python/contributing/overview). The contributing guide also explains our documentation types and their writing and quality standards.
+For more information on how to contribute to LangChain documentation, follow the steps outlined in the [contributing guide](https://docs.langchain.com/oss/python/contributing/overview). The contributing guide also explains our documentation types and their writing and quality standards.
 
 For detailed information about setting up your development environment and contributing to documentation, see the [documentation contributing guide](https://docs.langchain.com/oss/python/contributing/documentation).
 


### PR DESCRIPTION
## Overview
Fixed typo in README.md contributing section - removed duplicate 'o' in "how to o contribute"

## Type of change

**Type:** Fix typo

## Related issues/PRs
- GitHub issue: None
- Feature PR: N/A

- GitHub issue:
- Feature PR:



## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x ] I have read the [contributing guidelines](README.md)
- [x ] I have tested my changes locally using `docs dev`
- [x ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x ] I have updated navigation in `src/docs.json` if needed

## Additional notes
This is a minor typo fix in the main README.md file. The change does not affect any documentation content, code examples, or navigation structure - only corrects a spelling error in the contributing instructions.
