### PR TITLE
docs(langsmith): add agent server runtime architecture

### DIFF
--- a/src/langsmith/agent-server-scale.mdx
+++ b/src/langsmith/agent-server-scale.mdx
@@ -5,6 +5,10 @@ sidebarTitle: Configure Agent Server for scale
 
 The default configuration for LangSmith Agent Server is designed to handle substantial read and write load across a variety of different workloads. By following the best practices outlined below, you can tune your Agent Server to perform optimally for your specific workload. This page describes scaling considerations for the Agent Server and provides examples to help configure your deployment.
 
+<Tip>
+If you're not yet familiar with how API servers and queue workers operate at the container level, read the [runtime architecture](/langsmith/agent-server#runtime-architecture) overview first.
+</Tip>
+
 For some example self-hosted configurations, refer to the [Example Agent Server configurations for scale](#example-agent-server-configurations-for-scale) section.
 
 ## Scaling for write load

--- a/src/langsmith/agent-server.mdx
+++ b/src/langsmith/agent-server.mdx
@@ -57,6 +57,42 @@ Agent Server can be deployed using different methods depending on your infrastru
 Cloud deployments are available on all LangSmith plans. Hybrid and self-hosted options require an Enterprise plan and license key. To acquire a license key, [contact our sales team](https://www.langchain.com/contact-sales).
 </Note>
 
+## Runtime architecture
+
+The following description applies to the non-distributed runtime variant of LangSmith Deployment.
+
+### Container architecture
+
+A typical deployment consists of two kinds of long-running containers, both built from the same Docker image (a base image with your project code installed on top):
+
+- **API servers** handle client requests (creating runs, reading thread state, streaming results) but do not execute agent code themselves.
+- **Queue workers** are the execution engine. They listen to the durable task queue, execute your graph code, and write checkpoints.
+
+Containers are **stateless* but persistent. At least 1 queue worker must listen to the task queue at any time to ensure no runs are orphaned. The containers can serve many runs over their lifetime.
+
+API servers and queue workers are separate container pools and [scale independently](/langsmith/data-plane#autoscaling).
+
+### Run execution lifecycle
+
+When you invoke a run, the request flows through several components:
+
+1. A client sends a request to an API server, which creates a pending run in the durable task queue.
+2. A queue worker picks up the run, acquires a lease on it, loads the appropriate graph, and begins execution. The queue enforces that at most 1 run can be executed for a given thread at one time.
+3. As the graph executes, the worker writes checkpoints to the persistence layer (the frequency depends on the [durability mode](/oss/langgraph/durable-execution#durability-modes)) and broadcasts streaming events over the configured pubsub provider.
+4. If the client opened a `/stream` connection, the API server subscribes to the pubsub channel and forwards events to the client via server-sent events in real time.
+5. When execution completes, the worker updates the run status and releases its slot for the next run.
+
+Each worker handles up to [`N_JOBS_PER_WORKER`](/langsmith/env-var#n-jobs-per-worker) runs concurrently (default: 10), so a single worker container serves many runs in parallel. See [Configure Agent Server for scale](/langsmith/agent-server-scale) for tuning guidance.
+
+### Graph loading and compilation
+
+How and when your graph is compiled depends on how you register it in your [application structure](/langsmith/application-structure):
+
+1. **Compiled graph**: If you export an already-compiled graph (a `CompiledGraph` instance), it is loaded once at container startup and reused for every run. This is the most efficient path.
+2. **Factory function**: If you export an agent factory function, the server invokes it each time it needs the graph. Factories receive the run's configuration, enabling per-run graph customization (for example, choosing different models or tools based on the assistant config). Keep factory functions lightweight for best performance.
+
+In both cases, the server automatically injects the checkpointer and memory store configured for that deployment at runtime. **You should not configure these in your graph code**, since the server needs to manage these for other operations.
+
 ## Learn more
 
 - [Application Structure](/langsmith/application-structure) guide explains how to structure your application for deployment.

--- a/src/langsmith/data-plane.mdx
+++ b/src/langsmith/data-plane.mdx
@@ -73,6 +73,8 @@ For number of pending runs, the autoscaler targets 10 pending runs. For example,
 
 Each metric is computed independently and the autoscaler will determine the scaling action based on the metric that results in the largest number of containers.
 
+These metrics don't all apply to every container type. [Queue workers](/langsmith/agent-server#runtime-architecture) scale on pending run count — when the backlog grows, more workers spin up to drain it. [API servers](/langsmith/agent-server#runtime-architecture) scale on CPU and memory, responding to client request volume. This means a spike in run submissions won't slow down read operations like fetching thread state. For self-hosted configuration details, see [Configure Agent Server for scale](/langsmith/agent-server-scale).
+
 Scale down actions are delayed for 30 minutes before any action is taken. In other words, if the autoscaler decides to scale down a deployment, it will first wait for 30 minutes before scaling down. After 30 minutes, the metrics are recomputed and the deployment will scale down if the recomputed metrics result in a lower number of containers than the current number. Otherwise, the deployment remains scaled up. This "cool down" period ensures that deployments do not scale up and down too frequently.
 
 ### Static IP addresses


### PR DESCRIPTION
## Summary

- Adds a "Runtime architecture" section to `agent-server.mdx` covering container architecture (API servers vs queue workers), run execution lifecycle, and graph loading/compilation behavior
- Expands the autoscaling section in `data-plane.mdx` to explain how API servers and queue workers scale on different signals
- Adds a cross-link tip in `agent-server-scale.mdx` pointing readers to the runtime architecture overview

## Context

Forward-deployed engineers had questions about container lifecycle, concurrency, graph compilation, and scaling that weren't covered in the public docs. All claims verified against the langgraph-api codebase.

## Test plan

- [ ] Verify MDX renders correctly in Mintlify preview
- [ ] Confirm internal links resolve (especially anchor links to `#runtime-architecture` and `#autoscaling`)
- [ ] Review prose for accuracy against langgraph-api source
