### PR TITLE
Add sync components to langchain_elasticsearch docs

### DIFF
--- a/reference/python/docs/integrations/langchain_elasticsearch.md
+++ b/reference/python/docs/integrations/langchain_elasticsearch.md
@@ -14,9 +14,9 @@ title: Elasticsearch
 ::: langchain_elasticsearch._async.cache.AsyncElasticsearchCache
 ::: langchain_elasticsearch._async.cache.AsyncElasticsearchEmbeddingsCache
 ::: langchain_elasticsearch._async.chat_history.AsyncElasticsearchChatMessageHistory
-::: langchain_elasticsearch._sync.embeddings.AsyncElasticsearchEmbeddings
-::: langchain_elasticsearch._sync.vectorstores.AsyncElasticsearchStore
-::: langchain_elasticsearch._sync.retrievers.AsyncElasticsearchRetriever
-::: langchain_elasticsearch._sync.cache.AsyncElasticsearchCache
-::: langchain_elasticsearch._sync.cache.AsyncElasticsearchEmbeddingsCache
-::: langchain_elasticsearch._sync.chat_history.AsyncElasticsearchChatMessageHistory
+::: langchain_elasticsearch._sync.embeddings.ElasticsearchEmbeddings
+::: langchain_elasticsearch._sync.vectorstores.ElasticsearchStore
+::: langchain_elasticsearch._sync.retrievers.ElasticsearchRetriever
+::: langchain_elasticsearch._sync.cache.ElasticsearchCache
+::: langchain_elasticsearch._sync.cache.ElasticsearchEmbeddingsCache
+::: langchain_elasticsearch._sync.chat_history.ElasticsearchChatMessageHistory


### PR DESCRIPTION
Previously was reverted due to a typo langchain-ai/docs#2021. The original PR was [this](https://github.com/langchain-ai/docs/pull/1960)
This PR fixes typo and adds sync docs for elasticsearch docs 

Please see screenshot below of local dev run for example of a sync module that was properly rendered
<img width="2382" height="1255" alt="Screenshot 2026-01-27 at 4 08 18 PM" src="https://github.com/user-attachments/assets/e2dcb0fe-03af-4175-9edd-b1176d0e7bec" />
