### PR TITLE
docs: migrate deprecated initialize_agent examples to create_agent (batch 4)

### DIFF
--- a/src/oss/python/integrations/tools/clickup.mdx
+++ b/src/oss/python/integrations/tools/clickup.mdx
@@ -16,7 +16,7 @@ pip install -qU langchain-community
 %autoreload 2
 from datetime import datetime
 
-from langchain.agents import AgentType, initialize_agent
+from langchain.agents import create_agent
 from langchain_community.agent_toolkits.clickup.toolkit import ClickupToolkit
 from langchain_community.utilities.clickup import ClickupAPIWrapper
 from langchain_openai import OpenAI
@@ -93,8 +93,10 @@ Note: If you know this is the wrong ID, you can pass it at initialization.
 ```python
 llm = OpenAI(temperature=0, openai_api_key="")
 
-agent = initialize_agent(
-    toolkit.get_tools(), llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True
+agent = create_agent(
+    model=llm,
+    tools=toolkit.get_tools(),
+    verbose=True,
 )
 ```
 
@@ -106,7 +108,7 @@ def print_and_run(command):
     print("\033[94m$ COMMAND\033[0m")
     print(command)
     print("\n\033[94m$ AGENT\033[0m")
-    response = agent.run(command)
+    response = agent.invoke({"input": command})
     print("".join(["-"] * 80))
     return response
 ```

--- a/src/oss/python/integrations/tools/connery.mdx
+++ b/src/oss/python/integrations/tools/connery.mdx
@@ -58,7 +58,7 @@ You can see a LangSmith trace of this example [here](https://smith.langchain.com
 ```python
 import os
 
-from langchain.agents import AgentType, initialize_agent
+from langchain.agents import create_agent
 from langchain_community.agent_toolkits.connery import ConneryToolkit
 from langchain_community.tools.connery import ConneryService
 from langchain_openai import ChatOpenAI
@@ -79,13 +79,17 @@ connery_toolkit = ConneryToolkit.create_instance(connery_service)
 
 # Use OpenAI Functions agent to execute the prompt using actions from the Connery Toolkit.
 llm = ChatOpenAI(temperature=0)
