### PR TITLE
correctly link to OpenAI structured output constraints

### DIFF
--- a/src/oss/python/integrations/chat/openai.mdx
+++ b/src/oss/python/integrations/chat/openai.mdx
@@ -289,7 +289,7 @@ As of Aug 6, 2024, OpenAI supports a `strict` argument when calling tools that w
 <Note>
     If `strict=True` the tool definition will also be validated, and a subset of JSON schema are accepted. Crucially, schema cannot have optional args (those with default values).
 
-    Read [the full docs](https://platform.openai.com/docs/guides/structured-outputs/supported-schemas) on what types of schema are supported.
+    Read [the full docs](https://developers.openai.com/api/docs/guides/structured-outputs#supported-schemas) on what types of schema are supported.
 </Note>
 
 ```python


### PR DESCRIPTION
The structure of the OpenAI docs has changed. The documentation is now on the parent page in a section.

## Overview
Fix OpenAI Structured Output / Supported Schemas Link

## Type of change

**Type:** Fix link

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes

