### PR TITLE
fix: Fixed example issue in the SQL agent doc from python to typescript

### DIFF
--- a/src/code-samples/langchain/sql-agent.ts
+++ b/src/code-samples/langchain/sql-agent.ts
@@ -147,6 +147,84 @@ for await (const step of stream) {
 }
 // :snippet-end:
 
+// :snippet-start: sql-agent-hitl-middleware-js
+import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
+import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
+
+const agent = createAgent({
+  model: "gpt-5.4",
+  tools: [executeSql],
+  systemPrompt: await getSystemPrompt(),
+  middleware: [
+    // [!code highlight]
+    humanInTheLoopMiddleware({
+      // [!code highlight]
+      interruptOn: {
+        execute_sql: true, // [!code highlight]
+      },
+      descriptionPrefix: "Tool execution pending approval", // [!code highlight]
+    }),
+  ], // [!code highlight]
+  checkpointer: new MemorySaver(), // [!code highlight]
+});
+// :snippet-end:
+
+// :snippet-start: sql-agent-hitl-run-js
+const question = "Which genre, on average, has the longest tracks?";
+const config = { configurable: { thread_id: "1" } }; // [!code highlight]
+
+const stream = await agent.stream(
+  { messages: [{ role: "user", content: question }] },
+  { ...config, streamMode: "values" }, // [!code highlight]
+);
+for await (const step of stream) {
+  if ("__interrupt__" in step) {
+    // [!code highlight]
+    console.log("INTERRUPTED:"); // [!code highlight]
+    for (const interrupt of step.__interrupt__) {
+      // [!code highlight]
+      for (const request of interrupt.value.actionRequests) {
+        // [!code highlight]
+        console.log(request.description); // [!code highlight]
+      }
+    }
+  } else if (step.messages) {
+    const message = step.messages.at(-1);
+    console.log(`${message.role}: ${JSON.stringify(message.content, null, 2)}`);
+  }
+}
+// :snippet-end:
+
+// :snippet-start: sql-agent-hitl-resume-js
+import { Command } from "@langchain/langgraph"; // [!code highlight]
+
+// :remove-start:
+if (false) {
+  // :remove-end:
+  for await (const step of await agent.stream(
+    new Command({ resume: { decisions: [{ type: "approve" }] } }), // [!code highlight]
+    { ...config, streamMode: "values" },
+  )) {
+    if (step.messages) {
+      const message = step.messages.at(-1);
+      console.log(
+        `${message.role}: ${JSON.stringify(message.content, null, 2)}`,
+      );
+    }
+    if ("__interrupt__" in step) {
+      console.log("INTERRUPTED:");
+      for (const interrupt of step.__interrupt__) {
+        for (const request of interrupt.value.actionRequests) {
+          console.log(request.description);
+        }
+      }
+    }
+  }
+  // :remove-start:
+}
+// :remove-end:
+// :snippet-end:
+
 // :remove-start:
 async function main() {
   const dbPath = await resolveDbPath();

--- a/src/code-samples/langchain/sql-agent.ts
+++ b/src/code-samples/langchain/sql-agent.ts
@@ -128,7 +128,7 @@ Rules:
 // :snippet-start: sql-agent-create-agent-js
 import { createAgent } from "langchain";
 
-const agent = createAgent({
+let agent = createAgent({
   model: "gpt-5.4",
   tools: [executeSql],
   systemPrompt: await getSystemPrompt(),
@@ -136,12 +136,12 @@ const agent = createAgent({
 // :snippet-end:
 
 // :snippet-start: sql-agent-run-agent-js
-const question = "Which genre, on average, has the longest tracks?";
-const stream = await agent.stream(
+let question = "Which genre, on average, has the longest tracks?";
+
+for await (const step of await agent.stream(
   { messages: [{ role: "user", content: question }] },
   { streamMode: "values" },
-);
-for await (const step of stream) {
+)) {
   const message = step.messages.at(-1);
   console.log(`${message.role}: ${JSON.stringify(message.content, null, 2)}`);
 }
@@ -151,7 +151,7 @@ for await (const step of stream) {
 import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
 import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
 
-const agent = createAgent({
+agent = createAgent({
   model: "gpt-5.4",
   tools: [executeSql],
   systemPrompt: await getSystemPrompt(),
@@ -170,14 +170,13 @@ const agent = createAgent({
 // :snippet-end:
 
 // :snippet-start: sql-agent-hitl-run-js
-const question = "Which genre, on average, has the longest tracks?";
+question = "Which genre, on average, has the longest tracks?";
 const config = { configurable: { thread_id: "1" } }; // [!code highlight]
 
-const stream = await agent.stream(
+for await (const step of await agent.stream(
   { messages: [{ role: "user", content: question }] },
   { ...config, streamMode: "values" }, // [!code highlight]
-);
-for await (const step of stream) {
+)) {
   if ("__interrupt__" in step) {
     // [!code highlight]
     console.log("INTERRUPTED:"); // [!code highlight]
@@ -198,31 +197,23 @@ for await (const step of stream) {
 // :snippet-start: sql-agent-hitl-resume-js
 import { Command } from "@langchain/langgraph"; // [!code highlight]
 
-// :remove-start:
-if (false) {
-  // :remove-end:
-  for await (const step of await agent.stream(
-    new Command({ resume: { decisions: [{ type: "approve" }] } }), // [!code highlight]
-    { ...config, streamMode: "values" },
-  )) {
-    if (step.messages) {
-      const message = step.messages.at(-1);
-      console.log(
-        `${message.role}: ${JSON.stringify(message.content, null, 2)}`,
-      );
-    }
-    if ("__interrupt__" in step) {
-      console.log("INTERRUPTED:");
-      for (const interrupt of step.__interrupt__) {
-        for (const request of interrupt.value.actionRequests) {
-          console.log(request.description);
-        }
+for await (const step of await agent.stream(
+  new Command({ resume: { decisions: [{ type: "approve" }] } }), // [!code highlight]
+  { ...config, streamMode: "values" },
+)) {
+  if (step.messages) {
+    const message = step.messages.at(-1);
+    console.log(`${message.role}: ${JSON.stringify(message.content, null, 2)}`);
+  }
+  if ("__interrupt__" in step) {
+    console.log("INTERRUPTED:");
+    for (const interrupt of step.__interrupt__) {
+      for (const request of interrupt.value.actionRequests) {
+        console.log(request.description);
       }
     }
   }
-  // :remove-start:
 }
-// :remove-end:
 // :snippet-end:
 
 // :remove-start:

--- a/src/oss/langchain/sql-agent.mdx
+++ b/src/oss/langchain/sql-agent.mdx
@@ -23,6 +23,9 @@ import SqlAgentCreateAgentJs from '/snippets/code-samples/sql-agent-create-agent
 import SqlAgentRunAgentJs from '/snippets/code-samples/sql-agent-run-agent-js.mdx';
 import SqlAgentStudioPy from '/snippets/code-samples/sql-agent-studio-py.mdx';
 import SqlAgentStudioJs from '/snippets/code-samples/sql-agent-studio-js.mdx';
+import SqlAgentHitlMiddlewareJs from '/snippets/code-samples/sql-agent-hitl-middleware-js.mdx';
+import SqlAgentHitlRunJs from '/snippets/code-samples/sql-agent-hitl-run-js.mdx';
+import SqlAgentHitlResumeJs from '/snippets/code-samples/sql-agent-hitl-resume-js.mdx';
 
 ## Overview
 
@@ -426,6 +429,50 @@ Tool Calls:
     query: SELECT Genre.Name, AVG(Track.Milliseconds) AS AvgDuration FROM Track JOIN Genre ON Track.GenreId = Genre.GenreId GROUP BY Genre.Name ORDER BY AvgDuration DESC LIMIT 5;
 ================================= Tool Message =================================
 Name: sql_db_query
+
+[('Sci Fi & Fantasy', 2911783.0384615385), ('Science Fiction', 2625549.076923077), ('Drama', 2575283.78125), ('TV Shows', 2145041.0215053763), ('Comedy', 1585263.705882353)]
+================================== Ai Message ==================================
+
+The genre with the longest average track length is "Sci Fi & Fantasy" with an average duration of about 2,911,783 milliseconds, followed by "Science Fiction" and "Drama."
+```
+
+Refer to the [human-in-the-loop guide](/oss/langchain/human-in-the-loop) for details.
+:::
+
+:::js
+It can be prudent to check the agent's SQL queries before they are executed for any unintended actions or inefficiencies.
+
+LangChain agents feature support for built-in [human-in-the-loop middleware](/oss/langchain/human-in-the-loop) to add oversight to agent tool calls. Let's configure the agent to pause for human review on calling the `execute_sql` tool:
+
+<SqlAgentHitlMiddlewareJs />
+<Note>
+We've added a [checkpointer](/oss/langchain/short-term-memory) to our agent to allow execution to be paused and resumed. See the [human-in-the-loop guide](/oss/langchain/human-in-the-loop) for detalis on this as well as available middleware configurations.
+</Note>
+
+On running the agent, it will now pause for review before executing the `execute_sql` tool:
+
+<SqlAgentHitlRunJs />
+```
+...
+
+INTERRUPTED:
+Tool execution pending approval
+
+Tool: execute_sql
+Args: {'query': 'SELECT g.Name AS Genre, AVG(t.Milliseconds) AS AvgTrackLength FROM Track t JOIN Genre g ON t.GenreId = g.GenreId GROUP BY g.Name ORDER BY AvgTrackLength DESC LIMIT 1;'}
+```
+We can resume execution, in this case accepting the query, using [Command](/oss/langgraph/use-graph-api#combine-control-flow-and-state-updates-with-command):
+
+<SqlAgentHitlResumeJs />
+```
+================================== Ai Message ==================================
+Tool Calls:
+  execute_sql (call_7oz86Epg7lYRqi9rQHbZPS1U)
+ Call ID: call_7oz86Epg7lYRqi9rQHbZPS1U
+  Args:
+    query: SELECT Genre.Name, AVG(Track.Milliseconds) AS AvgDuration FROM Track JOIN Genre ON Track.GenreId = Genre.GenreId GROUP BY Genre.Name ORDER BY AvgDuration DESC LIMIT 5;
+================================= Tool Message =================================
+Name: execute_sql
 
 [('Sci Fi & Fantasy', 2911783.0384615385), ('Science Fiction', 2625549.076923077), ('Drama', 2575283.78125), ('TV Shows', 2145041.0215053763), ('Comedy', 1585263.705882353)]
 ================================== Ai Message ==================================

--- a/src/snippets/code-samples/evaluate-rag-dataset-js.mdx
+++ b/src/snippets/code-samples/evaluate-rag-dataset-js.mdx
@@ -27,9 +27,6 @@ const outputs = [
 ];
 
 const datasetName = "Lilian Weng Blogs Q&A";
-for await (const existingDataset of client.listDatasets({ datasetName })) {
-  await client.deleteDataset({ datasetId: existingDataset.id });
-}
 const dataset = await client.createDataset(datasetName);
 await client.createExamples({ inputs, outputs, datasetId: dataset.id });
 ```

--- a/src/snippets/code-samples/evaluate-rag-reference-js.mdx
+++ b/src/snippets/code-samples/evaluate-rag-reference-js.mdx
@@ -107,9 +107,7 @@ const outputs = [
 ];
 
 const datasetName = "Lilian Weng Blogs Q&A";
-for await (const existingDataset of client.listDatasets({ datasetName })) {
-  await client.deleteDataset({ datasetId: existingDataset.id });
-}
+
 const dataset = await client.createDataset(datasetName);
 await client.createExamples({ inputs, outputs, datasetId: dataset.id });
 

--- a/src/snippets/code-samples/sql-agent-create-agent-js.mdx
+++ b/src/snippets/code-samples/sql-agent-create-agent-js.mdx
@@ -2,7 +2,7 @@
     ```ts Google
     import { createAgent } from "langchain";
     
-    const agent = createAgent({
+    let agent = createAgent({
       model: "google-genai:gemini-3.5-flash",
       tools: [executeSql],
       systemPrompt: await getSystemPrompt(),
@@ -12,7 +12,7 @@
     ```ts OpenAI
     import { createAgent } from "langchain";
     
-    const agent = createAgent({
+    let agent = createAgent({
       model: "openai:gpt-5.4",
       tools: [executeSql],
       systemPrompt: await getSystemPrompt(),
@@ -22,7 +22,7 @@
     ```ts Anthropic
     import { createAgent } from "langchain";
     
-    const agent = createAgent({
+    let agent = createAgent({
       model: "anthropic:claude-sonnet-4-6",
       tools: [executeSql],
       systemPrompt: await getSystemPrompt(),
@@ -32,7 +32,7 @@
     ```ts OpenRouter
     import { createAgent } from "langchain";
     
-    const agent = createAgent({
+    let agent = createAgent({
       model: "openrouter:anthropic/claude-sonnet-4-6",
       tools: [executeSql],
       systemPrompt: await getSystemPrompt(),
@@ -42,7 +42,7 @@
     ```ts Fireworks
     import { createAgent } from "langchain";
     
-    const agent = createAgent({
+    let agent = createAgent({
       model: "fireworks:accounts/fireworks/models/qwen3p5-397b-a17b",
       tools: [executeSql],
       systemPrompt: await getSystemPrompt(),
@@ -52,7 +52,7 @@
     ```ts Baseten
     import { createAgent } from "langchain";
     
-    const agent = createAgent({
+    let agent = createAgent({
       model: "baseten:zai-org/GLM-5",
       tools: [executeSql],
       systemPrompt: await getSystemPrompt(),
@@ -62,7 +62,7 @@
     ```ts Ollama
     import { createAgent } from "langchain";
     
-    const agent = createAgent({
+    let agent = createAgent({
       model: "ollama:devstral-2",
       tools: [executeSql],
       systemPrompt: await getSystemPrompt(),

--- a/src/snippets/code-samples/sql-agent-hitl-middleware-js.mdx
+++ b/src/snippets/code-samples/sql-agent-hitl-middleware-js.mdx
@@ -1,0 +1,155 @@
+<CodeGroup>
+    ```ts Google
+    import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
+    import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
+    
+    const agent = createAgent({
+      model: "google-genai:gemini-3.5-flash",
+      tools: [executeSql],
+      systemPrompt: await getSystemPrompt(),
+      middleware: [
+        // [!code highlight]
+        humanInTheLoopMiddleware({
+          // [!code highlight]
+          interruptOn: {
+            execute_sql: true, // [!code highlight]
+          },
+          descriptionPrefix: "Tool execution pending approval", // [!code highlight]
+        }),
+      ], // [!code highlight]
+      checkpointer: new MemorySaver(), // [!code highlight]
+    });
+    ```
+
+    ```ts OpenAI
+    import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
+    import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
+    
+    const agent = createAgent({
+      model: "openai:gpt-5.4",
+      tools: [executeSql],
+      systemPrompt: await getSystemPrompt(),
+      middleware: [
+        // [!code highlight]
+        humanInTheLoopMiddleware({
+          // [!code highlight]
+          interruptOn: {
+            execute_sql: true, // [!code highlight]
+          },
+          descriptionPrefix: "Tool execution pending approval", // [!code highlight]
+        }),
+      ], // [!code highlight]
+      checkpointer: new MemorySaver(), // [!code highlight]
+    });
+    ```
+
+    ```ts Anthropic
+    import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
+    import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
+    
+    const agent = createAgent({
+      model: "anthropic:claude-sonnet-4-6",
+      tools: [executeSql],
+      systemPrompt: await getSystemPrompt(),
+      middleware: [
+        // [!code highlight]
+        humanInTheLoopMiddleware({
+          // [!code highlight]
+          interruptOn: {
+            execute_sql: true, // [!code highlight]
+          },
+          descriptionPrefix: "Tool execution pending approval", // [!code highlight]
+        }),
+      ], // [!code highlight]
+      checkpointer: new MemorySaver(), // [!code highlight]
+    });
+    ```
+
+    ```ts OpenRouter
+    import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
+    import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
+    
+    const agent = createAgent({
+      model: "openrouter:anthropic/claude-sonnet-4-6",
+      tools: [executeSql],
+      systemPrompt: await getSystemPrompt(),
+      middleware: [
+        // [!code highlight]
+        humanInTheLoopMiddleware({
+          // [!code highlight]
+          interruptOn: {
+            execute_sql: true, // [!code highlight]
+          },
+          descriptionPrefix: "Tool execution pending approval", // [!code highlight]
+        }),
+      ], // [!code highlight]
+      checkpointer: new MemorySaver(), // [!code highlight]
+    });
+    ```
+
+    ```ts Fireworks
+    import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
+    import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
+    
+    const agent = createAgent({
+      model: "fireworks:accounts/fireworks/models/qwen3p5-397b-a17b",
+      tools: [executeSql],
+      systemPrompt: await getSystemPrompt(),
+      middleware: [
+        // [!code highlight]
+        humanInTheLoopMiddleware({
+          // [!code highlight]
+          interruptOn: {
+            execute_sql: true, // [!code highlight]
+          },
+          descriptionPrefix: "Tool execution pending approval", // [!code highlight]
+        }),
+      ], // [!code highlight]
+      checkpointer: new MemorySaver(), // [!code highlight]
+    });
+    ```
+
+    ```ts Baseten
+    import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
+    import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
+    
+    const agent = createAgent({
+      model: "baseten:zai-org/GLM-5",
+      tools: [executeSql],
+      systemPrompt: await getSystemPrompt(),
+      middleware: [
+        // [!code highlight]
+        humanInTheLoopMiddleware({
+          // [!code highlight]
+          interruptOn: {
+            execute_sql: true, // [!code highlight]
+          },
+          descriptionPrefix: "Tool execution pending approval", // [!code highlight]
+        }),
+      ], // [!code highlight]
+      checkpointer: new MemorySaver(), // [!code highlight]
+    });
+    ```
+
+    ```ts Ollama
+    import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
+    import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
+    
+    const agent = createAgent({
+      model: "ollama:devstral-2",
+      tools: [executeSql],
+      systemPrompt: await getSystemPrompt(),
+      middleware: [
+        // [!code highlight]
+        humanInTheLoopMiddleware({
+          // [!code highlight]
+          interruptOn: {
+            execute_sql: true, // [!code highlight]
+          },
+          descriptionPrefix: "Tool execution pending approval", // [!code highlight]
+        }),
+      ], // [!code highlight]
+      checkpointer: new MemorySaver(), // [!code highlight]
+    });
+    ```
+</CodeGroup>

--- a/src/snippets/code-samples/sql-agent-hitl-middleware-js.mdx
+++ b/src/snippets/code-samples/sql-agent-hitl-middleware-js.mdx
@@ -3,7 +3,7 @@
     import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
     import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
     
-    const agent = createAgent({
+    agent = createAgent({
       model: "google-genai:gemini-3.5-flash",
       tools: [executeSql],
       systemPrompt: await getSystemPrompt(),
@@ -25,7 +25,7 @@
     import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
     import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
     
-    const agent = createAgent({
+    agent = createAgent({
       model: "openai:gpt-5.4",
       tools: [executeSql],
       systemPrompt: await getSystemPrompt(),
@@ -47,7 +47,7 @@
     import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
     import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
     
-    const agent = createAgent({
+    agent = createAgent({
       model: "anthropic:claude-sonnet-4-6",
       tools: [executeSql],
       systemPrompt: await getSystemPrompt(),
@@ -69,7 +69,7 @@
     import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
     import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
     
-    const agent = createAgent({
+    agent = createAgent({
       model: "openrouter:anthropic/claude-sonnet-4-6",
       tools: [executeSql],
       systemPrompt: await getSystemPrompt(),
@@ -91,7 +91,7 @@
     import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
     import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
     
-    const agent = createAgent({
+    agent = createAgent({
       model: "fireworks:accounts/fireworks/models/qwen3p5-397b-a17b",
       tools: [executeSql],
       systemPrompt: await getSystemPrompt(),
@@ -113,7 +113,7 @@
     import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
     import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
     
-    const agent = createAgent({
+    agent = createAgent({
       model: "baseten:zai-org/GLM-5",
       tools: [executeSql],
       systemPrompt: await getSystemPrompt(),
@@ -135,7 +135,7 @@
     import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code highlight]
     import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
     
-    const agent = createAgent({
+    agent = createAgent({
       model: "ollama:devstral-2",
       tools: [executeSql],
       systemPrompt: await getSystemPrompt(),

--- a/src/snippets/code-samples/sql-agent-hitl-resume-js.mdx
+++ b/src/snippets/code-samples/sql-agent-hitl-resume-js.mdx
@@ -1,23 +1,21 @@
 ```ts
 import { Command } from "@langchain/langgraph"; // [!code highlight]
 
-  for await (const step of await agent.stream(
-    new Command({ resume: { decisions: [{ type: "approve" }] } }), // [!code highlight]
-    { ...config, streamMode: "values" },
-  )) {
-    if (step.messages) {
-      const message = step.messages.at(-1);
-      console.log(
-        `${message.role}: ${JSON.stringify(message.content, null, 2)}`,
-      );
-    }
-    if ("__interrupt__" in step) {
-      console.log("INTERRUPTED:");
-      for (const interrupt of step.__interrupt__) {
-        for (const request of interrupt.value.actionRequests) {
-          console.log(request.description);
-        }
+for await (const step of await agent.stream(
+  new Command({ resume: { decisions: [{ type: "approve" }] } }), // [!code highlight]
+  { ...config, streamMode: "values" },
+)) {
+  if (step.messages) {
+    const message = step.messages.at(-1);
+    console.log(`${message.role}: ${JSON.stringify(message.content, null, 2)}`);
+  }
+  if ("__interrupt__" in step) {
+    console.log("INTERRUPTED:");
+    for (const interrupt of step.__interrupt__) {
+      for (const request of interrupt.value.actionRequests) {
+        console.log(request.description);
       }
     }
   }
+}
 ```

--- a/src/snippets/code-samples/sql-agent-hitl-resume-js.mdx
+++ b/src/snippets/code-samples/sql-agent-hitl-resume-js.mdx
@@ -1,0 +1,23 @@
+```ts
+import { Command } from "@langchain/langgraph"; // [!code highlight]
+
+  for await (const step of await agent.stream(
+    new Command({ resume: { decisions: [{ type: "approve" }] } }), // [!code highlight]
+    { ...config, streamMode: "values" },
+  )) {
+    if (step.messages) {
+      const message = step.messages.at(-1);
+      console.log(
+        `${message.role}: ${JSON.stringify(message.content, null, 2)}`,
+      );
+    }
+    if ("__interrupt__" in step) {
+      console.log("INTERRUPTED:");
+      for (const interrupt of step.__interrupt__) {
+        for (const request of interrupt.value.actionRequests) {
+          console.log(request.description);
+        }
+      }
+    }
+  }
+```

--- a/src/snippets/code-samples/sql-agent-hitl-run-js.mdx
+++ b/src/snippets/code-samples/sql-agent-hitl-run-js.mdx
@@ -1,0 +1,25 @@
+```ts
+const question = "Which genre, on average, has the longest tracks?";
+const config = { configurable: { thread_id: "1" } }; // [!code highlight]
+
+const stream = await agent.stream(
+  { messages: [{ role: "user", content: question }] },
+  { ...config, streamMode: "values" }, // [!code highlight]
+);
+for await (const step of stream) {
+  if ("__interrupt__" in step) {
+    // [!code highlight]
+    console.log("INTERRUPTED:"); // [!code highlight]
+    for (const interrupt of step.__interrupt__) {
+      // [!code highlight]
+      for (const request of interrupt.value.actionRequests) {
+        // [!code highlight]
+        console.log(request.description); // [!code highlight]
+      }
+    }
+  } else if (step.messages) {
+    const message = step.messages.at(-1);
+    console.log(`${message.role}: ${JSON.stringify(message.content, null, 2)}`);
+  }
+}
+```

--- a/src/snippets/code-samples/sql-agent-hitl-run-js.mdx
+++ b/src/snippets/code-samples/sql-agent-hitl-run-js.mdx
@@ -1,12 +1,11 @@
 ```ts
-const question = "Which genre, on average, has the longest tracks?";
+question = "Which genre, on average, has the longest tracks?";
 const config = { configurable: { thread_id: "1" } }; // [!code highlight]
 
-const stream = await agent.stream(
+for await (const step of await agent.stream(
   { messages: [{ role: "user", content: question }] },
   { ...config, streamMode: "values" }, // [!code highlight]
-);
-for await (const step of stream) {
+)) {
   if ("__interrupt__" in step) {
     // [!code highlight]
     console.log("INTERRUPTED:"); // [!code highlight]

--- a/src/snippets/code-samples/sql-agent-run-agent-js.mdx
+++ b/src/snippets/code-samples/sql-agent-run-agent-js.mdx
@@ -1,10 +1,10 @@
 ```ts
-const question = "Which genre, on average, has the longest tracks?";
-const stream = await agent.stream(
+let question = "Which genre, on average, has the longest tracks?";
+
+for await (const step of await agent.stream(
   { messages: [{ role: "user", content: question }] },
   { streamMode: "values" },
-);
-for await (const step of stream) {
+)) {
   const message = step.messages.at(-1);
   console.log(`${message.role}: ${JSON.stringify(message.content, null, 2)}`);
 }


### PR DESCRIPTION
## Overview
Fixes the documentation issue in `Build a SQL agent` documentation

## Type of change

In `Build a SQL agent` documentation, on typescript language selection the example under the `6. Implement human-in-the-loop review` was still showing in python language. This PR fixes the issue and changes it to typescript safely.

fixes #2566