### PR TITLE
fix: mention minimum app/helm version for disabling personal access token creation

### DIFF
--- a/src/langsmith/self-host-user-management.mdx
+++ b/src/langsmith/self-host-user-management.mdx
@@ -104,6 +104,10 @@ PERSONAL_ORGS_DISABLED="true"
 
 ### Disabling personal access token creation
 
+<Note>
+This feature requires Helm chart version 0.13.12 (application version 0.13.12) or later.
+</Note>
+
 By default, users can create Personal Access Tokens (PATs) in any organization. For self-hosted customers, an admin may want to globally disable PAT creation across all organizations. This environment variable allows an admin to prevent users from creating new PATs in any organization on the instance.
 
 To disable PAT creation for a single organization instead, see the [per-organization API option](/langsmith/manage-organization-by-api#security-settings).


### PR DESCRIPTION
## Summary
- Adds a `<Note>` to the "Disabling personal access token creation" section in `self-host-user-management.mdx` specifying the minimum Helm chart version (0.13.12) and application version (0.13.12) required for this feature.

## Test plan
- [x] Verify the note renders correctly on the Mintlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)