### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.7.37

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -5321,7 +5321,13 @@
           },
           "sort_by": {
             "type": "string",
-            "enum": ["thread_id", "status", "created_at", "updated_at"],
+            "enum": [
+              "thread_id",
+              "status",
+              "created_at",
+              "updated_at",
+              "state_updated_at"
+            ],
             "title": "Sort By",
             "description": "Sort by field."
           },
@@ -5339,6 +5345,7 @@
                 "thread_id",
                 "created_at",
                 "updated_at",
+                "state_updated_at",
                 "metadata",
                 "config",
                 "status",
@@ -5396,6 +5403,12 @@
             "format": "date-time",
             "title": "Updated At",
             "description": "The last time the thread was updated."
+          },
+          "state_updated_at": {
+            "type": "string",
+            "format": "date-time",
+            "title": "State Updated At",
+            "description": "The last time the thread state was updated."
           },
           "metadata": {
             "type": "object",


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.7.37**

This update was automatically generated by the sync workflow in the langgraph-api repository.