### PR TITLE
docs: add veritensor.mdx

### DIFF
--- a/src/oss/python/integrations/providers/veritensor.mdx
+++ b/src/oss/python/integrations/providers/veritensor.mdx
@@ -1,0 +1,49 @@
+---
+title: Veritensor
+description: Integrate Veritensor for securing RAG pipelines and document loaders.
+---
+
+[Veritensor](https://github.com/arsbr/Veritensor) is an open-source security scanner and firewall for AI artifacts.
+
+In the context of RAG (Retrieval-Augmented Generation), `Veritensor` can be used to wrap standard LangChain Document Loaders to prevent **Data Poisoning**, **Indirect Prompt Injections**, and **PII leaks** before the data is chunked and embedded into your Vector Database.
+
+It scans the raw files (PDF, DOCX, TXT) for stealth techniques (like hidden CSS text or HTML comments) and uses static analysis and entropy checks to sanitize the ingested data locally.
+
+## Installation and Setup
+
+You need to install the `veritensor` python package. To scan documents (PDF, DOCX), use the `[rag]` extra:
+
+```bash
+pip install "veritensor[rag]"
+```
+
+## Usage: Securing Document Loaders
+You can secure any existing LangChain `BaseLoader` by wrapping it with the `SecureLangChainLoader`.
+If `strict_mode=True`, the loader will raise a `VeritensorSecurityError` and block the ingestion process if malicious payloads (e.g., hidden "Ignore previous instructions" text) are detected in the document.
+
+```Python
+from langchain_community.document_loaders import PyPDFLoader
+from veritensor.integrations.langchain_guard import SecureLangChainLoader
+
+# 1. Initialize your standard document loader
+base_loader = PyPDFLoader("untrusted_user_upload.pdf")
+
+# 2. Wrap it in the Veritensor Guard
+secure_loader = SecureLangChainLoader(
+    file_path="untrusted_user_upload.pdf", 
+    base_loader=base_loader,
+    strict_mode=True # Blocks ingestion if threats are found
+)
+
+# 3. Safely load the documents
+try:
+    docs = secure_loader.load()
+    print(f"Successfully loaded {len(docs)} safe documents.")
+except Exception as e:
+    print(f"Security Alert: {e}")
+```
+
+## Advanced: Smart Filtering and PII
+Veritensor also supports PII (Personally Identifiable Information) detection using Microsoft Presidio. If you install the `[pii]` extra, the `SecureLangChainLoader` will automatically scan for and flag sensitive data during the loading phase.
+
+For more details on supported formats (including Parquet, Jupyter Notebooks, and Pickle models) and configuration options, visit the [Veritensor GitHub repository](https://github.com/arsbr/Veritensor).


### PR DESCRIPTION
## Overview
This PR adds documentation for `Veritensor`, an open-source AI security tool that provides a wrapper for LangChain Document Loaders (`SecureLangChainLoader`). 

Following our recent addition to the official [awesome-langchain](https://github.com/kyrolabs/awesome-langchain) list under the "Services" section, we wanted to provide clear, official documentation on how LangChain users can implement this security layer.

As RAG pipelines increasingly ingest untrusted or user-generated documents (PDFs, web scrapes), they become vulnerable to indirect prompt injections and data poisoning (e.g., hidden text via CSS). This integration allows developers to sanitize documents locally *before* they are passed to text splitters and vector stores, preventing malicious payloads from compromising the LLM.

## Type of change
- [x] New documentation page

## Related issues/PRs
- Feature PR: N/A

## Checklist
- [x] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes
The added documentation (`src/oss/python/integrations/providers/veritensor.mdx`) includes installation instructions and a code example demonstrating how to wrap a `PyPDFLoader` to block prompt injections, stealth attacks, and PII leaks during RAG data ingestion. 
I intentionally left `src/docs.json` untouched. I wasn't entirely sure which specific group/section would be the most appropriate place for Veritensor in your current sidebar structure (e.g., Document Loaders vs. Security integrations). 
Could you please advise on where it should go, or help link it in the navigation during the merge? Thank you!