### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.7.52

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -908,7 +908,7 @@
       "post": {
         "tags": ["Threads"],
         "summary": "Prune Threads",
-        "description": "Prune threads by ID. The 'delete' strategy removes threads entirely. The 'keep_latest' strategy prunes old checkpoints but keeps threads and their latest state (requires FF_USE_CORE_API=true).",
+        "description": "Prune threads by ID. The 'delete' strategy removes threads entirely. The 'keep_latest' strategy prunes old checkpoints but keeps threads and their latest state.",
         "operationId": "prune_threads_threads_prune_post",
         "requestBody": {
           "content": {
@@ -5640,7 +5640,7 @@
               "strategy": {
                 "type": "string",
                 "enum": ["delete", "keep_latest"],
-                "description": "The TTL strategy. 'delete' removes the entire thread. 'keep_latest' prunes old checkpoints but keeps the thread and its latest state (requires FF_USE_CORE_API=true).",
+                "description": "The TTL strategy. 'delete' removes the entire thread. 'keep_latest' prunes old checkpoints but keeps the thread and its latest state.",
                 "default": "delete"
               },
               "ttl": {
@@ -5684,7 +5684,7 @@
               "strategy": {
                 "type": "string",
                 "enum": ["delete", "keep_latest"],
-                "description": "The TTL strategy. 'delete' removes the entire thread. 'keep_latest' prunes old checkpoints but keeps the thread and its latest state (requires FF_USE_CORE_API=true).",
+                "description": "The TTL strategy. 'delete' removes the entire thread. 'keep_latest' prunes old checkpoints but keeps the thread and its latest state.",
                 "default": "delete"
               },
               "ttl": {
@@ -5713,7 +5713,7 @@
             "type": "string",
             "enum": ["delete", "keep_latest"],
             "title": "Strategy",
-            "description": "The prune strategy. 'delete' removes threads entirely. 'keep_latest' prunes old checkpoints but keeps threads and their latest state (requires FF_USE_CORE_API=true).",
+            "description": "The prune strategy. 'delete' removes threads entirely. 'keep_latest' prunes old checkpoints but keeps threads and their latest state.",
             "default": "delete"
           }
         },


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.7.52**

This update was automatically generated by the sync workflow in the langgraph-api repository.