### PR TITLE
docs(langsmith): update trace query filtering syntax with missing comparators and removing non-filterable fields

### DIFF
--- a/src/langsmith/trace-query-syntax.mdx
+++ b/src/langsmith/trace-query-syntax.mdx
@@ -40,9 +40,11 @@ The filtering grammar is based on common comparators on fields in the run object
 -   `lt` (less than)
 -   `eq` (equal to)
 -   `neq` (not equal to)
--   `has` (check if run contains a tag or metadata json blob)
--   `search` (search for a substring in a string field)
+-   `has` (check if run contains a tag or metadata JSON blob)
+-   `search` (full-text search across inputs and outputs — used without a field, e.g., `search("term")`)
+-   `like` / `notlike` (pattern matching with SQL LIKE syntax, e.g., `like(name, "%Chat%")`)
+-   `in` (check if value is in a list, e.g., `in(run_type, ["llm", "chain"])`)
 
-Additionally, you can combine multiple comparisons through the `and` operator.
+Additionally, you can combine multiple comparisons through the `and` and `or` operators.
 
-These can be applied on fields of the run object, such as its `id`, `name`, `run_type`, `start_time` / `end_time`, `latency`, `total_tokens`, `error`, `execution_order`, `tags`, and any associated feedback through `feedback_key` and `feedback_score`.
+These can be applied on fields of the run object, such as its `id`, `name`, `run_type`, `start_time` / `end_time`, `latency`, `error` (with `like`/`notlike` only), `tags`, and any associated feedback through `feedback_key` and `feedback_score`.


### PR DESCRIPTION
- Add comparators: like/notlike, in
- Add or operator (was only documenting and)
- Clarify search syntax (used without field name for full-text search)
- Remove non-filterable fields: total_tokens, execution_order
- new comparators added to the list have been tested

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change
**Type:** Update existing documentation

- Slack thread: https://langchain.slack.com/archives/C06UEEE4DSS/p1769031569700749

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x ] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed