### PR TITLE
docs: add Blindfold PII protection integration

### DIFF
--- a/src/oss/python/integrations/document_transformers/blindfold.mdx
+++ b/src/oss/python/integrations/document_transformers/blindfold.mdx
@@ -1,0 +1,129 @@
+---
+title: "Blindfold PII Transformer"
+description: "Integrate with the Blindfold PII document transformer using LangChain Python."
+---
+
+[Blindfold](https://blindfold.dev) detects and protects PII (personally identifiable information)
+across 18+ languages. The `BlindfoldPIITransformer` protects PII in LangChain `Document` objects,
+making it ideal for RAG pipelines and vector store indexing.
+
+## Installation
+
+```bash
+pip install -qU langchain-blindfold
+```
+
+## Setup
+
+You need a Blindfold API key. Sign up at [blindfold.dev](https://blindfold.dev) to get one
+with 1M free characters/month.
+
+```python
+import os
+
+os.environ["BLINDFOLD_API_KEY"] = "<your-api-key>"
+```
+
+## Usage
+
+### Tokenize PII in documents
+
+Replace PII with reversible tokens. The mapping is stored in document metadata
+so you can restore original values later.
+
+```python
+from langchain_blindfold import BlindfoldPIITransformer
+from langchain_core.documents import Document
+
+transformer = BlindfoldPIITransformer(pii_method="tokenize", policy="basic")
+
+docs = [
+    Document(page_content="Contact John Smith at john@example.com for details."),
+]
+
+protected_docs = transformer.transform_documents(docs)
+print(protected_docs[0].page_content)
+# "Contact <Person_1> at <Email Address_1> for details."
+print(protected_docs[0].metadata["blindfold_mapping"])
+# {"<Person_1>": "John Smith", "<Email Address_1>": "john@example.com"}
+```
+
+### Redact PII from documents
+
+Permanently remove PII when you don't need reversibility.
+
+```python
+transformer = BlindfoldPIITransformer(pii_method="redact", policy="hipaa_us")
+
+docs = [
+    Document(page_content="Patient Jane Doe, SSN 123-45-6789, diagnosed on 03/15/2024."),
+]
+
+redacted_docs = transformer.transform_documents(docs)
+print(redacted_docs[0].page_content)
+# "Patient [REDACTED], SSN [REDACTED], diagnosed on [REDACTED]."
+```
+
+### Available PII methods
+
+| Method | Description | Reversible |
+|---|---|---|
+| `tokenize` | Replace with tokens like `<Person_1>` | Yes |
+| `redact` | Remove PII entirely | No |
+| `mask` | Mask characters (e.g., `J***oe`) | No |
+| `hash` | Replace with hash values | No |
+| `synthesize` | Replace with synthetic data | No |
+| `encrypt` | AES-256 encrypted values | Yes |
+
+### Detection policies
+
+| Policy | Best for |
+|---|---|
+| `basic` | General PII (names, emails, phones, locations) |
+| `gdpr_eu` | GDPR compliance (IBANs, EU addresses, dates of birth) |
+| `hipaa_us` | HIPAA compliance (SSNs, medical record numbers) |
+| `pci_dss` | PCI DSS compliance (card numbers, CVVs) |
+| `strict` | Maximum detection with lower thresholds |
+
+### Region support
+
+For data residency requirements, specify a region:
+
+```python
+transformer = BlindfoldPIITransformer(
+    pii_method="tokenize",
+    policy="gdpr_eu",
+    region="eu",  # or "us"
+)
+```
+
+## Chain composition with Runnables
+
+For protecting prompts in LLM chains (rather than documents), use the `BlindfoldTokenizer`
+and `BlindfoldDetokenizer` Runnables:
+
+```python
+from langchain_blindfold import blindfold_protect
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_openai import ChatOpenAI
+
+tokenize, detokenize = blindfold_protect(policy="basic")
+
+prompt = ChatPromptTemplate.from_messages([
+    ("system", "You are a helpful assistant."),
+    ("user", "{input}"),
+])
+llm = ChatOpenAI(model="gpt-4o-mini")
+
+# PII is tokenized before the LLM and restored in the response
+chain = tokenize | prompt | llm | (lambda msg: msg.content) | detokenize
+
+result = chain.invoke("Please summarize the case for John Smith, john@example.com")
+# The LLM never sees the real name or email
+```
+
+## API reference
+
+- [langchain-blindfold on PyPI](https://pypi.org/project/langchain-blindfold/)
+- [GitHub repository](https://github.com/blindfold-dev/langchain-blindfold)
+- [Blindfold documentation](https://docs.blindfold.dev)

--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -458,6 +458,14 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
+        title="Blindfold"
+        href="/oss/integrations/providers/blindfold"
+        icon="link"
+    >
+        PII detection and protection for AI applications.
+    </Card>
+
+    <Card
         title="Blackboard"
         href="/oss/integrations/providers/blackboard"
         icon="link"

--- a/src/oss/python/integrations/providers/blindfold.mdx
+++ b/src/oss/python/integrations/providers/blindfold.mdx
@@ -1,0 +1,47 @@
+---
+title: "Blindfold"
+description: "PII detection and protection for AI applications."
+---
+
+[Blindfold](https://blindfold.dev) is a PII detection and protection gateway for AI applications.
+It detects sensitive data (names, emails, phone numbers, addresses, SSNs, and more) across 18+ languages
+and replaces it with reversible tokens before it reaches your LLM, then restores the original values in
+the response.
+
+## Installation
+
+```bash
+pip install langchain-blindfold
+```
+
+## Setup
+
+```python
+import os
+
+os.environ["BLINDFOLD_API_KEY"] = "<your-api-key>"
+```
+
+Sign up at [blindfold.dev](https://blindfold.dev) to get an API key with 1M free characters/month.
+
+## Integrations
+
+| Integration | Description |
+|---|---|
+| [Document Transformer](/oss/integrations/document_transformers/blindfold) | Protect PII in LangChain Documents for RAG pipelines and vector stores. |
+
+### Runnables for chain composition
+
+`langchain-blindfold` also provides `BlindfoldTokenizer` and `BlindfoldDetokenizer` Runnables that
+can be composed into any LangChain chain to protect PII in prompts and restore it in responses:
+
+```python
+from langchain_blindfold import blindfold_protect
+from langchain_openai import ChatOpenAI
+
+tokenize, detokenize = blindfold_protect(policy="basic")
+
+chain = tokenize | prompt | ChatOpenAI() | (lambda msg: msg.content) | detokenize
+```
+
+Learn more in the [langchain-blindfold documentation](https://docs.blindfold.dev/integrations/langchain).


### PR DESCRIPTION
## Summary

Add [Blindfold](https://blindfold.dev) as a LangChain integration provider. Blindfold is a PII detection and protection gateway for AI applications — it detects sensitive data (names, emails, phone numbers, addresses, SSNs, and more) across 18+ languages and replaces it with reversible tokens.

The [`langchain-blindfold`](https://pypi.org/project/langchain-blindfold/) package (already published on PyPI) provides:
- **`BlindfoldPIITransformer`** — Document transformer for protecting PII in RAG pipelines and vector stores
- **`BlindfoldTokenizer` / `BlindfoldDetokenizer`** — Runnables for composing PII protection into any LangChain chain
- **`blindfold_protect()`** — Convenience factory for paired tokenizer/detokenizer

### Files added/modified
- `src/oss/python/integrations/providers/blindfold.mdx` — Provider page with overview and setup
- `src/oss/python/integrations/document_transformers/blindfold.mdx` — Document transformer page with usage examples for all 6 PII methods (tokenize, redact, mask, hash, synthesize, encrypt), detection policies, region support, and chain composition
- `src/oss/python/integrations/providers/all_providers.mdx` — Added Card entry in alphabetical order

### Links
- PyPI: https://pypi.org/project/langchain-blindfold/
- GitHub: https://github.com/blindfold-dev/langchain-blindfold
- Docs: https://docs.blindfold.dev

## Checklist
- [x] Code examples have been tested and work correctly
- [x] Used root relative paths for internal links
- [x] Navigation in `src/docs.json` does not need updating (pages are discoverable via category index)