### PR TITLE
chore: Update constraints for API version 0.7.31

### DIFF
--- a/src/langsmith/setup-app-requirements-txt.mdx
+++ b/src/langsmith/setup-app-requirements-txt.mdx
@@ -46,7 +46,7 @@ The dependencies below will be included in the image, you can also use them in y
 
 ```
 langgraph>=0.4.10,<2
-langgraph-sdk>=0.2.0
+langgraph-sdk>=0.3.5
 langgraph-checkpoint>=3.0.1,<5
 langchain-core>=0.3.66
 langsmith>=0.6.3
@@ -62,9 +62,9 @@ structlog>=24.1.0
 cloudpickle>=3.0.0
 truststore>=0.1
 protobuf>=6.32.1,<7.0.0
-grpcio>=1.75.0,<2.0.0
-grpcio-tools>=1.75.0,<2.0.0
-grpcio-health-checking>=1.75.0,<2.0.0
+grpcio>=1.78.0,<1.79.0
+grpcio-tools>=1.78.0,<1.79.0
+grpcio-health-checking>=1.78.0,<1.79.0
 ```
 
 Example `requirements.txt` file:

--- a/src/langsmith/setup-pyproject.mdx
+++ b/src/langsmith/setup-pyproject.mdx
@@ -45,9 +45,9 @@ The dependencies below will be included in the image, you can also use them in y
 
 ```
 langgraph>=0.4.10,<2
-langgraph-sdk>=0.2.0
+langgraph-sdk>=0.3.5
 langgraph-checkpoint>=3.0.1,<5
-langchain-core>=0.3.67
+langchain-core>=0.3.66
 langsmith>=0.6.3
 orjson>=3.9.7,<3.10.17
 httpx>=0.25.0
@@ -61,9 +61,9 @@ structlog>=24.1.0
 cloudpickle>=3.0.0
 truststore>=0.1
 protobuf>=6.32.1,<7.0.0
-grpcio>=1.75.0,<2.0.0
-grpcio-tools>=1.75.0,<2.0.0
-grpcio-health-checking>=1.75.0,<2.0.0
+grpcio>=1.78.0,<1.79.0
+grpcio-tools>=1.78.0,<1.79.0
+grpcio-health-checking>=1.78.0,<1.79.0
 ```
 
 Example `pyproject.toml` file:


### PR DESCRIPTION
This PR updates the dependency constraints in the setup docs to match `api/constraints.txt`. Merge when convenient.

**Changes detected as of API version 0.7.31**

This update was automatically generated by the sync workflow in the langgraph-api repository.