### PR TITLE
docs: migrate deprecated initialize_agent examples to create_agent (batch 1)

### DIFF
--- a/src/oss/python/integrations/llms/amazon_api_gateway.mdx
+++ b/src/oss/python/integrations/llms/amazon_api_gateway.mdx
@@ -47,7 +47,7 @@ llm(prompt)
 ## Agent
 
 ```python
-from langchain.agents import AgentType, initialize_agent, load_tools
+from langchain.agents import create_agent, load_tools
 
 parameters = {
     "max_new_tokens": 50,
@@ -64,15 +64,13 @@ llm.model_kwargs = parameters
 tools = load_tools(["python_repl", "llm-math"], llm=llm)
 
 # Finally, let's initialize an agent with the tools, the language model, and the type of agent we want to use.
-agent = initialize_agent(
-    tools,
-    llm,
-    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
-    verbose=True,
+agent = create_agent(
+    model=llm,
+    tools=tools,
 )
 
 # Now let's test it out!
-agent.run(
+agent.invoke(
     """
 Write a Python script that prints "Hello, world!"
 """
@@ -100,7 +98,7 @@ Hello, world!
 ```
 
 ```python
-result = agent.run(
+result = agent.invoke(
     """
 What is 2.3 ^ 4.5?
 """

--- a/src/oss/python/integrations/providers/comet_tracking.mdx
+++ b/src/oss/python/integrations/providers/comet_tracking.mdx
@@ -17,7 +17,7 @@ In this guide we will demonstrate how to track your LangChain Experiments, Evalu
 ### Install comet and dependencies
 
 ```python
-pip install -qU  comet_ml langchain langchain-openai google-search-results spacy textstat pandas
+pip install -qU comet_ml langchain langchain-openai google-search-results spacy textstat pandas
 
 
 !{sys.executable} -m spacy download en_core_web_sm
@@ -99,7 +99,7 @@ comet_callback.flush_tracker(synopsis_chain, finish=True)
 ### Scenario 3: Using an Agent with tools
 
 ```python
-from langchain.agents import initialize_agent, load_tools
+from langchain.agents import create_agent, load_tools
 from langchain_community.callbacks import CometCallbackHandler
 from langchain_core.callbacks import StdOutCallbackHandler
 from langchain_openai import OpenAI
@@ -114,18 +114,19 @@ callbacks = [StdOutCallbackHandler(), comet_callback]
 llm = OpenAI(temperature=0.9, callbacks=callbacks)
 
 tools = load_tools(["serpapi", "llm-math"], llm=llm, callbacks=callbacks)
-agent = initialize_agent(
-    tools,
-    llm,
-    agent="zero-shot-react-description",
-    callbacks=callbacks,
-    verbose=True,
+
+agent = create_agent(
+    model=llm,
+    tools=tools,
 )
-agent.run(
+
+agent.invoke(
     "Who is Leo DiCaprio's girlfriend? What is her current age raised to the 0.43 power?"
 )
+
 comet_callback.flush_tracker(agent, finish=True)
 ```
+
 
 ### Scenario 4: Using custom evaluation metrics
 

--- a/src/oss/python/integrations/providers/google_serper.mdx
+++ b/src/oss/python/integrations/providers/google_serper.mdx
@@ -22,32 +22,37 @@ There exists a `GoogleSerperAPIWrapper` utility which wraps this API. To import 
 from langchain_community.utilities import GoogleSerperAPIWrapper
 ```
 
-You can use it as part of a Self Ask chain:
+You can use it as part of an agent with search tools:
 
 ```python
 from langchain_community.utilities import GoogleSerperAPIWrapper
 from langchain_openai import OpenAI
-from langchain.agents import initialize_agent, Tool
-from langchain.agents import AgentType
+from langchain.agents import create_agent, Tool
 
 import os
 
 os.environ["SERPER_API_KEY"] = ""
-os.environ['OPENAI_API_KEY'] = ""
+os.environ["OPENAI_API_KEY"] = ""
 
 llm = OpenAI(temperature=0)
 search = GoogleSerperAPIWrapper()
