### PR TITLE
Fix broken deepagents doc links returning 404

### DIFF
--- a/src/oss/concepts/products.mdx
+++ b/src/oss/concepts/products.mdx
@@ -123,7 +123,7 @@ While you can accomplish similar tasks with LangChain, LangGraph, and Deep Agent
 | Skills  | [Multi-agent skills](/oss/langchain/multi-agent/skills) | - | [Skills](/oss/deepagents/skills) |
 | Subagents | [Multi-agent subagents](/oss/langchain/multi-agent/subagents) | [Subgraphs](/oss/langgraph/use-subgraphs) | [Subagents](/oss/deepagents/subagents) |
 | Human-in-the-loop | [Human-in-the-loop middleware](/oss/langchain/human-in-the-loop) | [Interrupts](/oss/langgraph/interrupts) | [`interrupt_on` parameter](/oss/deepagents/harness#human-in-the-loop) |
-| Streaming | [Agent Streaming](/oss/langchain/streaming/overview) | [Streaming](/oss/langgraph/streaming) | [Streaming](/oss/deepagents/harness#streaming) |
+| Streaming | [Agent Streaming](/oss/langchain/streaming/overview) | [Streaming](/oss/langgraph/streaming) | [Streaming](/oss/deepagents/streaming/overview) |
 
 ## Learn more
 

--- a/src/oss/deepagents/overview.mdx
+++ b/src/oss/deepagents/overview.mdx
@@ -115,7 +115,7 @@ Use the **Deep Agents CLI** when you want a coding agent on the command line, bu
     Deep agents include a built-in [`write_todos`](/oss/langchain/middleware/built-in#to-do-list) tool that enables agents to break down complex tasks into discrete steps, track progress, and adapt plans as new information emerges.
 </Card>
 <Card title="Context management" icon="scissors">
-    File system tools ([`ls`](/oss/deepagents/harness#file-system-access), [`read_file`](/oss/deepagents/harness#file-system-access), [`write_file`](/oss/deepagents/harness#file-system-access), [`edit_file`](/oss/deepagents/harness#file-system-access)) allow agents to offload large context to in-memory or filesystem storage, preventing context window overflow and enabling work with variable-length tool results.
+    File system tools ([`ls`](/oss/deepagents/harness#virtual-filesystem-access), [`read_file`](/oss/deepagents/harness#virtual-filesystem-access), [`write_file`](/oss/deepagents/harness#virtual-filesystem-access), [`edit_file`](/oss/deepagents/harness#virtual-filesystem-access)) allow agents to offload large context to in-memory or filesystem storage, preventing context window overflow and enabling work with variable-length tool results.
 </Card>
 <Card title="Pluggable filesystem backends" icon="plug">
     The virtual filesystem is powered by [pluggable backends](/oss/deepagents/backends) that you can swap to fit your use case. Choose from in-memory state, local disk, LangGraph store for cross-thread persistence, [sandboxes](/oss/deepagents/sandboxes) for isolated code execution (Modal, Daytona, Deno), or combine multiple backends with composite routing. You can also implement your own custom backend.

--- a/src/oss/deepagents/quickstart.mdx
+++ b/src/oss/deepagents/quickstart.mdx
@@ -203,9 +203,9 @@ console.log(result.messages[result.messages.length - 1].content);
 
 Your deep agent automatically:
 
-1. **Plans its approach** using the built-in [`write_todos`](/oss/deepagents/harness#to-do-list-tracking) tool to break down the research task.
+1. **Plans its approach** using the built-in [`write_todos`](/oss/deepagents/harness#planning-capabilities) tool to break down the research task.
 1. **Conducts research** by calling the `internet_search` tool to gather information.
-1. **Manages context** by using file system tools ([`write_file`](/oss/deepagents/harness#file-system-access), [`read_file`](/oss/deepagents/harness#file-system-access)) to offload large search results.
+1. **Manages context** by using file system tools ([`write_file`](/oss/deepagents/harness#virtual-filesystem-access), [`read_file`](/oss/deepagents/harness#virtual-filesystem-access)) to offload large search results.
 1. **Spawns subagents** as needed to delegate complex subtasks to specialized subagents.
 1. **Synthesizes a report** to compile findings into a coherent response.
 

--- a/src/oss/python/releases/changelog.mdx
+++ b/src/oss/python/releases/changelog.mdx
@@ -14,7 +14,7 @@ rss: true
     ## `deepagents` v0.4
 
     * New integration packages for pluggable sandboxes: [langchain-modal](https://pypi.org/project/langchain-modal/), [langchain-daytona](https://pypi.org/project/langchain-daytona/), and [langchain-runloop](https://pypi.org/project/langchain-daytona/). See [sandboxes guide](/oss/deepagents/sandboxes) and example [data analysis tutorial](/oss/deepagents/data-analysis).
-    * Changes to [conversation history summarization](/oss/deepagents/harness#conversation-history-summarization):
+    * Changes to [conversation history summarization](/oss/deepagents/harness#summarization):
       * Summarization now happens in the model node via `wrap_model_call` events. Due to this we retain the full message history in the graph state.
       * More accurate token counting.
       * Summarization will now automatically trigger if a chat model raises a `ContextOverflowError` (defined in `langchain-core`). Currently `langchain-anthropic` and `langchain-openai` support this.


### PR DESCRIPTION
## Summary
- Fixes broken anchor links in deepagents documentation that return 404
- Updates 4 files with incorrect anchor references to match actual headings in `harness.mdx`

Fixes #2839

## Changes

| File | Broken anchor | Fixed anchor |
|------|--------------|--------------|
| `overview.mdx` | `#file-system-access` (×4) | `#virtual-filesystem-access` |
| `quickstart.mdx` | `#to-do-list-tracking` | `#planning-capabilities` |
| `quickstart.mdx` | `#file-system-access` (×2) | `#virtual-filesystem-access` |
| `products.mdx` | `/oss/deepagents/harness#streaming` | `/oss/deepagents/streaming/overview` |
| `changelog.mdx` | `#conversation-history-summarization` | `#summarization` |

## Test plan
- [ ] Verify all fixed links resolve correctly on the docs site
- [ ] Confirm no other broken deepagents anchors remain