### PR TITLE
reorder product dropdown

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -2,7 +2,7 @@
   "$schema": "https://mintlify.com/docs.json",
   "theme": "aspen",
   "name": "Docs by LangChain",
-  "description": "Documentation for LangChain, LangGraph, LangSmith, and more.",
+  "description": "Documentation for LangSmith, Agent Builder, and our open source packages.",
   "colors": {
     "primary": "#2F6868",
     "light": "#84C4C0",
@@ -86,6 +86,10 @@
         "header": "Company",
         "items": [
           {
+            "label": "Home",
+            "href": "https://langchain.com/"
+          },
+          {
             "label": "About",
             "href": "https://langchain.com/about"
           },
@@ -133,755 +137,6 @@
           "icon": "house",
           "pages": [
             "index"
-          ]
-        },
-        {
-          "product": "LangChain + LangGraph",
-          "icon": "link",
-          "description": "Open source frameworks",
-          "dropdowns": [
-            {
-              "dropdown": "Python",
-              "icon": "python",
-              "tabs": [
-                {
-                  "tab": "LangChain",
-                  "pages": [
-                    "oss/python/langchain/overview",
-                    {
-                      "group": "Get started",
-                      "pages": [
-                        "oss/python/langchain/install",
-                        "oss/python/langchain/quickstart",
-                        "oss/python/langchain/changelog-py",
-                        "oss/python/langchain/philosophy"
-                      ]
-                    },
-                    {
-                      "group": "Core components",
-                      "pages": [
-                        "oss/python/langchain/agents",
-                        "oss/python/langchain/models",
-                        "oss/python/langchain/messages",
-                        "oss/python/langchain/tools",
-                        "oss/python/langchain/short-term-memory",
-                        {
-                          "group": "Streaming",
-                          "pages": [
-                            "oss/python/langchain/streaming/overview",
-                            "oss/python/langchain/streaming/frontend"
-                          ]
-                        },
-                        "oss/python/langchain/structured-output"
-                      ]
-                    },
-                    {
-                      "group": "Middleware",
-                      "pages": [
-                        "oss/python/langchain/middleware/overview",
-                        "oss/python/langchain/middleware/built-in",
-                        "oss/python/langchain/middleware/custom"
-                      ]
-                    },
-                    {
-                      "group": "Advanced usage",
-                      "pages": [
-                        "oss/python/langchain/guardrails",
-                        "oss/python/langchain/runtime",
-                        "oss/python/langchain/context-engineering",
-                        "oss/python/langchain/mcp",
-                        "oss/python/langchain/human-in-the-loop",
-                        {
-                          "group": "Multi-agent",
-                          "pages": [
-                            "oss/python/langchain/multi-agent/index",
-                            "oss/python/langchain/multi-agent/subagents",
-                            "oss/python/langchain/multi-agent/handoffs",
-                            "oss/python/langchain/multi-agent/skills",
-                            "oss/python/langchain/multi-agent/router",
-                            "oss/python/langchain/multi-agent/custom-workflow"
-                          ]
-                        },
-                        "oss/python/langchain/retrieval",
-                        "oss/python/langchain/long-term-memory"
-                      ]
-                    },
-                    {
-                      "group": "Agent development",
-                      "pages": [
-                            "oss/python/langchain/studio",
-                            "oss/python/langchain/test",
-                            "oss/python/langchain/ui"
-                      ]
-                    },
-                    {
-                      "group": "Deploy with LangSmith",
-                      "pages": [
-                        "oss/python/langchain/deploy",
-                        "oss/python/langchain/observability"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "LangGraph",
-                  "pages": [
-                    "oss/python/langgraph/overview",
-                    {
-                      "group": "Get started",
-                      "pages": [
-                        "oss/python/langgraph/install",
-                        "oss/python/langgraph/quickstart",
-                        "oss/python/langgraph/local-server",
-                        "oss/python/langgraph/changelog-py",
-                        "oss/python/langgraph/thinking-in-langgraph",
-                        "oss/python/langgraph/workflows-agents"
-                      ]
-                    },
-                    {
-                      "group": "Capabilities",
-                      "pages": [
-                        "oss/python/langgraph/persistence",
-                        "oss/python/langgraph/durable-execution",
-                        "oss/python/langgraph/streaming",
-                        "oss/python/langgraph/interrupts",
-                        "oss/python/langgraph/use-time-travel",
-                        "oss/python/langgraph/add-memory",
-                        "oss/python/langgraph/use-subgraphs"
-                      ]
-                    },
-                    {
-                      "group": "Production",
-                      "pages": [
-                        "oss/python/langgraph/application-structure",
-                        "oss/python/langgraph/test",
-                        "oss/python/langgraph/studio",
-                        "oss/python/langgraph/ui",
-                        "oss/python/langgraph/deploy",
-                        "oss/python/langgraph/observability"
-                      ]
-                    },
-                    {
-                      "group": "LangGraph APIs",
-                      "pages": [
-                          {
-                            "group": "Graph API",
-                            "pages": [
-                              "oss/python/langgraph/choosing-apis",
-                              "oss/python/langgraph/graph-api",
-                              "oss/python/langgraph/use-graph-api"
-                            ]
-                          },
-                          {
-                          "group": "Functional API",
-                          "pages": [
-                            "oss/python/langgraph/functional-api",
-                            "oss/python/langgraph/use-functional-api"
-                          ]
-                        },
-                          "oss/python/langgraph/pregel"
-                          ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "Deep Agents",
-                  "pages": [
-                    "oss/python/deepagents/overview",
-                    {
-                      "group": "Get started",
-                      "pages": [
-                        "oss/python/deepagents/quickstart",
-                        "oss/python/deepagents/customization"
-                      ]
-                    },
-                    {
-                      "group": "Core capabilities",
-                      "pages": [
-                        "oss/python/deepagents/harness",
-                        "oss/python/deepagents/backends",
-                        "oss/python/deepagents/subagents",
-                        "oss/python/deepagents/human-in-the-loop",
-                        "oss/python/deepagents/long-term-memory",
-                        "oss/python/deepagents/middleware",
-                        "oss/python/deepagents/skills"
-                      ]
-                    },
-                    {
-                      "group": "Command line interface",
-                      "pages": [
-                        "oss/python/deepagents/cli"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "Integrations",
-                  "pages": [
-                    "oss/python/integrations/providers/overview",
-                    "oss/python/integrations/providers/all_providers",
-                    {
-                      "group": "Popular Providers",
-                      "icon": "user-group",
-                      "pages": [
-                        "oss/python/integrations/providers/openai",
-                        "oss/python/integrations/providers/anthropic",
-                        "oss/python/integrations/providers/google",
-                        "oss/python/integrations/providers/aws",
-                        "oss/python/integrations/providers/huggingface",
-                        "oss/python/integrations/providers/microsoft",
-                        "oss/python/integrations/providers/ollama",
-                        "oss/python/integrations/providers/groq"
-                      ]
-                    },
-                    {
-                      "group": "Integrations by component",
-                      "icon": "plug",
-                      "pages": [
-                        "oss/python/integrations/chat/index",
-                        "oss/python/integrations/tools/index",
-                        "oss/python/integrations/middleware/index",
-                        "oss/python/integrations/retrievers/index",
-                        "oss/python/integrations/splitters/index",
-                        "oss/python/integrations/text_embedding/index",
-                        "oss/python/integrations/vectorstores/index",
-                        "oss/python/integrations/document_loaders/index",
-                        "oss/python/integrations/stores/index"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "Learn",
-                  "pages": [
-                    "oss/python/learn",
-                    {
-                      "group": "Tutorials",
-                      "icon": "code",
-                      "pages": [
-                        {
-                          "group": "LangChain",
-                          "expanded": true,
-                          "pages": [
-                            "oss/python/langchain/knowledge-base",
-                            "oss/python/langchain/rag",
-                            "oss/python/langchain/sql-agent",
-                            "oss/python/langchain/voice-agent"
-                          ]
-                        },
-                        {
-                          "group": "Multi-agent",
-                          "expanded": true,
-                          "pages": [
-                            "oss/python/langchain/multi-agent/subagents-personal-assistant",
-                            "oss/python/langchain/multi-agent/handoffs-customer-support",
-                            "oss/python/langchain/multi-agent/router-knowledge-base",
-                            "oss/python/langchain/multi-agent/skills-sql-assistant"
-                          ]
-                        },
-                        {
-                          "group": "LangGraph",
-                          "expanded": true,
-                          "pages": [
-                            "oss/python/langgraph/agentic-rag",
-                            "oss/python/langgraph/sql-agent"
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "group": "Conceptual overviews",
-                      "icon": "book",
-                      "pages": [
-                        "oss/python/concepts/products",
-                        "oss/python/langchain/component-architecture",
-                        "oss/python/concepts/memory",
-                        "oss/python/concepts/context",
-                        "oss/python/langgraph/graph-api",
-                        "oss/python/langgraph/functional-api"
-                      ]
-                    },
-                    {
-                      "group": "Additional resources",
-                      "icon": "list",
-                      "pages": [
-                        "oss/python/langchain/academy",
-                        "oss/python/langgraph/case-studies",
-                        "oss/python/langchain/get-help"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "Reference",
-                  "pages": [
-                    "oss/python/reference/overview",
-                    {
-                      "group": "Reference",
-                      "pages": [
-                        "oss/python/reference/langchain-python",
-                        "oss/python/reference/langgraph-python",
-                        "oss/python/reference/integrations-python",
-                        "oss/python/reference/deepagents-python"
-                      ]
-                    },
-                    {
-                      "group": "Errors",
-                      "pages": [
-                        "oss/python/common-errors"
-                      ]
-                    },
-                    {
-                      "group": "Releases",
-                      "pages": [
-                        "oss/python/versioning",
-                        "oss/python/releases/changelog",
-                        {
-                          "group": "Releases",
-                          "pages": [
-                            "oss/python/releases/langchain-v1",
-                            "oss/python/releases/langgraph-v1"
-                          ]
-                        },
-                        {
-                          "group": "Migration guides",
-                          "pages": [
-                            "oss/python/migrate/langchain-v1",
-                            "oss/python/migrate/langgraph-v1"
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "group": "Policies",
-                      "pages": [
-                        "oss/python/release-policy",
-                        "oss/python/security-policy"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "Contribute",
-                  "pages": [
-                    "oss/python/contributing/overview",
-                    {
-                      "group": "Contribute",
-                      "icon": "heart-circle-plus",
-                      "pages": [
-                        "oss/python/contributing/documentation",
-                        "oss/python/contributing/code",
-                        {
-                          "group": "Integrations",
-                          "pages": [
-                            "oss/python/contributing/integrations-langchain",
-                            "oss/python/contributing/implement-langchain",
-                            "oss/python/contributing/standard-tests-langchain",
-                            "oss/python/contributing/publish-langchain",
-                            "oss/python/contributing/comarketing"
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            },
-            {
-              "dropdown": "TypeScript",
-              "icon": "square-js",
-              "tabs": [
-                {
-                  "tab": "LangChain",
-                  "pages": [
-                    "oss/javascript/langchain/overview",
-                    {
-                      "group": "Get started",
-                      "pages": [
-                        "oss/javascript/langchain/install",
-                        "oss/javascript/langchain/quickstart",
-                        "oss/javascript/langchain/changelog-js",
-                        "oss/javascript/langchain/philosophy"
-                      ]
-                    },
-                    {
-                      "group": "Core components",
-                      "pages": [
-                        "oss/javascript/langchain/agents",
-                        "oss/javascript/langchain/models",
-                        "oss/javascript/langchain/messages",
-                        "oss/javascript/langchain/tools",
-                        "oss/javascript/langchain/short-term-memory",
-                        {
-                          "group": "Streaming",
-                          "pages": [
-                            "oss/javascript/langchain/streaming/overview",
-                            "oss/javascript/langchain/streaming/frontend"
-                          ]
-                        },
-                        "oss/javascript/langchain/structured-output"
-                      ]
-                    },
-                    {
-                      "group": "Middleware",
-                      "pages": [
-                        "oss/javascript/langchain/middleware/overview",
-                        "oss/javascript/langchain/middleware/built-in",
-                        "oss/javascript/langchain/middleware/custom"
-                      ]
-                    },
-                    {
-                      "group": "Advanced usage",
-                      "pages": [
-                        "oss/javascript/langchain/guardrails",
-                        "oss/javascript/langchain/runtime",
-                        "oss/javascript/langchain/context-engineering",
-                        "oss/javascript/langchain/mcp",
-                        "oss/javascript/langchain/human-in-the-loop",
-                        {
-                          "group": "Multi-agent",
-                          "pages": [
-                            "oss/javascript/langchain/multi-agent/index",
-                            "oss/javascript/langchain/multi-agent/subagents",
-                            "oss/javascript/langchain/multi-agent/handoffs",
-                            "oss/javascript/langchain/multi-agent/skills",
-                            "oss/javascript/langchain/multi-agent/router",
-                            "oss/javascript/langchain/multi-agent/custom-workflow"
-                          ]
-                        },
-                        "oss/javascript/langchain/retrieval",
-                        "oss/javascript/langchain/long-term-memory"
-                      ]
-                    },
-                    {
-                      "group": "Agent development",
-                      "pages": [
-                            "oss/javascript/langchain/studio",
-                            "oss/javascript/langchain/test",
-                            "oss/javascript/langchain/ui"
-                      ]
-                    },
-                    {
-                      "group": "Deploy with LangSmith",
-                      "pages": [
-                        "oss/javascript/langchain/deploy",
-                        "oss/javascript/langchain/observability"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "LangGraph",
-                  "pages": [
-                    "oss/javascript/langgraph/overview",
-                    {
-                      "group": "Get started",
-                      "pages": [
-                        "oss/javascript/langgraph/install",
-                        "oss/javascript/langgraph/quickstart",
-                        "oss/javascript/langgraph/local-server",
-                        "oss/javascript/langgraph/changelog-js",
-                        "oss/javascript/langgraph/thinking-in-langgraph",
-                        "oss/javascript/langgraph/workflows-agents"
-                      ]
-                    },
-                    {
-                      "group": "Capabilities",
-                      "pages": [
-                        "oss/javascript/langgraph/persistence",
-                        "oss/javascript/langgraph/durable-execution",
-                        "oss/javascript/langgraph/streaming",
-                        "oss/javascript/langgraph/interrupts",
-                        "oss/javascript/langgraph/use-time-travel",
-                        "oss/javascript/langgraph/add-memory",
-                        "oss/javascript/langgraph/use-subgraphs"
-                        ]
-                    },
-                    {
-                      "group": "Production",
-                      "pages": [
-                        "oss/javascript/langgraph/application-structure",
-                        "oss/javascript/langgraph/test",
-                        "oss/javascript/langgraph/studio",
-                        "oss/javascript/langgraph/ui",
-                        "oss/javascript/langgraph/deploy",
-                        "oss/javascript/langgraph/observability"
-                      ]
-                    },
-                    {
-                      "group": "LangGraph APIs",
-                      "pages": [
-                        {
-                          "group": "Graph API",
-                          "pages": [
-                            "oss/javascript/langgraph/choosing-apis",
-                            "oss/javascript/langgraph/graph-api",
-                            "oss/javascript/langgraph/use-graph-api"
-                          ]
-                        },
-                        {
-                          "group": "Functional API",
-                          "pages": [
-                            "oss/javascript/langgraph/functional-api",
-                            "oss/javascript/langgraph/use-functional-api"
-                          ]
-                        },
-                        "oss/javascript/langgraph/pregel"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "Deep Agents",
-                  "pages": [
-                    "oss/javascript/deepagents/overview",
-                    {
-                      "group": "Get started",
-                      "pages": [
-                        "oss/javascript/deepagents/quickstart",
-                        "oss/javascript/deepagents/customization"
-                      ]
-                    },
-                    {
-                      "group": "Core capabilities",
-                      "pages": [
-                        "oss/javascript/deepagents/harness",
-                        "oss/javascript/deepagents/backends",
-                        "oss/javascript/deepagents/subagents",
-                        "oss/javascript/deepagents/human-in-the-loop",
-                        "oss/javascript/deepagents/long-term-memory",
-                        "oss/javascript/deepagents/middleware",
-                        "oss/javascript/deepagents/skills"
-                      ]
-                    },
-                    {
-                      "group": "Deep Agents CLI",
-                      "pages": [
-                        "oss/javascript/deepagents/cli"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "Integrations",
-                  "pages": [
-                    "oss/javascript/integrations/providers/overview",
-                    "oss/javascript/integrations/providers/all_providers",
-                    {
-                      "group": "Popular Providers",
-                      "icon": "user-group",
-                      "pages": [
-                        {
-                          "group": "OpenAI",
-                          "pages": [
-                            "oss/javascript/integrations/providers/openai",
-                            "oss/javascript/integrations/chat/openai",
-                            "oss/javascript/integrations/text_embedding/openai",
-                            "oss/javascript/integrations/tools/openai"
-                          ]
-                        },
-                        {
-                          "group": "Anthropic",
-                          "pages": [
-                            "oss/javascript/integrations/providers/anthropic",
-                            "oss/javascript/integrations/chat/anthropic",
-                            "oss/javascript/integrations/tools/anthropic"
-                          ]
-                        },
-                        {
-                          "group": "Google",
-                          "pages": [
-                            "oss/javascript/integrations/providers/google",
-                            "oss/javascript/integrations/chat/google_generative_ai",
-                            "oss/javascript/integrations/text_embedding/google_generativeai"
-                          ]
-                        },
-                        {
-                          "group": "AWS",
-                          "pages": [
-                            "oss/javascript/integrations/providers/aws",
-                            "oss/javascript/integrations/chat/bedrock",
-                            "oss/javascript/integrations/text_embedding/bedrock"
-                          ]
-                        },
-                        {
-                          "group": "Microsoft",
-                          "pages": [
-                            "oss/javascript/integrations/providers/microsoft",
-                            "oss/javascript/integrations/chat/azure",
-                            "oss/javascript/integrations/text_embedding/azure_openai"
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "group": "General integrations",
-                      "icon": "plug",
-                      "pages": [
-                        "oss/javascript/integrations/chat/index",
-                        "oss/javascript/integrations/tools/index",
-                        "oss/javascript/integrations/llms/index",
-                        "oss/javascript/integrations/middleware/index",
-                        "oss/javascript/integrations/stores/index",
-                        "oss/javascript/integrations/document_transformers/index",
-                        "oss/javascript/integrations/llm_caching/index",
-                        "oss/javascript/integrations/callbacks/index"
-                      ]
-                    },
-                    {
-                      "group": "RAG integrations",
-                      "icon": "database",
-                      "pages": [
-                        "oss/javascript/integrations/retrievers/index",
-                        "oss/javascript/integrations/splitters/index",
-                        "oss/javascript/integrations/text_embedding/index",
-                        "oss/javascript/integrations/vectorstores/index",
-                        "oss/javascript/integrations/document_loaders/index",
-                        "oss/javascript/integrations/stores/index"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "Learn",
-                  "pages": [
-                    "oss/javascript/learn",
-                    {
-                      "group": "Tutorials",
-                      "icon": "code",
-                      "pages": [
-                        {
-                          "group": "LangChain",
-                          "expanded": true,
-                          "pages": [
-                            "oss/javascript/langchain/knowledge-base",
-                            "oss/javascript/langchain/rag",
-                            "oss/javascript/langchain/sql-agent",
-                            "oss/javascript/langchain/voice-agent"
-                          ]
-                        },
-                        {
-                          "group": "Multi-agent",
-                          "expanded": true,
-                          "pages": [
-                            "oss/javascript/langchain/multi-agent/subagents-personal-assistant",
-                            "oss/javascript/langchain/multi-agent/handoffs-customer-support",
-                            "oss/javascript/langchain/multi-agent/router-knowledge-base",
-                            "oss/javascript/langchain/multi-agent/skills-sql-assistant"
-                          ]
-                        },
-                        {
-                          "group": "LangGraph",
-                          "expanded": true,
-                          "pages": [
-                            "oss/javascript/langgraph/agentic-rag"
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "group": "Conceptual overviews",
-                      "icon": "book",
-                      "pages": [
-                        "oss/javascript/concepts/products",
-                        "oss/javascript/langchain/component-architecture",
-                        "oss/javascript/concepts/memory",
-                        "oss/javascript/concepts/context",
-                        "oss/javascript/langgraph/graph-api",
-                        "oss/javascript/langgraph/functional-api"
-                      ]
-                    },
-                    {
-                      "group": "LangChain Academy",
-                      "icon": "graduation-cap",
-                      "pages": [
-                        "oss/javascript/langchain/academy"
-                      ]
-                    },
-                    {
-                      "group": "Additional resources",
-                      "icon": "list",
-                      "pages": [
-                        "oss/javascript/langgraph/case-studies",
-                        "oss/javascript/langchain/get-help"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "Reference",
-                  "pages": [
-                    "oss/javascript/reference/overview",
-                    {
-                      "group": "Reference",
-                      "pages": [
-                        "oss/javascript/reference/langchain-javascript",
-                        "oss/javascript/reference/langgraph-javascript",
-                        "oss/javascript/reference/deepagents-javascript"
-                      ]
-                    },
-                    {
-                      "group": "Errors",
-                      "pages": [
-                        "oss/javascript/common-errors"
-                      ]
-                    },
-                    {
-                      "group": "Releases",
-                      "pages": [
-                        "oss/javascript/versioning",
-                        "oss/javascript/releases/changelog",
-                        {
-                          "group": "Releases",
-                          "pages": [
-                            "oss/javascript/releases/langchain-v1",
-                            "oss/javascript/releases/langgraph-v1"
-                          ]
-                        },
-                        {
-                          "group": "Migration guides",
-                          "pages": [
-                            "oss/javascript/migrate/langchain-v1",
-                            "oss/javascript/migrate/langgraph-v1"
-                          ]
-                        }
-                      ]
-                    },
-                    {
-                      "group": "Policies",
-                      "pages": [
-                        "oss/javascript/release-policy",
-                        "oss/javascript/security-policy"
-                      ]
-                    }
-                  ]
-                },
-                {
-                  "tab": "Contribute",
-                  "pages": [
-                    "oss/javascript/contributing/overview",
-                    {
-                      "group": "Contribute",
-                      "icon": "heart-circle-plus",
-                      "pages": [
-                        "oss/javascript/contributing/documentation",
-                        "oss/javascript/contributing/code",
-                        {
-                          "group": "Integrations",
-                          "pages": [
-                            "oss/javascript/contributing/integrations-langchain",
-                            "oss/javascript/contributing/implement-langchain",
-                            "oss/javascript/contributing/standard-tests-langchain",
-                            "oss/javascript/contributing/publish-langchain",
-                            "oss/javascript/contributing/comarketing"
-                          ]
-                        }
-                      ]
-                    }
-                  ]
-                }
-              ]
-            }
           ]
         },
         {
@@ -1642,6 +897,755 @@
               "group": "Additional resources",
               "pages": [
                 "langsmith/agent-builder-pricing-faq"
+              ]
+            }
+          ]
+        },
+        {
+          "product": "Open source",
+          "icon": "box-open",
+          "description": "Deep Agents, LangChain, and LangGraph",
+          "dropdowns": [
+            {
+              "dropdown": "Python",
+              "icon": "python",
+              "tabs": [
+                {
+                  "tab": "LangChain",
+                  "pages": [
+                    "oss/python/langchain/overview",
+                    {
+                      "group": "Get started",
+                      "pages": [
+                        "oss/python/langchain/install",
+                        "oss/python/langchain/quickstart",
+                        "oss/python/langchain/changelog-py",
+                        "oss/python/langchain/philosophy"
+                      ]
+                    },
+                    {
+                      "group": "Core components",
+                      "pages": [
+                        "oss/python/langchain/agents",
+                        "oss/python/langchain/models",
+                        "oss/python/langchain/messages",
+                        "oss/python/langchain/tools",
+                        "oss/python/langchain/short-term-memory",
+                        {
+                          "group": "Streaming",
+                          "pages": [
+                            "oss/python/langchain/streaming/overview",
+                            "oss/python/langchain/streaming/frontend"
+                          ]
+                        },
+                        "oss/python/langchain/structured-output"
+                      ]
+                    },
+                    {
+                      "group": "Middleware",
+                      "pages": [
+                        "oss/python/langchain/middleware/overview",
+                        "oss/python/langchain/middleware/built-in",
+                        "oss/python/langchain/middleware/custom"
+                      ]
+                    },
+                    {
+                      "group": "Advanced usage",
+                      "pages": [
+                        "oss/python/langchain/guardrails",
+                        "oss/python/langchain/runtime",
+                        "oss/python/langchain/context-engineering",
+                        "oss/python/langchain/mcp",
+                        "oss/python/langchain/human-in-the-loop",
+                        {
+                          "group": "Multi-agent",
+                          "pages": [
+                            "oss/python/langchain/multi-agent/index",
+                            "oss/python/langchain/multi-agent/subagents",
+                            "oss/python/langchain/multi-agent/handoffs",
+                            "oss/python/langchain/multi-agent/skills",
+                            "oss/python/langchain/multi-agent/router",
+                            "oss/python/langchain/multi-agent/custom-workflow"
+                          ]
+                        },
+                        "oss/python/langchain/retrieval",
+                        "oss/python/langchain/long-term-memory"
+                      ]
+                    },
+                    {
+                      "group": "Agent development",
+                      "pages": [
+                            "oss/python/langchain/studio",
+                            "oss/python/langchain/test",
+                            "oss/python/langchain/ui"
+                      ]
+                    },
+                    {
+                      "group": "Deploy with LangSmith",
+                      "pages": [
+                        "oss/python/langchain/deploy",
+                        "oss/python/langchain/observability"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tab": "LangGraph",
+                  "pages": [
+                    "oss/python/langgraph/overview",
+                    {
+                      "group": "Get started",
+                      "pages": [
+                        "oss/python/langgraph/install",
+                        "oss/python/langgraph/quickstart",
+                        "oss/python/langgraph/local-server",
+                        "oss/python/langgraph/changelog-py",
+                        "oss/python/langgraph/thinking-in-langgraph",
+                        "oss/python/langgraph/workflows-agents"
+                      ]
+                    },
+                    {
+                      "group": "Capabilities",
+                      "pages": [
+                        "oss/python/langgraph/persistence",
+                        "oss/python/langgraph/durable-execution",
+                        "oss/python/langgraph/streaming",
+                        "oss/python/langgraph/interrupts",
+                        "oss/python/langgraph/use-time-travel",
+                        "oss/python/langgraph/add-memory",
+                        "oss/python/langgraph/use-subgraphs"
+                      ]
+                    },
+                    {
+                      "group": "Production",
+                      "pages": [
+                        "oss/python/langgraph/application-structure",
+                        "oss/python/langgraph/test",
+                        "oss/python/langgraph/studio",
+                        "oss/python/langgraph/ui",
+                        "oss/python/langgraph/deploy",
+                        "oss/python/langgraph/observability"
+                      ]
+                    },
+                    {
+                      "group": "LangGraph APIs",
+                      "pages": [
+                          {
+                            "group": "Graph API",
+                            "pages": [
+                              "oss/python/langgraph/choosing-apis",
+                              "oss/python/langgraph/graph-api",
+                              "oss/python/langgraph/use-graph-api"
+                            ]
+                          },
+                          {
+                          "group": "Functional API",
+                          "pages": [
+                            "oss/python/langgraph/functional-api",
+                            "oss/python/langgraph/use-functional-api"
+                          ]
+                        },
+                          "oss/python/langgraph/pregel"
+                          ]
+                    }
+                  ]
+                },
+                {
+                  "tab": "Deep Agents",
+                  "pages": [
+                    "oss/python/deepagents/overview",
+                    {
+                      "group": "Get started",
+                      "pages": [
+                        "oss/python/deepagents/quickstart",
+                        "oss/python/deepagents/customization"
+                      ]
+                    },
+                    {
+                      "group": "Core capabilities",
+                      "pages": [
+                        "oss/python/deepagents/harness",
+                        "oss/python/deepagents/backends",
+                        "oss/python/deepagents/subagents",
+                        "oss/python/deepagents/human-in-the-loop",
+                        "oss/python/deepagents/long-term-memory",
+                        "oss/python/deepagents/middleware",
+                        "oss/python/deepagents/skills"
+                      ]
+                    },
+                    {
+                      "group": "Command line interface",
+                      "pages": [
+                        "oss/python/deepagents/cli"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tab": "Integrations",
+                  "pages": [
+                    "oss/python/integrations/providers/overview",
+                    "oss/python/integrations/providers/all_providers",
+                    {
+                      "group": "Popular Providers",
+                      "icon": "user-group",
+                      "pages": [
+                        "oss/python/integrations/providers/openai",
+                        "oss/python/integrations/providers/anthropic",
+                        "oss/python/integrations/providers/google",
+                        "oss/python/integrations/providers/aws",
+                        "oss/python/integrations/providers/huggingface",
+                        "oss/python/integrations/providers/microsoft",
+                        "oss/python/integrations/providers/ollama",
+                        "oss/python/integrations/providers/groq"
+                      ]
+                    },
+                    {
+                      "group": "Integrations by component",
+                      "icon": "plug",
+                      "pages": [
+                        "oss/python/integrations/chat/index",
+                        "oss/python/integrations/tools/index",
+                        "oss/python/integrations/middleware/index",
+                        "oss/python/integrations/retrievers/index",
+                        "oss/python/integrations/splitters/index",
+                        "oss/python/integrations/text_embedding/index",
+                        "oss/python/integrations/vectorstores/index",
+                        "oss/python/integrations/document_loaders/index",
+                        "oss/python/integrations/stores/index"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tab": "Learn",
+                  "pages": [
+                    "oss/python/learn",
+                    {
+                      "group": "Tutorials",
+                      "icon": "code",
+                      "pages": [
+                        {
+                          "group": "LangChain",
+                          "expanded": true,
+                          "pages": [
+                            "oss/python/langchain/knowledge-base",
+                            "oss/python/langchain/rag",
+                            "oss/python/langchain/sql-agent",
+                            "oss/python/langchain/voice-agent"
+                          ]
+                        },
+                        {
+                          "group": "Multi-agent",
+                          "expanded": true,
+                          "pages": [
+                            "oss/python/langchain/multi-agent/subagents-personal-assistant",
+                            "oss/python/langchain/multi-agent/handoffs-customer-support",
+                            "oss/python/langchain/multi-agent/router-knowledge-base",
+                            "oss/python/langchain/multi-agent/skills-sql-assistant"
+                          ]
+                        },
+                        {
+                          "group": "LangGraph",
+                          "expanded": true,
+                          "pages": [
+                            "oss/python/langgraph/agentic-rag",
+                            "oss/python/langgraph/sql-agent"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "group": "Conceptual overviews",
+                      "icon": "book",
+                      "pages": [
+                        "oss/python/concepts/products",
+                        "oss/python/langchain/component-architecture",
+                        "oss/python/concepts/memory",
+                        "oss/python/concepts/context",
+                        "oss/python/langgraph/graph-api",
+                        "oss/python/langgraph/functional-api"
+                      ]
+                    },
+                    {
+                      "group": "Additional resources",
+                      "icon": "list",
+                      "pages": [
+                        "oss/python/langchain/academy",
+                        "oss/python/langgraph/case-studies",
+                        "oss/python/langchain/get-help"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tab": "Reference",
+                  "pages": [
+                    "oss/python/reference/overview",
+                    {
+                      "group": "Reference",
+                      "pages": [
+                        "oss/python/reference/langchain-python",
+                        "oss/python/reference/langgraph-python",
+                        "oss/python/reference/integrations-python",
+                        "oss/python/reference/deepagents-python"
+                      ]
+                    },
+                    {
+                      "group": "Errors",
+                      "pages": [
+                        "oss/python/common-errors"
+                      ]
+                    },
+                    {
+                      "group": "Releases",
+                      "pages": [
+                        "oss/python/versioning",
+                        "oss/python/releases/changelog",
+                        {
+                          "group": "Releases",
+                          "pages": [
+                            "oss/python/releases/langchain-v1",
+                            "oss/python/releases/langgraph-v1"
+                          ]
+                        },
+                        {
+                          "group": "Migration guides",
+                          "pages": [
+                            "oss/python/migrate/langchain-v1",
+                            "oss/python/migrate/langgraph-v1"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "group": "Policies",
+                      "pages": [
+                        "oss/python/release-policy",
+                        "oss/python/security-policy"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tab": "Contribute",
+                  "pages": [
+                    "oss/python/contributing/overview",
+                    {
+                      "group": "Contribute",
+                      "icon": "heart-circle-plus",
+                      "pages": [
+                        "oss/python/contributing/documentation",
+                        "oss/python/contributing/code",
+                        {
+                          "group": "Integrations",
+                          "pages": [
+                            "oss/python/contributing/integrations-langchain",
+                            "oss/python/contributing/implement-langchain",
+                            "oss/python/contributing/standard-tests-langchain",
+                            "oss/python/contributing/publish-langchain",
+                            "oss/python/contributing/comarketing"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "dropdown": "TypeScript",
+              "icon": "square-js",
+              "tabs": [
+                {
+                  "tab": "LangChain",
+                  "pages": [
+                    "oss/javascript/langchain/overview",
+                    {
+                      "group": "Get started",
+                      "pages": [
+                        "oss/javascript/langchain/install",
+                        "oss/javascript/langchain/quickstart",
+                        "oss/javascript/langchain/changelog-js",
+                        "oss/javascript/langchain/philosophy"
+                      ]
+                    },
+                    {
+                      "group": "Core components",
+                      "pages": [
+                        "oss/javascript/langchain/agents",
+                        "oss/javascript/langchain/models",
+                        "oss/javascript/langchain/messages",
+                        "oss/javascript/langchain/tools",
+                        "oss/javascript/langchain/short-term-memory",
+                        {
+                          "group": "Streaming",
+                          "pages": [
+                            "oss/javascript/langchain/streaming/overview",
+                            "oss/javascript/langchain/streaming/frontend"
+                          ]
+                        },
+                        "oss/javascript/langchain/structured-output"
+                      ]
+                    },
+                    {
+                      "group": "Middleware",
+                      "pages": [
+                        "oss/javascript/langchain/middleware/overview",
+                        "oss/javascript/langchain/middleware/built-in",
+                        "oss/javascript/langchain/middleware/custom"
+                      ]
+                    },
+                    {
+                      "group": "Advanced usage",
+                      "pages": [
+                        "oss/javascript/langchain/guardrails",
+                        "oss/javascript/langchain/runtime",
+                        "oss/javascript/langchain/context-engineering",
+                        "oss/javascript/langchain/mcp",
+                        "oss/javascript/langchain/human-in-the-loop",
+                        {
+                          "group": "Multi-agent",
+                          "pages": [
+                            "oss/javascript/langchain/multi-agent/index",
+                            "oss/javascript/langchain/multi-agent/subagents",
+                            "oss/javascript/langchain/multi-agent/handoffs",
+                            "oss/javascript/langchain/multi-agent/skills",
+                            "oss/javascript/langchain/multi-agent/router",
+                            "oss/javascript/langchain/multi-agent/custom-workflow"
+                          ]
+                        },
+                        "oss/javascript/langchain/retrieval",
+                        "oss/javascript/langchain/long-term-memory"
+                      ]
+                    },
+                    {
+                      "group": "Agent development",
+                      "pages": [
+                            "oss/javascript/langchain/studio",
+                            "oss/javascript/langchain/test",
+                            "oss/javascript/langchain/ui"
+                      ]
+                    },
+                    {
+                      "group": "Deploy with LangSmith",
+                      "pages": [
+                        "oss/javascript/langchain/deploy",
+                        "oss/javascript/langchain/observability"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tab": "LangGraph",
+                  "pages": [
+                    "oss/javascript/langgraph/overview",
+                    {
+                      "group": "Get started",
+                      "pages": [
+                        "oss/javascript/langgraph/install",
+                        "oss/javascript/langgraph/quickstart",
+                        "oss/javascript/langgraph/local-server",
+                        "oss/javascript/langgraph/changelog-js",
+                        "oss/javascript/langgraph/thinking-in-langgraph",
+                        "oss/javascript/langgraph/workflows-agents"
+                      ]
+                    },
+                    {
+                      "group": "Capabilities",
+                      "pages": [
+                        "oss/javascript/langgraph/persistence",
+                        "oss/javascript/langgraph/durable-execution",
+                        "oss/javascript/langgraph/streaming",
+                        "oss/javascript/langgraph/interrupts",
+                        "oss/javascript/langgraph/use-time-travel",
+                        "oss/javascript/langgraph/add-memory",
+                        "oss/javascript/langgraph/use-subgraphs"
+                        ]
+                    },
+                    {
+                      "group": "Production",
+                      "pages": [
+                        "oss/javascript/langgraph/application-structure",
+                        "oss/javascript/langgraph/test",
+                        "oss/javascript/langgraph/studio",
+                        "oss/javascript/langgraph/ui",
+                        "oss/javascript/langgraph/deploy",
+                        "oss/javascript/langgraph/observability"
+                      ]
+                    },
+                    {
+                      "group": "LangGraph APIs",
+                      "pages": [
+                        {
+                          "group": "Graph API",
+                          "pages": [
+                            "oss/javascript/langgraph/choosing-apis",
+                            "oss/javascript/langgraph/graph-api",
+                            "oss/javascript/langgraph/use-graph-api"
+                          ]
+                        },
+                        {
+                          "group": "Functional API",
+                          "pages": [
+                            "oss/javascript/langgraph/functional-api",
+                            "oss/javascript/langgraph/use-functional-api"
+                          ]
+                        },
+                        "oss/javascript/langgraph/pregel"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tab": "Deep Agents",
+                  "pages": [
+                    "oss/javascript/deepagents/overview",
+                    {
+                      "group": "Get started",
+                      "pages": [
+                        "oss/javascript/deepagents/quickstart",
+                        "oss/javascript/deepagents/customization"
+                      ]
+                    },
+                    {
+                      "group": "Core capabilities",
+                      "pages": [
+                        "oss/javascript/deepagents/harness",
+                        "oss/javascript/deepagents/backends",
+                        "oss/javascript/deepagents/subagents",
+                        "oss/javascript/deepagents/human-in-the-loop",
+                        "oss/javascript/deepagents/long-term-memory",
+                        "oss/javascript/deepagents/middleware",
+                        "oss/javascript/deepagents/skills"
+                      ]
+                    },
+                    {
+                      "group": "Deep Agents CLI",
+                      "pages": [
+                        "oss/javascript/deepagents/cli"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tab": "Integrations",
+                  "pages": [
+                    "oss/javascript/integrations/providers/overview",
+                    "oss/javascript/integrations/providers/all_providers",
+                    {
+                      "group": "Popular Providers",
+                      "icon": "user-group",
+                      "pages": [
+                        {
+                          "group": "OpenAI",
+                          "pages": [
+                            "oss/javascript/integrations/providers/openai",
+                            "oss/javascript/integrations/chat/openai",
+                            "oss/javascript/integrations/text_embedding/openai",
+                            "oss/javascript/integrations/tools/openai"
+                          ]
+                        },
+                        {
+                          "group": "Anthropic",
+                          "pages": [
+                            "oss/javascript/integrations/providers/anthropic",
+                            "oss/javascript/integrations/chat/anthropic",
+                            "oss/javascript/integrations/tools/anthropic"
+                          ]
+                        },
+                        {
+                          "group": "Google",
+                          "pages": [
+                            "oss/javascript/integrations/providers/google",
+                            "oss/javascript/integrations/chat/google_generative_ai",
+                            "oss/javascript/integrations/text_embedding/google_generativeai"
+                          ]
+                        },
+                        {
+                          "group": "AWS",
+                          "pages": [
+                            "oss/javascript/integrations/providers/aws",
+                            "oss/javascript/integrations/chat/bedrock",
+                            "oss/javascript/integrations/text_embedding/bedrock"
+                          ]
+                        },
+                        {
+                          "group": "Microsoft",
+                          "pages": [
+                            "oss/javascript/integrations/providers/microsoft",
+                            "oss/javascript/integrations/chat/azure",
+                            "oss/javascript/integrations/text_embedding/azure_openai"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "group": "General integrations",
+                      "icon": "plug",
+                      "pages": [
+                        "oss/javascript/integrations/chat/index",
+                        "oss/javascript/integrations/tools/index",
+                        "oss/javascript/integrations/llms/index",
+                        "oss/javascript/integrations/middleware/index",
+                        "oss/javascript/integrations/stores/index",
+                        "oss/javascript/integrations/document_transformers/index",
+                        "oss/javascript/integrations/llm_caching/index",
+                        "oss/javascript/integrations/callbacks/index"
+                      ]
+                    },
+                    {
+                      "group": "RAG integrations",
+                      "icon": "database",
+                      "pages": [
+                        "oss/javascript/integrations/retrievers/index",
+                        "oss/javascript/integrations/splitters/index",
+                        "oss/javascript/integrations/text_embedding/index",
+                        "oss/javascript/integrations/vectorstores/index",
+                        "oss/javascript/integrations/document_loaders/index",
+                        "oss/javascript/integrations/stores/index"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tab": "Learn",
+                  "pages": [
+                    "oss/javascript/learn",
+                    {
+                      "group": "Tutorials",
+                      "icon": "code",
+                      "pages": [
+                        {
+                          "group": "LangChain",
+                          "expanded": true,
+                          "pages": [
+                            "oss/javascript/langchain/knowledge-base",
+                            "oss/javascript/langchain/rag",
+                            "oss/javascript/langchain/sql-agent",
+                            "oss/javascript/langchain/voice-agent"
+                          ]
+                        },
+                        {
+                          "group": "Multi-agent",
+                          "expanded": true,
+                          "pages": [
+                            "oss/javascript/langchain/multi-agent/subagents-personal-assistant",
+                            "oss/javascript/langchain/multi-agent/handoffs-customer-support",
+                            "oss/javascript/langchain/multi-agent/router-knowledge-base",
+                            "oss/javascript/langchain/multi-agent/skills-sql-assistant"
+                          ]
+                        },
+                        {
+                          "group": "LangGraph",
+                          "expanded": true,
+                          "pages": [
+                            "oss/javascript/langgraph/agentic-rag"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "group": "Conceptual overviews",
+                      "icon": "book",
+                      "pages": [
+                        "oss/javascript/concepts/products",
+                        "oss/javascript/langchain/component-architecture",
+                        "oss/javascript/concepts/memory",
+                        "oss/javascript/concepts/context",
+                        "oss/javascript/langgraph/graph-api",
+                        "oss/javascript/langgraph/functional-api"
+                      ]
+                    },
+                    {
+                      "group": "LangChain Academy",
+                      "icon": "graduation-cap",
+                      "pages": [
+                        "oss/javascript/langchain/academy"
+                      ]
+                    },
+                    {
+                      "group": "Additional resources",
+                      "icon": "list",
+                      "pages": [
+                        "oss/javascript/langgraph/case-studies",
+                        "oss/javascript/langchain/get-help"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tab": "Reference",
+                  "pages": [
+                    "oss/javascript/reference/overview",
+                    {
+                      "group": "Reference",
+                      "pages": [
+                        "oss/javascript/reference/langchain-javascript",
+                        "oss/javascript/reference/langgraph-javascript",
+                        "oss/javascript/reference/deepagents-javascript"
+                      ]
+                    },
+                    {
+                      "group": "Errors",
+                      "pages": [
+                        "oss/javascript/common-errors"
+                      ]
+                    },
+                    {
+                      "group": "Releases",
+                      "pages": [
+                        "oss/javascript/versioning",
+                        "oss/javascript/releases/changelog",
+                        {
+                          "group": "Releases",
+                          "pages": [
+                            "oss/javascript/releases/langchain-v1",
+                            "oss/javascript/releases/langgraph-v1"
+                          ]
+                        },
+                        {
+                          "group": "Migration guides",
+                          "pages": [
+                            "oss/javascript/migrate/langchain-v1",
+                            "oss/javascript/migrate/langgraph-v1"
+                          ]
+                        }
+                      ]
+                    },
+                    {
+                      "group": "Policies",
+                      "pages": [
+                        "oss/javascript/release-policy",
+                        "oss/javascript/security-policy"
+                      ]
+                    }
+                  ]
+                },
+                {
+                  "tab": "Contribute",
+                  "pages": [
+                    "oss/javascript/contributing/overview",
+                    {
+                      "group": "Contribute",
+                      "icon": "heart-circle-plus",
+                      "pages": [
+                        "oss/javascript/contributing/documentation",
+                        "oss/javascript/contributing/code",
+                        {
+                          "group": "Integrations",
+                          "pages": [
+                            "oss/javascript/contributing/integrations-langchain",
+                            "oss/javascript/contributing/implement-langchain",
+                            "oss/javascript/contributing/standard-tests-langchain",
+                            "oss/javascript/contributing/publish-langchain",
+                            "oss/javascript/contributing/comarketing"
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
               ]
             }
           ]


### PR DESCRIPTION
<img width="692" height="274" alt="image" src="https://github.com/user-attachments/assets/44f2e382-7959-4ed3-b866-a708d5b5a312" />

This only reorders the product dropdown and renames `LangChain + LangGraph` to `Open source`.