### PR TITLE
feat: subgraph docs revamp

### DIFF
--- a/src/oss/langgraph/use-subgraphs.mdx
+++ b/src/oss/langgraph/use-subgraphs.mdx
@@ -602,7 +602,7 @@ The `checkpointer` parameter on `.compile()` controls subgraph persistence:
 |------|-----------------|----------|
 | [Per-invocation](#per-invocation-default) | `None` (default) | Each call starts fresh and inherits the parent's checkpointer to support [interrupts](/oss/langgraph/interrupts) and [durable execution](/oss/langgraph/durable-execution) within a single call. |
 | [Per-thread](#per-thread) | `True` | State accumulates across calls on the same thread. Each call picks up where the last one left off. |
-| [Stateless](#stateless) | `False` | No checkpointing at all — runs like a plain function call. No interrupts or durable execution. |
+| [Stateless](#stateless) | `False` | No checkpointing at all—runs like a plain function call. No interrupts or durable execution. |
 
 Per-invocation is the right choice for most applications, including [multi-agent](/oss/langchain/multi-agent) systems where subagents handle independent requests. Use per-thread when a subagent needs multi-turn conversation memory (for example, a research assistant that builds context over several exchanges).
 


### PR DESCRIPTION
# Subgraphs page reframing

## Problem

The subgraphs docs page used "stateless" and "stateful" as the top-level framing for subgraph persistence modes. This was misleading because `checkpointer=None` (the default) was labeled "stateless" despite actually having checkpoint state within each invocation (for interrupts, durable execution).

## New framing

### Structure

- **### Stateful** (new parent heading) groups:
  - **#### Per-invocation (default)** — `checkpointer=None`, each call fresh, supports interrupts/durable execution
  - **#### Per-thread** — `checkpointer=True`, state accumulates across calls
- **### Stateless** — `checkpointer=False`, no checkpointing at all

### Terminology updates throughout

- "stateless" / "stateful" section labels replaced with the new structure
- "stateful subgraphs/subagents" in body text updated to "per-thread subgraphs/subagents" where referring specifically to `checkpointer=True`
- Tab titles in "View subgraph state" updated to "Per-invocation" / "Per-thread"
- Reference table columns reordered: Per-invocation | Per-thread | Stateless
- Feature values in the reference table corrected to match the new column order

## Source code basis

From `langgraph/types.py`:

```python
Checkpointer = None | bool | BaseCheckpointSaver
"""Type of the checkpointer to use for a subgraph.

- `True` enables persistent checkpointing for this subgraph.
- `False` disables checkpointing, even if the parent graph has a checkpointer.
- `None` inherits checkpointer from the parent graph.
"""
```

- `checkpointer=False`: Explicitly disables all checkpointing, even when parent has a checkpointer
- `checkpointer=None`: Inherits parent checkpointer, supports interrupt/resume, but state resets each invocation (new scope per task)
- `checkpointer=True`: Inherits parent checkpointer, state persists across invocations via recast checkpoint namespace