### PR TITLE
feat: add changelog cross-reference to deep agents sidebar [closes DOC-844]

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -975,7 +975,8 @@
                       "pages": [
                         "oss/python/deepagents/quickstart",
                         "oss/python/deepagents/customization",
-                        "oss/python/deepagents/comparison"
+                        "oss/python/deepagents/comparison",
+                        "oss/python/deepagents/changelog-py"
                       ]
                     },
                     {
@@ -1351,7 +1352,8 @@
                       "pages": [
                         "oss/javascript/deepagents/quickstart",
                         "oss/javascript/deepagents/customization",
-                        "oss/javascript/deepagents/comparison"
+                        "oss/javascript/deepagents/comparison",
+                        "oss/javascript/deepagents/changelog-js"
                       ]
                     },
                     {

--- a/src/oss/deepagents/changelog-js.mdx
+++ b/src/oss/deepagents/changelog-js.mdx
@@ -1,0 +1,4 @@
+---
+title: Changelog
+url: "https://docs.langchain.com/oss/javascript/releases/changelog"
+---

--- a/src/oss/deepagents/changelog-py.mdx
+++ b/src/oss/deepagents/changelog-py.mdx
@@ -1,0 +1,4 @@
+---
+title: Changelog
+url: "https://docs.langchain.com/oss/python/releases/changelog"
+---


### PR DESCRIPTION
## Description
Adds a changelog link to the Deep Agents "Get started" sidebar section for both Python and JavaScript tabs, matching the pattern used by LangChain and LangGraph. This improves discoverability of the changelog which was previously hidden.

Resolves DOC-844

## Test Plan
- [ ] Verify the Deep Agents sidebar shows a "Changelog" link under "Get started" for both Python and JS tabs
- [ ] Verify the changelog link redirects to the shared releases changelog page