### PR TITLE
docs: Update OCI provider to link to samples directory

### DIFF
--- a/src/oss/python/integrations/providers/oci.mdx
+++ b/src/oss/python/integrations/providers/oci.mdx
@@ -307,18 +307,18 @@ llm = ChatOCIModelDeploymentTGI(
 
 ## Samples
 
-For comprehensive guides covering all features, see the [langchain-oci samples](https://github.com/oracle/langchain-oracle/tree/main/libs/oci/samples):
+For comprehensive guides covering all features, see the [langchain-oci samples](https://github.com/oracle/langchain-oracle/tree/main/samples):
 
 | Sample | Level | Topics |
 |--------|-------|--------|
-| [01: Getting Started](https://github.com/oracle/langchain-oracle/tree/main/libs/oci/samples/01-getting-started) | Beginner | Authentication, basic chat, providers |
-| [02: Vision & Multimodal](https://github.com/oracle/langchain-oracle/tree/main/libs/oci/samples/02-vision-and-multimodal) | Beginner | Image analysis, PDF, video, audio |
-| [03: Building AI Agents](https://github.com/oracle/langchain-oracle/tree/main/libs/oci/samples/03-building-ai-agents) | Intermediate | ReAct agents, tools, memory |
-| [04: Tool Calling Mastery](https://github.com/oracle/langchain-oracle/tree/main/libs/oci/samples/04-tool-calling-mastery) | Intermediate | Parallel tools, workflows |
-| [05: Structured Output](https://github.com/oracle/langchain-oracle/tree/main/libs/oci/samples/05-structured-output) | Intermediate | Pydantic schemas, JSON modes |
-| [07: Async for Production](https://github.com/oracle/langchain-oracle/tree/main/libs/oci/samples/07-async-for-production) | Advanced | ainvoke, astream, FastAPI |
-| [09: Provider Deep Dive](https://github.com/oracle/langchain-oracle/tree/main/libs/oci/samples/09-provider-deep-dive) | Specialized | Meta, Gemini, Cohere, xAI specifics |
-| [10: Embeddings](https://github.com/oracle/langchain-oracle/tree/main/libs/oci/samples/10-embeddings) | Specialized | Text & image embeddings, RAG |
+| [01: Getting Started](https://github.com/oracle/langchain-oracle/tree/main/samples/01-getting-started) | Beginner | Authentication, basic chat, providers |
+| [02: Vision & Multimodal](https://github.com/oracle/langchain-oracle/tree/main/samples/02-vision-and-multimodal) | Beginner | Image analysis, PDF, video, audio |
+| [03: Building AI Agents](https://github.com/oracle/langchain-oracle/tree/main/samples/03-building-ai-agents) | Intermediate | ReAct agents, tools, memory |
+| [04: Tool Calling Mastery](https://github.com/oracle/langchain-oracle/tree/main/samples/04-tool-calling-mastery) | Intermediate | Parallel tools, workflows |
+| [05: Structured Output](https://github.com/oracle/langchain-oracle/tree/main/samples/05-structured-output) | Intermediate | Pydantic schemas, JSON modes |
+| [07: Async for Production](https://github.com/oracle/langchain-oracle/tree/main/samples/07-async-for-production) | Advanced | ainvoke, astream, FastAPI |
+| [09: Provider Deep Dive](https://github.com/oracle/langchain-oracle/tree/main/samples/09-provider-deep-dive) | Specialized | Meta, Gemini, Cohere, xAI specifics |
+| [10: Embeddings](https://github.com/oracle/langchain-oracle/tree/main/samples/10-embeddings) | Specialized | Text & image embeddings, RAG |
 
 ---
 


### PR DESCRIPTION
## Summary

Update the OCI provider documentation to link to `samples/` instead of `tutorials/`. This aligns with the samples directory being added to langchain-oracle (see oracle/langchain-oracle#152).

## Changes
- Rename "Tutorials" section to "Samples"
- Update all GitHub links from `/tutorials/` to `/samples/`
- No content changes, just link updates

## Related
- oracle/langchain-oracle#152 - Add samples directory with code examples