### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.7.46

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -4279,6 +4279,63 @@
             "title": "Enabled",
             "description": "Whether the cron job should be enabled. Disabled crons are not executed.",
             "default": true
+          },
+          "stream_mode": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "values",
+                    "messages",
+                    "messages-tuple",
+                    "tasks",
+                    "checkpoints",
+                    "updates",
+                    "events",
+                    "debug",
+                    "custom"
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "values",
+                  "messages",
+                  "messages-tuple",
+                  "tasks",
+                  "checkpoints",
+                  "updates",
+                  "events",
+                  "debug",
+                  "custom"
+                ]
+              }
+            ],
+            "title": "Stream Mode",
+            "description": "The stream mode(s) to use.",
+            "default": ["values"]
+          },
+          "stream_subgraphs": {
+            "type": "boolean",
+            "title": "Stream Subgraphs",
+            "description": "Whether to stream output from subgraphs.",
+            "default": false
+          },
+          "stream_resumable": {
+            "type": "boolean",
+            "title": "Stream Resumable",
+            "description": "Whether to persist the stream chunks in order to resume the stream later.",
+            "default": false
+          },
+          "durability": {
+            "type": "string",
+            "enum": ["sync", "async", "exit"],
+            "title": "Durability",
+            "description": "Durability level for the run. Must be one of 'sync', 'async', or 'exit'.",
+            "default": "async"
           }
         },
         "type": "object",
@@ -4397,6 +4454,63 @@
             "type": "boolean",
             "title": "Enabled",
             "description": "Enable or disable the cron job."
+          },
+          "stream_mode": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "values",
+                    "messages",
+                    "messages-tuple",
+                    "tasks",
+                    "checkpoints",
+                    "updates",
+                    "events",
+                    "debug",
+                    "custom"
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "values",
+                  "messages",
+                  "messages-tuple",
+                  "tasks",
+                  "checkpoints",
+                  "updates",
+                  "events",
+                  "debug",
+                  "custom"
+                ]
+              }
+            ],
+            "title": "Stream Mode",
+            "description": "The stream mode(s) to use.",
+            "default": ["values"]
+          },
+          "stream_subgraphs": {
+            "type": "boolean",
+            "title": "Stream Subgraphs",
+            "description": "Whether to stream output from subgraphs.",
+            "default": false
+          },
+          "stream_resumable": {
+            "type": "boolean",
+            "title": "Stream Resumable",
+            "description": "Whether to persist the stream chunks in order to resume the stream later.",
+            "default": false
+          },
+          "durability": {
+            "type": "string",
+            "enum": ["sync", "async", "exit"],
+            "title": "Durability",
+            "description": "Durability level for the run. Must be one of 'sync', 'async', or 'exit'.",
+            "default": "async"
           }
         },
         "type": "object",
@@ -6177,6 +6291,63 @@
             "title": "Enabled",
             "description": "Whether the cron job should be enabled. Disabled crons are not executed.",
             "default": true
+          },
+          "stream_mode": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string",
+                  "enum": [
+                    "values",
+                    "messages",
+                    "messages-tuple",
+                    "tasks",
+                    "checkpoints",
+                    "updates",
+                    "events",
+                    "debug",
+                    "custom"
+                  ]
+                },
+                "type": "array"
+              },
+              {
+                "type": "string",
+                "enum": [
+                  "values",
+                  "messages",
+                  "messages-tuple",
+                  "tasks",
+                  "checkpoints",
+                  "updates",
+                  "events",
+                  "debug",
+                  "custom"
+                ]
+              }
+            ],
+            "title": "Stream Mode",
+            "description": "The stream mode(s) to use.",
+            "default": ["values"]
+          },
+          "stream_subgraphs": {
+            "type": "boolean",
+            "title": "Stream Subgraphs",
+            "description": "Whether to stream output from subgraphs.",
+            "default": false
+          },
+          "stream_resumable": {
+            "type": "boolean",
+            "title": "Stream Resumable",
+            "description": "Whether to persist the stream chunks in order to resume the stream later.",
+            "default": false
+          },
+          "durability": {
+            "type": "string",
+            "enum": ["sync", "async", "exit"],
+            "title": "Durability",
+            "description": "Durability level for the run. Must be one of 'sync', 'async', or 'exit'.",
+            "default": "async"
           }
         },
         "type": "object",


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.7.46**

This update was automatically generated by the sync workflow in the langgraph-api repository.