### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.7.51

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -3806,6 +3806,22 @@
         }
       }
     },
+    "/docs": {
+      "get": {
+        "tags": ["System"],
+        "summary": "API Documentation",
+        "description": "A local reference to the Agent Server API documentation.\n\nThis page renders a local OpenAPI JSON specification file (`openapi.json`). For self-hosted deployments, optionally specify the `MOUNT_PREFIX` environment variable in your server to add a custom prefix path to the `openapi.json` file (e.g. `{MOUNT_PREFIX}/openapi.json`).",
+        "operationId": "docs_get",
+        "responses": {
+          "200": {
+            "description": "Success",
+            "content": {
+              "text/html": {}
+            }
+          }
+        }
+      }
+    },
     "/ok": {
       "get": {
         "tags": ["System"],


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.7.51**

This update was automatically generated by the sync workflow in the langgraph-api repository.