### PR TITLE
Enhance before_model example to handle user preferences

### DIFF
--- a/src/oss/langchain/agents.mdx
+++ b/src/oss/langchain/agents.mdx
@@ -963,8 +963,14 @@ class CustomMiddleware(AgentMiddleware):
     state_schema = CustomState
     tools = [tool1, tool2]
 
-    def before_model(self, state: CustomState, runtime) -> dict[str, Any] | None:
-        ...
+    def before_model(self, state: CustomState, runtime: Runtime) -> dict[str, Any] | None:
+        if state["user_preferences"].get("style") == "technical":
+            return {
+                "messages": [
+                    {"role": "system", "content": "Provide detailed technical explanations"},
+                    *state["messages"]
+                ]
+            }
 
 agent = create_agent(
     model,
@@ -974,7 +980,7 @@ agent = create_agent(
 
 # The agent can now track additional state beyond messages
 result = agent.invoke({
-    "messages": [{"role": "user", "content": "I prefer technical explanations"}],
+    "messages": [{"role": "user", "content": "Explain the concept of machine learning"}],
     "user_preferences": {"style": "technical", "verbosity": "detailed"},
 })
 ```


### PR DESCRIPTION
## Overview
It just completed the example for state via middleware: https://docs.langchain.com/oss/python/langchain/agents#defining-state-via-middleware 

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
