### PR TITLE
revert: "Moved ToolCallRequest import" (merge on next langchain release)

### DIFF
--- a/src/oss/langchain/agents.mdx
+++ b/src/oss/langchain/agents.mdx
@@ -522,8 +522,7 @@ In some scenarios, you need to modify the set of tools available to the agent at
     ```python
     from langchain.tools import tool
     from langchain.agents import create_agent
-    from langchain.agents.middleware import AgentMiddleware, ModelRequest
-    from langchain.agents.middleware.types import ToolCallRequest
+    from langchain.agents.middleware import AgentMiddleware, ModelRequest, ToolCallRequest
 
     # A tool that will be added dynamically at runtime
     @tool


### PR DESCRIPTION
Reverts langchain-ai/docs#2358 following https://github.com/langchain-ai/langchain/pull/34894

Merge after `langchain 1.2.7`