### PR TITLE
fix: update scale docs with v13 release [INF-1443]

### DIFF
--- a/src/langsmith/self-host-scale.mdx
+++ b/src/langsmith/self-host-scale.mdx
@@ -21,7 +21,7 @@ The table below provides an overview comparing different LangSmith configuration
 | <Tooltip tip="Number of traces being ingested via SDKs or API endpoints">Traces submitted per second</Tooltip> | 10 | 1000 | 10 | 100 | 1000 |
 | **Frontend replicas**<br />(500m CPU, 1Gi per replica) | 1 (default) | 4 | 2 | 2 | 4 |
 | **Platform backend replicas**<br />(1 CPU, 2Gi per replica) | 3 (default) | 20 | 3 (default) | 3 (default) | 20 |
-| **Ingest Queue replicas**<br />(1 CPU, 2Gi per replica) | 3 (default) | 24 | 3 (default) | 6 | 24 |
+| **Ingest queue replicas**<br />(1 CPU, 2Gi per replica) | 3 (default) | 24 | 3 (default) | 6 | 24 |
 | **Backend replicas**<br />(1 CPU, 2Gi per replica) | 2 (default) | 5 | 40 | 16 | 50 |
 | **Redis resources** | 8 Gi (default) | 26 Gi external | 8 Gi (default) | 13Gi external | 26 Gi external |
 | **ClickHouse resources** | 4 CPU<br />16 Gi (default) | 10 CPU<br />32Gi memory | 8 CPU<br />16 Gi per replica | 16 CPU<br />24Gi memory | 14 CPU<br />24 Gi per replica |
@@ -174,11 +174,13 @@ platformBackend:
 #     maxReplicas: 20
 
 ingestQueue:
-  autoscaling:
-    keda:
-      enabled: true
-      minReplicaCount: 8
-      maxReplicaCount: 24
+  deployment:
+    replicas: 24 # OR enable KEDA autoscaling below
+# autoscaling:
+#   keda:
+#     enabled: true
+#     minReplicaCount: 8
+#     maxReplicaCount: 24
 
 backend:
   deployment:
@@ -233,11 +235,13 @@ frontend:
     replicas: 2
 
 ingestQueue:
-  autoscaling:
-    keda:
-      enabled: true
-      minReplicaCount: 2
-      maxReplicaCount: 3
+  deployment:
+    replicas: 3 # OR enable KEDA autoscaling below
+# autoscaling:
+#   keda:
+#     enabled: true
+#     minReplicaCount: 2
+#     maxReplicaCount: 3
 
 backend:
   deployment:
@@ -282,11 +286,13 @@ frontend:
     replicas: 2
 
 ingestQueue:
-  autoscaling:
-    keda:
-      enabled: true
-      minReplicaCount: 3
-      maxReplicaCount: 6
+  deployment:
+    replicas: 6 # OR enable KEDA autoscaling below
+# autoscaling:
+#   keda:
+#     enabled: true
+#     minReplicaCount: 3
+#     maxReplicaCount: 6
 
 backend:
   deployment:
@@ -373,11 +379,13 @@ platformBackend:
 #     maxReplicas: 20
 
 ingestQueue:
-  autoscaling:
-    keda:
-      enabled: true
-      minReplicaCount: 8
-      maxReplicaCount: 24
+  deployment:
+    replicas: 24 # OR enable KEDA autoscaling below
+# autoscaling:
+#   keda:
+#     enabled: true
+#     minReplicaCount: 8
+#     maxReplicaCount: 24
 
 backend:
   deployment:


### PR DESCRIPTION
## Overview
v13 introduced ingest queues which improve performance a lot for ingestion. we can now scale down number of queue pods as well as redis size.

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->

confirmed looks as expected locally:

<img width="1155" height="731" alt="Screenshot 2026-02-03 at 5 14 07 PM" src="https://github.com/user-attachments/assets/72abc2ee-7f8e-496a-a6aa-d8845648d5e1" />

<img width="664" height="650" alt="Screenshot 2026-02-03 at 5 17 42 PM" src="https://github.com/user-attachments/assets/e5454a62-618e-445a-9eb5-ee03f12b9794" />

<img width="698" height="658" alt="Screenshot 2026-02-03 at 5 18 07 PM" src="https://github.com/user-attachments/assets/f0d8f042-cc11-477b-bdad-c1cd9b2c2176" />
