### PR TITLE
Switch egress docs to 2 distinct sections

### DIFF
--- a/src/langsmith/self-host-egress.mdx
+++ b/src/langsmith/self-host-egress.mdx
@@ -7,10 +7,10 @@ sidebarTitle: Configure egress
 This page only applies to customers who are not running in offline (air-gapped) mode and assumes you are using a self-hosted LangSmith instance serving version 0.9.0 or later.
 </Info>
 
-Self-hosted LangSmith instances store all information locally and never send sensitive information outside of your network. However, unless you are running in offline mode, LangSmith requires egress to `https://beacon.langchain.com` for:
+Self-hosted LangSmith instances store all information locally and never send sensitive information outside of your network. However, unless you are running in offline mode, LangSmith requires egress to `https://beacon.langchain.com` for the following:
 
-1. **Billing telemetry** — License verification and subscription/usage reporting (required)
-2. **Operational telemetry** — Logs, metrics, and traces for support diagnostics (optional, can be disabled)
+- **Billing telemetry** — License verification and subscription/usage reporting (required)
+- **Operational telemetry** — Logs, metrics, and traces for support diagnostics (optional, can be disabled)
 
 <Warning>
 **Egress to `https://beacon.langchain.com` is required.** Refer to the [allowlisting IP section](/langsmith/cloud#allowlisting-ip-addresses) for static IP addresses, if needed.


### PR DESCRIPTION
## Overview
Should make telemetry separation much more clearer for customers

## Type of change

**Type:** Update existing documentation
## Related issues/PRs
[Closes INF-1565]

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [X] I have read the [contributing guidelines](README.md)
- [X] I have tested my changes locally using `docs dev`
- [X] All code examples have been tested and work correctly
- [X] I have used **root relative** paths for internal links
- [X] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
