### PR TITLE
reorganize OSS products

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -136,14 +136,106 @@
           ]
         },
         {
-          "product": "LangChain + LangGraph",
+          "product": "Deep Agents",
           "icon": "link",
-          "description": "Open source frameworks",
+          "description": "Build agents that can tackle any task",
           "dropdowns": [
             {
               "dropdown": "Python",
               "icon": "python",
               "tabs": [
+                {
+                  "tab": "Deep Agents",
+                  "pages": [
+                    "oss/python/deepagents/overview",
+                    {
+                      "group": "Get started",
+                      "pages": [
+                        "oss/python/deepagents/quickstart",
+                        "oss/python/deepagents/customization"
+                      ]
+                    },
+                    {
+                      "group": "Core capabilities",
+                      "pages": [
+                        "oss/python/deepagents/harness",
+                        "oss/python/deepagents/backends",
+                        "oss/python/deepagents/subagents",
+                        "oss/python/deepagents/human-in-the-loop",
+                        "oss/python/deepagents/long-term-memory",
+                        "oss/python/deepagents/middleware",
+                        "oss/python/deepagents/skills"
+                      ]
+                    },
+                    {
+                      "group": "Command line interface",
+                      "pages": [
+                        "oss/python/deepagents/cli"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tab": "LangGraph",
+                  "pages": [
+                    "oss/python/langgraph/overview",
+                    {
+                      "group": "Get started",
+                      "pages": [
+                        "oss/python/langgraph/install",
+                        "oss/python/langgraph/quickstart",
+                        "oss/python/langgraph/local-server",
+                        "oss/python/langgraph/changelog-py",
+                        "oss/python/langgraph/thinking-in-langgraph",
+                        "oss/python/langgraph/workflows-agents"
+                      ]
+                    },
+                    {
+                      "group": "Capabilities",
+                      "pages": [
+                        "oss/python/langgraph/persistence",
+                        "oss/python/langgraph/durable-execution",
+                        "oss/python/langgraph/streaming",
+                        "oss/python/langgraph/interrupts",
+                        "oss/python/langgraph/use-time-travel",
+                        "oss/python/langgraph/add-memory",
+                        "oss/python/langgraph/use-subgraphs"
+                      ]
+                    },
+                    {
+                      "group": "Production",
+                      "pages": [
+                        "oss/python/langgraph/application-structure",
+                        "oss/python/langgraph/test",
+                        "oss/python/langgraph/studio",
+                        "oss/python/langgraph/ui",
+                        "oss/python/langgraph/deploy",
+                        "oss/python/langgraph/observability"
+                      ]
+                    },
+                    {
+                      "group": "LangGraph APIs",
+                      "pages": [
+                          {
+                            "group": "Graph API",
+                            "pages": [
+                              "oss/python/langgraph/choosing-apis",
+                              "oss/python/langgraph/graph-api",
+                              "oss/python/langgraph/use-graph-api"
+                            ]
+                          },
+                          {
+                          "group": "Functional API",
+                          "pages": [
+                            "oss/python/langgraph/functional-api",
+                            "oss/python/langgraph/use-functional-api"
+                          ]
+                        },
+                          "oss/python/langgraph/pregel"
+                          ]
+                    }
+                  ]
+                },
                 {
                   "tab": "LangChain",
                   "pages": [
@@ -224,98 +316,6 @@
                   ]
                 },
                 {
-                  "tab": "LangGraph",
-                  "pages": [
-                    "oss/python/langgraph/overview",
-                    {
-                      "group": "Get started",
-                      "pages": [
-                        "oss/python/langgraph/install",
-                        "oss/python/langgraph/quickstart",
-                        "oss/python/langgraph/local-server",
-                        "oss/python/langgraph/changelog-py",
-                        "oss/python/langgraph/thinking-in-langgraph",
-                        "oss/python/langgraph/workflows-agents"
-                      ]
-                    },
-                    {
-                      "group": "Capabilities",
-                      "pages": [
-                        "oss/python/langgraph/persistence",
-                        "oss/python/langgraph/durable-execution",
-                        "oss/python/langgraph/streaming",
-                        "oss/python/langgraph/interrupts",
-                        "oss/python/langgraph/use-time-travel",
-                        "oss/python/langgraph/add-memory",
-                        "oss/python/langgraph/use-subgraphs"
-                      ]
-                    },
-                    {
-                      "group": "Production",
-                      "pages": [
-                        "oss/python/langgraph/application-structure",
-                        "oss/python/langgraph/test",
-                        "oss/python/langgraph/studio",
-                        "oss/python/langgraph/ui",
-                        "oss/python/langgraph/deploy",
-                        "oss/python/langgraph/observability"
-                      ]
-                    },
-                    {
-                      "group": "LangGraph APIs",
-                      "pages": [
-                          {
-                            "group": "Graph API",
-                            "pages": [
-                              "oss/python/langgraph/choosing-apis",
-                              "oss/python/langgraph/graph-api",
-                              "oss/python/langgraph/use-graph-api"
-                            ]
-                          },
-                          {
-                          "group": "Functional API",
-                          "pages": [
-                            "oss/python/langgraph/functional-api",
-                            "oss/python/langgraph/use-functional-api"
-                          ]
-                        },
-                          "oss/python/langgraph/pregel"
-                          ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "Deep Agents",
-                  "pages": [
-                    "oss/python/deepagents/overview",
-                    {
-                      "group": "Get started",
-                      "pages": [
-                        "oss/python/deepagents/quickstart",
-                        "oss/python/deepagents/customization"
-                      ]
-                    },
-                    {
-                      "group": "Core capabilities",
-                      "pages": [
-                        "oss/python/deepagents/harness",
-                        "oss/python/deepagents/backends",
-                        "oss/python/deepagents/subagents",
-                        "oss/python/deepagents/human-in-the-loop",
-                        "oss/python/deepagents/long-term-memory",
-                        "oss/python/deepagents/middleware",
-                        "oss/python/deepagents/skills"
-                      ]
-                    },
-                    {
-                      "group": "Command line interface",
-                      "pages": [
-                        "oss/python/deepagents/cli"
-                      ]
-                    }
-                  ]
-                },
-                {
                   "tab": "Integrations",
                   "pages": [
                     "oss/python/integrations/providers/overview",
@@ -360,6 +360,14 @@
                       "icon": "code",
                       "pages": [
                         {
+                          "group": "LangGraph",
+                          "expanded": true,
+                          "pages": [
+                            "oss/python/langgraph/agentic-rag",
+                            "oss/python/langgraph/sql-agent"
+                          ]
+                        },
+                        {
                           "group": "LangChain",
                           "expanded": true,
                           "pages": [
@@ -377,14 +385,6 @@
                             "oss/python/langchain/multi-agent/handoffs-customer-support",
                             "oss/python/langchain/multi-agent/router-knowledge-base",
                             "oss/python/langchain/multi-agent/skills-sql-assistant"
-                          ]
-                        },
-                        {
-                          "group": "LangGraph",
-                          "expanded": true,
-                          "pages": [
-                            "oss/python/langgraph/agentic-rag",
-                            "oss/python/langgraph/sql-agent"
                           ]
                         }
                       ]
@@ -492,6 +492,98 @@
               "icon": "square-js",
               "tabs": [
                 {
+                  "tab": "Deep Agents",
+                  "pages": [
+                    "oss/javascript/deepagents/overview",
+                    {
+                      "group": "Get started",
+                      "pages": [
+                        "oss/javascript/deepagents/quickstart",
+                        "oss/javascript/deepagents/customization"
+                      ]
+                    },
+                    {
+                      "group": "Core capabilities",
+                      "pages": [
+                        "oss/javascript/deepagents/harness",
+                        "oss/javascript/deepagents/backends",
+                        "oss/javascript/deepagents/subagents",
+                        "oss/javascript/deepagents/human-in-the-loop",
+                        "oss/javascript/deepagents/long-term-memory",
+                        "oss/javascript/deepagents/middleware",
+                        "oss/javascript/deepagents/skills"
+                      ]
+                    },
+                    {
+                      "group": "Deep Agents CLI",
+                      "pages": [
+                        "oss/javascript/deepagents/cli"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tab": "LangGraph",
+                  "pages": [
+                    "oss/javascript/langgraph/overview",
+                    {
+                      "group": "Get started",
+                      "pages": [
+                        "oss/javascript/langgraph/install",
+                        "oss/javascript/langgraph/quickstart",
+                        "oss/javascript/langgraph/local-server",
+                        "oss/javascript/langgraph/changelog-js",
+                        "oss/javascript/langgraph/thinking-in-langgraph",
+                        "oss/javascript/langgraph/workflows-agents"
+                      ]
+                    },
+                    {
+                      "group": "Capabilities",
+                      "pages": [
+                        "oss/javascript/langgraph/persistence",
+                        "oss/javascript/langgraph/durable-execution",
+                        "oss/javascript/langgraph/streaming",
+                        "oss/javascript/langgraph/interrupts",
+                        "oss/javascript/langgraph/use-time-travel",
+                        "oss/javascript/langgraph/add-memory",
+                        "oss/javascript/langgraph/use-subgraphs"
+                        ]
+                    },
+                    {
+                      "group": "Production",
+                      "pages": [
+                        "oss/javascript/langgraph/application-structure",
+                        "oss/javascript/langgraph/test",
+                        "oss/javascript/langgraph/studio",
+                        "oss/javascript/langgraph/ui",
+                        "oss/javascript/langgraph/deploy",
+                        "oss/javascript/langgraph/observability"
+                      ]
+                    },
+                    {
+                      "group": "LangGraph APIs",
+                      "pages": [
+                        {
+                          "group": "Graph API",
+                          "pages": [
+                            "oss/javascript/langgraph/choosing-apis",
+                            "oss/javascript/langgraph/graph-api",
+                            "oss/javascript/langgraph/use-graph-api"
+                          ]
+                        },
+                        {
+                          "group": "Functional API",
+                          "pages": [
+                            "oss/javascript/langgraph/functional-api",
+                            "oss/javascript/langgraph/use-functional-api"
+                          ]
+                        },
+                        "oss/javascript/langgraph/pregel"
+                      ]
+                    }
+                  ]
+                },
+                {
                   "tab": "LangChain",
                   "pages": [
                     "oss/javascript/langchain/overview",
@@ -566,98 +658,6 @@
                       "pages": [
                         "oss/javascript/langchain/deploy",
                         "oss/javascript/langchain/observability"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "LangGraph",
-                  "pages": [
-                    "oss/javascript/langgraph/overview",
-                    {
-                      "group": "Get started",
-                      "pages": [
-                        "oss/javascript/langgraph/install",
-                        "oss/javascript/langgraph/quickstart",
-                        "oss/javascript/langgraph/local-server",
-                        "oss/javascript/langgraph/changelog-js",
-                        "oss/javascript/langgraph/thinking-in-langgraph",
-                        "oss/javascript/langgraph/workflows-agents"
-                      ]
-                    },
-                    {
-                      "group": "Capabilities",
-                      "pages": [
-                        "oss/javascript/langgraph/persistence",
-                        "oss/javascript/langgraph/durable-execution",
-                        "oss/javascript/langgraph/streaming",
-                        "oss/javascript/langgraph/interrupts",
-                        "oss/javascript/langgraph/use-time-travel",
-                        "oss/javascript/langgraph/add-memory",
-                        "oss/javascript/langgraph/use-subgraphs"
-                        ]
-                    },
-                    {
-                      "group": "Production",
-                      "pages": [
-                        "oss/javascript/langgraph/application-structure",
-                        "oss/javascript/langgraph/test",
-                        "oss/javascript/langgraph/studio",
-                        "oss/javascript/langgraph/ui",
-                        "oss/javascript/langgraph/deploy",
-                        "oss/javascript/langgraph/observability"
-                      ]
-                    },
-                    {
-                      "group": "LangGraph APIs",
-                      "pages": [
-                        {
-                          "group": "Graph API",
-                          "pages": [
-                            "oss/javascript/langgraph/choosing-apis",
-                            "oss/javascript/langgraph/graph-api",
-                            "oss/javascript/langgraph/use-graph-api"
-                          ]
-                        },
-                        {
-                          "group": "Functional API",
-                          "pages": [
-                            "oss/javascript/langgraph/functional-api",
-                            "oss/javascript/langgraph/use-functional-api"
-                          ]
-                        },
-                        "oss/javascript/langgraph/pregel"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "Deep Agents",
-                  "pages": [
-                    "oss/javascript/deepagents/overview",
-                    {
-                      "group": "Get started",
-                      "pages": [
-                        "oss/javascript/deepagents/quickstart",
-                        "oss/javascript/deepagents/customization"
-                      ]
-                    },
-                    {
-                      "group": "Core capabilities",
-                      "pages": [
-                        "oss/javascript/deepagents/harness",
-                        "oss/javascript/deepagents/backends",
-                        "oss/javascript/deepagents/subagents",
-                        "oss/javascript/deepagents/human-in-the-loop",
-                        "oss/javascript/deepagents/long-term-memory",
-                        "oss/javascript/deepagents/middleware",
-                        "oss/javascript/deepagents/skills"
-                      ]
-                    },
-                    {
-                      "group": "Deep Agents CLI",
-                      "pages": [
-                        "oss/javascript/deepagents/cli"
                       ]
                     }
                   ]
@@ -751,16 +751,6 @@
                       "icon": "code",
                       "pages": [
                         {
-                          "group": "LangChain",
-                          "expanded": true,
-                          "pages": [
-                            "oss/javascript/langchain/knowledge-base",
-                            "oss/javascript/langchain/rag",
-                            "oss/javascript/langchain/sql-agent",
-                            "oss/javascript/langchain/voice-agent"
-                          ]
-                        },
-                        {
                           "group": "Multi-agent",
                           "expanded": true,
                           "pages": [
@@ -775,6 +765,16 @@
                           "expanded": true,
                           "pages": [
                             "oss/javascript/langgraph/agentic-rag"
+                          ]
+                        },
+                        {
+                          "group": "LangChain",
+                          "expanded": true,
+                          "pages": [
+                            "oss/javascript/langchain/knowledge-base",
+                            "oss/javascript/langchain/rag",
+                            "oss/javascript/langchain/sql-agent",
+                            "oss/javascript/langchain/voice-agent"
                           ]
                         }
                       ]

--- a/src/index.mdx
+++ b/src/index.mdx
@@ -17,12 +17,12 @@ mode: "custom"
             <Tab title="Python" icon="python">
                 <CardGroup cols={3}>
                     <Card
-                        title="LangChain (Python)"
-                        href="/oss/python/langchain/overview"
-                        icon="link"
+                        title="Deep Agents (Python)"
+                        href="/oss/python/deepagents/overview"
+                        icon="robot"
                         cta="Learn more"
                     >
-                        Quickly get started building agents, with any model provider of your choice.
+                        Quickly build agents that can tackle any task.
                     </Card>
                     <Card
                         title="LangGraph (Python)"
@@ -33,24 +33,24 @@ mode: "custom"
                         Control every step of your custom agent with low-level orchestration, memory, and human-in-the-loop support.
                     </Card>
                     <Card
-                        title="Deep Agents (Python)"
-                        href="/oss/python/deepagents/overview"
-                        icon="robot"
+                        title="LangChain (Python)"
+                        href="/oss/python/langchain/overview"
+                        icon="link"
                         cta="Learn more"
                     >
-                        Build agents that can tackle complex, multi-step tasks.
+                        Customize the building blocks of your agents.
                     </Card>
                 </CardGroup>
             </Tab>
             <Tab title="TypeScript" icon="js">
                 <CardGroup cols={3}>
                     <Card
-                        title="LangChain (TypeScript)"
-                        href="/oss/javascript/langchain/overview"
-                        icon="link"
+                        title="Deep Agents (TypeScript)"
+                        href="/oss/javascript/deepagents/overview"
+                        icon="robot"
                         cta="Learn more"
                     >
-                        Quickly get started building agents, with any model provider of your choice.
+                        Quickly build agents that can tackle any task.
                     </Card>
                     <Card
                         title="LangGraph (TypeScript)"
@@ -61,12 +61,12 @@ mode: "custom"
                         Control every step of your custom agent with low-level orchestration, memory, and human-in-the-loop support.
                     </Card>
                     <Card
-                        title="Deep Agents (TypeScript)"
-                        href="/oss/javascript/deepagents/overview"
-                        icon="robot"
+                        title="LangChain (TypeScript)"
+                        href="/oss/javascript/langchain/overview"
+                        icon="link"
                         cta="Learn more"
                     >
-                        Build agents that can tackle complex, multi-step tasks.
+                        Customize the building blocks of your agents.
                     </Card>
                 </CardGroup>
             </Tab>

--- a/src/oss/concepts/products.mdx
+++ b/src/oss/concepts/products.mdx
@@ -1,7 +1,7 @@
 ---
 title: Frameworks, runtimes, and harnesses
 sidebarTitle: LangChain vs. LangGraph vs. Deep Agents
-description: Understand the differences between LangChain, LangGraph, and DeepAgents and when to use each one
+description: Understand the differences between LangChain, LangGraph, and Deep Agents and when to use each one
 ---
 
 LangChain maintains several open source packages to help you build agents. Each serves a different purpose in the agent development stack. Understanding the distinctions between [agent frameworks](#agent-frameworks-like-langchain), [agent runtimes](#agent-runtimes-like-langgraph), and [agent harnesses](#agent-harnesses-like-the-deep-agents-sdk) helps you choose the right tool for your needs.

--- a/src/oss/deepagents/overview.mdx
+++ b/src/oss/deepagents/overview.mdx
@@ -4,19 +4,81 @@ sidebarTitle: Overview
 description: Build agents that can plan, use subagents, and leverage file systems for complex tasks
 ---
 
+Deep agents are the easiest way to start building agents and applications powered by LLMs—with builtin capabilities for task planing, file systems for context management, subagent-spawning, and long-term memory.
+You can use deep agents for any tasks, including complex, multi-step tasks.
+
 :::python
-[`deepagents`](https://pypi.org/project/deepagents/) is a standalone library for building agents that can tackle complex, multi-step tasks. Built on LangGraph and inspired by applications like Claude Code, Deep Research, and Manus, deep agents come with planning capabilities, file systems for context management, and the ability to spawn subagents.
+[`deepagents`](https://pypi.org/project/deepagents/) is a standalone library built on top of [LangChain](/oss/langchain/)'s core building blocks for agents and using [LangGraph](/oss/langgraph/)'s tooling for running agents in production.
 :::
 
 :::js
-[`deepagents`](https://www.npmjs.com/package/deepagents) is a standalone library for building agents that can tackle complex, multi-step tasks. Built on LangGraph and inspired by applications like Claude Code, Deep Research, and Manus, deep agents come with planning capabilities, file systems for context management, and the ability to spawn subagents.
+[`deepagents`](https://www.npmjs.com/package/deepagents) is a standalone library built on top of [LangChain](/oss/langchain/)'s core building blocks for agents and using [LangGraph](/oss/langgraph/)'s tooling for running agents in production.
 :::
 
 The `deepagents` library contains:
-- **Deep Agents SDK**: A package for building agents
+- **Deep Agents SDK**: A package for building agents that can handle any task
 - **Deep Agents CLI**: A coding tool built on top of the `deepagents` package
 
-## When to use deep agents
+[LangChain](/oss/langchain/) is the framework that provides the core building blocks for your agents.
+To learn more about the differences between LangChain, LangGraph, and Deep Agents, see [Frameworks, runtimes, and harnesses](/oss/concepts/products).
+
+## <Icon icon="wand-magic-sparkles" /> Create a deep agent
+
+:::python
+```python
+# pip install -qU deepagents
+from deepagents import create_deep_agent
+
+def get_weather(city: str) -> str:
+    """Get weather for a given city."""
+    return f"It's always sunny in {city}!"
+
+agent = create_deep_agent(
+    tools=[get_weather],
+    system_prompt="You are a helpful assistant",
+)
+
+# Run the agent
+agent.invoke(
+    {"messages": [{"role": "user", "content": "what is the weather in sf"}]}
+)
+```
+:::
+
+:::js
+```ts
+import * as z from "zod";
+// npm install deepagents langchain @langchain/core
+import { createDeepAgent } from "deepagents";
+import { tool } from "langchain";
+
+const getWeather = tool(
+  ({ city }) => `It's always sunny in ${city}!`,
+  {
+    name: "get_weather",
+    description: "Get the weather for a given city",
+    schema: z.object({
+      city: z.string(),
+    }),
+  },
+);
+
+const agent = createDeepAgent({
+  tools: [getWeather],
+  system: "You are a helpful assistant",
+});
+
+console.log(
+  await agent.invoke({
+    messages: [{ role: "user", content: "What's the weather in Tokyo?" }],
+  })
+);
+```
+:::
+
+See the [Quickstart](/oss/deepagents/quickstart/) and [Customization guide](/oss/deepagents/customization/) to get started building your own agents and applications with deep agents.
+
+## When to use the Deep Agents SDK vs. the Deep Agents CLI
 
 Use the **Deep Agents SDK** when you want to build agents that can:
 - **Handle complex, multi-step tasks** that require planning and decomposition
@@ -31,8 +93,6 @@ For building simpler agents, consider using LangChain's [`create_agent`](/oss/la
 :::js
 For building simpler agents, consider using LangChain's [`createAgent`](/oss/langchain/agents) or building a custom [LangGraph](/oss/langgraph/overview) workflow.
 :::
-
-## When to use Deep Agents CLI
 
 Use the **Deep Agents CLI** when you want to use an interactive deep agent on the command-line for coding or other tasks:
 
@@ -54,15 +114,6 @@ Use the **Deep Agents CLI** when you want to use an interactive deep agent on th
 <Card title="Long-term memory" icon="database">
     Extend agents with persistent memory across threads using LangGraph's [Memory Store](/oss/langgraph/persistence#memory-store). Agents can save and retrieve information from previous conversations.
 </Card>
-
-## Relationship to the LangChain ecosystem
-
-Deep agents is built on top of:
-- [LangGraph](/oss/langgraph/overview) - Underlying graph execution and state management
-- [LangChain](/oss/langchain/overview) - Tools and model integrations
-- [LangSmith](/langsmith/home) - Observability, evaluation, and deployment
-
-Deep agents applications can be deployed via [LangSmith Deployment](/langsmith/deployments) and monitored with [LangSmith Observability](/langsmith/observability).
 
 ## Get started
 

--- a/src/oss/langchain/overview.mdx
+++ b/src/oss/langchain/overview.mdx
@@ -4,11 +4,24 @@ sidebarTitle: Overview
 description: LangChain is an open source framework with a pre-built agent architecture and integrations for any model or tool — so you can build agents that adapt as fast as the ecosystem evolves
 ---
 
-LangChain is the easiest way to start building agents and applications powered by LLMs. With under 10 lines of code, you can connect to OpenAI, Anthropic, Google, and [more](/oss/integrations/providers/overview). LangChain provides a pre-built agent architecture and model integrations to help you get started quickly and seamlessly incorporate LLMs into your agents and applications.
+LangChain is the easy way to start building completely custom agents and applications powered by LLMs.
+With under 10 lines of code, you can connect to OpenAI, Anthropic, Google, and [more](/oss/integrations/providers/overview).
+LangChain provides a pre-built agent architecture and model integrations to help you get started quickly and seamlessly incorporate LLMs into your agents and applications.
 
-We recommend you use LangChain if you want to quickly build agents and autonomous applications. Use [LangGraph](/oss/langgraph/overview), our low-level agent orchestration framework and runtime, when you have more advanced needs that require a combination of deterministic and agentic workflows, heavy customization, and carefully controlled latency.
+<Tip>
+**LangChain vs. LangGraph vs. Deep Agents**
+
+While LangChain is easy to get started with, we recommend you start with [Deep Agents](/oss/deepagents/overview/) instead.
+Deep agents build on top of LangChain's agents but come with task planing, context management, subagent-spawning, and long-term memory.
+
+If you don't need these capabilities or would like to build your own for your agents and autonomous applications, start with LangChain.
+
+Use [LangGraph](/oss/langgraph/overview), our low-level agent orchestration framework and runtime, when you have more advanced needs that require a combination of deterministic and agentic workflows, heavy customization, and carefully controlled latency.
+</Tip>
 
 LangChain [agents](/oss/langchain/agents) are built on top of LangGraph in order to provide durable execution, streaming, human-in-the-loop, persistence, and more. You do not need to know LangGraph for basic LangChain agent usage.
+
+We recommend you use LangChain if you want to quickly build agents and autonomous applications.
 
 ## <Icon icon="wand-magic-sparkles" /> Create an agent
 


### PR DESCRIPTION
- moving Deep agents first in the tab ordering
- changing how we position deep agents and langchain to put deep agents first as **the** easiest way to build any agent. LangChain is the way to build agents if you wish to build your own custom tools 