### PR TITLE
Add warning against using 'config' as an argument name

### DIFF
--- a/src/oss/langchain/tools.mdx
+++ b/src/oss/langchain/tools.mdx
@@ -153,7 +153,7 @@ The following parameter names are reserved and cannot be used as tool arguments.
 To access runtime information, use the @[`ToolRuntime`] parameter instead of naming your own arguments `config` or `runtime`.
 
 <Warning>
-When defining a tool, do not use the argument name `config`.<br><br>
+When defining a tool, do not use the argument name `config`.
 
 LangChain's internal Runnable protocol reserves `config` for passing a @[`RunnableConfig`] object (used for callbacks and tracing). If your tool function includes a parameter named `config`, the orchestration layer will attempt to pass internal configuration into it, which may lead to a TypeError regarding missing positional arguments or unexpected types.
 


### PR DESCRIPTION
"I am adding a warning to the conceptual guides regarding the config reserved keyword. This documentation update provides necessary context for the informative error introduced in PR #34112, helping developers avoid the TypeError described in Issue #34029 before they hit the validation check. My goal is to improve the 'fail-fast' developer experience by making these constraints explicit in the documentation."

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x ] I have read the [contributing guidelines](README.md)
- [ x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
