### PR TITLE
fix: correct personal orgs flag name [closes DOC-806]

### DIFF
--- a/src/langsmith/self-host-user-management.mdx
+++ b/src/langsmith/self-host-user-management.mdx
@@ -97,7 +97,7 @@ config:
 
 ```bash Docker
 # In your .env file
-PERSONAL_ORGS_DISABLED="true"
+FF_PERSONAL_ORGS_DISABLED="true"
 ```
 
 </CodeGroup>


### PR DESCRIPTION
## Description
Updates the self-hosted user management docs to show the correct feature flag name for disabling personal organizations. This avoids confusion for self-hosted deployments using the .env configuration.

Changes:
- Replace PERSONAL_ORGS_DISABLED with FF_PERSONAL_ORGS_DISABLED in the Docker example

Resolves DOC-806

AI agent assistance was used to make this change.

## Test Plan
- [x] `make format` (fails: ruff not found)
- [x] `make lint` (fails: ruff not found)
