### PR TITLE
Update the supported ttl strategies

### DIFF
--- a/src/langsmith/configure-ttl.mdx
+++ b/src/langsmith/configure-ttl.mdx
@@ -33,7 +33,7 @@ Add a `checkpointer.ttl` configuration to your `langgraph.json` file:
 ```
 
 - `strategy`: Specifies the action taken on expiration.
-    - `"delete"`: Removes the entire thread (all associated run and checkpoint data) when the TTL expires.
+    - `"delete"`: Removes the entire thread including all associated run and checkpoint data when the TTL expires.
     - `"keep_latest"`: Retains the thread and latest checkpoint, but deletes older checkpoint data that subsequent runs won't need.
 - `sweep_interval_minutes`: Defines how often, in minutes, the system checks for expired checkpoints.
 - `default_ttl`: Sets the default lifespan of threads (and corresponding checkpoints) in minutes (e.g., 43200 minutes = 30 days). Applies only to checkpoints created after this configuration is deployed; existing checkpoints/threads are not changed. To clear older data, delete it explicitly.


### PR DESCRIPTION
 Fixes DOC-735

Adds `keep_latest` to TTL strategy configuration

## Preview

https://langchain-5e9cc07a-preview-ttlstr-1771345811-5c31d57.mintlify.app/langsmith/configure-ttl#configuring-thread-and-checkpoint-ttl