### PR TITLE
chore: add deprecation warning to readme [closes DOC-739]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # LangChain Docs
 
+> [!CAUTION]
+> **This repository is deprecated and is no longer actively maintained.** Please do not use this repository for new projects. It exists only as a historical archive.
+
 🦜 **Welcome!** This repository contains the documentation build pipeline for LangChain projects.
 
 * 🏠 [`docs.langchain.com`](https://docs.langchain.com) is our docs home, centralizing LangChain, LangGraph, LangSmith, and LangChain Labs (Deep Agents, Open SWE, Open Agent Platform). This site is hosted on [Mintlify](https://mintlify.com).

--- a/scripts/check_import_mappings.py
+++ b/scripts/check_import_mappings.py
@@ -133,7 +133,7 @@ def analyze_init_file(init_file: Path, package_path: Path) -> dict[str, Any]:
                 if node.module and node.module.startswith("langchain_core"):
                     for alias in node.names:
                         # The name as it appears in this module (alias or original)
-                        local_name = alias.asname if alias.asname else alias.name
+                        local_name = alias.asname or alias.name
 
                         # Store the import mapping
                         langchain_core_imports[local_name] = {

--- a/tests/unit_tests/test_check_pr_imports.py
+++ b/tests/unit_tests/test_check_pr_imports.py
@@ -30,8 +30,8 @@ def test_load_existing_mappings() -> None:
     with patch("scripts.check_pr_imports.Path") as mock_path:
         mock_path.return_value.exists.return_value = True
         temp_file_path = Path(temp_path)
-        mock_path.return_value.open.return_value.__enter__ = (
-            lambda _: temp_file_path.open()
+        mock_path.return_value.open.return_value.__enter__ = lambda _: (
+            temp_file_path.open()
         )
         mock_path.return_value.open.return_value.__exit__ = Mock(return_value=None)
 


### PR DESCRIPTION
## Description
Adds a prominent deprecation warning to the root README.md to inform users that this repository is deprecated and should not be used for new projects.

Changes:
- Added a `> [!CAUTION]` GitHub alert block at the top of `README.md` stating the repo is deprecated

Resolves DOC-739

## Test Plan
- [ ] Verify the deprecation warning renders correctly on GitHub (should appear as a red caution box)
- [ ] Verify the rest of the README content is unchanged