### PR TITLE
feat: highlight pluggable filesystem backends on deep agents overview [closes DOC-745]

### DIFF
--- a/src/oss/deepagents/overview.mdx
+++ b/src/oss/deepagents/overview.mdx
@@ -85,7 +85,7 @@ See the [Quickstart](/oss/deepagents/quickstart/) and [Customization guide](/oss
 Use the **Deep Agents SDK** when you want to build agents that can:
 - **Handle complex, multi-step tasks** that require planning and decomposition
 - **Manage large amounts of context** through file system tools
-- **Swap filesystem backends** — use in-memory state, local disk, durable stores, [sandboxes](/oss/deepagents/sandboxes), or [your own custom backend](/oss/deepagents/backends)
+- **Swap filesystem backends** to use in-memory state, local disk, durable stores, [sandboxes](/oss/deepagents/sandboxes), or [your own custom backend](/oss/deepagents/backends)
 - **Delegate work** to specialized subagents for context isolation
 - **Persist memory** across conversations and threads
 


### PR DESCRIPTION
## Description
Updates the Deep Agents landing page (`overview.mdx`) to make the pluggable filesystem backends feature more prominent, as requested by Chester Curme.

Changes:
- Added a new "Pluggable filesystem backends" card to the **Core capabilities** section, describing all available backends (in-memory state, local disk, LangGraph store, sandboxes, composite routing, and custom backends) with links to the backends and sandboxes pages
- Added a bullet point about swappable filesystem backends in the **When to use** section
- Added a "Backends" card to the **Get started** CardGroup sections for both Python and JavaScript

Resolves DOC-745

## Test Plan
- [ ] Verify the overview page renders correctly at `/oss/python/deepagents/overview`
- [ ] Verify the new "Pluggable filesystem backends" card appears in the Core capabilities section
- [ ] Verify the "Backends" card appears in the Get started sections for both Python and JS
- [ ] Verify all links (`/oss/deepagents/backends`, `/oss/deepagents/sandboxes`) resolve correctly
- [ ] Verify the new bullet in the "When to use" section renders properly