### PR TITLE
Fix calendar agent system prompt to not schdeule events when unavailable

### DIFF
--- a/src/oss/langchain/multi-agent/subagents-personal-assistant.mdx
+++ b/src/oss/langchain/multi-agent/subagents-personal-assistant.mdx
@@ -755,7 +755,7 @@ def get_available_time_slots(
 # Step 2: Create specialized sub-agents
 # ============================================================================
 
-model = init_chat_model("gpt-4.1")  # for example
+model = init_chat_model("gpt-5.4")  # for example
 
 calendar_agent = create_agent(
     model,


### PR DESCRIPTION
## Overview
I was trying out the [complete working example](https://docs.langchain.com/oss/javascript/langchain/multi-agent/subagents-personal-assistant#complete-working-example) of the personal assistant tutorial and with the current system prompt, the calendar scheduling agent would always schedule an event, even if `get_available_time_slots` would not return a matching time slot. For example when I change the code of `get_available_time_slots` to something like this:

```python
@tool
def get_available_time_slots(
    attendees: list[str],
    date: str,  # ISO format: "2024-01-15"
    duration_minutes: int
) -> list[str]:
    """Check calendar availability for given attendees on a specific date."""
    return []
```
Although this is just a tutorial of course, I think the sub agent should be _smart_ enough to not schedule an event if there is no available time slot. This PR corrects the system prompt of the agent so that events are not scheduled, in the case where there is no suitable time slot.

I also changed the model of the complete example from `claude-haiku-4-5-20251001` to `gpt-4.1` since I never got the agent to work with the Anthropic model.

Note that I have tested the python code but could not test the typescript example.


## Type of change

**Type:** Fix bug

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [X] I have read the [contributing guidelines](README.md)
- [X] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
