### PR TITLE
Update customization.mdx to fix examples for using skills

### DIFF
--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -362,6 +362,7 @@ To add skills to your deep agent, pass them as an argument to `create_deep_agent
     ```python
     from urllib.request import urlopen
     from deepagents import create_deep_agent
+    from deepagents.backends.utils import create_file_data
     from langgraph.checkpoint.memory import MemorySaver
 
     checkpointer = MemorySaver()
@@ -371,11 +372,11 @@ To add skills to your deep agent, pass them as an argument to `create_deep_agent
         skill_content = response.read().decode('utf-8')
 
     skills_files = {
-        "/skills/langgraph-docs/SKILL.md": skill_content
+        "/skills/langgraph-docs/SKILL.md": create_file_data(skill_content)
     }
 
     agent = create_deep_agent(
-        skills=["./skills/"],
+        skills=["/skills/"],
         checkpointer=checkpointer,
     )
 
@@ -399,6 +400,7 @@ To add skills to your deep agent, pass them as an argument to `create_deep_agent
     from urllib.request import urlopen
     from deepagents import create_deep_agent
     from deepagents.backends import StoreBackend
+    from deepagents.backends.utils import create_file_data
     from langgraph.store.memory import InMemoryStore
 
 
@@ -411,13 +413,13 @@ To add skills to your deep agent, pass them as an argument to `create_deep_agent
     store.put(
         namespace=("filesystem",),
         key="/skills/langgraph-docs/SKILL.md",
-        value=skill_content
+        value=create_file_data(skill_content)
     )
 
     agent = create_deep_agent(
         backend=(lambda rt: StoreBackend(rt)),
         store=store,
-        skills=["./skills/"]
+        skills=["/skills/"]
     )
 
     result = agent.invoke(


### PR DESCRIPTION
## Overview
This PR fix the example code of using skills:
- When using `StateBackend`, the value of `files` should be a `FileData`. Otherwise, the code will throw an error.
- When using `StoreBackend`, the value should be a `FileData`.
- When specifying `skills`, the path should be an absolute path. Otherwise, the generated system prompt won't contain the skills.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
N/A

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [X] I have read the [contributing guidelines](README.md)
- [X] I have tested my changes locally using `docs dev`
- [X] All code examples have been tested and work correctly
- [X] I have used **root relative** paths for internal links
- [X] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
N/A
