### PR TITLE
add exceptions for large tool result eviction

### DIFF
--- a/src/oss/deepagents/harness.mdx
+++ b/src/oss/deepagents/harness.mdx
@@ -46,7 +46,7 @@ The [`FilesystemMiddleware`](/oss/deepagents/middleware) automatically evicts la
 - When exceeded, writes the result using the configured backend
 - Replaces the tool result with a truncated preview and file reference
 - Agent can read the full result from the file system as needed
-- If the CLI /large_tool_results/ produces large results, they are written to `/large_tool_results/`.
+- If the CLI produces large results, they are written to `/large_tool_results/`.
 
 **Exceptions:**
 


### PR DESCRIPTION
This may be more information than needed. I wonder if we even need to mention the exceptions since for most of them this behaviour might be expected?