### PR TITLE
chore: Update env var

### DIFF
--- a/src/langsmith/env-var.mdx
+++ b/src/langsmith/env-var.mdx
@@ -98,16 +98,16 @@ For example, if the server is to be served under `https://example.com/langgraph`
 
 Number of jobs per worker for the Agent Server task queue. Defaults to `10`.
 
-## `LS_OTEL_ENABLED`
+## `LS_APM_OTEL_ENABLED`
 
-To configure configure OpenTelemetry APM tracing for your deployment, set `LS_OTEL_ENABLED` to `true` and `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_ENDPOINT` to the target trace ingestion endpoint. Note that both `LS_OTEL_ENABLED` and one of the other two export endpoints are required to activate OpenTelemetry APM tracing in server versions later than `0.7.17`.
+To configure configure OpenTelemetry APM tracing for your deployment, set `LS_APM_OTEL_ENABLED` to `true` and `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` or `OTEL_EXPORTER_OTLP_ENDPOINT` to the target trace ingestion endpoint. Note that both `LS_APM_OTEL_ENABLED` and one of the other two export endpoints are required to activate OpenTelemetry APM tracing in server versions later than `0.7.17`.
 
 Specify other [`OTEL_*` environment variables](https://opentelemetry.io/docs/collector/configuration/) to configure tracing, logging, and other instrumentation.
 
 ```shell
-# If you set LS_OTEL_ENABLED AND (OTEL_EXPORTER_OTLP_TRACES_ENDPOINT or OTEL_EXPORTER_OTLP_ENDPOINT),
+# If you set LS_APM_OTEL_ENABLED AND (OTEL_EXPORTER_OTLP_TRACES_ENDPOINT or OTEL_EXPORTER_OTLP_ENDPOINT),
 # the server starts with OpenTelemetry instrumentation enabled.
-LS_OTEL_ENABLED=true
+LS_APM_OTEL_ENABLED=true
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=<target trace ingestion endpoint>
 OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net
 OTEL_SERVICE_NAME=MY_LANGSMITH_DEPLOYMENT
@@ -125,7 +125,7 @@ OTEL_PYTHON_EXCLUDED_URLS=/metrics,/ok,/info
 For example, to submit OpenTelemetry traces to [New Relic's US region](https://docs.newrelic.com/docs/opentelemetry/best-practices/opentelemetry-otlp/), set the following:
 
 ```shell
-LS_OTEL_ENABLED=true
+LS_APM_OTEL_ENABLED=true
 OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://otlp.nr-data.net/v1/traces
 OTEL_EXPORTER_OTLP_ENDPOINT=https://otlp.nr-data.net
 OTEL_EXPORTER_OTLP_HEADERS=api-key=<YOUR_INGEST_LICENSE_KEY>


### PR DESCRIPTION
This is not yet released, but we updated the name in the pre-release to create less ambiguity with the langsmith SDK-specific env var.