### PR TITLE
formating: fix formatting in split_html.mdx for emphasis

### DIFF
--- a/src/oss/python/integrations/splitters/split_html.mdx
+++ b/src/oss/python/integrations/splitters/split_html.mdx
@@ -36,7 +36,7 @@ ___
 ### [HTMLSectionSplitter](#using-htmlsectionsplitter)
 
 <Info>
-Useful when you want to split HTML documents into larger sections, such as `<section>`, `<div>`, or custom-defined sections.
+**Useful when you want to split HTML documents into larger sections, such as `<section>`, `<div>`, or custom-defined sections.**
 </Info>
 
 **Description**: Similar to HTMLHeaderTextSplitter but focuses on splitting HTML into sections based on specified tags.
@@ -50,7 +50,7 @@ ___
 ### [HTMLSemanticPreservingSplitter](#using-htmlsemanticpreservingsplitter)
 
 <Info>
-**Ideal when you need to ensure that structured elements are not split across chunks, preserving contextual relevancy. **
+**Ideal when you need to ensure that structured elements are not split across chunks, preserving contextual relevancy.**
 </Info>
 
 **Description**: Splits HTML content into manageable chunks while preserving the semantic structure of important elements like tables, lists, and other HTML components.


### PR DESCRIPTION
This PR updates formatting within the HTML splitter documentation to improve consistency and readability. Specifically, it standardizes bold formatting within <Info> blocks and removes trailing whitespace.