### PR TITLE
fix: shorten deep agents table header [closes DOC-822]

### DIFF
--- a/src/oss/deepagents/comparison.mdx
+++ b/src/oss/deepagents/comparison.mdx
@@ -8,8 +8,8 @@ This page helps you understand how [LangChain Deep Agents](/oss/deepagents/overv
 
 ## Overview
 
-| Aspect | **LangChain Deep Agents** | **OpenCode** | **Claude Agent SDK** |
-| ------ | ------------------------- | ------------ | -------------------- |
+| Aspect | **Deep Agents** | **OpenCode** | **Claude Agent SDK** |
+| ------ | --------------- | ------------ | -------------------- |
 | **Primary use case** | Build production agents programmatically | Interactive coding agent in terminal, desktop, or IDE | Build production agents programmatically |
 | **Model support** | Model-agnostic (Anthropic, OpenAI, and 100s others) | 75+ providers including local models (Ollama) | Claude models (Anthropic, Azure, Vertex AI, AWS Bedrock) |
 | **License** | MIT | MIT | MIT (underlying Claude Code is proprietary) |


### PR DESCRIPTION
## Description
This updates the Deep Agents comparison page so the first column header in the overview table fits on one line, as requested in the linked Slack thread.

Changes:
- Replaced `LangChain Deep Agents` with `Deep Agents` in the overview table header on `src/oss/deepagents/comparison.mdx`
- Adjusted the table separator width to match the updated header text

Resolves DOC-822

## Test Plan
- [ ] Verify the comparison table header now displays `Deep Agents`
- [ ] Confirm the header fits on a single line at https://docs.langchain.com/oss/python/deepagents/comparison#comparison-with-opencode-and-claude-agent-sdk