### PR TITLE
Improve doc for memory and skills

### DIFF
--- a/src/code-samples/deepagents/customization-memory.py
+++ b/src/code-samples/deepagents/customization-memory.py
@@ -108,8 +108,21 @@ agent = create_deep_agent(
     },
     checkpointer=checkpointer,  # Required!
 )
+
+result = agent.invoke(
+    {
+        "messages": [
+            {
+                "role": "user",
+                "content": "Please tell me what's in your memory files.",
+            }
+        ],
+    },
+    config={"configurable": {"thread_id": "12345"}},
+)
 # :snippet-end:
 
 # :remove-start:
 assert agent is not None
+assert result is not None
 # :remove-end:

--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -618,6 +618,7 @@ You can pass one or more file paths to the `memory` parameter when creating your
 :::python
 
 <Tabs>
+<<<<<<< HEAD
     <Tab title="StateBackend">
         <CustomizationMemoryStatePy />
     </Tab>
@@ -627,6 +628,119 @@ You can pass one or more file paths to the `memory` parameter when creating your
     <Tab title="FilesystemBackend">
         <CustomizationMemoryFilesystemPy />
     </Tab>
+=======
+  <Tab title="StateBackend">
+    ```python
+    from urllib.request import urlopen
+
+    from deepagents import create_deep_agent
+    from deepagents.backends.utils import create_file_data
+    from langgraph.checkpoint.memory import MemorySaver
+
+    with urlopen("https://raw.githubusercontent.com/langchain-ai/deepagents/refs/heads/main/examples/text-to-sql-agent/AGENTS.md") as response:
+        agents_md = response.read().decode("utf-8")
+    checkpointer = MemorySaver()
+
+    agent = create_deep_agent(
+        memory=[
+            "/AGENTS.md"
+        ],
+        checkpointer=checkpointer,
+    )
+
+    result = agent.invoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Please tell me what's in your memory files.",
+                }
+            ],
+            # Seed the default StateBackend's in-state filesystem (virtual paths must start with "/").
+            "files": {"/AGENTS.md": create_file_data(agents_md)},
+        },
+        config={"configurable": {"thread_id": "123456"}},
+    )
+    ```
+  </Tab>
+  <Tab title="StoreBackend">
+    ```python
+    from urllib.request import urlopen
+
+    from deepagents import create_deep_agent
+    from deepagents.backends import StoreBackend
+    from deepagents.backends.utils import create_file_data
+    from langgraph.store.memory import InMemoryStore
+
+    with urlopen("https://raw.githubusercontent.com/langchain-ai/deepagents/refs/heads/main/examples/text-to-sql-agent/AGENTS.md") as response:
+        agents_md = response.read().decode("utf-8")
+
+    # Create the store and add the file to it
+    store = InMemoryStore()
+    file_data = create_file_data(agents_md)
+    store.put(
+        namespace=("filesystem",),
+        key="/AGENTS.md",
+        value=file_data
+    )
+
+    agent = create_deep_agent(
+        backend=(lambda rt: StoreBackend(rt)),
+        store=store,
+        memory=[
+            "/AGENTS.md"
+        ]
+    )
+
+    result = agent.invoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Please tell me what's in your memory files.",
+                }
+            ],
+        },
+        config={"configurable": {"thread_id": "12345"}},
+    )
+    ```
+  </Tab>
+  <Tab title="FilesystemBackend">
+    ```python
+    from deepagents import create_deep_agent
+    from langgraph.checkpoint.memory import MemorySaver
+    from deepagents.backends import FilesystemBackend
+
+    # Checkpointer is REQUIRED for human-in-the-loop
+    checkpointer = MemorySaver()
+
+    agent = create_deep_agent(
+        backend=FilesystemBackend(root_dir="/Users/user/{project}"),
+        memory=[
+            "./AGENTS.md"
+        ],
+        interrupt_on={
+            "write_file": True,  # Default: approve, edit, reject
+            "read_file": False,  # No interrupts needed
+            "edit_file": True    # Default: approve, edit, reject
+        },
+        checkpointer=checkpointer,  # Required!
+    )
+
+    result = agent.invoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Please tell me what's in your memory files.",
+                }
+            ],
+        },
+        config={"configurable": {"thread_id": "12345"}},
+    )
+    ```
+  </Tab>
+>>>>>>> 52a9f1dd4 (Improve doc for memory)
 </Tabs>
 
 :::

--- a/src/snippets/code-samples/customization-memory-filesystem-py.mdx
+++ b/src/snippets/code-samples/customization-memory-filesystem-py.mdx
@@ -20,6 +20,18 @@
         },
         checkpointer=checkpointer,  # Required!
     )
+    
+    result = agent.invoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Please tell me what's in your memory files.",
+                }
+            ],
+        },
+        config={"configurable": {"thread_id": "12345"}},
+    )
     ```
 
     ```python OpenAI
@@ -42,6 +54,18 @@
             "edit_file": True,   # Default: approve, edit, reject
         },
         checkpointer=checkpointer,  # Required!
+    )
+    
+    result = agent.invoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Please tell me what's in your memory files.",
+                }
+            ],
+        },
+        config={"configurable": {"thread_id": "12345"}},
     )
     ```
 
@@ -66,6 +90,18 @@
         },
         checkpointer=checkpointer,  # Required!
     )
+    
+    result = agent.invoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Please tell me what's in your memory files.",
+                }
+            ],
+        },
+        config={"configurable": {"thread_id": "12345"}},
+    )
     ```
 
     ```python OpenRouter
@@ -88,6 +124,18 @@
             "edit_file": True,   # Default: approve, edit, reject
         },
         checkpointer=checkpointer,  # Required!
+    )
+    
+    result = agent.invoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Please tell me what's in your memory files.",
+                }
+            ],
+        },
+        config={"configurable": {"thread_id": "12345"}},
     )
     ```
 
@@ -112,6 +160,18 @@
         },
         checkpointer=checkpointer,  # Required!
     )
+    
+    result = agent.invoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Please tell me what's in your memory files.",
+                }
+            ],
+        },
+        config={"configurable": {"thread_id": "12345"}},
+    )
     ```
 
     ```python Baseten
@@ -135,6 +195,18 @@
         },
         checkpointer=checkpointer,  # Required!
     )
+    
+    result = agent.invoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Please tell me what's in your memory files.",
+                }
+            ],
+        },
+        config={"configurable": {"thread_id": "12345"}},
+    )
     ```
 
     ```python Ollama
@@ -157,6 +229,18 @@
             "edit_file": True,   # Default: approve, edit, reject
         },
         checkpointer=checkpointer,  # Required!
+    )
+    
+    result = agent.invoke(
+        {
+            "messages": [
+                {
+                    "role": "user",
+                    "content": "Please tell me what's in your memory files.",
+                }
+            ],
+        },
+        config={"configurable": {"thread_id": "12345"}},
     )
     ```
 </CodeGroup>


### PR DESCRIPTION
## Overview
- Remove the unnecessary `files` for `agent.invoke` when using `StoreBackend`
- Add the code snippet for invoking agent when using `FilesystemBackend` (like the examples of other backends)

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [X] I have read the [contributing guidelines](README.md)
- [X] I have tested my changes locally using `docs dev`
- [X] All code examples have been tested and work correctly
- [X] I have used **root relative** paths for internal links
- [X] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
