### PR TITLE
docs(langsmith): update trace query syntax with missing comparators and fields

### DIFF
--- a/src/langsmith/trace-query-syntax.mdx
+++ b/src/langsmith/trace-query-syntax.mdx
@@ -40,9 +40,21 @@ The filtering grammar is based on common comparators on fields in the run object
 -   `lt` (less than)
 -   `eq` (equal to)
 -   `neq` (not equal to)
--   `has` (check if run contains a tag or metadata json blob)
--   `search` (search for a substring in a string field)
+-   `has` (check if run contains a tag or metadata JSON blob)
+-   `search` (full-text search across inputs, outputs, and error — note: used without a field, e.g., `search("term")`)
+-   `like` (pattern matching with SQL LIKE syntax, e.g., `like(name, "%Chat%")`)
+-   `notlike` (negative pattern matching)
+-   `in` (check if value is in a list, e.g., `in(run_type, ["llm", "chain"])`)
+-   `exists` (check if field has a value, e.g., `exists(end_time, true)`)
 
-Additionally, you can combine multiple comparisons through the `and` operator.
+Additionally, you can combine multiple comparisons through the `and` and `or` operators.
 
-These can be applied on fields of the run object, such as its `id`, `name`, `run_type`, `start_time` / `end_time`, `latency`, `total_tokens`, `error`, `execution_order`, `tags`, and any associated feedback through `feedback_key` and `feedback_score`.
+These can be applied on fields of the run object, including:
+
+-   `id`, `name`, `run_type`, `status`
+-   `start_time`, `end_time`, `latency`
+-   `is_root`, `trace_id`, `parent_run_id`
+-   `tags` (with `has`)
+-   `metadata_key`, `metadata_value` (for filtering by metadata key-value pairs)
+-   `input_key`, `input_value`, `output_key`, `output_value` (for filtering by input/output fields)
+-   `feedback_key`, `feedback_score`, `feedback_value`


### PR DESCRIPTION
## Summary

Updates the trace query syntax documentation to accurately reflect the backend implementation:

- **Add undocumented comparators**: `like`, `notlike`, `in`, `exists`
- **Add `or` operator** (previously only `and` was documented)
- **Clarify `search` syntax**: Used without a field name, e.g., `search("term")` for full-text search
- **Update filterable fields list**:
  - Added: `status`, `metadata_key/value`, `input_key/value`, `output_key/value`, `feedback_value`, `is_root`, `trace_id`, `parent_run_id`
  - Removed non-filterable: `total_tokens`, `execution_order`, `error`

## Test plan

- [x] Verified all comparators and fields via SDK testing against production API
- [x] Confirmed `search` only works without field specification
- [x] Confirmed `total_tokens` and `execution_order` are not filterable

🤖 Generated with [Claude Code](https://claude.ai/code)