### PR TITLE
fix(ci): rename workflows

### DIFF
--- a/.github/workflows/_check-links.yml
+++ b/.github/workflows/_check-links.yml
@@ -6,7 +6,7 @@
 # Usage:
 #   jobs:
 #     docs-validation:
-#       uses: ./.github/workflows/check-links.yml
+#       uses: ./.github/workflows/_check-links.yml
 #       with:
 #         python-version: "3.13"
 #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
         python-version:
           - "3.13"
     uses:
-      ./.github/workflows/check-links.yml
+      ./.github/workflows/_check-links.yml
     with:
       python-version: ${{ matrix.python-version }}
   check-generated-files:


### PR DESCRIPTION
to follow the convention that reusable workflows (those with `workflow_call` triggers) have a leading underscore