### PR TITLE
Add api key start for polly + links from obs eval prompt

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -200,6 +200,7 @@
                 "langsmith/observability-quickstart",
                 "langsmith/observability-concepts",
                 "langsmith/observability-llm-tutorial",
+                "langsmith/polly-observability",
                 {
                   "group": "Tracing setup",
                   "pages": [
@@ -368,6 +369,7 @@
                 "langsmith/evaluation-quickstart",
                 "langsmith/evaluation-concepts",
                 "langsmith/evaluation-approaches",
+                "langsmith/polly-evaluation",
                 {
                   "group": "Datasets",
                   "pages": [
@@ -525,6 +527,7 @@
                 "langsmith/prompt-engineering",
                 "langsmith/prompt-engineering-quickstart",
                 "langsmith/prompt-engineering-concepts",
+                "langsmith/polly-prompt-engineering",
                 {
                   "group": "Create and update prompts",
                   "pages": [

--- a/src/langsmith/polly-evaluation.mdx
+++ b/src/langsmith/polly-evaluation.mdx
@@ -1,0 +1,7 @@
+---
+title: LangSmith Polly
+sidebarTitle: Polly AI assistant
+url: "https://docs.langchain.com/langsmith/polly#evaluation"
+icon: "bird"
+tag: "Beta"
+---

--- a/src/langsmith/polly-observability.mdx
+++ b/src/langsmith/polly-observability.mdx
@@ -1,0 +1,7 @@
+---
+title: LangSmith Polly
+sidebarTitle: Polly AI assistant
+url: "https://docs.langchain.com/langsmith/polly#observability"
+icon: "bird"
+tag: "Beta"
+---

--- a/src/langsmith/polly-prompt-engineering.mdx
+++ b/src/langsmith/polly-prompt-engineering.mdx
@@ -1,0 +1,7 @@
+---
+title: LangSmith Polly
+sidebarTitle: Polly AI assistant
+url: "https://docs.langchain.com/langsmith/polly#prompt-engineering"
+icon: "bird"
+tag: "Beta"
+---

--- a/src/langsmith/polly.mdx
+++ b/src/langsmith/polly.mdx
@@ -1,7 +1,11 @@
 ---
 title: LangSmith Polly
-sidebarTitle: Polly (Beta)
+sidebarTitle: Polly AI assistant
+icon: "bird"
+tag: "Beta"
 ---
+
+import secret from '/snippets/langsmith/set-workspace-secrets.mdx';
 
 <Callout color="#4F46E5">
 **Polly is in beta.** Your [feedback](https://forum.langchain.com) on Polly is invaluable as the team refines its capabilities.
@@ -14,17 +18,25 @@ Polly helps you gain insight from your traces, conversation threads, and prompts
 <img src="/langsmith/images/polly.png" alt="LangSmith Polly icon" style={{float: 'left', marginRight: '20px', marginTop: '-1px', marginBottom: '20px', maxWidth: '100px'}} /> Polly appears in the right-hand bottom corner of the following locations within [LangSmith UI](https://smith.langchain.com):
 
 **Observability & Debugging:**
-- [Trace pages](#trace-pages) - Analyze individual runs and execution traces
-- [Thread views](#thread-views) - Understand conversation threads and user interactions
+- [Trace pages](#trace-pages): Analyze individual runs and execution traces.
+- [Thread views](#thread-views): Understand conversation threads and user interactions.
 
 **Prompt Engineering:**
-- [Prompt Playground](#prompt-playground) - Edit and optimize prompts
-- [Prompt Hub pages](#prompt-hub-pages) - Explore and understand shared prompts
+- [Prompt Playground](#prompt-playground): Edit and optimize prompts.
+- [Prompt Hub pages](#prompt-hub-pages): Explore and understand shared prompts.
 
 **Evaluation & Testing:**
-- [Dataset Experiments](#dataset-experiments) - Analyze experiment results and compare runs
-- [Dataset Examples](#dataset-examples) - Browse and understand dataset structure
-- [Annotation Queues](#annotation-queues) - Review runs and make informed annotation decisions
+- [Dataset Experiments](#dataset-experiments): Analyze experiment results and compare runs.
+- [Dataset Examples](#dataset-examples): Browse and understand dataset structure.
+- [Annotation Queues](#annotation-queues): Review runs and make informed annotation decisions.
+
+## Get started
+
+Before you start using Polly, you need to add an API key for the model you're using:
+
+<secret/>
+
+## Observability
 
 ### Trace pages
 
@@ -45,6 +57,8 @@ Under the **Threads** tab, Polly analyzes conversation [threads](/langsmith/obse
 - "What issues is the user experiencing?"
 - "Was the user's problem solved?"
 - "What was the main topic of this thread?"
+
+## Prompt engineering
 
 ### Prompt Playground
 
@@ -77,6 +91,8 @@ When viewing a prompt in the [LangSmith Hub](/langsmith/prompt-engineering-conce
 - "What tools does this prompt use?"
 - "Explain the structure of this prompt"
 - "What are the key instructions in this prompt?"
+
+## Evaluation
 
 ### Dataset Experiments
 

--- a/src/snippets/langsmith/set-workspace-secrets.mdx
+++ b/src/snippets/langsmith/set-workspace-secrets.mdx
@@ -1,7 +1,7 @@
-In the [LangSmith UI](https://smith.langchain.com), ensure that your OpenAI API key is set as a [workspace secret](/langsmith/administration-overview#workspace-secrets).
+In the [LangSmith UI](https://smith.langchain.com), ensure that your API key is set as a [workspace secret](/langsmith/administration-overview#workspace-secrets).
 
 1. Navigate to <Icon icon="gear" /> **Settings** and then move to the **Secrets** tab.
-1. Select **Add secret** and enter the `OPENAI_API_KEY` and your API key as the **Value**.
+1. Select **Add secret** and enter the key environment variable (e.g.,`OPENAI_API_KEY` or `ANTHROPIC_API_KEY`) and your API key as the **Value**.
 1. Select **Save secret**.
 
 <Note> When adding workspace secrets in the LangSmith UI, make sure the secret keys match the environment variable names expected by your model provider.</Note>


### PR DESCRIPTION
Fixes DOC-718

Adds a get started snippet for model api key to the polly page. Updated to use a beta tag on the sidebar. Updated the sidebar title for clarity. Adding page links to the obs, evals, prompt eng sections to elevate polly in those areas.

## Preview

https://langchain-5e9cc07a-preview-pollyu-1770914171-f0d9bbb.mintlify.app/langsmith/polly