### PR TITLE
Correct API reference for Chroma vector store

### DIFF
--- a/src/oss/python/integrations/vectorstores/chroma.mdx
+++ b/src/oss/python/integrations/vectorstores/chroma.mdx
@@ -345,7 +345,7 @@ for doc in results:
 
 #### Other search methods
 
-There are a variety of other search methods that are not covered in this notebook, such as MMR search. For a full list of the search abilities available for `AstraDBVectorStore` check out the [API reference](https://python.langchain.com/api_reference/astradb/vectorstores/langchain_astradb.vectorstores.AstraDBVectorStore.html).
+There are a variety of other search methods that are not covered in this notebook, such as MMR search. For a full list of the search abilities available for `Chroma` check out the [API reference](https://python.langchain.com/api_reference/chroma/vectorstores/langchain_chroma.vectorstores.Chroma.html).
 
 ### Query by turning into retriever
 


### PR DESCRIPTION
Updated the API reference link from AstraDBVectorStore to Chroma.

## Overview
Chroma vector store had an incorrect reference to AstraDBVectorStore

## Type of change

**Type:** [Fix typo/link]

## Related issues/PRs

Resolves #2381 



## Checklist

- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
