### PR TITLE
feat: add thread read/unread behavior note for AB [closes DOC-746]

### DIFF
--- a/src/langsmith/agent-builder-essentials.mdx
+++ b/src/langsmith/agent-builder-essentials.mdx
@@ -29,13 +29,20 @@ Here are some popular ways to trigger your agent:
   </Card>
 </CardGroup>
 
-## Thread notifications
+## Threads
 
-How agent responses appear in your inbox depends on whether the agent uses triggers:
+Threads are conversations between you and your agent. Each thread contains messages, agent responses, and any actions the agent takes.
 
-**Chat agents (no trigger):** When the agent responds, the thread is marked as **unread** by default. The thread moves to read when you view it. You can manually mark it as unread at any time.
+To view threads, navigate to your agent in the [LangSmith UI](https://smith.langchain.com). The inbox shows all threads for that agent. Click on a thread to view the conversation.
 
-**Trigger-based agents:** When the agent responds, the thread is marked as **read** by default. Subsequent responses within the thread also remain read. You can manually mark it as unread at any time.
+### Read and unread status
+
+How threads are marked depends on whether the agent uses triggers:
+
+- **Chat agents (no trigger):** Responses mark the thread as **unread**. Viewing the thread marks it as read.
+- **Trigger-based agents:** Responses keep the thread as **read** by default.
+
+You can manually mark any thread as read or unread at any time.
 
 ## Skills
 


### PR DESCRIPTION
## Description
Adds a new "Thread notifications" section to the Agent Builder essentials page
that documents how threads are marked as read/unread depending on the agent type.

This addresses a documentation gap where users had no reference for understanding
the default read/unread behavior of threads in Agent Builder:

- **Chat agents (no trigger):** Responses are marked as unread by default, moving
  to read when the user views them.
- **Trigger-based agents:** Responses are marked as read by default, remaining
  read for subsequent responses within the thread.
- Both types allow the user to manually mark threads as unread at any time.

The section is placed in `agent-builder-essentials.mdx` right after the Triggers
section, since the behavior is directly tied to whether an agent uses triggers.

Resolves DOC-746

## Test Plan
- [x] Verify the new "Thread notifications" section renders correctly in the Mintlify preview
- [x] Confirm the section appears between "Triggers" and "Skills" on the Essentials page
- [x] Verify no broken links or formatting issues are introduced