### PR TITLE
(docs) add KServe chat integration docs for Python and JavaScript

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -3179,6 +3179,18 @@
       "destination": "/oss/javascript/integrations"
     },
     {
+      "source": "/oss/javascript/integrations/chat/langchain-kserve",
+      "destination": "/oss/javascript/integrations/chat/kserve"
+    },
+    {
+      "source": "/oss/python/integrations/chat/langchain-kserve",
+      "destination": "/oss/python/integrations/chat/kserve"
+    },
+    {
+      "source": "/oss/integrations/chat/langchain-kserve",
+      "destination": "/oss/integrations/chat/kserve"
+    },
+    {
       "source": "/langsmith/index-datasets-for-dynamic-few-shot-example-selection",
       "destination": "/langsmith/manage-datasets"
     },

--- a/src/oss/javascript/integrations/chat/index.mdx
+++ b/src/oss/javascript/integrations/chat/index.mdx
@@ -304,6 +304,13 @@ Certain model providers offer endpoints that are compatible with OpenAI's (legac
         cta="View guide"
     />
     <Card
+        title="KServe"
+        icon="link"
+        href="/oss/integrations/chat/kserve"
+        arrow="true"
+        cta="View guide"
+    />
+    <Card
         title="MistralAI"
         icon="link"
         href="/oss/integrations/chat/mistral"

