### PR TITLE
docs: migrate deprecated initialize_agent examples to create_agent (batch 5)

### DIFF
--- a/src/oss/python/integrations/tools/connery.mdx
+++ b/src/oss/python/integrations/tools/connery.mdx
@@ -116,7 +116,7 @@ NOTE: Connery Action is a structured tool, so you can only use it in the agents 
 ```python
 import os
 
-from langchain.agents import AgentType, initialize_agent
+from langchain.agents import create_agent
 from langchain_community.tools.connery import ConneryService
 from langchain_openai import ChatOpenAI
 

--- a/src/oss/python/integrations/tools/human_tools.mdx
+++ b/src/oss/python/integrations/tools/human_tools.mdx
@@ -11,7 +11,7 @@ pip install -qU  langchain-community
 ```
 
 ```python
-from langchain.agents import AgentType, initialize_agent, load_tools
+from langchain.agents import create_agent, load_tools
 from langchain_openai import ChatOpenAI, OpenAI
 
 llm = ChatOpenAI(temperature=0.0)
@@ -21,10 +21,9 @@ tools = load_tools(
     llm=math_llm,
 )
 
-agent_chain = initialize_agent(
-    tools,
-    llm,
-    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+agent_chain = create_agent(
+    model=llm,
+    tools=tools,
     verbose=True,
 )
 ```
@@ -33,7 +32,9 @@ In the above code you can see the tool takes input directly from command line.
 You can customize `prompt_func` and `input_func` according to your need (as shown below).
 
 ```python
-agent_chain.run("What's my friend Eric's surname?")
+agent_chain.invoke(
+    {"input": "What's my friend Eric's surname?"}
+)
 # Answer with 'Zhu'
 ```
 
@@ -93,16 +94,17 @@ tool = HumanInputRun(input_func=get_input)
 ```
 
 ```python
