### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.7.55

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -3082,6 +3082,15 @@
                 "type": "string"
               }
             }
+          },
+          {
+            "name": "refresh_ttl",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "boolean"
+            },
+            "description": "Whether to refresh the TTL on this read operation. If not provided, uses the store's default behavior."
           }
         ],
         "responses": {
@@ -5994,6 +6003,22 @@
             "type": "object",
             "title": "Value",
             "description": "A dictionary containing the item's data."
+          },
+          "index": {
+            "oneOf": [
+              { "type": "boolean", "enum": [false] },
+              { "type": "array", "items": { "type": "string" } },
+              { "type": "null" }
+            ],
+            "default": null,
+            "title": "Index",
+            "description": "Controls search indexing - null (use defaults), false (disable), or list of field paths to index."
+          },
+          "ttl": {
+            "type": ["number", "null"],
+            "default": null,
+            "title": "TTL",
+            "description": "Optional time-to-live in minutes for the item, or null for no expiration."
           }
         },
         "title": "StorePutRequest",
@@ -6053,6 +6078,12 @@
             "type": ["string", "null"],
             "title": "Query",
             "description": "Query string for semantic/vector search."
+          },
+          "refresh_ttl": {
+            "type": ["boolean", "null"],
+            "default": null,
+            "title": "Refresh TTL",
+            "description": "Whether to refresh the TTL on items returned by this search. If null, uses the store's default behavior."
           }
         },
         "title": "StoreSearchRequest",


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.7.55**

This update was automatically generated by the sync workflow in the langgraph-api repository.