### PR TITLE
docs: Update install.mdx to specify compatible Bun version

### DIFF
--- a/src/oss/langchain/install.mdx
+++ b/src/oss/langchain/install.mdx
@@ -38,7 +38,7 @@ To install the LangChain package:
 
     ```bash bun
     bun add langchain @langchain/core
-    # Requires Node.js 20+
+    # Requires Bun v1.0.0+
     ```
     </CodeGroup>
 :::


### PR DESCRIPTION
Bun is not a package manager for Node.js but a standalone JS runtime, therefore we can specify which version of Bun to use with langchain. 

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Update existing documentation]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
