### PR TITLE
docs: migrate deprecated initialize_agent examples to create_agent (batch 2)

### DIFF
--- a/src/oss/python/integrations/callbacks/argilla.mdx
+++ b/src/oss/python/integrations/callbacks/argilla.mdx
@@ -183,7 +183,7 @@ Finally, as a more advanced workflow, you can create an agent that uses some too
 > Note that for this scenario we'll be using Google Search API (Serp API) so you will need to both install `google-search-results` as `pip install google-search-results`, and to set the Serp API Key as `os.environ["SERPAPI_API_KEY"] = "..."` (you can find it at [serpapi.com/dashboard](https://serpapi.com/dashboard)), otherwise the example below won't work.
 
 ```python
-from langchain.agents import AgentType, initialize_agent, load_tools
+from langchain.agents import create_agent, load_tools
 from langchain_core.callbacks.stdout import StdOutCallbackHandler
 from langchain_openai import OpenAI
 
@@ -192,17 +192,19 @@ argilla_callback = ArgillaCallbackHandler(
     api_url=os.environ["ARGILLA_API_URL"],
     api_key=os.environ["ARGILLA_API_KEY"],
 )
+
 callbacks = [StdOutCallbackHandler(), argilla_callback]
 llm = OpenAI(temperature=0.9, callbacks=callbacks)
 
 tools = load_tools(["serpapi"], llm=llm, callbacks=callbacks)
-agent = initialize_agent(
-    tools,
-    llm,
-    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+
+agent = create_agent(
+    model=llm,
+    tools=tools,
     callbacks=callbacks,
 )
-agent.run("Who was the first president of the United States of America?")
+
+agent.invoke("Who was the first president of the United States of America?")
 ```
 
 ```text

--- a/src/oss/python/integrations/callbacks/sagemaker_tracking.mdx
+++ b/src/oss/python/integrations/callbacks/sagemaker_tracking.mdx
@@ -41,7 +41,7 @@ from langchain_community.callbacks.sagemaker_callback import SageMakerCallbackHa
 ```
 
 ```python
-from langchain.agents import initialize_agent, load_tools
+from langchain.agents import create_agent, load_tools
 from langchain_classic.chains import LLMChain, SimpleSequentialChain
 from langchain_core.prompts import PromptTemplate
 from langchain_openai import OpenAI
@@ -154,11 +154,11 @@ with Run(
 ```python
 RUN_NAME = "run-scenario-3"
 PROMPT_TEMPLATE = "Who is the oldest person alive? And what is their current age raised to the power of 1.51?"
-```
 
-```python
 with Run(
-    experiment_name=EXPERIMENT_NAME, run_name=RUN_NAME, sagemaker_session=session
+    experiment_name=EXPERIMENT_NAME,
+    run_name=RUN_NAME,
+    sagemaker_session=session,
 ) as run:
     # Create SageMaker Callback
     sagemaker_callback = SageMakerCallbackHandler(run)
