### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.7.29

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -4318,7 +4318,7 @@
           "metadata": {
             "type": "object",
             "title": "Metadata",
-            "description": "Metadata to assign to the cron job runs."
+            "description": "Metadata to merge with existing cron job metadata."
           },
           "config": {
             "properties": {


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.7.29**

This update was automatically generated by the sync workflow in the langgraph-api repository.