### PR TITLE
deployments: remove model-specific encryption handlers section

### DIFF
--- a/src/langsmith/encryption.mdx
+++ b/src/langsmith/encryption.mdx
@@ -232,38 +232,6 @@ Common fields to leave **unencrypted** for search and filtering:
 
 - Checkpoint blobs (graph execution state)
 
-#### Model-specific handlers
-
-Register different handlers for different model types using `@encryption.encrypt.json.assistant`, `@encryption.encrypt.json.run`, etc. Use `ctx.field` to vary behavior by field:
-
-```python
-from langgraph_sdk import Encryption, EncryptionContext
-
-encryption = Encryption()
-
-@encryption.encrypt.json
-async def default_encrypt(ctx: EncryptionContext, data: dict) -> dict:
-    return encrypt_with_skip_fields(data, SKIP_FIELDS)
-
-@encryption.encrypt.json.assistant
-async def encrypt_assistant(ctx: EncryptionContext, data: dict) -> dict:
-    if ctx.field == "context":
-        # Assistant context may contain API keys or system prompts—encrypt everything
-        return encrypt_with_skip_fields(data, skip_fields=set())
-    # Assistant metadata—skip system fields
-    return encrypt_with_skip_fields(data, SKIP_FIELDS)
-
-@encryption.decrypt.json
-async def default_decrypt(ctx: EncryptionContext, data: dict) -> dict:
-    return decrypt_encrypted_fields(data)
-
-@encryption.decrypt.json.assistant
-async def decrypt_assistant(ctx: EncryptionContext, data: dict) -> dict:
-    return decrypt_encrypted_fields(data)
-```
-
-Supported model types: `thread`, `assistant`, `run`, `cron`, `store`, `checkpoint`.
-
 #### Deriving context from authentication
 
 Instead of passing `X-Encryption-Context` explicitly, derive encryption context from the authenticated user:


### PR DESCRIPTION
Remove the "Model-specific handlers" subsection from the encryption at-rest docs

## Why

The `@encryption.encrypt.json.assistant` / `@encryption.encrypt.json.run` sub-decorator pattern shown in this section does not exist in the `langgraph_sdk` `Encryption` class. The class only exposes `encrypt.blob`, `encrypt.json`, `decrypt.blob`, `decrypt.json`, and `context` decorators — no further chaining to model types is supported.

These model-specific annotations were removed from the SDK a while ago, but I must've forgotten to update the docs or lost a commit at the end of the long-lived PR that added this doc.

Verified by reading the installed SDK source at `langgraph_sdk/encryption/__init__.py`.

## Review notes

Just a deletion — no new content, no other files changed.