### PR TITLE
Fix link reference for Azure Kubernetes Service

### DIFF
--- a/src/langsmith/kubernetes.mdx
+++ b/src/langsmith/kubernetes.mdx
@@ -21,7 +21,7 @@ LangChain has successfully tested LangSmith on the following Kubernetes distribu
 
 - Google Kubernetes Engine (GKE)
 - Amazon Elastic Kubernetes Service (EKS): For architecture patterns and best practices, refer to [self-hosting on AWS](/langsmith/aws-self-hosted).
-- Azure Kubernetes Service (AKS): For architecture patterns and best practices, refer to [self-hosting on AWS](/langsmith/azure-self-hosted).
+- Azure Kubernetes Service (AKS): For architecture patterns and best practices, refer to [self-hosting on AKS](/langsmith/azure-self-hosted).
 - OpenShift (4.14+)
 - Minikube and Kind (for development purposes)
 


### PR DESCRIPTION
## Overview
There's a typo in the self hosting guide, where a link to Azure self host guide is shown as "Self hosting on AWS"

## Type of change

**Type:** Fix typo

## Related issues/PRs


<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist

- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
