### PR TITLE
Fix: URL fixes for broken integrations AG-UI and CopilotKit

### DIFF
--- a/src/oss/javascript/integrations/providers/all_providers.mdx
+++ b/src/oss/javascript/integrations/providers/all_providers.mdx
@@ -57,7 +57,7 @@ Connect LangGraph agents to front ends.
 <Columns cols={3}>
   <Card
     title="AG-UI Protocol"
-    href="https://docs.ag-ui.com/getting-started/quickstart-langgraph-js"
+    href="https://docs.ag-ui.com/quickstart/applications"
     icon="link"
   >
     Open event-based protocol for connecting LangGraph agents to any frontend.
@@ -65,7 +65,7 @@ Connect LangGraph agents to front ends.
 
   <Card
     title="CopilotKit"
-    href="https://docs.copilotkit.ai/coagents/quickstart/langgraph-js"
+    href="https://docs.copilotkit.ai/langgraph/"
     icon="brand-react"
   >
     React framework with pre-built UI components for AI copilots.

--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -43,7 +43,7 @@ Browse the complete collection of integrations available for Python. LangChain P
 
     <Card
         title="AG-UI Protocol"
-        href="https://docs.ag-ui.com/getting-started/quickstart-langgraph-python"
+        href="https://docs.ag-ui.com/quickstart/applications"
         icon="link"
     >
         Open event-based protocol for connecting LangGraph agents to any frontend.


### PR DESCRIPTION
## Overview
The [LangGraph integrations](https://docs.langchain.com/oss/javascript/integrations/providers/all_providers#langgraph-integrations) links are broken -- they both returning 404.

- [AG-UI Protocol](https://docs.ag-ui.com/getting-started/quickstart-langgraph-js)
- [CopilotKit](https://docs.copilotkit.ai/langgraph/quickstart/langgraph-js)

## Type of change

**Type:** Link

## Related issues/PRs

- "closes #2764 "

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed