### PR TITLE
Update MCP connection instructions for VS Code

### DIFF
--- a/src/use-these-docs.mdx
+++ b/src/use-these-docs.mdx
@@ -67,7 +67,7 @@ If you're using OpenAI Codex CLI, run this command in your terminal to add the s
 codex mcp add langchain-docs --url https://docs.langchain.com/mcp
 ```
 
-### Connect with Cursor or Antigravity
+### Connect with Cursor
 
 Add the following to your MCP settings configuration file:
 
@@ -90,6 +90,20 @@ Add the following to your MCP settings configuration file:
   "servers": {
     "docs-langchain": {
       "url": "https://docs.langchain.com/mcp"
+    }
+  }
+}
+```
+
+### Connect with Antigravity
+
+Add the following to your MCP settings configuration file:
+
+```json
+{
+  "mcpServers": {
+    "docs-langchain": {
+      "serverUrl": "https://docs.langchain.com/mcp"
     }
   }
 }


### PR DESCRIPTION
## Overview
VS Code uses `servers` instead of `mcpServers` in its MCP settings as described in [their docs][1].

For reference, here's [documentation from Cursor][2] that confirms they use `mcpServers`. I've confirmed that Antigravity also uses `mcpServers` by manually checking the settings as they do not mention it in [their docs][3]. Note that Antigravity also uses `serverUrl` rather than `url` like Cursor and VS Code.

In summary, there should be three configurations:
- **Cursor**: `mcpServers` and `url`
- **VS Code**: `servers` and `url`
- **Antigravity**: `mcpServers` and `serverUrl`

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
None

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
None

[1]: https://code.visualstudio.com/docs/copilot/customization/mcp-servers#_other-options-to-add-an-mcp-server
[2]: https://cursor.com/docs/context/mcp#using-mcpjson
[3]: https://antigravity.google/docs/mcp#connecting-custom-mcp-servers
