### PR TITLE
Adjustment to integration guide titling

### DIFF
--- a/src/langsmith/trace-anthropic.mdx
+++ b/src/langsmith/trace-anthropic.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with Anthropic
+title: Trace Anthropic applications
 sidebarTitle: Anthropic
 ---
 

--- a/src/langsmith/trace-claude-agent-sdk.mdx
+++ b/src/langsmith/trace-claude-agent-sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace Claude Agent SDK
+title: Trace Claude Agent SDK applications
 sidebarTitle: Claude Agent SDK
 ---
 

--- a/src/langsmith/trace-claude-code.mdx
+++ b/src/langsmith/trace-claude-code.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace Claude Code
+title: Trace Claude Code applications
 sidebarTitle: Claude Code
 ---
 

--- a/src/langsmith/trace-deep-agents.mdx
+++ b/src/langsmith/trace-deep-agents.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with Deep Agents
+title: Trace Deep Agents applications
 sidebarTitle: Deep Agents
 ---
 

--- a/src/langsmith/trace-openai.mdx
+++ b/src/langsmith/trace-openai.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with OpenAI
+title: Trace OpenAI applications
 sidebarTitle: OpenAI
 ---
 

--- a/src/langsmith/trace-with-autogen.mdx
+++ b/src/langsmith/trace-with-autogen.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with AutoGen
+title: Trace AutoGen applications
 sidebarTitle: AutoGen
 ---
 

--- a/src/langsmith/trace-with-crewai.mdx
+++ b/src/langsmith/trace-with-crewai.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with CrewAI
+title: Trace CrewAI applications
 sidebarTitle: CrewAI
 ---
 

--- a/src/langsmith/trace-with-google-adk.mdx
+++ b/src/langsmith/trace-with-google-adk.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with Google ADK
+title: Trace Google ADK applications
 sidebarTitle: Google ADK
 ---
 

--- a/src/langsmith/trace-with-google-gemini.mdx
+++ b/src/langsmith/trace-with-google-gemini.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with Google Gemini
+title: Trace Google Gemini applications
 sidebarTitle: Google Gemini
 ---
 

--- a/src/langsmith/trace-with-instructor.mdx
+++ b/src/langsmith/trace-with-instructor.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with Instructor
+title: Trace Instructor applications
 sidebarTitle: Instructor (Python only)
 ---
 

--- a/src/langsmith/trace-with-langchain.mdx
+++ b/src/langsmith/trace-with-langchain.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with LangChain (Python and JS/TS)
+title: Trace LangChain applications (Python and JS/TS)
 sidebarTitle: LangChain
 ---
 

--- a/src/langsmith/trace-with-langgraph.mdx
+++ b/src/langsmith/trace-with-langgraph.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with LangGraph
+title: Trace LangGraph applications
 sidebarTitle: LangGraph
 ---
 

--- a/src/langsmith/trace-with-livekit.mdx
+++ b/src/langsmith/trace-with-livekit.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with LiveKit
+title: Trace LiveKit applications
 sidebarTitle: LiveKit
 ---
 

--- a/src/langsmith/trace-with-mastra.mdx
+++ b/src/langsmith/trace-with-mastra.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with Mastra
+title: Trace Mastra applications
 sidebarTitle: Mastra
 ---
 

--- a/src/langsmith/trace-with-microsoft-agent-framework.mdx
+++ b/src/langsmith/trace-with-microsoft-agent-framework.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with Microsoft Agent Framework
+title: Trace Microsoft Agent Framework applications
 sidebarTitle: Microsoft Agent Framework
 ---
 

--- a/src/langsmith/trace-with-mistral.mdx
+++ b/src/langsmith/trace-with-mistral.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with Mistral
+title: Trace Mistral applications
 sidebarTitle: Mistral
 ---
 

--- a/src/langsmith/trace-with-openai-agents-sdk.mdx
+++ b/src/langsmith/trace-with-openai-agents-sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with OpenAI Agents SDK
+title: Trace OpenAI Agents SDK applications
 sidebarTitle: OpenAI Agents SDK
 ---
 

--- a/src/langsmith/trace-with-pipecat.mdx
+++ b/src/langsmith/trace-with-pipecat.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with Pipecat
+title: Trace Pipecat applications
 sidebarTitle: Pipecat
 ---
 

--- a/src/langsmith/trace-with-pydantic-ai.mdx
+++ b/src/langsmith/trace-with-pydantic-ai.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with PydanticAI
+title: Trace PydanticAI applications
 sidebarTitle: PydanticAI
 ---
 

--- a/src/langsmith/trace-with-semantic-kernel.mdx
+++ b/src/langsmith/trace-with-semantic-kernel.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with Semantic Kernel
+title: Trace Semantic Kernel applications
 sidebarTitle: Semantic Kernel
 ---
 

--- a/src/langsmith/trace-with-vercel-ai-sdk.mdx
+++ b/src/langsmith/trace-with-vercel-ai-sdk.mdx
@@ -1,5 +1,5 @@
 ---
-title: Trace with the Vercel AI SDK (JS/TS only)
+title: Trace Vercel AI SDK applications (JS/TS only)
 sidebarTitle: Vercel AI SDK
 ---
 


### PR DESCRIPTION
Currently, a lot of the integration guide pages have the titles "Trace with x" this is confusing, because it sounds like the tracing is being done with whatever product x is. Adjusting these — there are a few pages that our left in the "Trace with" pattern as it is correct for that tooling.