--- a/src/oss/javascript/integrations/chat/kserve.mdx
+++ b/src/oss/javascript/integrations/chat/kserve.mdx
@@ -1,0 +1,162 @@
+---
+title: "ChatKServe integration"
+description: "Integrate with the ChatKServe chat model using LangChain JavaScript."
+---
+
+This guide provides a quick overview for getting started with KServe [chat models](/oss/langchain/models). Use `@bitkaio/langchain-kserve` to connect LangChain.js apps to models served on KServe, including OpenAI-compatible and V2 protocol endpoints.
+
+## Overview
+
+### Integration details
+
+| Class | Package | Serializable | [PY support](/oss/integrations/chat/kserve) | Downloads | Version |
+| :--- | :--- | :---: | :---: | :---: | :---: |
+| `ChatKServe` | [`@bitkaio/langchain-kserve`](https://www.npmjs.com/package/@bitkaio/langchain-kserve) | ❌ | ✅ | ![NPM - Downloads](https://img.shields.io/npm/dm/@bitkaio/langchain-kserve?style=flat-square&label=%20) | ![NPM - Version](https://img.shields.io/npm/v/@bitkaio/langchain-kserve?style=flat-square&label=%20) |
+
+### Model features
+
+| [Tool calling](/oss/langchain/tools) | [Structured output](/oss/langchain/structured-output) | [Image input](/oss/langchain/messages#multimodal) | Audio input | Video input | [Token-level streaming](/oss/langchain/streaming/) | [Token usage](/oss/langchain/models#token-usage) | [Logprobs](/oss/langchain/models#log-probabilities) |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| ✅* | ✅* | ✅* | ❌ | ❌ | ✅ | ✅* | ✅* |
+
+<Info>
+    Features marked with `*` require an OpenAI-compatible KServe endpoint. V2 protocol endpoints support text generation and streaming, but not tool calling, vision, structured output, or logprobs.
+</Info>
+
+## Setup
+
+Install the integration package:
+
+<CodeGroup>
+```bash npm
+npm install @bitkaio/langchain-kserve @langchain/core
+```
+```bash yarn
+yarn add @bitkaio/langchain-kserve @langchain/core
+```
+```bash pnpm
+pnpm add @bitkaio/langchain-kserve @langchain/core
+```
+</CodeGroup>
+
+Optionally set credentials and tracing:
+
+```bash
+export KSERVE_API_KEY="your-api-key"
+# export LANGSMITH_TRACING="true"
+# export LANGSMITH_API_KEY="your-api-key"
+```
+
+## Instantiation
+
+```typescript
+import { ChatKServe } from "@bitkaio/langchain-kserve";
+
+const model = new ChatKServe({
+  baseUrl: "https://qwen-coder.my-cluster.example.com",
+  modelName: "qwen2.5-coder-32b-instruct",
+  protocol: "auto", // "auto", "openai", or "v2"
+  temperature: 0.2,
+  maxTokens: 1024,
+  timeout: 120_000,
+  maxRetries: 3,
+});
+```
+
+## Invocation
+
+```typescript
+const response = await model.invoke([
+  ["system", "You are a concise TypeScript assistant."],
+  ["human", "Write a binary search function."],
+]);
+
+console.log(response.content);
+```
+
+## Streaming
+
+```typescript
+const stream = await model.stream("Explain transformers in one paragraph.");
+
+for await (const chunk of stream) {
+  process.stdout.write((chunk.content as string) ?? "");
+}
+```
+
+## Tool calling
+
+Tool calling works with OpenAI-compatible endpoints.
+
+```typescript
+import { tool } from "@langchain/core/tools";
+import { z } from "zod";
+
+const searchTool = tool(
+  async ({ query }) => `Results for: ${query}`,
+  {
+    name: "search_codebase",
+    description: "Search the codebase for relevant code",
+    schema: z.object({ query: z.string() }),
+  }
+);
+
+const modelWithTools = model.bindTools([searchTool], { toolChoice: "auto" });
+const result = await modelWithTools.invoke("Find usages of AuthService.");
+
+console.log(result.tool_calls);
+console.log(result.invalid_tool_calls);
+```
+
+## Structured output
+
+```typescript
+import { z } from "zod";
+
+const Person = z.object({
+  name: z.string(),
+  age: z.number(),
+});
+
+const structuredModel = model.withStructuredOutput(Person);
+const result = await structuredModel.invoke("Extract: John is 30 years old.");
+console.log(result);
+```
+
+## Vision input
+
+```typescript
+import { HumanMessage } from "@langchain/core/messages";
+import { readFile } from "node:fs/promises";
+
+const imageData = await readFile("chart.png", { encoding: "base64" });
+
+const message = new HumanMessage({
+  content: [
+    { type: "text", text: "Describe this chart." },
+    {
+      type: "image_url",
+      image_url: { url: `data:image/png;base64,${imageData}` },
+    },
+  ],
+});
+
+const response = await model.invoke([message]);
+console.log(response.content);
+```
+
+## Protocol selection
+
+By default, `protocol: "auto"` probes the endpoint:
+
+1. `GET /v1/models` (OpenAI-compatible)
+2. Fallback to V2 Inference Protocol
+
+Set `protocol: "openai"` or `protocol: "v2"` to force a specific protocol.
+
+## API reference
+
+For detailed documentation of all features and options, see:
+
+- [TypeScript package README](https://github.com/bitkaio/langchain-kserve/tree/main/typescript)
+- [NPM package](https://www.npmjs.com/package/@bitkaio/langchain-kserve)

--- a/src/oss/python/integrations/chat/index.mdx
+++ b/src/oss/python/integrations/chat/index.mdx
@@ -268,6 +268,14 @@ Certain model providers offer endpoints that are compatible with OpenAI's [Chat 
 
 
 <Card
+    title="KServe"
+    icon="link"
+    href="/oss/integrations/chat/kserve"
+    arrow="true"
+    cta="View guide"
+/>
+
+<Card
     title="LiteLLM"
     icon="link"
     href="/oss/integrations/chat/litellm"

--- a/src/oss/python/integrations/chat/kserve.mdx
+++ b/src/oss/python/integrations/chat/kserve.mdx
@@ -1,0 +1,172 @@
+---
+title: "ChatKServe integration"
+description: "Integrate with the ChatKServe chat model using LangChain Python."
+---
+
+This guide provides a quick overview for getting started with KServe [chat models](/oss/langchain/models). Use `langchain-kserve` to connect LangChain apps to models served on KServe, including OpenAI-compatible and V2 protocol endpoints.
+
+## Overview
+
+### Integration details
+
+| Class | Package | Serializable | JS/TS support | Downloads | Latest Version |
+| :--- | :--- | :---: | :---: | :---: | :---: |
+| `ChatKServe` | [`langchain-kserve`](https://pypi.org/project/langchain-kserve/) | beta | ❌ | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain-kserve?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-kserve?style=flat-square&label=%20) |
+
+### Model features
+
+| [Tool calling](/oss/langchain/tools) | [Structured output](/oss/langchain/structured-output) | [Image input](/oss/langchain/messages#multimodal) | Audio input | Video input | [Token-level streaming](/oss/langchain/streaming/) | Native async | [Token usage](/oss/langchain/models#token-usage) | [Logprobs](/oss/langchain/models#log-probabilities) |
+| :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| ✅* | ✅* | ✅* | ❌ | ❌ | ✅ | ✅ | ✅* | ✅* |
+
+<Info>
+    Features marked with `*` require an OpenAI-compatible KServe endpoint. V2 protocol endpoints support text generation and streaming, but not tool calling, vision, structured output, or logprobs.
+</Info>
+
+## Setup
+
+Install the integration package:
+
+<CodeGroup>
+    ```bash pip
+    pip install -U langchain-kserve
+    ```
+    ```bash uv
+    uv add langchain-kserve
+    ```
+</CodeGroup>
+
+If your endpoint requires bearer-token authentication, set `KSERVE_API_KEY`:
+
+```python
+import getpass
+import os
+
+if "KSERVE_API_KEY" not in os.environ:
+    os.environ["KSERVE_API_KEY"] = getpass.getpass("Enter your KServe API key: ")
+```
+
+To enable automated tracing of model calls, set your [LangSmith](/langsmith/home) key:
+
+```python
+os.environ["LANGSMITH_API_KEY"] = getpass.getpass("Enter your LangSmith API key: ")
+os.environ["LANGSMITH_TRACING"] = "true"
+```
+
+## Instantiation
+
+```python
+from langchain_kserve import ChatKServe
+
+model = ChatKServe(
+    base_url="https://qwen-coder.default.svc.cluster.local",
+    model_name="qwen2.5-coder-32b-instruct",
+    protocol="auto",  # "auto", "openai", or "v2"
+    temperature=0.2,
+    max_tokens=1024,
+    timeout=120,
+    max_retries=3,
+)
+```
+
+## Invocation
+
+```python
+messages = [
+    ("system", "You are a concise Python assistant."),
+    ("human", "Write a binary search function."),
+]
+
+response = model.invoke(messages)
+print(response.content)
+```
+
+## Streaming and async
+
+```python
+for chunk in model.stream("Explain transformers in one paragraph."):
+    print(chunk.content, end="", flush=True)
+```
+
+```python
+import asyncio
+
+async def main() -> None:
+    result = await model.ainvoke("What is KServe?")
+    print(result.content)
+
+    async for chunk in model.astream("List 3 use cases for model serving."):
+        print(chunk.content, end="", flush=True)
+
+asyncio.run(main())
+```
+
+## Tool calling
+
+Tool calling works with OpenAI-compatible endpoints.
+
+```python
+from langchain_core.tools import tool
+
+@tool
+def get_weather(city: str) -> str:
+    """Get current weather for a city."""
+    return f"It is sunny in {city}."
+
+tool_model = model.bind_tools([get_weather])
+response = tool_model.invoke("What is the weather in Berlin?")
+print(response.tool_calls)
+```
+
+## Structured output
+
+```python
+from pydantic import BaseModel
+
+class Person(BaseModel):
+    name: str
+    age: int
+
+structured_model = model.with_structured_output(Person)
+result = structured_model.invoke("Extract: John is 30 years old.")
+print(result)
+```
+
+## Vision input
+
+```python
+import base64
+import pathlib
+from langchain_core.messages import HumanMessage
+
+image_data = base64.b64encode(pathlib.Path("chart.png").read_bytes()).decode()
+
+message = HumanMessage(
+    content=[
+        {"type": "text", "text": "Describe this chart."},
+        {
+            "type": "image_url",
+            "image_url": {"url": f"data:image/png;base64,{image_data}"},
+        },
+    ]
+)
+
+response = model.invoke([message])
+print(response.content)
+```
+
+## Protocol selection
+
+By default, `protocol="auto"` probes the endpoint:
+
+1. `GET /v1/models` (OpenAI-compatible)
+2. Fallback to V2 Inference Protocol
+
+Set `protocol="openai"` or `protocol="v2"` to force a specific protocol.
+
+## API reference
+
+For full configuration and usage examples, see:
+
+- [langchain-kserve README](https://github.com/bitkaio/langchain-kserve/tree/main/python)
+- [langchain-kserve on PyPI](https://pypi.org/project/langchain-kserve/)

--- a/src/oss/python/integrations/chat/kserve.mdx
+++ b/src/oss/python/integrations/chat/kserve.mdx
@@ -106,7 +106,7 @@ asyncio.run(main())
 Tool calling works with OpenAI-compatible endpoints.
 
 ```python
-from langchain_core.tools import tool
+from langchain.tools import tool
 
 @tool
 def get_weather(city: str) -> str:
@@ -137,7 +137,7 @@ print(result)
 ```python
 import base64
 import pathlib
-from langchain_core.messages import HumanMessage
+from langchain.messages import HumanMessage
 
 image_data = base64.b64encode(pathlib.Path("chart.png").read_bytes()).decode()
 


### PR DESCRIPTION
## Overview
Add new KServe integration docs for both Python and JavaScript/TypeScript chat models, including setup, instantiation, invocation, streaming, tool calling, structured output, vision input, and protocol behavior. Also add discoverability updates in integration index pages and route aliases in src/docs.json.

## Type of change
Type: New documentation page

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json`

## Additional notes
Added pages:
- src/oss/python/integrations/chat/kserve.mdx
- src/oss/javascript/integrations/chat/kserve.mdx

Updated index pages:
- src/oss/python/integrations/chat/index.mdx
- src/oss/javascript/integrations/chat/index.mdx

Added docs.json aliases for langchain-kserve URL variants to canonical /kserve routes.