### PR TITLE
Fix syntax error for mcp docs

### DIFF
--- a/src/oss/langchain/mcp.mdx
+++ b/src/oss/langchain/mcp.mdx
@@ -66,7 +66,7 @@ async def main():
     print(math_response)
     print(weather_response)
 
-if "__main__" == __name__:
+if __name__ == "__main__":
     asyncio.run(main())
 ```
 :::


### PR DESCRIPTION
## Overview
fix syntax error, "await outside async function" for a code snippet in mcp documents

## Type of change

Update existing documentation / Fix typo/bug/link/formatting


## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed


## Additional notes
<!-- Any other information that would be helpful for reviewers -->
