### PR TITLE
docs: warn against enterprise clustering policy for redis

### DIFF
--- a/src/langsmith/self-host-external-redis.mdx
+++ b/src/langsmith/self-host-external-redis.mdx
@@ -28,7 +28,7 @@ For cloud-specific IAM/Workload Identity authentication, refer to the [IAM authe
 
 * Note: We only officially support Redis versions >= 5.
 * We support both Standalone and Redis Cluster. See the appropriate sections for deployment instructions.
-* **Azure Cache for Redis:** We do not support the Enterprise clustering policy. Use the OSS clustering policy instead. See [Azure clustering policy documentation](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-enterprise-tiers#clustering-policy) for details.
+* **Azure Cache for Redis:** LangSmith does not support the Enterprise clustering policy. Use the OSS clustering policy instead. See [Azure clustering policy documentation](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-best-practices-enterprise-tiers#clustering-policy) for details.
 * We support no authentication, password, and [IAM/Workload Identity](#iam-authentication) authentication.
 * By default, we recommend an instance with at least 2 vCPUs and 8GB of memory. However, the actual requirements will depend on your tracing workload. We recommend monitoring your Redis instance and scaling up as needed.
 


### PR DESCRIPTION
Small warning on a specific azure setting we don't support
