### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/_check-links.yml
+++ b/.github/workflows/_check-links.yml
@@ -32,6 +32,8 @@ env:
 jobs:
   check-links:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 20
     name: "Documentation Build & Link Check (Python ${{ inputs.python-version }})"
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/langchain-ai/docs/security/code-scanning/14](https://github.com/langchain-ai/docs/security/code-scanning/14)

In general, the fix is to add an explicit `permissions` block that grants only the minimal required scopes to the `GITHUB_TOKEN`. For this workflow, the job checks out code and builds/tests docs locally; it doesn’t interact with GitHub resources in a way that requires write access, so `contents: read` is sufficient.

The best change with no behavior impact is to add a `permissions` section under the `check-links` job (or at the workflow root). To keep the change narrowly scoped to the flagged area, add it to the job definition, just after `runs-on: ubuntu-latest` (around line 34–35). This will restrict that job’s token to read-only repository contents, which still allows `actions/checkout` to function and does not affect any other functionality.

No new imports, methods, or other definitions are needed; this is a pure YAML configuration update inside `.github/workflows/_check-links.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
