### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.7.55

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -4350,7 +4350,7 @@
             "type": "string",
             "enum": ["sync", "async", "exit"],
             "title": "Durability",
-            "description": "Durability level for the run. Must be one of 'sync', 'async', or 'exit'.",
+            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/durable-execution#durability-modes) for more details.",
             "default": "async"
           }
         },
@@ -4525,7 +4525,7 @@
             "type": "string",
             "enum": ["sync", "async", "exit"],
             "title": "Durability",
-            "description": "Durability level for the run. Must be one of 'sync', 'async', or 'exit'.",
+            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/durable-execution#durability-modes) for more details.",
             "default": "async"
           }
         },
@@ -5070,14 +5070,15 @@
           "checkpoint_during": {
             "type": "boolean",
             "title": "Checkpoint During",
-            "description": "Whether to checkpoint during the run.",
+            "description": "Whether to checkpoint during the run.\n\nDeprecated. Use `durability` instead to control checkpoint persistence behavior during the run.",
+            "deprecated": true,
             "default": false
           },
           "durability": {
             "type": "string",
             "enum": ["sync", "async", "exit"],
             "title": "Durability",
-            "description": "Durability level for the run. Must be one of 'sync', 'async', or 'exit'.",
+            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/durable-execution#durability-modes) for more details.",
             "default": "async"
           }
         },
@@ -5267,14 +5268,15 @@
           "checkpoint_during": {
             "type": "boolean",
             "title": "Checkpoint During",
-            "description": "Whether to checkpoint during the run.",
+            "description": "Whether to checkpoint during the run.\n\nDeprecated. Use `durability` instead to control checkpoint persistence behavior during the run.",
+            "deprecated": true,
             "default": false
           },
           "durability": {
             "type": "string",
             "enum": ["sync", "async", "exit"],
             "title": "Durability",
-            "description": "Durability level for the run. Must be one of 'sync', 'async', or 'exit'.",
+            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/durable-execution#durability-modes) for more details.",
             "default": "async"
           }
         },
@@ -6376,7 +6378,7 @@
             "type": "string",
             "enum": ["sync", "async", "exit"],
             "title": "Durability",
-            "description": "Durability level for the run. Must be one of 'sync', 'async', or 'exit'.",
+            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/durable-execution#durability-modes) for more details.",
             "default": "async"
           }
         },


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.7.55**

This update was automatically generated by the sync workflow in the langgraph-api repository.