### PR TITLE
Fix broken multi-agent link in agents documentation

### DIFF
--- a/src/oss/langchain/agents.mdx
+++ b/src/oss/langchain/agents.mdx
@@ -1044,7 +1044,7 @@ For more details on message types and formatting, see [Messages](/oss/langchain/
 ### Name
 
 :::python
-Set an optional @[`name`][create_agent(name)] for the agent. This is used as the node identifier when adding the agent as a subgraph in [multi-agent systems](/oss/langgraph/multi-agent):
+Set an optional @[`name`][create_agent(name)] for the agent. This is used as the node identifier when adding the agent as a subgraph in [multi-agent systems](/oss/langchain/multi-agent):
 
 ```python
 agent = create_agent(
@@ -1055,7 +1055,7 @@ agent = create_agent(
 ```
 :::
 :::js
-Set an optional `name` for the agent. This is used as the node identifier when adding the agent as a subgraph in [multi-agent systems](/oss/langgraph/multi-agent):
+Set an optional `name` for the agent. This is used as the node identifier when adding the agent as a subgraph in [multi-agent systems](/oss/langchain/multi-agent):
 
 ```ts
 const agent = createAgent({


### PR DESCRIPTION
Fixes #2761. Corrects broken links in agents documentation where multi-agent systems link pointed to /oss/langgraph/multi-agent instead of /oss/langchain/multi-agent.