### PR TITLE
Document workspace switching in langsmith

### DIFF
--- a/src/langsmith/faq.mdx
+++ b/src/langsmith/faq.mdx
@@ -99,7 +99,16 @@ You can also [configure a custom separator](/langsmith/user-management#configure
 
 See Okta's troubleshooting guide here: https://help.okta.com/en-us/content/topics/users-groups-profiles/usgp-group-push-troubleshoot.htm.
 
+### *In LangSmith, how do I change my workspace?*
+
+Select your workspace from the picker in the bottom left of the LangSmith UI.
+
+Click your profile icon in the bottom left to open the Organizations drawer, then choose the workspace from the dropdown. This changes your context for traces, projects, datasets, and other workspace resources.
+
+Organization Admins can access all workspaces in their organization. Other roles may only be able to access specific workspaces.
+
 ## Deployment
+
 
 ### Do I need to use LangChain to use LangGraph? what's the difference?
 


### PR DESCRIPTION
## Description
This update adds a direct FAQ answer for switching workspaces in the LangSmith UI so users can quickly find the navigation path without relying on external support responses.

Changes made:
- Added a new FAQ entry to `src/langsmith/faq.mdx`: "In LangSmith, how do I change my workspace?"
- Documented the UI flow: use the bottom-left profile/workspace picker, open the Organizations drawer, and choose a workspace from the dropdown.
- Added role-based clarification that Organization Admins can access all org workspaces, while other roles may be limited.

Resolves DOC-829.

## Test Plan
- [ ] Verify the new FAQ entry appears on the LangSmith FAQ page with correct formatting.
- [ ] Confirm the instructions match current LangSmith UI behavior for workspace switching.
- [ ] Run `make format` and `make lint` (repo currently reports pre-existing lint violations outside this change).

## Preview

[https://langchain-5e9cc07a-preview-opensw-1772648257-7d84c9f.mintlify.app/langsmith/faq#in-langsmith-how-do-i-change-my-workspace](https://langchain-5e9cc07a-preview-opensw-1772648257-7d84c9f.mintlify.app/langsmith/faq#in-langsmith-how-do-i-change-my-workspace)