@@ -167,18 +167,25 @@ with Run(
     llm = OpenAI(callbacks=[sagemaker_callback], **HPARAMS)
 
     # Define tools
-    tools = load_tools(["serpapi", "llm-math"], llm=llm, callbacks=[sagemaker_callback])
+    tools = load_tools(
+        ["serpapi", "llm-math"],
+        llm=llm,
+        callbacks=[sagemaker_callback],
+    )
 
-    # Initialize agent with all the tools
-    agent = initialize_agent(
-        tools, llm, agent="zero-shot-react-description", callbacks=[sagemaker_callback]
+    # Create agent
+    agent = create_agent(
+        model=llm,
+        tools=tools,
+        callbacks=[sagemaker_callback],
     )
 
     # Run agent
-    agent.run(input=PROMPT_TEMPLATE)
+    agent.invoke(PROMPT_TEMPLATE)
 
-    # Reset the callback
+    # Reset callback
     sagemaker_callback.flush_tracker()
+
 ```
 
 ## Load log data

--- a/src/oss/python/integrations/providers/aim_tracking.mdx
+++ b/src/oss/python/integrations/providers/aim_tracking.mdx
@@ -103,21 +103,23 @@ aim_callback.flush_tracker(
 <h3>Scenario 3</h3> The third scenario involves an agent with tools.
 
 ```python
-from langchain.agents import AgentType, initialize_agent, load_tools
+from langchain.agents import create_agent, load_tools
 ```
 
 ```python
 # scenario 3 - Agent with Tools
 tools = load_tools(["serpapi", "llm-math"], llm=llm, callbacks=callbacks)
-agent = initialize_agent(
-    tools,
-    llm,
-    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+
+agent = create_agent(
+    model=llm,
+    tools=tools,
     callbacks=callbacks,
 )
-agent.run(
+
+agent.invoke(
     "Who is Leo DiCaprio's girlfriend? What is her current age raised to the 0.43 power?"
 )
+
 aim_callback.flush_tracker(langchain_asset=agent, reset=False, finish=True)
 ```
 

--- a/src/oss/python/integrations/providers/clearml_tracking.mdx
+++ b/src/oss/python/integrations/providers/clearml_tracking.mdx
@@ -318,19 +318,23 @@ To show a more advanced workflow, let's create an agent with access to tools. Th
 You can now also see the use of the `finish=True` keyword, which will fully close the ClearML Task, instead of just resetting the parameters and prompts for a new conversation.
 
 ```python
-from langchain.agents import AgentType, initialize_agent, load_tools
+from langchain.agents import create_agent, load_tools
 
 # SCENARIO 2 - Agent with Tools
 tools = load_tools(["serpapi", "llm-math"], llm=llm, callbacks=callbacks)
-agent = initialize_agent(
-    tools,
-    llm,
-    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+
+agent = create_agent(
+    model=llm,
+    tools=tools,
     callbacks=callbacks,
 )
-agent.run("Who is the wife of the person who sang summer of 69?")
+
+agent.invoke("Who is the wife of the person who sang summer of 69?")
+
 clearml_callback.flush_tracker(
-    langchain_asset=agent, name="Agent with Tools", finish=True
+    langchain_asset=agent,
+    name="Agent with Tools",
+    finish=True,
 )
 ```
 

--- a/src/oss/python/integrations/providers/flyte.mdx
+++ b/src/oss/python/integrations/providers/flyte.mdx
@@ -28,7 +28,7 @@ First, import the necessary dependencies to support your LangChain experiments.
 import os
 
 from flytekit import ImageSpec, task
-from langchain.agents import AgentType, initialize_agent, load_tools
+from langchain.agents import create_agent, load_tools
 from langchain.callbacks import FlyteCallbackHandler
 from langchain_classic.chains import LLMChain
 from langchain_openai import ChatOpenAI
@@ -119,22 +119,26 @@ Playwright: This is a synopsis for the above play:"""
 ```python
 @task(disable_deck=False, container_image=custom_image)
 def langchain_agent() -> str:
-    llm = OpenAI(
+    llm = ChatOpenAI(
         model_name="gpt-3.5-turbo",
         temperature=0,
         callbacks=[FlyteCallbackHandler()],
     )
+
     tools = load_tools(
-        ["serpapi", "llm-math"], llm=llm, callbacks=[FlyteCallbackHandler()]
+        ["serpapi", "llm-math"],
+        llm=llm,
+        callbacks=[FlyteCallbackHandler()],
     )
-    agent = initialize_agent(
-        tools,
-        llm,
-        agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+
+    agent = create_agent(
+        model=llm,
+        tools=tools,
         callbacks=[FlyteCallbackHandler()],
         verbose=True,
     )
-    return agent.run(
+
+    return agent.invoke(
         "Who is Leonardo DiCaprio's girlfriend? Could you calculate her current age and raise it to the power of 0.43?"
     )
 ```

--- a/src/oss/python/integrations/providers/wandb_tracing.mdx
+++ b/src/oss/python/integrations/providers/wandb_tracing.mdx
@@ -6,7 +6,7 @@ description: "Integrate with Weights & Biases tracing using LangChain Python."
 There are two recommended ways to trace your LangChains:
 
 1. Setting the `LANGCHAIN_WANDB_TRACING` environment variable to "true".
-1. Using a context manager with tracing_enabled() to trace a particular block of code.
+1. Using a context manager with `wandb_tracing_enabled()` to trace a particular block of code.
 
 **Note** if the environment variable is set, all code will be traced, regardless of whether or not it's within the context manager.
 
@@ -19,29 +19,25 @@ os.environ["LANGCHAIN_WANDB_TRACING"] = "true"
 
 # wandb documentation to configure wandb using env variables
 # https://docs.wandb.ai/guides/track/advanced/environment-variables
-# here we are configuring the wandb project name
 os.environ["WANDB_PROJECT"] = "langchain-tracing"
 
-from langchain.agents import AgentType, initialize_agent, load_tools
+from langchain.agents import create_agent, load_tools
 from langchain_openai import OpenAI
 ```
 
 ```python
-# Agent run with tracing. Ensure that OPENAI_API_KEY is set appropriately to run this example.
+# Agent run with tracing. Ensure OPENAI_API_KEY is set appropriately to run this example.
 
 llm = OpenAI(temperature=0)
 tools = load_tools(["llm-math"], llm=llm)
-```
 
-```python
-agent = initialize_agent(
-    tools, llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True
+agent = create_agent(
+    model=llm,
+    tools=tools,
+    verbose=True,
 )
 
-agent.run("What is 2 raised to .123243 power?")  # this should be traced
-# A url with for the trace sesion like the following should print in your console:
-# https://wandb.ai/<wandb_entity>/<wandb_project>/runs/<run_id>
-# The url can be used to view the trace session in wandb.
+agent.invoke("What is 2 raised to .123243 power?")
 ```
 
 ```python
@@ -51,9 +47,9 @@ if "LANGCHAIN_WANDB_TRACING" in os.environ:
 
 # enable tracing using a context manager
 with wandb_tracing_enabled():
-    agent.run("What is 5 raised to .123243 power?")  # this should be traced
+    agent.invoke("What is 5 raised to .123243 power?")
 
-agent.run("What is 2 raised to .123243 power?")  # this should not be traced
+agent.invoke("What is 2 raised to .123243 power?")
 ```
 
 ```text


### PR DESCRIPTION
Migrates several docs examples from the deprecated initialize_agent to the current create_agent API.

Updated integrations:

- Wandb Tracing
- Flyte
- ClearML Tracking
- Aim Tracking
- Argilla
- Sagemaker Tracking

This is part of the migration discussed in https://github.com/langchain-ai/docs/issues/2473.