-agent_chain = initialize_agent(
-    tools,
-    llm,
-    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+agent_chain = create_agent(
+    model=llm,
+    tools=tools,
     verbose=True,
 )
 ```
 
 ```python
-agent_chain.run("I need help attributing a quote")
+agent_chain.invoke(
+    {"input": "I need help attributing a quote"}
+)
 ```
 
 ```text

--- a/src/oss/python/integrations/tools/jira.mdx
+++ b/src/oss/python/integrations/tools/jira.mdx
@@ -29,7 +29,7 @@ pip install -qU langchain-community langchain-openai
 ```python
 import os
 
-from langchain.agents import AgentType, initialize_agent
+from langchain.agents import create_agent
 from langchain_community.agent_toolkits.jira.toolkit import JiraToolkit
 from langchain_community.utilities.jira import JiraAPIWrapper
 from langchain_openai import OpenAI
@@ -84,13 +84,19 @@ Let's see what individual tools are in the Jira toolkit:
 ```
 
 ```python
-agent = initialize_agent(
-    toolkit.get_tools(), llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True
+agent = create_agent(
+    model=llm,
+    tools=toolkit.get_tools(),
+    verbose=True,
 )
 ```
 
 ```python
-agent.run("make a new issue in project PW to remind me to make more fried rice")
+agent.invoke(
+    {
+        "input": "make a new issue in project PW to remind me to make more fried rice"
+    }
+)
 ```
 
 ```text

--- a/src/oss/python/integrations/tools/memorize.mdx
+++ b/src/oss/python/integrations/tools/memorize.mdx
@@ -12,7 +12,7 @@ This tool requires LLMs that support fine-tuning. Currently, only `langchain.llm
 ```python
 import os
 
-from langchain.agents import AgentExecutor, AgentType, initialize_agent, load_tools
+from langchain.agents import create_agent, load_tools
 from langchain_classic.chains import LLMChain
 from langchain.memory import ConversationBufferMemory
 from langchain_community.llms import GradientLLM
@@ -61,12 +61,10 @@ tools = load_tools(["memorize"], llm=llm)
 ## Initiate the Agent
 
 ```python
-agent = initialize_agent(
-    tools,
-    llm,
-    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
+agent = create_agent(
+    model=llm,
+    tools=tools,
     verbose=True,
-    # memory=ConversationBufferMemory(memory_key="chat_history", return_messages=True),
 )
 ```
 
@@ -75,8 +73,10 @@ agent = initialize_agent(
 Ask the agent to memorize a piece of text.
 
 ```python
-agent.run(
-    "Please remember the fact in detail:\nWith astonishing dexterity, Zara Tubikova set a world record by solving a 4x4 Rubik's Cube variation blindfolded in under 20 seconds, employing only their feet."
+agent.invoke(
+    {
+        "input": "Please remember the fact in detail:\nWith astonishing dexterity, Zara Tubikova set a world record by solving a 4x4 Rubik's Cube variation blindfolded in under 20 seconds, employing only their feet."
+    }
 )
 ```
 

--- a/src/oss/python/integrations/tools/office365.mdx
+++ b/src/oss/python/integrations/tools/office365.mdx
@@ -50,25 +50,21 @@ tools
 ## Use within an Agent
 
 ```python
-from langchain.agents import AgentType, initialize_agent
+from langchain.agents import create_agent
 from langchain_openai import OpenAI
 ```
 
 ```python
 llm = OpenAI(temperature=0)
-agent = initialize_agent(
+agent = create_agent(
+    model=llm,
     tools=toolkit.get_tools(),
-    llm=llm,
-    verbose=False,
-    agent=AgentType.STRUCTURED_CHAT_ZERO_SHOT_REACT_DESCRIPTION,
 )
 ```
 
 ```python
-agent.run(
-    "Create an email draft for me to edit of a letter from the perspective of a sentient parrot"
-    " who is looking to collaborate on some research with her"
-    " estranged friend, a cat. Under no circumstances may you send the message, however."
+agent.invoke(
+    {"input": "Create an email draft for me to edit of a letter from the perspective of a sentient parrot who is looking to collaborate on some research with her estranged friend, a cat. Under no circumstances may you send the message, however."}
 )
 ```
 
@@ -77,8 +73,8 @@ agent.run(
 ```
 
 ```python
-agent.run(
-    "Could you search in my drafts folder and let me know if any of them are about collaboration?"
+agent.invoke(
+    {"input": "Could you search in my drafts folder and let me know if any of them are about collaboration?"}
 )
 ```
 
@@ -87,8 +83,8 @@ agent.run(
 ```
 
 ```python
-agent.run(
-    "Can you schedule a 30 minute meeting with a sentient parrot to discuss research collaborations on October 3, 2023 at 2 pm Easter Time?"
+agent.invoke(
+    {"input": "Can you schedule a 30 minute meeting with a sentient parrot to discuss research collaborations on October 3, 2023 at 2 pm Eastern Time?"}
 )
 ```
 
@@ -104,8 +100,8 @@ agent.run(
 ```
 
 ```python
-agent.run(
-    "Can you tell me if I have any events on October 3, 2023 in Eastern Time, and if so, tell me if any of them are with a sentient parrot?"
+agent.invoke(
+    {"input": "Can you tell me if I have any events on October 3, 2023 in Eastern Time, and if so, tell me if any of them are with a sentient parrot?"}
 )
 ```
 

--- a/src/oss/python/integrations/tools/openapi_nla.mdx
+++ b/src/oss/python/integrations/tools/openapi_nla.mdx
@@ -10,7 +10,7 @@ This notebook demonstrates a sample composition of the `Speak`, `Klarna`, and `S
 ### First, import dependencies and load the LLM
 
 ```python
-from langchain.agents import AgentType, initialize_agent
+from langchain.agents import create_agent
 from langchain_community.agent_toolkits import NLAToolkit
 from langchain_community.utilities import Requests
 from langchain_openai import OpenAI
@@ -58,18 +58,16 @@ When responding with your Final Answer, remember that the person you are respond
 
 ```python
 natural_language_tools = speak_toolkit.get_tools() + klarna_toolkit.get_tools()
-mrkl = initialize_agent(
-    natural_language_tools,
-    llm,
-    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
-    verbose=True,
-    agent_kwargs={"format_instructions": openapi_format_instructions},
+mrkl = create_agent(
+    model=llm,
+    tools=natural_language_tools,
+    system_prompt=openapi_format_instructions,
 )
 ```
 
 ```python
-mrkl.run(
-    "I have an end of year party for my Italian class and have to buy some Italian clothes for it"
+mrkl.invoke(
+    {"input": "I have an end of year party for my Italian class and have to buy some Italian clothes for it"}
 )
 ```
 
@@ -151,12 +149,10 @@ print(f"{len(natural_language_api_tools)} tools loaded.")
 
 ```python
 # Create an agent with the new tools
-mrkl = initialize_agent(
-    natural_language_api_tools,
-    llm,
-    agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION,
-    verbose=True,
-    agent_kwargs={"format_instructions": openapi_format_instructions},
+mrkl = create_agent(
+    model=llm,
+    tools=natural_language_api_tools,
+    system_prompt=openapi_format_instructions,
 )
 ```
 
@@ -170,7 +166,7 @@ user_input = (
 ```
 
 ```python
-mrkl.run(user_input)
+mrkl.invoke({"input": user_input})
 ```
 
 ```text

--- a/src/oss/python/integrations/tools/sceneXplain.mdx
+++ b/src/oss/python/integrations/tools/sceneXplain.mdx
@@ -32,20 +32,23 @@ tool = SceneXplainTool()
 The tool can be used in any LangChain agent as follows:
 
 ```python
-from langchain.agents import initialize_agent
+from langchain.agents import create_agent
+from langchain_classic.chains import LLMChain
 from langchain.memory import ConversationBufferMemory
 from langchain_openai import OpenAI
 
 llm = OpenAI(temperature=0)
 memory = ConversationBufferMemory(memory_key="chat_history")
-agent = initialize_agent(
-    tools, llm, memory=memory, agent="conversational-react-description", verbose=True
+agent = create_agent(
+    model=llm,
+    tools=tools,
+    memory=memory,
 )
-output = agent.run(
-    input=(
-        "What is in this image https://storage.googleapis.com/causal-diffusion.appspot.com/imagePrompts%2F0rw369i5h9t%2Foriginal.png. "
-        "Is it movie or a game? If it is a movie, what is the name of the movie?"
-    )
+
+output = agent.invoke(
+    {
+        "input": "What is in this image https://storage.googleapis.com/causal-diffusion.appspot.com/imagePrompts%2F0rw369i5h9t%2Foriginal.png. Is it movie or a game? If it is a movie, what is the name of the movie?"
+    }
 )
 
 print(output)

--- a/src/oss/python/integrations/tools/zapier.mdx
+++ b/src/oss/python/integrations/tools/zapier.mdx
@@ -36,7 +36,7 @@ os.environ["ZAPIER_NLA_API_KEY"] = os.environ.get("ZAPIER_NLA_API_KEY", "")
 Zapier tools can be used with an agent. See the example below.
 
 ```python
-from langchain.agents import AgentType, initialize_agent
+from langchain.agents import create_agent
 from langchain_community.agent_toolkits import ZapierToolkit
 from langchain_community.utilities.zapier import ZapierNLAWrapper
 from langchain_openai import OpenAI
@@ -53,14 +53,17 @@ from langchain_openai import OpenAI
 llm = OpenAI(temperature=0)
 zapier = ZapierNLAWrapper()
 toolkit = ZapierToolkit.from_zapier_nla_wrapper(zapier)
-agent = initialize_agent(
-    toolkit.get_tools(), llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True
+agent = create_agent(
+    model=llm,
+    tools=toolkit.get_tools(),
 )
 ```
 
 ```python
-agent.run(
-    "Summarize the last email I received regarding Silicon Valley Bank. Send the summary to the #test-zapier channel in slack."
+agent.invoke(
+    {
+        "input": "Summarize the last email I received regarding Silicon Valley Bank. Send the summary to the #test-zapier channel in slack."
+    }
 )
 ```
 
@@ -215,11 +218,12 @@ The developer is tasked with handling the OAuth handshaking to procure and refre
 llm = OpenAI(temperature=0)
 zapier = ZapierNLAWrapper(zapier_nla_oauth_access_token="<fill in access token here>")
 toolkit = ZapierToolkit.from_zapier_nla_wrapper(zapier)
-agent = initialize_agent(
-    toolkit.get_tools(), llm, agent=AgentType.ZERO_SHOT_REACT_DESCRIPTION, verbose=True
+agent = create_agent(
+    model=llm,
+    tools=toolkit.get_tools(),
 )
 
-agent.run(
-    "Summarize the last email I received regarding Silicon Valley Bank. Send the summary to the #test-zapier channel in slack."
-)
+agent.invoke({
+    "input": "Summarize the last email I received regarding Silicon Valley Bank. Send the summary to the #test-zapier channel in slack."
+})
 ```


### PR DESCRIPTION
Migrates several docs examples from the deprecated initialize_agent to the current create_agent API.

Updated integrations:

- Zapier
- SceneXPlain
- OpenAPI NLA
- Office365
- Memorize
- Connery
- Jira
- Human Tools

This is the last batch :)
This is part of the migration discussed in https://github.com/langchain-ai/docs/issues/2473.