### PR TITLE
chore: Update LSD onboarding

### DIFF
--- a/src/langsmith/local-server.mdx
+++ b/src/langsmith/local-server.mdx
@@ -9,7 +9,7 @@ This quickstart shows you how to set up a LangGraph application locally for test
 
 Before you begin, ensure you have:
 - An API key for [LangSmith](https://smith.langchain.com/settings) (free to sign up).
-- **Python server:** [uv](https://docs.astral.sh/uv/getting-started/installation/) installed.
+- [uv](https://docs.astral.sh/uv/getting-started/installation/) for Python or [npx](https://docs.npmjs.com/cli/commands/npx) for TypeScript.
 
 ## 1. Create a LangGraph app
 


### PR DESCRIPTION
a) too many steps.
b) for python, the dep management can get annoying if you are pip installing to a global namespace. Better to just use `uv` now that it's so popular