### PR TITLE
Add prereqs for agent builder & insights self-hosted pages

### DIFF
--- a/src/langsmith/agent-builder-self-hosted.mdx
+++ b/src/langsmith/agent-builder-self-hosted.mdx
@@ -16,8 +16,7 @@ Before enabling Agent Builder, you must complete the following setup steps:
 1. Install the base LangSmith platform:
    - [Install on Kubernetes](/langsmith/kubernetes).
    - [Install on Docker](/langsmith/docker).
-1. Enable LangSmith Deployment (agent deployment capabilities):
-   - [Enable LangSmith Deployment](/langsmith/deploy-self-hosted-full-platform).
+1. [Enable LangSmith Deployment](/langsmith/deploy-self-hosted-full-platform) (agent deployment capabilities).
 
 ## Components
 

--- a/src/langsmith/insights-self-hosted.mdx
+++ b/src/langsmith/insights-self-hosted.mdx
@@ -16,8 +16,7 @@ Before enabling Insights, you must complete the following setup steps:
 1. Install the base LangSmith platform:
    - [Install on Kubernetes](/langsmith/kubernetes).
    - [Install on Docker](/langsmith/docker).
-1. Enable LangSmith Deployment (agent deployment capabilities):
-   - [Enable LangSmith Deployment](/langsmith/deploy-self-hosted-full-platform).
+1. [Enable LangSmith Deployment](/langsmith/deploy-self-hosted-full-platform) (agent deployment capabilities).
 
 ## Components
 


### PR DESCRIPTION
Fixes DOC-700

Add prerequisite sections to Agent Builder and Insights self-hosted pages for LangSmith Deployment install