### PR TITLE
Add links to go + java reference docs from tab

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -846,6 +846,8 @@
                 "langsmith/reference",
                 "langsmith/smith-python-sdk",
                 "langsmith/smith-js-ts-sdk",
+                "langsmith/smith-go-sdk",
+                "langsmith/smith-java-sdk",
                 "langsmith/langgraph-python-sdk",
                 "langsmith/langgraph-js-ts-sdk",
                 "langsmith/smith-api-ref",

--- a/src/langsmith/reference.mdx
+++ b/src/langsmith/reference.mdx
@@ -6,12 +6,13 @@ mode: wide
 
 The following sections provide API references and SDK documentation for LangSmith:
 
-<Columns cols={3}>
+## LangSmith SDKs
+
+<CardGroup cols={2}>
   <Card
     title="Python SDK"
     icon="brand-python"
     href="/langsmith/smith-python-sdk"
-    arrow="true"
   >
     Reference documentation for the LangSmith Python SDK.
   </Card>
@@ -20,16 +21,34 @@ The following sections provide API references and SDK documentation for LangSmit
     title="JavaScript/TypeScript SDK"
     icon="brand-javascript"
     href="/langsmith/smith-js-ts-sdk"
-    arrow="true"
   >
     Reference documentation for the LangSmith JavaScript/TypeScript SDK.
   </Card>
 
   <Card
+    title="Go SDK"
+    icon="brand-golang"
+    href="/langsmith/smith-go-sdk"
+  >
+    Reference documentation for the LangSmith Go SDK.
+  </Card>
+
+  <Card
+    title="Java SDK"
+    icon="coffee"
+    href="/langsmith/smith-java-sdk"
+  >
+    Reference documentation for the LangSmith Java SDK.
+  </Card>
+</CardGroup>
+
+## LangGraph SDKs
+
+<CardGroup cols={2}>
+  <Card
     title="LangGraph Python SDK"
     icon="sitemap"
     href="/langsmith/langgraph-python-sdk"
-    arrow="true"
   >
     Reference documentation for deploying LangGraph applications with Python.
   </Card>
@@ -38,16 +57,18 @@ The following sections provide API references and SDK documentation for LangSmit
     title="LangGraph JS/TS SDK"
     icon="sitemap"
     href="/langsmith/langgraph-js-ts-sdk"
-    arrow="true"
   >
     Reference documentation for deploying LangGraph applications with JavaScript/TypeScript.
   </Card>
+</CardGroup>
 
+## APIs
+
+<CardGroup cols={2}>
   <Card
     title="LangSmith API"
     icon="code"
     href="/langsmith/smith-api-ref"
-    arrow="true"
   >
     Complete REST API reference for LangSmith platform features.
   </Card>
@@ -56,8 +77,7 @@ The following sections provide API references and SDK documentation for LangSmit
     title="Deployment APIs"
     icon="server"
     href="/langsmith/server-api-ref"
-    arrow="true"
   >
     API references for self-hosted and hybrid LangSmith deployments.
   </Card>
-</Columns>
+</CardGroup>

--- a/src/langsmith/smith-go-sdk.mdx
+++ b/src/langsmith/smith-go-sdk.mdx
@@ -1,0 +1,5 @@
+---
+title: LangSmith Go SDK
+sidebarTitle: LangSmith Go SDK
+url: "https://reference.langchain.com/go/langsmith"
+---

--- a/src/langsmith/smith-java-sdk.mdx
+++ b/src/langsmith/smith-java-sdk.mdx
@@ -1,0 +1,5 @@
+---
+title: LangSmith Java SDK
+sidebarTitle: LangSmith Java SDK
+url: "https://reference.langchain.com/java/langsmith"
+---


### PR DESCRIPTION
Fixes DOC-766

https://langchain-5e9cc07a-preview-refere-1772556628-956e385.mintlify.app/langsmith/reference