### PR TITLE
docs: warn that @auth.on filter fields must be left unencrypted

### DIFF
--- a/src/langsmith/encryption.mdx
+++ b/src/langsmith/encryption.mdx
@@ -197,7 +197,7 @@ async def decrypt_json(ctx: EncryptionContext, data: dict) -> dict:
 
 Common fields to leave **unencrypted** for search and filtering:
 
-- Fields used as filters in your [`@auth.on` handlers](./custom_auth) (e.g., `owner`, `tenant_id`) — if these are encrypted, auth isolation silently breaks because the stored value no longer matches the plaintext filter. LangGraph Server will return a 422 error if it detects this at write time.
+- Fields used as filters in your [`@auth.on` handlers](/langsmith/set-up-custom-auth) (e.g., `owner`, `tenant_id`) — if these are encrypted, auth isolation silently breaks because the stored value no longer matches the plaintext filter. LangGraph Server will return a 422 error if it detects this at write time.
 - Other user-defined fields for access control queries
 - `run_id`, `thread_id`, `graph_id`, `assistant_id`, `user_id`, `checkpoint_id` — system-populated identifiers
 - `source`, `step`, `parents`, `run_attempt` — system-populated execution state


### PR DESCRIPTION
Adds a callout in the custom encryption docs noting that fields used as auth filters must stay unencrypted — otherwise the stored encrypted value won't match the plaintext filter and auth isolation silently breaks. LangGraph Server (as of 0.7.57) will return a 422 at write time if it detects this.