### PR TITLE
fix(docs): scope Python SQL agent review section

### DIFF
--- a/src/oss/langchain/sql-agent.mdx
+++ b/src/oss/langchain/sql-agent.mdx
@@ -451,6 +451,7 @@ agent = create_agent(
 
 :::
 
+:::python
 ## 6. Implement human-in-the-loop review
 
 It can be prudent to check the agent's SQL queries before they are executed for any unintended actions or inefficiencies.
@@ -545,6 +546,8 @@ The genre with the longest average track length is "Sci Fi & Fantasy" with an av
 ```
 
 Refer to the [human-in-the-loop guide](/oss/langchain/human-in-the-loop) for details.
+
+:::
 
 :::js
 ## 4. Execute SQL queries


### PR DESCRIPTION
## Summary
- scope the human-in-the-loop SQL agent section to the Python tab
- prevent Python examples from leaking into the JavaScript SQL agent page

## Root cause
The Build a SQL agent doc was missing a :::python wrapper around the human-in-the-loop review section in src/oss/langchain/sql-agent.mdx, so that Python content appeared on the JavaScript page as well.

## Testing
- verified the MDX section is now wrapped with :::python and closed before the :::js section

<img width="2878" height="1452" alt="image" src="https://github.com/user-attachments/assets/21396488-4891-4aea-89ac-03cba016a2e3" />
