### PR TITLE
correct wrong names of params and remove redundant imports for vLLM chat integration docs

### DIFF
--- a/src/oss/python/integrations/chat/vllm.mdx
+++ b/src/oss/python/integrations/chat/vllm.mdx
@@ -49,11 +49,6 @@ Now we can instantiate our model object and generate chat completions:
 
 ```python
 from langchain.messages import HumanMessage, SystemMessage
-from langchain_core.prompts.chat import (
-    ChatPromptTemplate,
-    HumanMessagePromptTemplate,
-    SystemMessagePromptTemplate,
-)
 from langchain_openai import ChatOpenAI
 ```
 
@@ -62,8 +57,8 @@ inference_server_url = "http://localhost:8000/v1"
 
 llm = ChatOpenAI(
     model="mosaicml/mpt-7b",
-    openai_api_key="EMPTY",
-    openai_api_base=inference_server_url,
+    api_key="your api key goes here",
+    base_url=inference_server_url,
     max_tokens=5,
     temperature=0,
 )


### PR DESCRIPTION
## Overview
Correct wrong names of params to ChatOpenAI() and remove redundant imports for vLLM chat integration docs

## Type of change

Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed


## Additional notes
<!-- Any other information that would be helpful for reviewers -->
