### PR TITLE
fix: update outdated prerequisites on insights page [closes DOC-848]

### DIFF
--- a/src/langsmith/insights.mdx
+++ b/src/langsmith/insights.mdx
@@ -13,9 +13,9 @@ Insights uses hierarchical categorization to make sense of your data and highlig
 
 ## Prerequisites
 
-- A [model configuration](/langsmith/model-configurations) set up for Insights in your workspace
-- Permissions to create rules in LangSmith (required to generate new Insights Reports)
-- Permissions to view tracing projects LangSmith (required to view existing Insights Reports)
+- A [model configuration](/langsmith/model-configurations) set up for Insights in your workspace.
+- Permissions to create rules in LangSmith (required to generate new Insights Reports).
+- Permissions to view tracing projects LangSmith (required to view existing Insights Reports).
 
 ## Generate your first Insights report
 
@@ -139,7 +139,7 @@ Explain how your data is organized—are these single runs or multi-turn convers
 
 ### Choose a model provider
 
-Select a model provider to power the Insights Agent. See [model configurations](/langsmith/model-configurations) for details on configuring providers and controlling model availability for Insights.
+Select a model provider to power the Insights Agent. For details on configuring providers and controlling model availability for Insights, refer to [model configurations](/langsmith/model-configurations).
 
 ### Using a prebuilt config
 


### PR DESCRIPTION
## Description
Replaces the outdated OpenAI/Anthropic API key prerequisite on the Insights page with a link to the model configurations page. Also updates the setup step and "Choose a model provider" section to reference model configurations instead of workspace secrets.

Resolves DOC-848

## Test Plan
- [ ] Verify the Insights page renders correctly with the updated prerequisites and links to the model configurations page