### PR TITLE
docs: fix markdown text splitter example usage

### DIFF
--- a/src/oss/integrations/splitters/code_splitter.mdx
+++ b/src/oss/integrations/splitters/code_splitter.mdx
@@ -381,7 +381,7 @@ const mdSplitter = RecursiveCharacterTextSplitter.fromLanguage(
     "markdown",
     { chunkSize: 60, chunkOverlap: 0 }
 );
-const mdDocs = mdSplitter.createDocuments([{ pageContent: markdownText }]);
+const mdDocs = mdSplitter.createDocuments([ markdownText ]);
 console.log(mdDocs);
 ```
 ```javascript


### PR DESCRIPTION
## Overview
This PR fixes an incorrect JavaScript example in the Markdown text splitter documentation.  
The existing example passed `{ pageContent }` objects to `createDocuments`, but the method expects an array of strings (`string[]`). This mismatch caused a runtime error when users followed the docs.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue: fixes langchain-ai/langchainjs#9840
- Feature PR: N/A

<!-- For LangChain employees, if applicable: -->
- Linear issue: N/A
- Slack thread: N/A

## Checklist
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed (not required for this change)

## Additional notes
This is a documentation-only fix and does not change any runtime behavior.  
The updated example now aligns with the `createDocuments(texts: string[])` method signature used throughout the codebase and tests.
