### PR TITLE
Documentation bug fix for JsonToolkit

### DIFF
--- a/src/oss/python/integrations/tools/json.mdx
+++ b/src/oss/python/integrations/tools/json.mdx
@@ -26,7 +26,7 @@ from langchain_openai import OpenAI
 ```python
 with open("openai_openapi.yml") as f:
     data = yaml.load(f, Loader=yaml.FullLoader)
-json_spec = JsonSpec(dict_={}, max_value_length=4000)
+json_spec = JsonSpec(dict_=data, max_value_length=4000)
 json_toolkit = JsonToolkit(spec=json_spec)
 
 json_agent_executor = create_json_agent(


### PR DESCRIPTION
## Overview
Update json.mdx, documentation for JsonToolkit

## Type of change: Bug fix

Currently in the code example the yaml is loaded and stored as `data` but then on initializing json_spec an empty dict is passed as the `dict_` arg, with data never used. This is fixed by passing `data` to json_spec, ensuring the code example executes without errors when copied and pasted directly

## Related issues/PRs
No issues or PRs reporting this bug found

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

