### PR TITLE
fix: update granular usage instructions for self hosted offline

### DIFF
--- a/src/langsmith/self-hosted-changelog.mdx
+++ b/src/langsmith/self-hosted-changelog.mdx
@@ -30,7 +30,7 @@ rss: true
 - Implemented initial design for a tools page with feature flags.
 - Added icon-only filter popover mode to the frontend filter UI.
 - Added beacon endpoint for Self Hosted Agent Builder Runs Limiting.
-- Added new Granular Usage tab for reporting billable usage by workspace, project, user, and API key (enable with `DEFAULT_ORG_FEATURE_ENABLE_GRANULAR_USAGE_REPORTING=true` and `GRANULAR_USAGE_TABLE_ENABLED=true` environment variables in `commonEnv`)
+- Enable new Granular Usage tab for reporting billable usage by workspace, project, user, and API key (enable with `DEFAULT_ORG_FEATURE_ENABLE_GRANULAR_USAGE_REPORTING=true` and `GRANULAR_USAGE_TABLE_ENABLED=true` environment variables in `commonEnv`)
 
 **Download the Helm chart:** [`langsmith-0.13.12.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.12/langsmith-0.13.12.tgz)
 </Update>


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

A fix for self hosted offline granular usage was added in the last release 

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR: 

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
