### PR TITLE
chore: add documentation for tools stream mode

### DIFF
--- a/src/oss/langgraph/streaming.mdx
+++ b/src/oss/langgraph/streaming.mdx
@@ -12,8 +12,13 @@ What's possible with LangGraph streaming:
 * <Icon icon="chart-bar" size={16} /> [**Stream subgraph outputs**](#stream-subgraph-outputs) — include outputs from both the parent graph and any nested subgraphs.
 * <Icon icon="binary" size={16} /> [**Stream LLM tokens**](#messages) — capture token streams from anywhere: inside nodes, subgraphs, or tools.
 * <Icon icon="table" size={16} /> [**Stream custom data**](#stream-custom-data) — send custom updates or progress signals directly from tool functions.
-* <Icon icon="tool" size={16} /> [**Stream tool progress**](#stream-tool-progress) — track tool lifecycle events (`start`, `progress`, `end`, `error`) in real time. JS only.
+:::js
+* <Icon icon="tool" size={16} /> [**Stream tool progress**](#stream-tool-progress) — track tool lifecycle events (`start`, `progress`, `end`, `error`) in real time.
 * <Icon icon="stack-push" size={16} /> [**Use multiple streaming modes**](#stream-multiple-modes) — choose from `values` (full state), `updates` (state deltas), `messages` (LLM tokens + metadata), `custom` (arbitrary user data), `tools` (tool lifecycle events), or `debug` (detailed traces).
+:::
+:::python
+* <Icon icon="stack-push" size={16} /> [**Use multiple streaming modes**](#stream-multiple-modes) — choose from `values` (full state), `updates` (state deltas), `messages` (LLM tokens + metadata), `custom` (arbitrary user data), or `debug` (detailed traces).
+:::
 
 ## Supported stream modes
 
@@ -25,14 +30,26 @@ Pass one or more of the following stream modes as a list to the @[`stream`][Comp
 Pass one or more of the following stream modes as a list to the @[`stream`][CompiledStateGraph.stream] method:
 :::
 
-| Mode       | Description                                                                                                                                                                         |
-| ---------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `values`   | Streams the full value of the state after each step of the graph.                                                                                                                   |
-| `updates`  | Streams the updates to the state after each step of the graph. If multiple updates are made in the same step (e.g., multiple nodes are run), those updates are streamed separately. |
-| `custom`   | Streams custom data from inside your graph nodes.                                                                                                                                   |
-| `messages` | Streams 2-tuples (LLM token, metadata) from any graph nodes where an LLM is invoked.                                                                                                |
-| `tools`    | Streams tool-call lifecycle events (`on_tool_start`, `on_tool_event`, `on_tool_end`, `on_tool_error`) from tool execution. JS only.                                                  |
-| `debug`    | Streams as much information as possible throughout the execution of the graph.                                                                                                      |
+:::js
+| Mode | Description |
+| ---- | ----------- |
+| `values` | Streams the full value of the state after each step of the graph. |
+| `updates` | Streams the updates to the state after each step of the graph. If multiple updates are made in the same step (e.g., multiple nodes are run), those updates are streamed separately. |
+| `custom` | Streams custom data from inside your graph nodes. |
+| `messages` | Streams 2-tuples (LLM token, metadata) from any graph nodes where an LLM is invoked. |
+| `tools` | Streams tool-call lifecycle events (`on_tool_start`, `on_tool_event`, `on_tool_end`, `on_tool_error`) from tool execution. |
+| `debug` | Streams as much information as possible throughout the execution of the graph. |
+:::
+
+:::python
+| Mode | Description |
+| ---- | ----------- |
+| `values` | Streams the full value of the state after each step of the graph. |
+| `updates` | Streams the updates to the state after each step of the graph. If multiple updates are made in the same step (e.g., multiple nodes are run), those updates are streamed separately. |
+| `custom` | Streams custom data from inside your graph nodes. |
+| `messages` | Streams 2-tuples (LLM token, metadata) from any graph nodes where an LLM is invoked. |
+| `debug` | Streams as much information as possible throughout the execution of the graph. |
+:::
 
 ## Basic usage example
 
@@ -1039,9 +1056,9 @@ To send **custom user-defined data** from inside a LangGraph node or tool, follo
 </Tabs>
 :::
 
-## Stream tool progress
-
 :::js
+
+## Stream tool progress
 
 Use the `tools` stream mode to receive real-time lifecycle events for tool executions. This is useful for showing progress indicators, partial results, and error states in your UI while tools are running.
 
@@ -1324,7 +1341,7 @@ function TravelPlanner() {
 Both stream modes can surface tool progress, but they serve different purposes:
 
 * **`tools`** — automatically emits structured lifecycle events (`on_tool_start`, `on_tool_event`, `on_tool_end`, `on_tool_error`) with no code changes needed in your tools beyond using `async function*`. The `useStream` hook provides the reactive `toolProgress` array out of the box.
-* **`custom`** — gives you full control over what data is emitted and when, using `config.writer()`. Use this when you need freeform data that doesn't map to the tool lifecycle, or when you want to stream from nodes (not just tools).
+* **`custom`** — gives you full control over what data is emitted and when using `config.writer()`. Use this when you need freeform data that doesn't map to the tool lifecycle, or when you want to stream from nodes (not just tools).
 
 :::
 


### PR DESCRIPTION
## Overview
Adds documentation for the tools stream mode in LangGraph (JavaScript only). Updates include:
- Intro: New bullet for “Stream tool progress” and an updated “Use multiple streaming modes” bullet that includes tools.
- Supported stream modes: New table row for tools describing tool-call lifecycle events (on_tool_start, on_tool_event, on_tool_end, on_tool_error).
- New section “Stream tool progress” (JS): How to use the tools stream mode to get real-time tool lifecycle events; defining tools as async generators that yield progress; consuming events in server-side code; using the useStream hook and toolProgress in React; extended example (travel agent with flight/hotel tools and progress UI); and when to use tools vs custom stream mode.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- Feature PR:
 - https://github.com/langchain-ai/langchainjs/pull/10102
 - https://github.com/langchain-ai/langgraphjs/pull/1984
 - https://github.com/langchain-ai/langgraphjs/pull/2000

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)
