### PR TITLE
docs: replace deprecated initialize_agent in NASA integration example

### DIFF
--- a/src/oss/python/integrations/tools/nasa.mdx
+++ b/src/oss/python/integrations/tools/nasa.mdx
@@ -13,21 +13,21 @@ This notebook shows how to use agents to interact with the NASA toolkit. The too
 ### Initializing the agent
 
 ```python
-pip install -qU langchain-community langgraph langchain-openai
+pip install -qU langchain langchain-community langchain-openai
 ```
 
 ```python
-from langgraph.prebuilt import create_react_agent
+from langchain.agents import create_agent
 from langchain_community.agent_toolkits.nasa.toolkit import NasaToolkit
 from langchain_community.utilities.nasa import NasaAPIWrapper
 from langchain_openai import OpenAI
 
-llm = OpenAI(temperature=0)
+llm = OpenAI(model="gpt-4o-mini", temperature=0)
 nasa = NasaAPIWrapper()
 toolkit = NasaToolkit.from_nasa_api_wrapper(nasa)
 
-agent = create_react_agent(
-    llm,
+agent = create_agent(
+    model=llm,
     tools=toolkit.get_tools(),
 )
 ```
@@ -35,20 +35,18 @@ agent = create_react_agent(
 ### Querying media assets
 
 ```python
-agent.invoke({
-    "messages": [
-        {"role": "user", "content": "Can you find three pictures of the moon published between 2014 and 2020?"}
-    ]
-})
+agent.invoke(
+    "Can you find three pictures of the moon published between 2014 and 2020?"
+)
 ```
 
 ### Querying details about media assets
 
 ```python
-output = agent.invoke({
-    "messages": [
-        {"role": "user", "content": "Where can I find the metadata manifest for NASA asset NHQ_2019_0311?"}
-    ]
-})
+output = agent.invoke(
+    "Where can I find the metadata manifest for NASA asset NHQ_2019_0311?"
+)
+
+print(output)
 ```
 


### PR DESCRIPTION
Fixes #2473 

Replaced deprecated initialize_agent with create_agent
in NASA integration documentation example.

This aligns the docs with the current recommended API.
