### PR TITLE
Add integration guide for Bedrock

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -963,6 +963,7 @@
                           "pages": [
                             "langsmith/trace-openai",
                             "langsmith/trace-anthropic",
+                            "langsmith/trace-bedrock",
                             "langsmith/trace-with-google-gemini",
                             "langsmith/trace-with-mistral"
                           ]

--- a/src/langsmith/integrations.mdx
+++ b/src/langsmith/integrations.mdx
@@ -42,7 +42,8 @@ mode: wide
 
     <Card
     title="Amazon Bedrock"
-    icon="/images/providers/bedrock-icon.png" horizontal />
+    icon="/images/providers/bedrock-icon.png"
+    href="/langsmith/trace-bedrock" horizontal />
 
     <Card
     title="DeepSeek"

--- a/src/langsmith/trace-bedrock.mdx
+++ b/src/langsmith/trace-bedrock.mdx
@@ -1,0 +1,139 @@
+---
+title: Trace Amazon Bedrock applications
+sidebarTitle: Bedrock
+---
+
+This guide shows you how to trace [Amazon Bedrock](https://aws.amazon.com/bedrock) model calls using LangSmith. Amazon Bedrock is a fully managed service that offers a choice of high-performing foundation models from leading AI companies via an API. By integrating LangSmith tracing, you can monitor, debug, and optimize your Bedrock applications with detailed observability into model interactions, latency, token usage, and custom metadata.
+
+LangSmith automatically captures traces when you use [LangChain's Bedrock integrations](/oss/integrations/providers/aws), providing insights into:
+
+- Request and response payloads
+- Token usage and costs
+- Latency and performance metrics
+- Custom tags and metadata for filtering and analysis
+- Multi-step chains and agent workflows
+
+## Installation
+
+<CodeGroup>
+
+```bash pip
+pip install -qU langchain-aws
+```
+
+```bash npm
+npm install @langchain/community @langchain/core @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+
+```bash yarn
+yarn add @langchain/community @langchain/core @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+
+```bash pnpm
+pnpm add @langchain/community @langchain/core @aws-crypto/sha256-js @aws-sdk/credential-provider-node @smithy/protocol-http @smithy/signature-v4 @smithy/eventstream-codec @smithy/util-utf8 @aws-sdk/types
+```
+
+</CodeGroup>
+
+The Python integration requires [`langchain-aws`](https://pypi.org/project/langchain-aws/), which provides the `ChatBedrockConverse` class for interacting with Bedrock models. The JavaScript integration requires [`@langchain/community`](https://www.npmjs.com/package/@langchain/community) for the Bedrock chat model, plus several AWS SDK packages for authentication, request signing, and streaming support.
+
+## Setup
+
+To enable LangSmith tracing, configure your [LangSmith API key](/langsmith/create-account-api-key) and project settings. You'll also need to set up your AWS credentials to authenticate with Bedrock.
+
+### LangSmith configuration
+
+```bash
+export LANGSMITH_API_KEY=<your_langsmith_api_key>
+export LANGSMITH_PROJECT=<your_project_name> # optional, defaults to "default"
+export LANGSMITH_TRACING=true
+```
+
+You can obtain your LangSmith API key from [smith.langchain.com](https://smith.langchain.com) by navigating to **Settings** > **API Keys**. The `LANGSMITH_PROJECT` variable allows you to organize traces into different projects.
+
+### AWS credentials
+
+Configure your AWS credentials to authenticate with Bedrock. You'll need an AWS account with Bedrock access enabled. Follow the [AWS setup instructions](https://docs.aws.amazon.com/bedrock/latest/userguide/setting-up.html) to create your credentials and [enable model access](https://docs.aws.amazon.com/bedrock/latest/userguide/model-access.html):
+
+```bash
+export AWS_ACCESS_KEY_ID=<your_aws_access_key_id>
+export AWS_SECRET_ACCESS_KEY=<your_aws_secret_key>
+export AWS_SESSION_TOKEN=<your_session_token> # only if using temporary credentials
+export AWS_DEFAULT_REGION=<your_bedrock_region> # e.g., us-east-1 or us-west-2
+```
+
+## Configure tracing
+
+Once your environment variables are set, LangSmith will automatically trace all Bedrock model calls made through LangChain. You can enhance traces with custom tags and metadata to make filtering and analysis easier. Tags help you categorize traces (e.g., by environment, feature, or test type), while metadata allows you to attach arbitrary key-value pairs for detailed context.
+
+The following example shows you how to invoke a Bedrock model with tracing enabled and custom metadata attached:
+
+<CodeGroup>
+
+```python Python
+from langchain_aws import ChatBedrockConverse
+
+# Initialize the Bedrock chat model
+model = ChatBedrockConverse(
+    model="us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+)
+
+# Invoke the model with tracing metadata
+response = model.invoke(
+    "Hello! How can I use LangSmith with Bedrock?",
+    config={
+        "tags": ["aws-bedrock", "langsmith", "integration-test"],
+        "metadata": {
+            "env": "dev",
+            "model_provider": "bedrock",
+            "model_id": "claude-sonnet-4.5"
+        }
+    }
+)
+
+print(response)
+```
+
+```typescript TypeScript
+import { ChatBedrockConverse } from "@langchain/community/chat_models/bedrock";
+
+// Initialize the Bedrock Claude model
+const model = new ChatBedrockConverse({
+  model: "us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+  region: process.env.AWS_DEFAULT_REGION || "us-east-1",
+});
+
+// Invoke the model with LangSmith tracing metadata
+const response = await model.invoke(
+  "Hello! How can I use LangSmith with Bedrock?",
+  {
+    tags: ["aws-bedrock", "langsmith", "integration-test"],
+    metadata: {
+      env: "dev",
+      model_provider: "bedrock",
+      model_id: "claude-sonnet-4.5"
+    }
+  }
+);
+
+console.log(response);
+```
+
+</CodeGroup>
+
+## View traces in LangSmith
+
+After running your code, navigate to your LangSmith project at [smith.langchain.com](https://smith.langchain.com) to view the traces. Each trace includes:
+
+- **Request details**: Input messages, model parameters, and configuration
+- **Response details**: Model output, token usage, and response metadata
+- **Performance metrics**: Latency, tokens per second, and cost estimates
+- **Custom metadata**: Tags and metadata you provided in the `config` parameter
+
+You can filter traces by tags (e.g., `aws-bedrock` or `integration-test`), search by metadata fields, or drill into specific traces to debug issues.
+
+## Next steps
+
+- Learn more about [LangSmith features](/langsmith) including evaluation, datasets, and feedback
+- Explore [Bedrock model capabilities](https://docs.aws.amazon.com/bedrock/latest/userguide/models-features.html) like tool calling, streaming, and prompt caching
+- Review [LangChain Bedrock integration documentation](/oss/integrations/chat/bedrock) for advanced features like extended thinking and citations


### PR DESCRIPTION
Fixes DOC-587

Adds integration tracing guide for Amazon Bedrock using the Langchain bedrock integration.

https://langchain-5e9cc07a-preview-bedroc-1770239053-9adaa95.mintlify.app/langsmith/trace-bedrock