### PR TITLE
fix: add missing back tick

### DIFF
--- a/src/langsmith/agent-server-scale.mdx
+++ b/src/langsmith/agent-server-scale.mdx
@@ -64,7 +64,7 @@ If an assistant requires synchronous blocking operations, set [`BG_JOB_ISOLATED_
 
 Minimize redundant checkpointing by setting [`durability`](/oss/langgraph/durable-execution#durability-modes) to the minimum value necessary to ensure your data is durable.
 
-The default durability mode is `"async", meaning checkpoints are written after each step asynchronously. If an assistant needs to persist only the final state of the run, `durability` can be set to `"exit"`, storing only the final state of the run. This can be set when creating the run:
+The default durability mode is `"async"`, meaning checkpoints are written after each step asynchronously. If an assistant needs to persist only the final state of the run, `durability` can be set to `"exit"`, storing only the final state of the run. This can be set when creating the run:
 
 ```python
 from langgraph_sdk import get_client


### PR DESCRIPTION
## Overview
Small fix for formatting on the agent server scaling page.

## Type of change

**Type:** Fix typo

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue: N/A
- Feature PR: N/A

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [X] I have read the [contributing guidelines](README.md)
- [X] I have tested my changes locally using `docs dev`
- [X] All code examples have been tested and work correctly
- [X] I have used **root relative** paths for internal links
- [X] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
