### PR TITLE
fix: typo in manage-prompts-programmatically

### DIFF
--- a/src/langsmith/manage-prompts-programmatically.mdx
+++ b/src/langsmith/manage-prompts-programmatically.mdx
@@ -143,7 +143,7 @@ await hub.push("joke-generator-with-model", {
 
 ## Pull a prompt
 
-To pull a prompt, you can use the `pull prompt` method, which returns a the prompt as a langchain `PromptTemplate`.
+To pull a prompt, you can use the `pull prompt` method, which returns the prompt as a langchain `PromptTemplate`.
 
 To pull a **private prompt** you do not need to specify the owner handle (though you can, if you have one set).
 


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** Fix typo

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
