### PR TITLE
Update minimax.mdx for Chinese user

### DIFF
--- a/src/oss/python/integrations/chat/minimax.mdx
+++ b/src/oss/python/integrations/chat/minimax.mdx
@@ -20,7 +20,9 @@ from langchain.messages import HumanMessage
 ```
 
 ```python
-chat = MiniMaxChat()
+chat = MiniMaxChat(
+    # base_url="https://api.minimaxi.com/v1/text/chatcompletion_v2" use this base_url if you are in China
+)
 ```
 
 ```python


### PR DESCRIPTION
update base_url for Chinese user

## Overview
<!-- Brief description of what documentation is being added/updated -->
I'm in China, when I call LLM and will get an error
```
Exception: Invalid API Key Provided
```

And then I check MiniMax doc find that in China I shoud use this base_url
```
https://api.minimaxi.com/v1/text/chatcompletion_v2
```

## Type of change

**Type:** Update existing documentation 




## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
