### PR TITLE
Enhance streaming output for agent messages

### DIFF
--- a/src/oss/langchain/agents.mdx
+++ b/src/oss/langchain/agents.mdx
@@ -1044,13 +1044,18 @@ We've seen how the agent can be called with `invoke` to get a final response. If
 
 :::python
 ```python
+from langchain.messages import AIMessage, HumanMessage
+
 for chunk in agent.stream({
     "messages": [{"role": "user", "content": "Search for AI news and summarize the findings"}]
 }, stream_mode="values"):
     # Each chunk contains the full state at that point
     latest_message = chunk["messages"][-1]
     if latest_message.content:
-        print(f"Agent: {latest_message.content}")
+        if isinstance(latest_message, HumanMessage):
+            print(f"User: {latest_message.content}")
+        elif isinstance(latest_message, AIMessage):
+            print(f"Agent: {latest_message.content}")
     elif latest_message.tool_calls:
         print(f"Calling tools: {[tc['name'] for tc in latest_message.tool_calls]}")
 ```


### PR DESCRIPTION
## Overview
Agent streams user messages as well. We need to check whether the message is from a user or an agent.

## Type of change

**Type:** Update existing documentation /bug

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