-agent = initialize_agent(
-    connery_toolkit.get_tools(), llm, AgentType.OPENAI_FUNCTIONS, verbose=True
+
+agent = create_agent(
+    model=llm,
+    tools=connery_toolkit.get_tools(),
+    verbose=True,
 )
-result = agent.run(
-    f"""Make a short summary of the webpage http://www.paulgraham.com/vb.html in three sentences
+result = agent.invoke({
+    "input": f"""Make a short summary of the webpage http://www.paulgraham.com/vb.html in three sentences
 and send it to {recepient_email}. Include the link to the webpage into the body of the email."""
-)
+})
+
 print(result)
 ```
 
@@ -150,12 +154,16 @@ You can see a LangSmith trace of this example [here](https://smith.langchain.com
 
 ```python
 llm = ChatOpenAI(temperature=0)
-agent = initialize_agent(
-    [send_email_action], llm, AgentType.OPENAI_FUNCTIONS, verbose=True
+
+agent = create_agent(
+    model=llm,
+    tools=[send_email_action],
+    verbose=True,
 )
-agent_run_result = agent.run(
-    f"Send an email to the {recepient_email} and say that I will be late for the meeting."
-)
+agent_run_result = agent.invoke({
+    "input": f"Send an email to the {recepient_email} and say that I will be late for the meeting."
+})
+
 print(agent_run_result)
 ```
 

--- a/src/oss/python/integrations/tools/e2b_data_analysis.mdx
+++ b/src/oss/python/integrations/tools/e2b_data_analysis.mdx
@@ -35,7 +35,7 @@ from langchain_community.tools import E2BDataAnalysisTool
 ```python
 import os
 
-from langchain.agents import AgentType, initialize_agent
+from langchain.agents import create_agent
 from langchain_openai import ChatOpenAI
 
 os.environ["E2B_API_KEY"] = "<E2B_API_KEY>"
@@ -85,23 +85,20 @@ Create a `Tool` object and initialize the LangChain agent.
 
 ```python
 tools = [e2b_data_analysis_tool.as_tool()]
-
 llm = ChatOpenAI(model="gpt-4", temperature=0)
-agent = initialize_agent(
-    tools,
-    llm,
-    agent=AgentType.OPENAI_FUNCTIONS,
+agent = create_agent(
+    model=llm,
+    tools=tools,
     verbose=True,
-    handle_parsing_errors=True,
 )
 ```
 
 Now we can ask the agent questions about the CSV file we uploaded earlier.
 
 ```python
-agent.run(
-    "What are the 5 longest movies on netflix released between 2000 and 2010? Create a chart with their lengths."
-)
+agent.invoke({
+    "input": "What are the 5 longest movies on netflix released between 2000 and 2010? Create a chart with their lengths."
+})
 ```
 
 ```text

--- a/src/oss/python/integrations/tools/edenai_tools.mdx
+++ b/src/oss/python/integrations/tools/edenai_tools.mdx
@@ -43,7 +43,7 @@ from langchain_community.tools.edenai import (
 ```
 
 ```python
-from langchain.agents import AgentType, initialize_agent
+from langchain.agents import create_agent
 from langchain_community.llms import EdenAI
 
 llm = EdenAI(
@@ -59,12 +59,10 @@ tools = [
     EdenAiParsingIDTool(providers=["amazon", "klippa"], language="en"),
     EdenAiParsingInvoiceTool(providers=["amazon", "google"], language="en"),
 ]
-agent_chain = initialize_agent(
-    tools,
-    llm,
-    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+agent_chain = create_agent(
+    model=llm,
+    tools=tools,
     verbose=True,
-    return_intermediate_steps=True,
 )
 ```
 
@@ -77,7 +75,7 @@ second : if it does contain explicit content i want to know what is the explicit
 third : i want to make the text into speech .
 if there is URL in the observations , you will always put it in the output (final answer) .
 """
-result = agent_chain(input_)
+result = agent_chain.invoke({"input": input_})
 ```
 
 ```text
@@ -139,7 +137,7 @@ second : if it does contain objects , i want to know if any of them is harmful,
 third : if none of them is harmfull , make this text into a speech : 'this item is safe' .
 if there is URL in the observations , you will always put it in the output (final answer) .
 """
-result = agent_chain(input_)
+result = agent_chain.invoke({"input": input_})
 ```
 
 ```text
@@ -224,7 +222,7 @@ i want to extract the information in it.
 create a text welcoming the person by his name and make it into speech .
 if there is URL in the observations , you will always put it in the output (final answer) .
 """
-result = agent_chain(input_)
+result = agent_chain.invoke({"input": input_})
 ```
 
 ```text
@@ -278,7 +276,7 @@ and answer these questions :
 who is the customer ?
 what is the company name ?
 """
-result = agent_chain()
+result = agent_chain.invoke({"input": input_})
 ```
 
 ```text

--- a/src/oss/python/integrations/tools/eleven_labs_tts.mdx
+++ b/src/oss/python/integrations/tools/eleven_labs_tts.mdx
@@ -48,47 +48,46 @@ tts.stream_speech(text_to_speak)
 ## Use within an Agent
 
 ```python
-from langchain.agents import AgentType, initialize_agent, load_tools
+from langchain.agents import create_agent, load_tools
 from langchain_openai import OpenAI
 ```
 
 ```python
 llm = OpenAI(temperature=0)
 tools = load_tools(["eleven_labs_text2speech"])
-agent = initialize_agent(
+agent = create_agent(
+    model=llm,
     tools=tools,
-    llm=llm,
-    agent=AgentType.STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION,
     verbose=True,
 )
 ```
 
 ```python
-audio_file = agent.run("Tell me a joke and read it out for me.")
+audio_file = agent.invoke(
+    {"input": "Tell me a joke and read it out for me."}
+)
 ```
 
 ```text
 > Entering new AgentExecutor chain...
 Action:
-\`\`\`
 {
   "action": "eleven_labs_text2speech",
   "action_input": {
     "query": "Why did the chicken cross the playground? To get to the other slide!"
   }
 }
-\`\`\`
-
+```
 
 Observation: /tmp/tmpsfg783f1.wav
 Thought: I have the audio file ready to be sent to the human
 Action:
-\`\`\`
+```
 {
   "action": "Final Answer",
   "action_input": "/tmp/tmpsfg783f1.wav"
 }
-\`\`\`
+```
 
 
 

--- a/src/oss/python/integrations/tools/gitlab.mdx
+++ b/src/oss/python/integrations/tools/gitlab.mdx
@@ -62,7 +62,7 @@ Before initializing your agent, the following environmental variables need to be
 ```python
 import os
 
-from langchain.agents import AgentType, initialize_agent
+from langchain.agents import create_agent
 from langchain_community.agent_toolkits.gitlab.toolkit import GitLabToolkit
 from langchain_community.utilities.gitlab import GitLabAPIWrapper
 from langchain_openai import OpenAI
@@ -84,14 +84,18 @@ os.environ["OPENAI_API_KEY"] = ""
 llm = OpenAI(temperature=0)
 gitlab = GitLabAPIWrapper()
 toolkit = GitLabToolkit.from_gitlab_api_wrapper(gitlab)
-agent = initialize_agent(
-    toolkit.get_tools(), llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True
+agent = create_agent(
+    model=llm,
+    tools=toolkit.get_tools(),
+    verbose=True,
 )
 ```
 
 ```python
-agent.run(
-    "You have the software engineering capabilities of a Google Principle engineer. You are tasked with completing issues on a gitlab repository. Please look at the open issues and complete them by creating merge requests that solve the issues."
+agent.invoke(
+    {
+        "input": "You have the software engineering capabilities of a Google Principle engineer. You are tasked with completing issues on a gitlab repository. Please look at the open issues and complete them by creating merge requests that solve the issues."
+    }
 )
 ```
 

--- a/src/oss/python/integrations/tools/gradio_tools.mdx
+++ b/src/oss/python/integrations/tools/gradio_tools.mdx
@@ -59,7 +59,7 @@ from gradio_tools.tools import (
     StableDiffusionTool,
     TextToVideoTool,
 )
-from langchain.agents import initialize_agent
+from langchain.agents import create_agent
 from langchain.memory import ConversationBufferMemory
 from langchain_openai import OpenAI
 
@@ -72,16 +72,21 @@ tools = [
     TextToVideoTool().langchain,
 ]
 
-
-agent = initialize_agent(
-    tools, llm, memory=memory, agent="conversational-react-description", verbose=True
+agent = create_agent(
+    model=llm,
+    tools=tools,
+    memory=memory,
+    verbose=True,
 )
-output = agent.run(
-    input=(
-        "Please create a photo of a dog riding a skateboard "
-        "but improve my prompt prior to using an image generator."
-        "Please caption the generated image and create a video for it using the improved prompt."
-    )
+
+output = agent.invoke(
+    {
+        "input": (
+            "Please create a photo of a dog riding a skateboard "
+            "but improve my prompt prior to using an image generator."
+            "Please caption the generated image and create a video for it using the improved prompt."
+        )
+    }
 )
 ```
 


### PR DESCRIPTION
Migrates several docs examples from the deprecated initialize_agent to the current create_agent API.

Updated integrations:

- Gradio Tools
- GitLab
- Eleven Labs TTS
- EdenAI Tools
- e2b Data Analysis
- Connery
- Clickup

This is part of the migration discussed in https://github.com/langchain-ai/docs/issues/2473.