### PR TITLE
oss(deepagents): fix chat model tab snippets

### DIFF
--- a/src/snippets/chat-model-tabs-da.mdx
+++ b/src/snippets/chat-model-tabs-da.mdx
@@ -30,14 +30,11 @@
             ```python Model Class
             import os
             from langchain_openai import ChatOpenAI
-            from langchain.chat_models import init_chat_model
             from deepagents import create_deep_agent
 
             os.environ["OPENAI_API_KEY"] = "sk-..."
 
-            model = init_chat_model(
-                model=ChatOpenAI(model="gpt-4.1")
-            )
+            model = ChatOpenAI(model="gpt-4.1")
             agent = create_deep_agent(model=model)
             ```
         </CodeGroup>
@@ -72,14 +69,11 @@
             ```python Model Class
             import os
             from langchain_anthropic import ChatAnthropic
-            from langchain.chat_models import init_chat_model
             from deepagents import create_deep_agent
 
             os.environ["ANTHROPIC_API_KEY"] = "sk-..."
 
-            model = init_chat_model(
-                model=ChatAnthropic(model="claude-sonnet-4-5-20250929")
-            )
+            model = ChatAnthropic(model="claude-sonnet-4-5-20250929")
             agent = create_deep_agent(model=model)
             ```
         </CodeGroup>
@@ -121,18 +115,15 @@
             ```python Model Class
             import os
             from langchain_openai import AzureChatOpenAI
-            from langchain.chat_models import init_chat_model
             from deepagents import create_deep_agent
 
             os.environ["AZURE_OPENAI_API_KEY"] = "..."
             os.environ["AZURE_OPENAI_ENDPOINT"] = "..."
             os.environ["OPENAI_API_VERSION"] = "2025-03-01-preview"
 
-            model = init_chat_model(
-                model=AzureChatOpenAI(
-                    model="gpt-4.1",
-                    azure_deployment=os.environ["AZURE_OPENAI_DEPLOYMENT_NAME"]
-                )
+            model = AzureChatOpenAI(
+                model="gpt-4.1",
+                azure_deployment=os.environ["AZURE_OPENAI_DEPLOYMENT_NAME"],
             )
             agent = create_deep_agent(model=model)
             ```
@@ -168,14 +159,11 @@
             ```python Model Class
             import os
             from langchain_google_genai import ChatGoogleGenerativeAI
-            from langchain.chat_models import init_chat_model
             from deepagents import create_deep_agent
 
             os.environ["GOOGLE_API_KEY"] = "..."
 
-            model = init_chat_model(
-                model=ChatGoogleGenerativeAI(model="gemini-2.5-flash-lite")
-            )
+            model = ChatGoogleGenerativeAI(model="gemini-2.5-flash-lite")
             agent = create_deep_agent(model=model)
             ```
         </CodeGroup>
@@ -215,15 +203,12 @@
             ```
             ```python Model Class
             from langchain_aws import ChatBedrock
-            from langchain.chat_models import init_chat_model
             from deepagents import create_deep_agent
 
             # Follow the steps here to configure your credentials:
             # https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started.html
 
-            model = init_chat_model(
-                model=ChatBedrock(model="anthropic.claude-3-5-sonnet-20240620-v1:0")
-            )
+            model = ChatBedrock(model="anthropic.claude-3-5-sonnet-20240620-v1:0")
             agent = create_deep_agent(model=model)
             ```
         </CodeGroup>
@@ -270,7 +255,6 @@
             ```python Model Class
             import os
             from langchain_huggingface import ChatHuggingFace, HuggingFaceEndpoint
-            from langchain.chat_models import init_chat_model
             from deepagents import create_deep_agent
 
             os.environ["HUGGINGFACEHUB_API_TOKEN"] = "hf_..."
@@ -280,9 +264,7 @@
                 temperature=0.7,
                 max_length=1024,
             )
-            model = init_chat_model(
-                model=ChatHuggingFace(llm=llm)
-            )
+            model = ChatHuggingFace(llm=llm)
             agent = create_deep_agent(model=model)
             ```
         </CodeGroup>


### PR DESCRIPTION
- Remove unnecessary `init_chat_model()` calls that wrapped already-instantiated `BaseChatModel` instances in the Deep Agents "Model Class" code examples
- Affects all provider tabs (OpenAI, Anthropic, Azure, Google, AWS Bedrock, HuggingFace) in the chat model tabs snippet

## Why

`init_chat_model()` is a convenience function that converts a **string** model identifier (e.g., `"openai:gpt-4.1"`) into a `BaseChatModel` instance. Wrapping an already-instantiated `BaseChatModel` (e.g., `ChatOpenAI(model="gpt-4.1")`) inside `init_chat_model(model=...)` is wrong — the object is already the type that `init_chat_model` would return. This also removes the unnecessary `from langchain.chat_models import `init_chat_model` import from each example.

---

I think the confusion may have arose from `LLMToolSelectorMiddleware`