### PR TITLE
fix(oss): use absolute statebackend skills source path

### DIFF
--- a/src/snippets/skills-usage-tabs-py.mdx
+++ b/src/snippets/skills-usage-tabs-py.mdx
@@ -17,7 +17,7 @@
     }
 
     agent = create_deep_agent(
-        skills=["./skills/"],
+        skills=["/skills/"],
         checkpointer=checkpointer,
     )
 


### PR DESCRIPTION
the Python `StateBackend` skills snippet seeded files under `/skills/...` but configured `create_deep_agent(skills=["./skills/"])`.  

For `StateBackend`, skill source matching is path-prefix based against virtual paths, so this mismatch can prevent skill discovery in the example.