### PR TITLE
Add documentation for using LiteLLM with ChatOpenAI

### DIFF
--- a/src/oss/python/integrations/providers/litellm.mdx
+++ b/src/oss/python/integrations/providers/litellm.mdx
@@ -54,7 +54,7 @@ uv add langchain-openai
 ```
 </CodeGroup>
 
-##Export Environment Variable
+## Export Environment Variable
 ```bash
 export LITELLM_API_KEY="your-litellm-api-key"
 export LITELLM_BASE_URL="http://localhost:4000"


### PR DESCRIPTION
**Description:** 
This PR adds documentation describing an undocumented but functional integration pattern for using LiteLLM as a backend for LangChain’s `ChatOpenAI`.

The guide explains how to configure `api_key`, `base_url`, and `extra_body.allowed_openai_params` to ensure compatibility with LiteLLM’s request validation model.

**Why:**  
LiteLLM is frequently used as an OpenAI-compatible proxy, but LangChain does not currently document how to integrate with it safely. This documentation reduces trial-and-error and prevents silent request failures.

**Scope:**  
- Documentation only  
- No code changes  
- No dependency changes  

---

## 🧪 Testing Notes

Tested locally using:
- LiteLLM proxy (local)
- Hosted model configured in LiteLLM
- `ChatOpenAI.invoke()` with parameter allowlisting

A minimal test script can be included separately if needed.
[liteLLM test.py](https://github.com/user-attachments/files/24950446/liteLLM.test.py)

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
