### PR TITLE
Add support for ChatNVIDIADynamo in NVIDIA AI integration

### DIFF
--- a/src/oss/python/integrations/chat/nvidia_ai_endpoints.mdx
+++ b/src/oss/python/integrations/chat/nvidia_ai_endpoints.mdx
@@ -460,37 +460,6 @@ for chunk in llm_critical.stream("Give a one-sentence summary of GPU computing."
     print(chunk.content, end="", flush=True)
 ```
 
-### Use in LangChain chains
-
-`ChatNVIDIADynamo` works in LangChain chains and pipelines the same way as `ChatNVIDIA`.
-
-```python
-from langchain_core.output_parsers import StrOutputParser
-from langchain_core.prompts import ChatPromptTemplate
-
-prompt = ChatPromptTemplate.from_messages([
-    ("system", "Classify the user's intent into exactly one category: "
-               "billing, technical_support, general_inquiry, or complaint. "
-               "Respond with only the category name."),
-    ("user", "{input}"),
-])
-
-classifier_chain = (
-    prompt
-    | ChatNVIDIADynamo(
-        base_url=BASE_URL,
-        model=MODEL,
-        osl=5,
-        priority=10,
-        latency_sensitivity=1.0,
-    )
-    | StrOutputParser()
-)
-
-intent = classifier_chain.invoke({"input": "My invoice has the wrong amount"})
-print(f"Detected intent: {intent}")
-```
-
 ### Inspect the payload
 
 For debugging, inspect the exact payload that `ChatNVIDIADynamo` sends to the NIM endpoint using the internal `_get_payload` method.


### PR DESCRIPTION
Extended the NVIDIA AI integration documentation to introduce `ChatNVIDIADynamo`. This includes usage examples, configuration options, and detailed explanations of its advanced features like routing hints and priority scheduling for distributed inference with NVIDIA Dynamo.

## Overview
Extended the NVIDIA AI integration documentation to introduce `ChatNVIDIADynamo`. This includes usage examples, configuration options, and detailed explanations of its advanced features like routing hints and priority scheduling for distributed inference with NVIDIA Dynamo.

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
