### PR TITLE
Add MultiMail toolkit integration

### DIFF
--- a/src/oss/python/integrations/tools/multimail.mdx
+++ b/src/oss/python/integrations/tools/multimail.mdx
@@ -1,0 +1,82 @@
+---
+title: "MultiMail toolkit integration"
+description: "Integrate with MultiMail using LangChain Python — email for AI agents with graduated oversight."
+---
+
+[MultiMail](https://multimail.dev) is an email platform built specifically for AI agents. It provides graduated oversight modes so agents can earn email autonomy incrementally — from full human approval to fully autonomous sending.
+
+## Setup
+
+Install the integration package:
+
+```bash
+pip install langchain-multimail
+```
+
+Get your API key from the [MultiMail dashboard](https://multimail.dev/dashboard).
+
+## Instantiation
+
+```python
+from langchain_multimail import MultiMailToolkit
+
+toolkit = MultiMailToolkit(api_key="mm_live_...")
+tools = toolkit.get_tools()
+```
+
+## Available tools
+
+| Tool | Description |
+|------|-------------|
+| `check_inbox` | Check a mailbox inbox with optional status filter |
+| `read_email` | Read a specific email by ID |
+| `send_email` | Send a new email |
+| `reply_email` | Reply to an existing email |
+| `search_contacts` | Search the contact list |
+| `list_pending` | List emails pending human approval |
+| `decide_email` | Approve or reject a pending email |
+| `get_thread` | Get a full email thread |
+| `tag_email` | Add tags to an email |
+
+## Usage with an agent
+
+```python
+from langchain_openai import ChatOpenAI
+from langchain.agents import create_tool_calling_agent, AgentExecutor
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_multimail import MultiMailToolkit
+
+toolkit = MultiMailToolkit(api_key="mm_live_...")
+tools = toolkit.get_tools()
+
+llm = ChatOpenAI(model="gpt-4o")
+prompt = ChatPromptTemplate.from_messages([
+    ("system", "You are a helpful email assistant. Use the MultiMail tools to help manage email."),
+    ("human", "{input}"),
+    ("placeholder", "{agent_scratchpad}"),
+])
+
+agent = create_tool_calling_agent(llm, tools, prompt)
+executor = AgentExecutor(agent=agent, tools=tools)
+
+result = executor.invoke({"input": "Check my inbox for support@example.com and summarize unread emails"})
+print(result["output"])
+```
+
+## Oversight modes
+
+MultiMail supports graduated trust levels for AI agents:
+
+| Mode | Behavior |
+|------|----------|
+| `gated_all` | All actions require human approval |
+| `gated_send` | Sends require approval; reads are automatic |
+| `monitored` | Agent acts autonomously; human can review |
+| `autonomous` | Full autonomous operation |
+
+## Related
+
+- [MultiMail documentation](https://multimail.dev)
+- [GitHub](https://github.com/multimail-dev/langchain-multimail)
+- [PyPI](https://pypi.org/project/langchain-multimail/)
+- [API reference](https://multimail.dev/api)


### PR DESCRIPTION
## Summary

Adds an integration page for [MultiMail](https://multimail.dev) — an email platform built for AI agents with graduated oversight modes.

- **Package**: [`langchain-multimail`](https://pypi.org/project/langchain-multimail/) on PyPI
- **Source**: [github.com/multimail-dev/langchain-multimail](https://github.com/multimail-dev/langchain-multimail)
- **Tools**: 9 tools (check_inbox, read_email, send_email, reply_email, search_contacts, list_pending, decide_email, get_thread, tag_email)
- **Auth**: API key based

MultiMail provides graduated trust levels for AI agents (gated_all → gated_send → monitored → autonomous), letting agents earn email autonomy incrementally.