### PR TITLE
docs(oss): add suggested models to Deep Agents models page

### DIFF
--- a/src/oss/deepagents/models.mdx
+++ b/src/oss/deepagents/models.mdx
@@ -100,8 +100,7 @@ These models perform well on the [Deep Agents eval suite](https://github.com/lan
 - **[Anthropic](/oss/integrations/providers/anthropic)**: `claude-opus-4-6`, `claude-opus-4-5`, `claude-sonnet-4-6`, `claude-sonnet-4`, `claude-sonnet-4-5`, `claude-haiku-4-5`, `claude-opus-4-1`
 - **[OpenAI](/oss/integrations/providers/openai)**: `gpt-5.4`, `gpt-4o`, `gpt-4.1`, `o4-mini`, `gpt-5.2-codex`, `gpt-4o-mini`, `o3`
 - **[Google](/oss/integrations/providers/google)**: `gemini-3-flash-preview`, `gemini-3.1-pro-preview`
-- **Open-weight models** (we recommend [Baseten](/oss/integrations/providers/baseten) and [Fireworks](/oss/integrations/providers/fireworks) for fast inference): `GLM-5`, `Kimi-K2.5`, `MiniMax-M2.5`
-- **Other open-weight models**: `qwen3.5-397B-A17B`, `devstral-2-123B`
+- **Open-weight models**: `GLM-5`, `Kimi-K2.5`, `MiniMax-M2.5`, `qwen3.5-397B-A17B`, `devstral-2-123B`
 
 ## Learn more
 


### PR DESCRIPTION
Adds a 'Suggested models' section to the Deep Agents models page listing models that score >= 0.90 correctness on the eval suite, grouped by provider. Includes Anthropic, OpenAI, Google, and open-weight models available via Baseten and Fireworks (GLM-5, Kimi-K2.5, MiniMax-M2.5), plus Qwen3.5-397B-A17B and Devstral-2-123B.

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview).