### PR TITLE
docs: add missing console log example to BinaryOperatorAggregate

### DIFF
--- a/src/oss/langgraph/pregel.mdx
+++ b/src/oss/langgraph/pregel.mdx
@@ -462,6 +462,10 @@ Below are a few different examples to give you a sense of the Pregel API.
 
     app.invoke({"a": "foo"})
     ```
+
+    ```console
+    { 'c': 'foofoo | foofoofoofoo' }
+    ```
     :::
 
     :::js


### PR DESCRIPTION
## Overview
Add missing console log example to **BinaryOperatorAggregate** ([related docs link](https://docs.langchain.com/oss/python/langgraph/pregel#examples))
### As-Is
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/544e11e3-9d46-434f-a97a-7cffd6c63c03" />

### To-Be
<img width="400" height="400" alt="image" src="https://github.com/user-attachments/assets/1a91e48e-85ae-4ab0-a067-b80b954271a7" />

## Type of change

**Type:**  Update existing documentation

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
