### PR TITLE
docs(community): update You.com integration pages for v1 API

### DIFF
--- a/src/oss/python/integrations/providers/you.mdx
+++ b/src/oss/python/integrations/providers/you.mdx
@@ -5,18 +5,56 @@ description: "Integrate with You using LangChain Python."
 
 >[You](https://you.com/about) company provides an AI productivity platform.
 
+## Installation and setup
+
+You need a You.com API key. Get one at [you.com/platform](https://you.com/platform).
+
+Set your API key as an environment variable:
+
+```python
+import os
+
+os.environ["YDC_API_KEY"] = "<your-api-key>"
+```
+
+Install `langchain-community`:
+
+```bash
+pip install -qU langchain-community
+```
+
 ## Retriever
 
 See a [usage example](/oss/integrations/retrievers/you-retriever).
 
 ```python
-from langchain_community.retrievers.you import YouRetriever
+from langchain_community.retrievers import YouRetriever
 ```
 
 ## Tools
 
 See a [usage example](/oss/integrations/tools/you).
 
+### YouSearchTool
+
+Lets agents run web searches via the You.com Search API.
+
 ```python
 from langchain_community.tools.you import YouSearchTool
+```
+
+### YouContentsTool
+
+Lets agents extract page content from URLs via the You.com Contents API.
+
+```python
+from langchain_community.tools.you import YouContentsTool
+```
+
+## Utility
+
+The underlying wrapper that powers both the retriever and tools.
+
+```python
+from langchain_community.utilities import YouSearchAPIWrapper
 ```

--- a/src/oss/python/integrations/retrievers/you-retriever.mdx
+++ b/src/oss/python/integrations/retrievers/you-retriever.mdx
@@ -3,15 +3,15 @@ title: "You.com integration"
 description: "Integrate with the You.com retriever using LangChain Python."
 ---
 
->[you.com API](https://api.you.com) is a suite of tools designed to help developers ground the output of LLMs in the most recent, most accurate, most relevant information that may not have been included in their training dataset.
+The [You.com API](https://docs.you.com/api-reference/) is a suite of tools designed to help developers ground the output of LLMs in the most recent, most accurate, most relevant information that may not have been included in their training dataset.
 
 ## Setup
 
 The retriever lives in the `langchain-community` package.
 
-You also need to set your you.com API key.
+You also need to set your You.com API key.
 
-```python
+```bash
 pip install -qU langchain-community
 ```
 
@@ -22,12 +22,6 @@ os.environ["YDC_API_KEY"] = ""
 
 # For use in Chaining section
 os.environ["OPENAI_API_KEY"] = ""
-
-## ALTERNATIVE: load YDC_API_KEY from a .env file
-
-# !pip install --quiet -U python-dotenv
-# import dotenv
-# dotenv.load_dotenv()
 ```
 
 It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability
@@ -35,7 +29,6 @@ It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"
 # os.environ["LANGSMITH_API_KEY"] = getpass.getpass()
-# os.environ["LANGSMITH_PROJECT"] = 'Experimentz'
 ```
 
 ## Utility usage
@@ -43,117 +36,119 @@ os.environ["LANGSMITH_TRACING"] = "true"
 ```python
 from langchain_community.utilities import YouSearchAPIWrapper
 
-utility = YouSearchAPIWrapper(num_web_results=1)
-
+utility = YouSearchAPIWrapper(count=3)
 utility
 ```
 
-```python
-import json
+### Raw results
 
-# .raw_results returns the unaltered response from the API
+```python
 response = utility.raw_results(query="What is the weather in NY")
-# API returns an object with a `hits` key containing a list of hits
-hits = response["hits"]
+hits = response["results"]["web"]
 
-# with `num_web_results=1`, `hits` should be len of 1
 print(len(hits))
-
-print(json.dumps(hits, indent=2))
+print(list(hits[0].keys()))
 ```
 
-```text
-1
-[
-  {
-    "description": "Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com",
-    "snippets": [
-      "10 Day Weather-Manhattan, NY\nToday43\u00b0/39\u00b01%\nToday\nSun 31 | Day\nGenerally cloudy. High 43F. Winds W at 10 to 15 mph.\n- Humidity54%\n- UV Index0 of 11\n- Sunrise7:19 am\n- Sunset4:38 pm\nSun 31 | Night\nCloudy. Low 39F. Winds light and variable.\n- Humidity70%\n- UV Index0 of 11\n- Moonrise9:13 pmWaning Gibbous\n- Moonset10:28 am\nMon 0145\u00b0/33\u00b07%\nMon 01\nMon 01 | Day\nConsiderable cloudiness. High around 45F. Winds light and variable.\n- Humidity71%\n- UV Index1 of 11\n- Sunrise7:19 am\n- Sunset4:39 pm\nMon 01 | Night\nA few clouds. Low 33F. Winds NNW at 5 to 10 mph.\n- Humidity64%\n- UV Index0 of 11\n- Moonrise10:14 pmWaning Gibbous\n- Moonset10:49 am\nTue 0246\u00b0/35\u00b04%\nTue 02\nTue 02 | Day\nMainly sunny. High 46F. Winds NW at 5 to 10 mph.\n- Humidity52%\n- UV Index2 of 11\n- Sunrise7:19 am\n- Sunset4:40 pm\nTue 02 | Night\nA few clouds overnight. Low around 35F. Winds W at 5 to 10 mph.\n- Humidity64%\n- UV Index0 of 11\n- Moonrise11:13 pmWaning Gibbous\n- Moonset11:08 am\nWed 0346\u00b0/38\u00b04%\nWed 03\nWed 03 | Day",
-      "Radar\nLatest News\nOur Changing World\nYour Privacy\nTo personalize your product experience, we collect data from your device. We also may use or disclose to specific data vendors your precise geolocation data to provide the Services. To learn more please refer to our Privacy Policy.\nChoose how my information is shared",
-      "- Humidity82%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:34 pm\nTue 26 | Night\nCloudy with light rain developing after midnight. Low 47F. Winds light and variable. Chance of rain 80%.\n- Humidity90%\n- UV Index0 of 11\n- Moonrise4:00 pmFull Moon\n- Moonset7:17 am\nWed 2754\u00b0/49\u00b093%\nWed 27\nWed 27 | Day\nRain. High 54F. Winds E at 5 to 10 mph. Chance of rain 90%. Rainfall near a half an inch.\n- Humidity93%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:35 pm\nWed 27 | Night\nSteady light rain in the evening. Showers continuing late. Low 49F. Winds light and variable. Chance of rain 70%.\n- Humidity91%\n- UV Index0 of 11\n- Moonrise4:59 pmFull Moon\n- Moonset8:12 am\nThu 2853\u00b0/42\u00b019%\nThu 28\nThu 28 | Day\nCloudy skies early will become partly cloudy later in the day. Slight chance of a rain shower. High 53F. Winds WSW at 5 to 10 mph.\n- Humidity77%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:36 pm\nThu 28 | Night\nPartly cloudy skies. Low 42F. Winds W at 5 to 10 mph.\n- Humidity71%\n- UV Index0 of 11",
-      "- Moonrise2:20 amWaning Crescent\n- Moonset12:33 pm\nSun 0740\u00b0/29\u00b019%\nSun 07\nSun 07 | Day\nIntervals of clouds and sunshine. High around 40F. Winds NW at 5 to 10 mph.\n- Humidity57%\n- UV Index2 of 11\n- Sunrise7:19 am\n- Sunset4:44 pm\nSun 07 | Night\nA few clouds from time to time. Low 29F. Winds NNW at 5 to 10 mph.\n- Humidity60%\n- UV Index0 of 11\n- Moonrise3:28 amWaning Crescent\n- Moonset1:04 pm\nMon 0840\u00b0/32\u00b035%\nMon 08\nMon 08 | Day\nPartly cloudy early followed mostly cloudy skies and a few snow showers later in the day. High near 40F. Winds N at 5 to 10 mph. Chance of snow 40%.\n- UV Index1 of 11\n- Sunrise7:19 am\n- Sunset4:45 pm\nMon 08 | Night\nVariable clouds with snow showers or flurries. Low 32F. Winds NNE at 5 to 10 mph. Chance of snow 60%. Snow accumulations less than one inch.\n- UV Index0 of 11\n- Moonrise4:40 amWaning Crescent\n- Moonset1:43 pm\nLatest News\nOur Changing World\nYour Privacy",
-      "- Humidity91%\n- UV Index0 of 11\n- Moonrise5:50 amWaning Crescent\n- Moonset2:35 pm\nWed 1056\u00b0/39\u00b034%\nWed 10\nWed 10 | Day\nA shower or two possible early with partly cloudy skies in the afternoon. Morning high of 56F with temps falling to near 45. Winds SW at 15 to 25 mph. Chance of rain 30%.\n- Humidity66%\n- UV Index1 of 11\n- Sunrise7:19 am\n- Sunset4:47 pm\nWed 10 | Night\nA few clouds from time to time. Low 39F. Winds WSW at 10 to 20 mph.\n- Humidity64%\n- UV Index0 of 11\n- Moonrise6:56 amWaning Crescent\n- Moonset3:38 pm\nThu 1147\u00b0/38\u00b05%\nThu 11\nThu 11 | Day\nPartly cloudy. High 47F. Winds WSW at 5 to 10 mph.\n- Humidity62%\n- UV Index2 of 11\n- Sunrise7:19 am\n- Sunset4:48 pm\nThu 11 | Night\nMostly clear skies. Low 38F. Winds W at 5 to 10 mph.\n- Humidity66%\n- UV Index0 of 11\n- Moonrise7:52 amNew Moon\n- Moonset4:53 pm\nFri 1248\u00b0/42\u00b019%\nFri 12\nFri 12 | Day\nIntervals of clouds and sunshine. High 48F. Winds WSW at 5 to 10 mph.\n- Humidity62%\n- UV Index2 of 11\n- Sunrise7:18 am\n- Sunset4:49 pm",
-      "Sat 1346\u00b0/36\u00b053%\nSat 13\nSat 13 | Day\nCloudy with showers. High 46F. Winds WSW at 10 to 15 mph. Chance of rain 50%.\n- Humidity73%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:50 pm\nSat 13 | Night\nRain showers early transitioning to snow showers late. Low 36F. Winds W at 10 to 15 mph. Chance of precip 50%.\n- Humidity70%\n- UV Index0 of 11\n- Moonrise9:14 amWaxing Crescent\n- Moonset7:33 pm\nSun 1442\u00b0/34\u00b037%\nSun 14\nSun 14 | Day\nSnow showers early will transition to a few showers later. High 42F. Winds WSW at 10 to 15 mph. Chance of rain 40%.\n- Humidity63%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:51 pm\nSun 14 | Night\nVariable clouds with snow showers. Low 34F. Winds W at 10 to 15 mph. Chance of snow 60%. Snow accumulations less than one inch.\n- UV Index0 of 11\n- Moonrise9:44 amWaxing Crescent\n- Moonset8:52 pm\nMon 1540\u00b0/31\u00b051%\nMon 15\nMon 15 | Day",
-      "- Humidity70%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:34 pm\nMon 25 | Night\nOvercast with showers at times. Low 43F. Winds light and variable. Chance of rain 40%.\n- Humidity80%\n- UV Index0 of 11\n- Moonrise3:08 pmWaxing Gibbous\n- Moonset6:14 am\nTue 2653\u00b0/45\u00b058%\nTue 26\nTue 26 | Day\nOvercast with rain showers at times. High 53F. Winds E at 5 to 10 mph. Chance of rain 60%.\n- Humidity79%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:34 pm\nTue 26 | Night\nShowers early then scattered thunderstorms developing late. Low near 45F. Winds ESE at 5 to 10 mph. Chance of rain 60%.\n- Humidity93%\n- UV Index0 of 11\n- Moonrise4:00 pmFull Moon\n- Moonset7:17 am\nWed 2751\u00b0/41\u00b058%\nWed 27\nWed 27 | Day\nCloudy with showers. High 51F. Winds WSW at 5 to 10 mph. Chance of rain 60%.\n- Humidity79%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:35 pm\nWed 27 | Night\nCloudy with showers. Low 41F. Winds NW at 5 to 10 mph. Chance of rain 60%.\n- Humidity72%\n- UV Index0 of 11\n- Moonrise4:59 pmFull Moon\n- Moonset8:13 am"
-    ],
-    "thumbnail_url": "https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw",
-    "title": "10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...",
-    "url": "https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US"
-  }
-]
-```
+### Parsed results
 
 ```python
-# .results returns parsed results with each snippet in a Document
 response = utility.results(query="What is the weather in NY")
 
-# .results should have a Document for each `snippet`
 print(len(response))
-
-print(response)
+print(response[0].page_content[:200])
+print(response[0].metadata.keys())
 ```
 
+Each document's metadata includes:
+- `url`: source page URL
+- `title`: page title
+- `description`: page description
+- `thumbnail_url`: thumbnail image URL (if available)
+- `favicon_url`: site favicon URL
+- `page_age`: estimated page age
+
+### Livecrawl (full page content)
+
+Enable livecrawl to get the full page content instead of snippets:
+
 ```python
-7
-[Document(page_content='10 Day Weather-Manhattan, NY\nToday43°/39°1%\nToday\nSun 31 | Day\nGenerally cloudy. High 43F. Winds W at 10 to 15 mph.\n- Humidity54%\n- UV Index0 of 11\n- Sunrise7:19 am\n- Sunset4:38 pm\nSun 31 | Night\nCloudy. Low 39F. Winds light and variable.\n- Humidity70%\n- UV Index0 of 11\n- Moonrise9:13 pmWaning Gibbous\n- Moonset10:28 am\nMon 0145°/33°7%\nMon 01\nMon 01 | Day\nConsiderable cloudiness. High around 45F. Winds light and variable.\n- Humidity71%\n- UV Index1 of 11\n- Sunrise7:19 am\n- Sunset4:39 pm\nMon 01 | Night\nA few clouds. Low 33F. Winds NNW at 5 to 10 mph.\n- Humidity64%\n- UV Index0 of 11\n- Moonrise10:14 pmWaning Gibbous\n- Moonset10:49 am\nTue 0246°/35°4%\nTue 02\nTue 02 | Day\nMainly sunny. High 46F. Winds NW at 5 to 10 mph.\n- Humidity52%\n- UV Index2 of 11\n- Sunrise7:19 am\n- Sunset4:40 pm\nTue 02 | Night\nA few clouds overnight. Low around 35F. Winds W at 5 to 10 mph.\n- Humidity64%\n- UV Index0 of 11\n- Moonrise11:13 pmWaning Gibbous\n- Moonset11:08 am\nWed 0346°/38°4%\nWed 03\nWed 03 | Day', metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': 'https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw', 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com'}), Document(page_content='Radar\nLatest News\nOur Changing World\nYour Privacy\nTo personalize your product experience, we collect data from your device. We also may use or disclose to specific data vendors your precise geolocation data to provide the Services. To learn more please refer to our Privacy Policy.\nChoose how my information is shared', metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': 'https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw', 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com'}), Document(page_content='- Humidity82%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:34 pm\nTue 26 | Night\nCloudy with light rain developing after midnight. Low 47F. Winds light and variable. Chance of rain 80%.\n- Humidity90%\n- UV Index0 of 11\n- Moonrise4:00 pmFull Moon\n- Moonset7:17 am\nWed 2754°/49°93%\nWed 27\nWed 27 | Day\nRain. High 54F. Winds E at 5 to 10 mph. Chance of rain 90%. Rainfall near a half an inch.\n- Humidity93%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:35 pm\nWed 27 | Night\nSteady light rain in the evening. Showers continuing late. Low 49F. Winds light and variable. Chance of rain 70%.\n- Humidity91%\n- UV Index0 of 11\n- Moonrise4:59 pmFull Moon\n- Moonset8:12 am\nThu 2853°/42°19%\nThu 28\nThu 28 | Day\nCloudy skies early will become partly cloudy later in the day. Slight chance of a rain shower. High 53F. Winds WSW at 5 to 10 mph.\n- Humidity77%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:36 pm\nThu 28 | Night\nPartly cloudy skies. Low 42F. Winds W at 5 to 10 mph.\n- Humidity71%\n- UV Index0 of 11', metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': 'https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw', 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com'}), Document(page_content='- Moonrise2:20 amWaning Crescent\n- Moonset12:33 pm\nSun 0740°/29°19%\nSun 07\nSun 07 | Day\nIntervals of clouds and sunshine. High around 40F. Winds NW at 5 to 10 mph.\n- Humidity57%\n- UV Index2 of 11\n- Sunrise7:19 am\n- Sunset4:44 pm\nSun 07 | Night\nA few clouds from time to time. Low 29F. Winds NNW at 5 to 10 mph.\n- Humidity60%\n- UV Index0 of 11\n- Moonrise3:28 amWaning Crescent\n- Moonset1:04 pm\nMon 0840°/32°35%\nMon 08\nMon 08 | Day\nPartly cloudy early followed mostly cloudy skies and a few snow showers later in the day. High near 40F. Winds N at 5 to 10 mph. Chance of snow 40%.\n- UV Index1 of 11\n- Sunrise7:19 am\n- Sunset4:45 pm\nMon 08 | Night\nVariable clouds with snow showers or flurries. Low 32F. Winds NNE at 5 to 10 mph. Chance of snow 60%. Snow accumulations less than one inch.\n- UV Index0 of 11\n- Moonrise4:40 amWaning Crescent\n- Moonset1:43 pm\nLatest News\nOur Changing World\nYour Privacy', metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': 'https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw', 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com'}), Document(page_content='- Humidity91%\n- UV Index0 of 11\n- Moonrise5:50 amWaning Crescent\n- Moonset2:35 pm\nWed 1056°/39°34%\nWed 10\nWed 10 | Day\nA shower or two possible early with partly cloudy skies in the afternoon. Morning high of 56F with temps falling to near 45. Winds SW at 15 to 25 mph. Chance of rain 30%.\n- Humidity66%\n- UV Index1 of 11\n- Sunrise7:19 am\n- Sunset4:47 pm\nWed 10 | Night\nA few clouds from time to time. Low 39F. Winds WSW at 10 to 20 mph.\n- Humidity64%\n- UV Index0 of 11\n- Moonrise6:56 amWaning Crescent\n- Moonset3:38 pm\nThu 1147°/38°5%\nThu 11\nThu 11 | Day\nPartly cloudy. High 47F. Winds WSW at 5 to 10 mph.\n- Humidity62%\n- UV Index2 of 11\n- Sunrise7:19 am\n- Sunset4:48 pm\nThu 11 | Night\nMostly clear skies. Low 38F. Winds W at 5 to 10 mph.\n- Humidity66%\n- UV Index0 of 11\n- Moonrise7:52 amNew Moon\n- Moonset4:53 pm\nFri 1248°/42°19%\nFri 12\nFri 12 | Day\nIntervals of clouds and sunshine. High 48F. Winds WSW at 5 to 10 mph.\n- Humidity62%\n- UV Index2 of 11\n- Sunrise7:18 am\n- Sunset4:49 pm', metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': 'https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw', 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com'}), Document(page_content='Sat 1346°/36°53%\nSat 13\nSat 13 | Day\nCloudy with showers. High 46F. Winds WSW at 10 to 15 mph. Chance of rain 50%.\n- Humidity73%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:50 pm\nSat 13 | Night\nRain showers early transitioning to snow showers late. Low 36F. Winds W at 10 to 15 mph. Chance of precip 50%.\n- Humidity70%\n- UV Index0 of 11\n- Moonrise9:14 amWaxing Crescent\n- Moonset7:33 pm\nSun 1442°/34°37%\nSun 14\nSun 14 | Day\nSnow showers early will transition to a few showers later. High 42F. Winds WSW at 10 to 15 mph. Chance of rain 40%.\n- Humidity63%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:51 pm\nSun 14 | Night\nVariable clouds with snow showers. Low 34F. Winds W at 10 to 15 mph. Chance of snow 60%. Snow accumulations less than one inch.\n- UV Index0 of 11\n- Moonrise9:44 amWaxing Crescent\n- Moonset8:52 pm\nMon 1540°/31°51%\nMon 15\nMon 15 | Day', metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': 'https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw', 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com'}), Document(page_content='- Humidity70%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:34 pm\nMon 25 | Night\nOvercast with showers at times. Low 43F. Winds light and variable. Chance of rain 40%.\n- Humidity80%\n- UV Index0 of 11\n- Moonrise3:08 pmWaxing Gibbous\n- Moonset6:14 am\nTue 2653°/45°58%\nTue 26\nTue 26 | Day\nOvercast with rain showers at times. High 53F. Winds E at 5 to 10 mph. Chance of rain 60%.\n- Humidity79%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:34 pm\nTue 26 | Night\nShowers early then scattered thunderstorms developing late. Low near 45F. Winds ESE at 5 to 10 mph. Chance of rain 60%.\n- Humidity93%\n- UV Index0 of 11\n- Moonrise4:00 pmFull Moon\n- Moonset7:17 am\nWed 2751°/41°58%\nWed 27\nWed 27 | Day\nCloudy with showers. High 51F. Winds WSW at 5 to 10 mph. Chance of rain 60%.\n- Humidity79%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:35 pm\nWed 27 | Night\nCloudy with showers. Low 41F. Winds NW at 5 to 10 mph. Chance of rain 60%.\n- Humidity72%\n- UV Index0 of 11\n- Moonrise4:59 pmFull Moon\n- Moonset8:13 am', metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': 'https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw', 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com'})]
+utility = YouSearchAPIWrapper(count=2, livecrawl="web", livecrawl_formats="markdown")
+docs = utility.results("python programming language")
+
+# Full page content instead of snippets
+print(len(docs[0].page_content))
+```
+
+When livecrawl is enabled, each result returns one document with the full page content
+rather than multiple snippet documents per page.
+
+### Contents API
+
+Extract content from specific URLs:
+
+```python
+utility = YouSearchAPIWrapper()
+docs = utility.contents(
+    urls=["https://en.wikipedia.org/wiki/Python_(programming_language)"],
+    formats=["markdown"],
+)
+
+print(docs[0].page_content[:200])
 ```
 
 ## Retriever usage
 
 ```python
-from langchain_community.retrievers.you import YouRetriever
+from langchain_community.retrievers import YouRetriever
 
-retriever = YouRetriever(num_web_results=1)
+retriever = YouRetriever(count=3)
+docs = retriever.invoke("What is the weather in NY")
 
-retriever
+print(len(docs))
+print(docs[0].metadata)
 ```
 
+### With livecrawl
+
 ```python
-# .invoke wraps utility.results
-response = retriever.invoke("What is the weather in NY")
+retriever = YouRetriever(count=2, livecrawl="web", livecrawl_formats="markdown")
+docs = retriever.invoke("python programming")
 
-# .invoke should have a Document for each `snippet`
-print(len(response))
-
-print(response)
+print(len(docs[0].page_content))
 ```
 
+### Async support
+
 ```python
-7
-[Document(page_content='10 Day Weather-Manhattan, NY\nToday43°/39°1%\nToday\nSun 31 | Day\nGenerally cloudy. High 43F. Winds W at 10 to 15 mph.\n- Humidity54%\n- UV Index0 of 11\n- Sunrise7:19 am\n- Sunset4:38 pm\nSun 31 | Night\nCloudy. Low 39F. Winds light and variable.\n- Humidity70%\n- UV Index0 of 11\n- Moonrise9:13 pmWaning Gibbous\n- Moonset10:28 am\nMon 0145°/33°7%\nMon 01\nMon 01 | Day\nConsiderable cloudiness. High around 45F. Winds light and variable.\n- Humidity71%\n- UV Index1 of 11\n- Sunrise7:19 am\n- Sunset4:39 pm\nMon 01 | Night\nA few clouds. Low 33F. Winds NNW at 5 to 10 mph.\n- Humidity64%\n- UV Index0 of 11\n- Moonrise10:14 pmWaning Gibbous\n- Moonset10:49 am\nTue 0246°/35°4%\nTue 02\nTue 02 | Day\nMainly sunny. High 46F. Winds NW at 5 to 10 mph.\n- Humidity52%\n- UV Index2 of 11\n- Sunrise7:19 am\n- Sunset4:40 pm\nTue 02 | Night\nA few clouds overnight. Low around 35F. Winds W at 5 to 10 mph.\n- Humidity64%\n- UV Index0 of 11\n- Moonrise11:13 pmWaning Gibbous\n- Moonset11:08 am\nWed 0346°/38°4%\nWed 03\nWed 03 | Day', metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': 'https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw', 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com'}), Document(page_content='Radar\nLatest News\nOur Changing World\nYour Privacy\nTo personalize your product experience, we collect data from your device. We also may use or disclose to specific data vendors your precise geolocation data to provide the Services. To learn more please refer to our Privacy Policy.\nChoose how my information is shared', metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': 'https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw', 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com'}), Document(page_content='- Humidity82%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:34 pm\nTue 26 | Night\nCloudy with light rain developing after midnight. Low 47F. Winds light and variable. Chance of rain 80%.\n- Humidity90%\n- UV Index0 of 11\n- Moonrise4:00 pmFull Moon\n- Moonset7:17 am\nWed 2754°/49°93%\nWed 27\nWed 27 | Day\nRain. High 54F. Winds E at 5 to 10 mph. Chance of rain 90%. Rainfall near a half an inch.\n- Humidity93%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:35 pm\nWed 27 | Night\nSteady light rain in the evening. Showers continuing late. Low 49F. Winds light and variable. Chance of rain 70%.\n- Humidity91%\n- UV Index0 of 11\n- Moonrise4:59 pmFull Moon\n- Moonset8:12 am\nThu 2853°/42°19%\nThu 28\nThu 28 | Day\nCloudy skies early will become partly cloudy later in the day. Slight chance of a rain shower. High 53F. Winds WSW at 5 to 10 mph.\n- Humidity77%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:36 pm\nThu 28 | Night\nPartly cloudy skies. Low 42F. Winds W at 5 to 10 mph.\n- Humidity71%\n- UV Index0 of 11', metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': 'https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw', 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com'}), Document(page_content='- Moonrise2:20 amWaning Crescent\n- Moonset12:33 pm\nSun 0740°/29°19%\nSun 07\nSun 07 | Day\nIntervals of clouds and sunshine. High around 40F. Winds NW at 5 to 10 mph.\n- Humidity57%\n- UV Index2 of 11\n- Sunrise7:19 am\n- Sunset4:44 pm\nSun 07 | Night\nA few clouds from time to time. Low 29F. Winds NNW at 5 to 10 mph.\n- Humidity60%\n- UV Index0 of 11\n- Moonrise3:28 amWaning Crescent\n- Moonset1:04 pm\nMon 0840°/32°35%\nMon 08\nMon 08 | Day\nPartly cloudy early followed mostly cloudy skies and a few snow showers later in the day. High near 40F. Winds N at 5 to 10 mph. Chance of snow 40%.\n- UV Index1 of 11\n- Sunrise7:19 am\n- Sunset4:45 pm\nMon 08 | Night\nVariable clouds with snow showers or flurries. Low 32F. Winds NNE at 5 to 10 mph. Chance of snow 60%. Snow accumulations less than one inch.\n- UV Index0 of 11\n- Moonrise4:40 amWaning Crescent\n- Moonset1:43 pm\nLatest News\nOur Changing World\nYour Privacy', metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': 'https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw', 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com'}), Document(page_content='- Humidity91%\n- UV Index0 of 11\n- Moonrise5:50 amWaning Crescent\n- Moonset2:35 pm\nWed 1056°/39°34%\nWed 10\nWed 10 | Day\nA shower or two possible early with partly cloudy skies in the afternoon. Morning high of 56F with temps falling to near 45. Winds SW at 15 to 25 mph. Chance of rain 30%.\n- Humidity66%\n- UV Index1 of 11\n- Sunrise7:19 am\n- Sunset4:47 pm\nWed 10 | Night\nA few clouds from time to time. Low 39F. Winds WSW at 10 to 20 mph.\n- Humidity64%\n- UV Index0 of 11\n- Moonrise6:56 amWaning Crescent\n- Moonset3:38 pm\nThu 1147°/38°5%\nThu 11\nThu 11 | Day\nPartly cloudy. High 47F. Winds WSW at 5 to 10 mph.\n- Humidity62%\n- UV Index2 of 11\n- Sunrise7:19 am\n- Sunset4:48 pm\nThu 11 | Night\nMostly clear skies. Low 38F. Winds W at 5 to 10 mph.\n- Humidity66%\n- UV Index0 of 11\n- Moonrise7:52 amNew Moon\n- Moonset4:53 pm\nFri 1248°/42°19%\nFri 12\nFri 12 | Day\nIntervals of clouds and sunshine. High 48F. Winds WSW at 5 to 10 mph.\n- Humidity62%\n- UV Index2 of 11\n- Sunrise7:18 am\n- Sunset4:49 pm', metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': 'https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw', 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com'}), Document(page_content='Sat 1346°/36°53%\nSat 13\nSat 13 | Day\nCloudy with showers. High 46F. Winds WSW at 10 to 15 mph. Chance of rain 50%.\n- Humidity73%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:50 pm\nSat 13 | Night\nRain showers early transitioning to snow showers late. Low 36F. Winds W at 10 to 15 mph. Chance of precip 50%.\n- Humidity70%\n- UV Index0 of 11\n- Moonrise9:14 amWaxing Crescent\n- Moonset7:33 pm\nSun 1442°/34°37%\nSun 14\nSun 14 | Day\nSnow showers early will transition to a few showers later. High 42F. Winds WSW at 10 to 15 mph. Chance of rain 40%.\n- Humidity63%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:51 pm\nSun 14 | Night\nVariable clouds with snow showers. Low 34F. Winds W at 10 to 15 mph. Chance of snow 60%. Snow accumulations less than one inch.\n- UV Index0 of 11\n- Moonrise9:44 amWaxing Crescent\n- Moonset8:52 pm\nMon 1540°/31°51%\nMon 15\nMon 15 | Day', metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': 'https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw', 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com'}), Document(page_content='- Humidity70%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:34 pm\nMon 25 | Night\nOvercast with showers at times. Low 43F. Winds light and variable. Chance of rain 40%.\n- Humidity80%\n- UV Index0 of 11\n- Moonrise3:08 pmWaxing Gibbous\n- Moonset6:14 am\nTue 2653°/45°58%\nTue 26\nTue 26 | Day\nOvercast with rain showers at times. High 53F. Winds E at 5 to 10 mph. Chance of rain 60%.\n- Humidity79%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:34 pm\nTue 26 | Night\nShowers early then scattered thunderstorms developing late. Low near 45F. Winds ESE at 5 to 10 mph. Chance of rain 60%.\n- Humidity93%\n- UV Index0 of 11\n- Moonrise4:00 pmFull Moon\n- Moonset7:17 am\nWed 2751°/41°58%\nWed 27\nWed 27 | Day\nCloudy with showers. High 51F. Winds WSW at 5 to 10 mph. Chance of rain 60%.\n- Humidity79%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:35 pm\nWed 27 | Night\nCloudy with showers. Low 41F. Winds NW at 5 to 10 mph. Chance of rain 60%.\n- Humidity72%\n- UV Index0 of 11\n- Moonrise4:59 pmFull Moon\n- Moonset8:13 am', metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': 'https://imgs.search.brave.com/9xHc5-Bh2lvLyRJwQqeegm3gzoF6hawlpF8LZEjFLo8/rs:fit:200:200:1/g:ce/aHR0cHM6Ly9zLnct/eC5jby8yNDB4MTgw/X3R3Y19kZWZhdWx0/LnBuZw', 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Be prepared with the most accurate 10-day forecast for Manhattan, NY with highs, lows, chance of precipitation from The Weather Channel and Weather.com'})]
+retriever = YouRetriever(count=3)
+docs = await retriever.ainvoke("What is the weather in NY")
+print(len(docs))
 ```
 
 ## Chaining
 
-```python
-# you need a model to use in the chain
-!pip install -qU langchain-openai
+```bash
+pip install -qU langchain-openai
 ```
 
 ```python
-from langchain_community.retrievers.you import YouRetriever
+from langchain_community.retrievers import YouRetriever
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough
 from langchain_openai import ChatOpenAI
 
-# set up runnable
 runnable = RunnablePassthrough
 
-# set up retriever, limit sources to one
-retriever = YouRetriever(num_web_results=1)
-
-# set up model
-model = ChatOpenAI(model="gpt-3.5-turbo-16k")
-
-# set up output parser
+retriever = YouRetriever(count=3)
+model = ChatOpenAI(model="gpt-4o-mini")
 output_parser = StrOutputParser()
 ```
 
 ### Invoke
 
 ```python
-# set up prompt that expects one question
 prompt = ChatPromptTemplate.from_template(
     """Answer the question based only on the context provided.
 
@@ -162,7 +157,6 @@ Context: {context}
 Question: {question}"""
 )
 
-# set up chain
 chain = (
     runnable.assign(context=(lambda x: x["question"]) | retriever)
     | prompt
@@ -171,52 +165,19 @@ chain = (
 )
 
 output = chain.invoke({"question": "what is the weather in NY today"})
-
 print(output)
-```
-
-```text
-The weather in New York City today is 43° with a high/low of --/39°. The wind is 3 mph, humidity is 63%, and the air quality is considered good.
 ```
 
 ### Stream
 
 ```python
-# set up prompt that expects one question
-prompt = ChatPromptTemplate.from_template(
-    """Answer the question based only on the context provided.
-
-Context: {context}
-
-Question: {question}"""
-)
-
-# set up chain - same as above
-chain = (
-    runnable.assign(context=(lambda x: x["question"]) | retriever)
-    | prompt
-    | model
-    | output_parser
-)
-
 for s in chain.stream({"question": "what is the weather in NY today"}):
     print(s, end="", flush=True)
-```
-
-```text
-The weather in New York City today is a high of 39°F and a low of 31°F with a feels like temperature of 43°F. The wind speed is 3 mph, humidity is 63%, and the air quality is considered to be good.
 ```
 
 ### Batch
 
 ```python
-chain = (
-    runnable.assign(context=(lambda x: x["question"]) | retriever)
-    | prompt
-    | model
-    | output_parser
-)
-
 output = chain.batch(
     [
         {"question": "what is the weather in NY today"},
@@ -226,9 +187,4 @@ output = chain.batch(
 
 for o in output:
     print(o)
-```
-
-```text
-Based on the provided context, the weather in New York City today is 43° with a high/low of --/39°.
-Based on the provided context, the current weather in San Francisco is partly cloudy with a temperature of 61°F and a humidity of 57%.
 ```

--- a/src/oss/python/integrations/tools/you.mdx
+++ b/src/oss/python/integrations/tools/you.mdx
@@ -1,17 +1,17 @@
 ---
-title: "You.com search integration"
-description: "Integrate with the You.com search tool using LangChain Python."
+title: "You.com integration"
+description: "Integrate with the You.com tools using LangChain Python."
 ---
 
-The [you.com API](https://api.you.com) is a suite of tools designed to help developers ground the output of LLMs in the most recent, most accurate, most relevant information that may not have been included in their training dataset.
+The [You.com API](https://docs.you.com/api-reference/) is a suite of tools designed to help developers ground the output of LLMs in the most recent, most accurate, most relevant information that may not have been included in their training dataset.
 
 ## Setup
 
-The tool lives in the `langchain-community` package.
+The tools live in the `langchain-community` package.
 
-You also need to set your you.com API key.
+You also need to set your You.com API key.
 
-```python
+```bash
 pip install -qU langchain-community
 ```
 
@@ -20,14 +20,8 @@ import os
 
 os.environ["YDC_API_KEY"] = ""
 
-# For use in Chaining section
+# For use in Agent section
 os.environ["OPENAI_API_KEY"] = ""
-
-## ALTERNATIVE: load YDC_API_KEY from a .env file
-
-# !pip install --quiet -U python-dotenv
-# import dotenv
-# dotenv.load_dotenv()
 ```
 
 It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability
@@ -37,99 +31,97 @@ os.environ["LANGSMITH_TRACING"] = "true"
 # os.environ["LANGSMITH_API_KEY"] = getpass.getpass()
 ```
 
-## Tool usage
+## YouSearchTool
+
+Wraps the You.com Search API. An agent can use this tool to search the web for current information.
 
 ```python
 from langchain_community.tools.you import YouSearchTool
 from langchain_community.utilities.you import YouSearchAPIWrapper
 
-api_wrapper = YouSearchAPIWrapper(num_web_results=1)
+api_wrapper = YouSearchAPIWrapper(count=3)
 tool = YouSearchTool(api_wrapper=api_wrapper)
-
 tool
 ```
 
-```text
-YouSearchTool(api_wrapper=YouSearchAPIWrapper(ydc_api_key='x', num_web_results=1, safesearch=None, country=None, k=None, n_snippets_per_hit=None, endpoint_type='search', n_hits=None))
-```
-
 ```python
-# .invoke wraps utility.results
 response = tool.invoke("What is the weather in NY")
 
-# .invoke should have a Document for each `snippet`
 print(len(response))
+print(response[0].page_content[:200])
+print(response[0].metadata.keys())
+```
 
-for item in response:
-    print(item)
+### With livecrawl
+
+Get full page content instead of snippets:
+
+```python
+api_wrapper = YouSearchAPIWrapper(
+    count=2, livecrawl="web", livecrawl_formats="markdown"
+)
+tool = YouSearchTool(api_wrapper=api_wrapper)
+
+response = tool.invoke("python programming")
+print(len(response[0].page_content))
+```
+
+## YouContentsTool
+
+Wraps the You.com Contents API. An agent can use this tool to extract content from specific URLs.
+
+```python
+from langchain_community.tools.you import YouContentsTool
+from langchain_community.utilities.you import YouSearchAPIWrapper
+
+api_wrapper = YouSearchAPIWrapper()
+tool = YouContentsTool(api_wrapper=api_wrapper)
+tool
 ```
 
 ```python
-7
-page_content='10 Day Weather-Manhattan, NY\nToday43°/39°1%\nToday\nSun 31 | Day\nGenerally cloudy. High 43F. Winds W at 10 to 15 mph.\n- Humidity54%\n- UV Index0 of 11\n- Sunrise7:19 am\n- Sunset4:38 pm\nSun 31 | Night\nCloudy. Low 39F. Winds light and variable.\n- Humidity70%\n- UV Index0 of 11\n- Moonrise9:13 pmWaning Gibbous\n- Moonset10:28 am\nMon 0145°/33°7%\nMon 01\nMon 01 | Day\nConsiderable cloudiness. High around 45F. Winds light and variable.\n- Humidity71%\n- UV Index1 of 11\n- Sunrise7:19 am\n- Sunset4:39 pm\nMon 01 | Night\nA few clouds. Low 33F. Winds NNW at 5 to 10 mph.\n- Humidity64%\n- UV Index0 of 11\n- Moonrise10:14 pmWaning Gibbous\n- Moonset10:49 am\nTue 0246°/35°4%\nTue 02\nTue 02 | Day\nMainly sunny. High 46F. Winds NW at 5 to 10 mph.\n- Humidity52%\n- UV Index2 of 11\n- Sunrise7:19 am\n- Sunset4:40 pm\nTue 02 | Night\nA few clouds overnight. Low around 35F. Winds W at 5 to 10 mph.\n- Humidity64%\n- UV Index0 of 11\n- Moonrise11:13 pmWaning Gibbous\n- Moonset11:08 am\nWed 0346°/38°4%\nWed 03\nWed 03 | Day' metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': None, 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Some sun in the morning with increasing clouds during the afternoon. High around 45F. Winds SSE at 5 to 10 mph. ... Cloudy with showers. Low near 40F. Winds SSE at 5 to 10 mph. Chance of rain 60%. ... A steady rain in the morning. Showers continuing in the afternoon.'}
-page_content='Radar\nLatest News\nOur Changing World\nYour Privacy\nTo personalize your product experience, we collect data from your device. We also may use or disclose to specific data vendors your precise geolocation data to provide the Services. To learn more please refer to our Privacy Policy.\nChoose how my information is shared' metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': None, 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Some sun in the morning with increasing clouds during the afternoon. High around 45F. Winds SSE at 5 to 10 mph. ... Cloudy with showers. Low near 40F. Winds SSE at 5 to 10 mph. Chance of rain 60%. ... A steady rain in the morning. Showers continuing in the afternoon.'}
-page_content='- Humidity82%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:34 pm\nTue 26 | Night\nCloudy with light rain developing after midnight. Low 47F. Winds light and variable. Chance of rain 80%.\n- Humidity90%\n- UV Index0 of 11\n- Moonrise4:00 pmFull Moon\n- Moonset7:17 am\nWed 2754°/49°93%\nWed 27\nWed 27 | Day\nRain. High 54F. Winds E at 5 to 10 mph. Chance of rain 90%. Rainfall near a half an inch.\n- Humidity93%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:35 pm\nWed 27 | Night\nSteady light rain in the evening. Showers continuing late. Low 49F. Winds light and variable. Chance of rain 70%.\n- Humidity91%\n- UV Index0 of 11\n- Moonrise4:59 pmFull Moon\n- Moonset8:12 am\nThu 2853°/42°19%\nThu 28\nThu 28 | Day\nCloudy skies early will become partly cloudy later in the day. Slight chance of a rain shower. High 53F. Winds WSW at 5 to 10 mph.\n- Humidity77%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:36 pm\nThu 28 | Night\nPartly cloudy skies. Low 42F. Winds W at 5 to 10 mph.\n- Humidity71%\n- UV Index0 of 11' metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': None, 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Some sun in the morning with increasing clouds during the afternoon. High around 45F. Winds SSE at 5 to 10 mph. ... Cloudy with showers. Low near 40F. Winds SSE at 5 to 10 mph. Chance of rain 60%. ... A steady rain in the morning. Showers continuing in the afternoon.'}
-page_content='- Moonrise2:20 amWaning Crescent\n- Moonset12:33 pm\nSun 0740°/29°19%\nSun 07\nSun 07 | Day\nIntervals of clouds and sunshine. High around 40F. Winds NW at 5 to 10 mph.\n- Humidity57%\n- UV Index2 of 11\n- Sunrise7:19 am\n- Sunset4:44 pm\nSun 07 | Night\nA few clouds from time to time. Low 29F. Winds NNW at 5 to 10 mph.\n- Humidity60%\n- UV Index0 of 11\n- Moonrise3:28 amWaning Crescent\n- Moonset1:04 pm\nMon 0840°/32°35%\nMon 08\nMon 08 | Day\nPartly cloudy early followed mostly cloudy skies and a few snow showers later in the day. High near 40F. Winds N at 5 to 10 mph. Chance of snow 40%.\n- UV Index1 of 11\n- Sunrise7:19 am\n- Sunset4:45 pm\nMon 08 | Night\nVariable clouds with snow showers or flurries. Low 32F. Winds NNE at 5 to 10 mph. Chance of snow 60%. Snow accumulations less than one inch.\n- UV Index0 of 11\n- Moonrise4:40 amWaning Crescent\n- Moonset1:43 pm\nLatest News\nOur Changing World\nYour Privacy' metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': None, 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Some sun in the morning with increasing clouds during the afternoon. High around 45F. Winds SSE at 5 to 10 mph. ... Cloudy with showers. Low near 40F. Winds SSE at 5 to 10 mph. Chance of rain 60%. ... A steady rain in the morning. Showers continuing in the afternoon.'}
-page_content='- Humidity91%\n- UV Index0 of 11\n- Moonrise5:50 amWaning Crescent\n- Moonset2:35 pm\nWed 1056°/39°34%\nWed 10\nWed 10 | Day\nA shower or two possible early with partly cloudy skies in the afternoon. Morning high of 56F with temps falling to near 45. Winds SW at 15 to 25 mph. Chance of rain 30%.\n- Humidity66%\n- UV Index1 of 11\n- Sunrise7:19 am\n- Sunset4:47 pm\nWed 10 | Night\nA few clouds from time to time. Low 39F. Winds WSW at 10 to 20 mph.\n- Humidity64%\n- UV Index0 of 11\n- Moonrise6:56 amWaning Crescent\n- Moonset3:38 pm\nThu 1147°/38°5%\nThu 11\nThu 11 | Day\nPartly cloudy. High 47F. Winds WSW at 5 to 10 mph.\n- Humidity62%\n- UV Index2 of 11\n- Sunrise7:19 am\n- Sunset4:48 pm\nThu 11 | Night\nMostly clear skies. Low 38F. Winds W at 5 to 10 mph.\n- Humidity66%\n- UV Index0 of 11\n- Moonrise7:52 amNew Moon\n- Moonset4:53 pm\nFri 1248°/42°19%\nFri 12\nFri 12 | Day\nIntervals of clouds and sunshine. High 48F. Winds WSW at 5 to 10 mph.\n- Humidity62%\n- UV Index2 of 11\n- Sunrise7:18 am\n- Sunset4:49 pm' metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': None, 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Some sun in the morning with increasing clouds during the afternoon. High around 45F. Winds SSE at 5 to 10 mph. ... Cloudy with showers. Low near 40F. Winds SSE at 5 to 10 mph. Chance of rain 60%. ... A steady rain in the morning. Showers continuing in the afternoon.'}
-page_content='Sat 1346°/36°53%\nSat 13\nSat 13 | Day\nCloudy with showers. High 46F. Winds WSW at 10 to 15 mph. Chance of rain 50%.\n- Humidity73%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:50 pm\nSat 13 | Night\nRain showers early transitioning to snow showers late. Low 36F. Winds W at 10 to 15 mph. Chance of precip 50%.\n- Humidity70%\n- UV Index0 of 11\n- Moonrise9:14 amWaxing Crescent\n- Moonset7:33 pm\nSun 1442°/34°37%\nSun 14\nSun 14 | Day\nSnow showers early will transition to a few showers later. High 42F. Winds WSW at 10 to 15 mph. Chance of rain 40%.\n- Humidity63%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:51 pm\nSun 14 | Night\nVariable clouds with snow showers. Low 34F. Winds W at 10 to 15 mph. Chance of snow 60%. Snow accumulations less than one inch.\n- UV Index0 of 11\n- Moonrise9:44 amWaxing Crescent\n- Moonset8:52 pm\nMon 1540°/31°51%\nMon 15\nMon 15 | Day' metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': None, 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Some sun in the morning with increasing clouds during the afternoon. High around 45F. Winds SSE at 5 to 10 mph. ... Cloudy with showers. Low near 40F. Winds SSE at 5 to 10 mph. Chance of rain 60%. ... A steady rain in the morning. Showers continuing in the afternoon.'}
-page_content='- Humidity70%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:34 pm\nMon 25 | Night\nOvercast with showers at times. Low 43F. Winds light and variable. Chance of rain 40%.\n- Humidity80%\n- UV Index0 of 11\n- Moonrise3:08 pmWaxing Gibbous\n- Moonset6:14 am\nTue 2653°/45°58%\nTue 26\nTue 26 | Day\nOvercast with rain showers at times. High 53F. Winds E at 5 to 10 mph. Chance of rain 60%.\n- Humidity79%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:34 pm\nTue 26 | Night\nShowers early then scattered thunderstorms developing late. Low near 45F. Winds ESE at 5 to 10 mph. Chance of rain 60%.\n- Humidity93%\n- UV Index0 of 11\n- Moonrise4:00 pmFull Moon\n- Moonset7:17 am\nWed 2751°/41°58%\nWed 27\nWed 27 | Day\nCloudy with showers. High 51F. Winds WSW at 5 to 10 mph. Chance of rain 60%.\n- Humidity79%\n- UV Index1 of 11\n- Sunrise7:18 am\n- Sunset4:35 pm\nWed 27 | Night\nCloudy with showers. Low 41F. Winds NW at 5 to 10 mph. Chance of rain 60%.\n- Humidity72%\n- UV Index0 of 11\n- Moonrise4:59 pmFull Moon\n- Moonset8:13 am' metadata={'url': 'https://weather.com/weather/tenday/l/New+York+NY+USNY0996:1:US', 'thumbnail_url': None, 'title': '10-Day Weather Forecast for Manhattan, NY - The Weather Channel ...', 'description': 'Some sun in the morning with increasing clouds during the afternoon. High around 45F. Winds SSE at 5 to 10 mph. ... Cloudy with showers. Low near 40F. Winds SSE at 5 to 10 mph. Chance of rain 60%. ... A steady rain in the morning. Showers continuing in the afternoon.'}
+response = tool.invoke(
+    {"urls": ["https://en.wikipedia.org/wiki/Python_(programming_language)"]}
+)
+
+print(len(response))
+print(response[0].page_content[:200])
 ```
 
-## Chaining
+### Async support
 
-We show here how to use it as part of an [agent](/oss/langchain/agents). We use the OpenAI Functions Agent, so we will need to setup and install the required dependencies for that. We will also use [LangSmith Hub](https://smith.langchain.com/hub) to pull the prompt from, so we will need to install that.
-
-```python
-# you need a model to use in the chain
-!pip install -qU langchain langchain-openai langchainhub langchain-community
-```
+Both tools support async:
 
 ```python
-from langchain_classic import hub
-from langchain.agents import AgentExecutor, create_openai_functions_agent
-from langchain_openai import ChatOpenAI
-
-instructions = """You are an assistant."""
-base_prompt = hub.pull("langchain-ai/openai-functions-template")
-prompt = base_prompt.partial(instructions=instructions)
-llm = ChatOpenAI(temperature=0)
-you_tool = YouSearchTool(api_wrapper=YouSearchAPIWrapper(num_web_results=1))
-tools = [you_tool]
-agent = create_openai_functions_agent(llm, tools, prompt)
-agent_executor = AgentExecutor(
-    agent=agent,
-    tools=tools,
-    verbose=True,
+response = await tool.ainvoke(
+    {"urls": ["https://en.wikipedia.org/wiki/Python_(programming_language)"]}
 )
 ```
 
-```python
-agent_executor.invoke({"input": "What is the weather in NY today?"})
+## Use within an agent
+
+```bash
+pip install -qU langchain langchain-openai langgraph langchain-community
 ```
 
 ```python
-> Entering new AgentExecutor chain...
+from langchain_community.tools.you import YouSearchTool, YouContentsTool
+from langchain_community.utilities.you import YouSearchAPIWrapper
+from langchain_openai import ChatOpenAI
+from langgraph.prebuilt import create_react_agent
 
-Invoking: `you_search` with `{'query': 'weather in NY today'}`
+api_wrapper = YouSearchAPIWrapper(count=3)
+search_tool = YouSearchTool(api_wrapper=api_wrapper)
+contents_tool = YouContentsTool(api_wrapper=api_wrapper)
 
+llm = ChatOpenAI(model="gpt-4o-mini", temperature=0)
 
-[Document(page_content="New York City, NY Forecast\nWeather Today in New York City, NY\nFeels Like43°\n7:17 am\n4:32 pm\nHigh / Low\n--/39°\nWind\n3 mph\nHumidity\n63%\nDew Point\n31°\nPressure\n30.44 in\nUV Index\n0 of 11\nVisibility\n10 mi\nMoon Phase\nWaxing Gibbous\nAdvertisement\nLatest News\nHealth & Activities\nAdvertisement\nAir Quality Index\nGood\nAir quality is considered satisfactory, and air pollution poses little or no risk.\nAdvertisement\nHappening Near New York City, NY\nPopular Nextdoor posts\nHas anyone announced --in which case I apologize--that Bo's Bagels--opened yesterday where Tommy's pizza once was on uptown side of Broadway, bet 155 and 156.They have been incredibly successful in Harlem ( W.116th) and are now spreading their wings. Open 8-3 now, will go later soon, delivers and has many varieties baked on site!!! Just had lunch there!!\nWash Hts S (W155-W159-Bdway)\nNeighbor\n4d ago", metadata={'url': 'https://weather.com/weather/today/l/96f2f84af9a5f5d452eb0574d4e4d8a840c71b05e22264ebdc0056433a642c84', 'thumbnail_url': None, 'title': 'Weather Forecast and Conditions for New York City, NY - The Weather ...', 'description': 'Today’s and tonight’s New York City, NY weather forecast, weather conditions and Doppler radar from The Weather Channel and Weather.com'}), Document(page_content='time hearing racial slurs in my life and in NYC. So I don’t know why tonight’s encounter makes me feel so helpless and sad. Her apartment is on our usual route for walks, and now I’m already thinking about how I need to behave if this situation repeats again. This just doesn’t feel fair. How would you handle it? Thanks for reading!', metadata={'url': 'https://weather.com/weather/today/l/96f2f84af9a5f5d452eb0574d4e4d8a840c71b05e22264ebdc0056433a642c84', 'thumbnail_url': None, 'title': 'Weather Forecast and Conditions for New York City, NY - The Weather ...', 'description': 'Today’s and tonight’s New York City, NY weather forecast, weather conditions and Doppler radar from The Weather Channel and Weather.com'}), Document(page_content="Hell's Kitchen\nNeighbor\n4d ago\nJust curious.Are the M100/M100 and BX19 buses free? It seems like I'm the only one who pays. Even had a group of non-payers give attitude because I held up the line to pay my fare. Non-payers being whole families, men and women of all ages. I remember when you used to be scared to walk on for free but do understand the drivers are told not to intervene. Still it should either be free or paid fare.\nHamilton Hts (W148St-Broadway)\nNeighbor\n4d ago\nHey there, I am a journalism student at Craig Newmark School of Journalism looking for stories in the Lower East Side and East Village.Any ideas?\nAlphabet City\nNeighbor\n8d ago\nProvided by\nAdvertisement\nYour Privacy\nTo personalize your product experience, we collect data from your device. We also may use or disclose to specific data vendors your precise geolocation data to provide the Services. To learn more please refer to our Privacy Policy.\nReview All Privacy and Ad Settings\nChoose how my information is shared", metadata={'url': 'https://weather.com/weather/today/l/96f2f84af9a5f5d452eb0574d4e4d8a840c71b05e22264ebdc0056433a642c84', 'thumbnail_url': None, 'title': 'Weather Forecast and Conditions for New York City, NY - The Weather ...', 'description': 'Today’s and tonight’s New York City, NY weather forecast, weather conditions and Doppler radar from The Weather Channel and Weather.com'}), Document(page_content='Review All Privacy and Ad Settings\nChoose how my information is shared', metadata={'url': 'https://weather.com/weather/today/l/96f2f84af9a5f5d452eb0574d4e4d8a840c71b05e22264ebdc0056433a642c84', 'thumbnail_url': None, 'title': 'Weather Forecast and Conditions for New York City, NY - The Weather ...', 'description': 'Today’s and tonight’s New York City, NY weather forecast, weather conditions and Doppler radar from The Weather Channel and Weather.com'}), Document(page_content='2d ago\nProvided by\nAdvertisement\nYour Privacy\nTo personalize your product experience, we collect data from your device. We also may use or disclose to specific data vendors your precise geolocation data to provide the Services. To learn more please refer to our Privacy Policy.\nReview All Privacy and Ad Settings\nChoose how my information is shared', metadata={'url': 'https://weather.com/weather/today/l/96f2f84af9a5f5d452eb0574d4e4d8a840c71b05e22264ebdc0056433a642c84', 'thumbnail_url': None, 'title': 'Weather Forecast and Conditions for New York City, NY - The Weather ...', 'description': 'Today’s and tonight’s New York City, NY weather forecast, weather conditions and Doppler radar from The Weather Channel and Weather.com'}), Document(page_content="Lenox Hill\nNeighbor\n8d ago\nParking.It is getting worst. What happened to resident-only neighborhood parking program? With this upcoming congested traffic tolling below 96th Street, competition for parking bordering the zone is going to get tougher. This should be part of the congested traffic agenda.\nCent Harlem S (120-FDouglass)\nNeighbor\n9d ago\nI thought these sites were much more localized.If there is one for the UWS I'll join it but have no reason to be reading about Yorkville or Union NJ.\nLincoln Sq (W70-Amst-66-WEnd)\nNeighbor\n10d ago\nProvided by\nAdvertisement\nYour Privacy\nTo personalize your product experience, we collect data from your device. We also may use or disclose to specific data vendors your precise geolocation data to provide the Services. To learn more please refer to our Privacy Policy.\nReview All Privacy and Ad Settings\nChoose how my information is shared", metadata={'url': 'https://weather.com/weather/today/l/96f2f84af9a5f5d452eb0574d4e4d8a840c71b05e22264ebdc0056433a642c84', 'thumbnail_url': None, 'title': 'Weather Forecast and Conditions for New York City, NY - The Weather ...', 'description': 'Today’s and tonight’s New York City, NY weather forecast, weather conditions and Doppler radar from The Weather Channel and Weather.com'})]The weather in New York City today is as follows:
-- Feels Like: 43°F
-- High/Low: --/39°F
-- Wind: 3 mph
-- Humidity: 63%
-- Dew Point: 31°F
-- Pressure: 30.44 in
-- UV Index: 0 of 11
-- Visibility: 10 mi
-- Moon Phase: Waxing Gibbous
+agent = create_react_agent(llm, [search_tool, contents_tool])
 
-For more details, you can visit [The Weather Channel](https://weather.com/weather/today/l/96f2f84af9a5f5d452eb0574d4e4d8a840c71b05e22264ebdc0056433a642c84).
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "What is the weather in NY today?"}]}
+)
 
-> Finished chain.
-```
-
-```text
-{'input': 'What is the weather in NY today?',
- 'output': 'The weather in New York City today is as follows:\n- Feels Like: 43°F\n- High/Low: --/39°F\n- Wind: 3 mph\n- Humidity: 63%\n- Dew Point: 31°F\n- Pressure: 30.44 in\n- UV Index: 0 of 11\n- Visibility: 10 mi\n- Moon Phase: Waxing Gibbous\n\nFor more details, you can visit [The Weather Channel](https://weather.com/weather/today/l/96f2f84af9a5f5d452eb0574d4e4d8a840c71b05e22264ebdc0056433a642c84).'}
+for message in result["messages"]:
+    message.pretty_print()
 ```


### PR DESCRIPTION
## Summary

- Updates all three You.com integration doc pages (provider, retriever, tools) to reflect the v1 API changes from langchain-ai/langchain-community#544
- Adds documentation for new `YouContentsTool` (Contents API wrapper)
- Replaces deprecated parameters (`num_web_results` -> `count`) and old API response examples
- Adds livecrawl usage examples showing full page content retrieval
- Updates agent example from deprecated `create_openai_functions_agent` to `create_react_agent` with LangGraph
- Adds async usage examples and Contents API examples
- Updates API doc links from `api.you.com` to `docs.you.com/api-reference/`

## Files changed

| File | What changed |
|------|-------------|
| `providers/you.mdx` | Added `YouContentsTool` import, utility import, setup section |
| `retrievers/you-retriever.mdx` | Rewrote with `count` param, livecrawl examples, new metadata fields, async support, Contents API |
| `tools/you.mdx` | Added `YouContentsTool` section, livecrawl examples, modern LangGraph agent pattern |

## Dependencies

Depends on the `langchain-community` PR landing first (updates to `YouSearchAPIWrapper`, `YouRetriever`, `YouSearchTool`, new `YouContentsTool`).

---

**Code PR**: https://github.com/langchain-ai/langchain-community/pull/544 (this docs update depends on the code PR landing first)