### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.7.51

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -3810,7 +3810,7 @@
       "get": {
         "tags": ["System"],
         "summary": "API Documentation",
-        "description": "A local reference to the Agent Server API documentation.\n\nThis page renders a local OpenAPI JSON specification file (`openapi.json`). For self-hosted deployments, optionally specify the `MOUNT_PREFIX` environment variable in your server to add a custom prefix path to the `openapi.json` file (e.g. `{MOUNT_PREFIX}/openapi.json`).",
+        "description": "A local reference to the Agent Server API documentation.",
         "operationId": "docs_get",
         "responses": {
           "200": {
@@ -5046,7 +5046,7 @@
             },
             "type": "array",
             "title": "Feedback Keys",
-            "description": "Feedback keys to assign to run."
+            "description": "Generate pre-signed URLs for assigning feedback keys to the run.\n\nFor each key specified, a unique URL will be generated that can be called to assign the feedback key to the run. See [LangSmith Feedback](https://docs.langchain.com/langsmith/observability-concepts#feedback) for more details."
           },
           "multitask_strategy": {
             "type": "string",
@@ -5231,7 +5231,7 @@
             },
             "type": "array",
             "title": "Feedback Keys",
-            "description": "Feedback keys to assign to run."
+            "description": "Generate pre-signed URLs for assigning feedback keys to the run.\n\nFor each key specified, a unique URL will be generated that can be called to assign the feedback key to the run. See [LangSmith Feedback](https://docs.langchain.com/langsmith/observability-concepts#feedback) for more details."
           },
           "stream_subgraphs": {
             "type": "boolean",
@@ -5485,6 +5485,15 @@
             },
             "title": "Select",
             "description": "Specify which fields to return. If not provided, all fields are returned."
+          },
+          "extract": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            },
+            "title": "Extract",
+            "description": "Map of alias to JSONB path for extracting specific values. Paths must start with values, metadata, config, or interrupts. Example: {\"last_msg\": \"values.messages[-1]\"}.",
+            "maxProperties": 10
           }
         },
         "type": "object",
@@ -5586,6 +5595,11 @@
                 "description": "When the thread will expire."
               }
             }
+          },
+          "extracted": {
+            "type": "object",
+            "title": "Extracted",
+            "description": "Extracted values from thread JSONB columns, populated when extract is specified in search request."
           }
         },
         "type": "object",


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.7.51**

This update was automatically generated by the sync workflow in the langgraph-api repository.