### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.7.56

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -3130,7 +3130,8 @@
     "/store/items/search": {
       "post": {
         "tags": ["Store"],
-        "summary": "Search for items within a namespace prefix.",
+        "summary": "Search or list items within a namespace prefix.",
+        "description": "Lists items ordered by last updated time. If a `query` is provided, performs a natural language search instead. Supports pagination via `limit` and `offset`, and filtering via `filter`.",
         "operationId": "search_items",
         "requestBody": {
           "required": true,
@@ -6077,7 +6078,7 @@
           "query": {
             "type": ["string", "null"],
             "title": "Query",
-            "description": "Query string for semantic/vector search."
+            "description": "Optional natural language search query. If not provided, items are returned ordered by last updated time (listing mode). If provided, performs a natural language search over item contents."
           },
           "refresh_ttl": {
             "type": ["boolean", "null"],
@@ -6087,7 +6088,7 @@
           }
         },
         "title": "StoreSearchRequest",
-        "description": "Request to search for items within a namespace prefix."
+        "description": "Request to list or search for items within a namespace prefix. Without a query, lists items by last updated time. With a query, performs natural language search."
       },
       "StoreListNamespacesRequest": {
         "type": "object",


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.7.56**

This update was automatically generated by the sync workflow in the langgraph-api repository.