+
 tools = [
     Tool(
         name="Intermediate Answer",
         func=search.run,
-        description="useful for when you need to ask with search"
+        description="useful for when you need to ask with search",
     )
 ]
 
-self_ask_with_search = initialize_agent(tools, llm, agent=AgentType.SELF_ASK_WITH_SEARCH, verbose=True)
-self_ask_with_search.run("What is the hometown of the reigning men's U.S. Open champion?")
+agent = create_agent(
+    model=llm,
+    tools=tools,
+)
+
+agent.invoke("What is the hometown of the reigning men's U.S. Open champion?")
 ```
+
 
 #### Output
 ```

--- a/src/oss/python/integrations/providers/searchapi.mdx
+++ b/src/oss/python/integrations/providers/searchapi.mdx
@@ -20,31 +20,35 @@ There is a SearchApiAPIWrapper utility which wraps this API. To import this util
 from langchain_community.utilities import SearchApiAPIWrapper
 ```
 
-You can use it as part of a Self Ask chain:
+You can use it as part of an agent with search tools:
 
 ```python
 from langchain_community.utilities import SearchApiAPIWrapper
 from langchain_openai import OpenAI
-from langchain.agents import initialize_agent, Tool
-from langchain.agents import AgentType
+from langchain.agents import create_agent, Tool
 
 import os
 
 os.environ["SEARCHAPI_API_KEY"] = ""
-os.environ['OPENAI_API_KEY'] = ""
+os.environ["OPENAI_API_KEY"] = ""
 
 llm = OpenAI(temperature=0)
 search = SearchApiAPIWrapper()
+
 tools = [
     Tool(
         name="Intermediate Answer",
         func=search.run,
-        description="useful for when you need to ask with search"
+        description="useful for when you need to ask with search",
     )
 ]
 
-self_ask_with_search = initialize_agent(tools, llm, agent=AgentType.SELF_ASK_WITH_SEARCH, verbose=True)
-self_ask_with_search.run("Who lived longer: Plato, Socrates, or Aristotle?")
+agent = create_agent(
+    model=llm,
+    tools=tools,
+)
+
+agent.invoke("Who lived longer: Plato, Socrates, or Aristotle?")
 ```
 
 #### Output

--- a/src/oss/python/integrations/tools/chatgpt_plugins.mdx
+++ b/src/oss/python/integrations/tools/chatgpt_plugins.mdx
@@ -17,31 +17,29 @@ Note 1: This currently only works for plugins with no auth.
 Note 2: There are almost certainly other ways to do this, this is just a first pass. If you have better ideas, please open a PR!
 
 ```python
-pip install -qU langchain-community
+pip install -qU langchain langchain-community langchain-openai
 ```
 
 ```python
+from langchain.agents import create_agent, load_tools
 from langchain_community.tools import AIPluginTool
-```
-
-```python
-from langchain.agents import AgentType, initialize_agent, load_tools
 from langchain_openai import ChatOpenAI
-```
 
-```python
-tool = AIPluginTool.from_plugin_url("https://www.klarna.com/.well-known/ai-plugin.json")
-```
+tool = AIPluginTool.from_plugin_url(
+    "https://www.klarna.com/.well-known/ai-plugin.json"
+)
 
-```python
 llm = ChatOpenAI(temperature=0)
+
 tools = load_tools(["requests_all"])
 tools += [tool]
 
-agent_chain = initialize_agent(
-    tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True
+agent = create_agent(
+    model=llm,
+    tools=tools,
 )
-agent_chain.run("what t shirts are available in klarna?")
+
+agent.invoke("what t shirts are available in klarna?")
 ```
 
 ```text


### PR DESCRIPTION
Migrates several docs examples from the deprecated `initialize_agent` to the current `create_agent` API.

Updated integrations:
- ChatGPT plugins
- SearchAPI
- Google Serper
- Amazon API Gateway
- Comet tracking

This is part of the migration discussed in #2473.
