### PR TITLE
docs: add AWS Bedrock Prompt Caching middleware guide

### DIFF
--- a/src/oss/javascript/integrations/middleware/bedrock.mdx
+++ b/src/oss/javascript/integrations/middleware/bedrock.mdx
@@ -1,0 +1,79 @@
+---
+title: AWS Bedrock middleware
+---
+
+Middleware specifically designed for AWS Bedrock models. Learn more about [middleware](/oss/langchain/middleware/overview).
+
+| Middleware | Description |
+|------------|-------------|
+| [Prompt caching](#prompt-caching) | Reduce costs by caching repetitive prompt prefixes |
+
+## Prompt caching
+
+Reduce costs and latency by automatically caching static or repetitive prompt content for supported Bedrock models (like Claude 3.5 Sonnet/Haiku). This middleware automatically identifies the last cacheable message in your history and adds the required `ephemeral` flag.
+
+Prompt caching is useful for the following:
+
+- Applications with long, static system prompts
+- Agents with many tool definitions
+- Long conversations where history is reused
+
+<Info>
+    Learn more about [AWS Bedrock prompt caching](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) strategies and pricing.
+</Info>
+
+```typescript
+import { BedrockChat } from "@langchain/community/chat_models/bedrock";
+import { bedrockPromptCachingMiddleware } from "langchain/agents/middleware/provider/bedrock";
+
+const model = new BedrockChat({
+  model: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+  region: "us-east-1",
+  credentials: {
+    accessKeyId: process.env.BEDROCK_AWS_ACCESS_KEY_ID!,
+    secretAccessKey: process.env.BEDROCK_AWS_SECRET_ACCESS_KEY!,
+  },
+});
+
+const modelWithCaching = bedrockPromptCachingMiddleware({
+  minMessagesToCache: 2,
+})(model);
+<Accordion title="Configuration options">
+
+<ParamField body="enableCaching" type="boolean" default="true"> Whether to enable caching. If false, the middleware passes messages through unchanged. </ParamField>
+
+<ParamField body="minMessagesToCache" type="number" default="2"> Minimum number of messages required in the history before caching is applied. This prevents caching on very short conversations where it might not be cost-effective. </ParamField>
+
+</Accordion>
+
+<Accordion title="Full example">
+
+The middleware automatically detects the last cacheable message (User, System, or AI) in the conversation history and applies the ephemeral cache control block to it.
+
+```typescript
+import { HumanMessage, SystemMessage } from "@langchain/core/messages";
+import { BedrockChat } from "@langchain/community/chat_models/bedrock";
+import { bedrockPromptCachingMiddleware } from "langchain/agents/middleware/provider/bedrock";
+
+// 1. Setup the model
+const model = new BedrockChat({
+  model: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+  region: "us-east-1",
+});
+
+// 2. Add the middleware
+const cachedModel = bedrockPromptCachingMiddleware({
+  minMessagesToCache: 2
+})(model);
+
+const messages = [
+  new SystemMessage("You are a helpful AI assistant with access to a large library of documents."),
+  new HumanMessage("Summarize the following text: ... [Large Text] ..."),
+];
+
+// 3. Invoke
+// The middleware will automatically tag the last message for caching
+const response = await cachedModel.invoke(messages);
+
+console.log(response.content);
+</Accordion>

--- a/src/oss/langchain/middleware/built-in.mdx
+++ b/src/oss/langchain/middleware/built-in.mdx
@@ -2389,17 +2389,20 @@ These middleware are optimized for specific LLM providers. See each provider's d
 <Columns cols={2}>
 
 :::python
-    <Card title="Anthropic" href="/oss/integrations/middleware/anthropic" icon="anthropic" arrow>
+    <Card title="Anthropic" href="/oss/python/integrations/middleware/anthropic" icon="anthropic" arrow>
         Prompt caching, bash tool, text editor, memory, and file search middleware for Claude models.
     </Card>
-    <Card title="OpenAI" href="/oss/integrations/middleware/openai" icon="openai" arrow>
+    <Card title="OpenAI" href="/oss/python/integrations/middleware/openai" icon="openai" arrow>
         Content moderation middleware for OpenAI models.
     </Card>
 :::
 
 :::js
-    <Card title="Anthropic" href="/oss/integrations/middleware/anthropic" icon="anthropic" arrow>
+    <Card title="Anthropic" href="/oss/javascript/integrations/middleware/anthropic" icon="anthropic" arrow>
         Prompt caching, bash tool, text editor, memory, and file search middleware for Claude models.
+    </Card>
+    <Card title="AWS Bedrock" href="/oss/javascript/integrations/middleware/bedrock" icon="aws" arrow>
+        Prompt caching middleware for Bedrock models.
     </Card>
 :::
 </Columns>


### PR DESCRIPTION
## Overview
This PR adds documentation for the new AWS Bedrock Prompt Caching Middleware. It introduces a new integration guide and updates the middleware index to include AWS Bedrock alongside other providers like Anthropic and OpenAI.

## Type of change

**Type:** New documentation page / Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
GitHub issue:

Feature PR: langchain-ai/langchainjs#9838

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)
