### PR TITLE
fix: typo "vartiables" to "variables" on few-shot evaluators page [closes DOC-852]

### DIFF
--- a/src/langsmith/create-few-shot-evaluators.mdx
+++ b/src/langsmith/create-few-shot-evaluators.mdx
@@ -27,7 +27,7 @@ Before enabling few-shot examples, set up your LLM-as-a-judge evaluator. If you 
 
 Each few-shot example is formatted according to the variable mapping specified in the configuration. The variable mapping for few-shot examples, should contain the same variables as your main prompt, plus a `few_shot_explanation` and a `score` variable which should have the same name as your feedback key.
 
-For example, if your main prompt has variables `question` and `response`, and your evaluator outputs a `correctness` score, then your few-shot prompt should have the vartiables `question`, `response`, `few_shot_explanation`, and `correctness`.
+For example, if your main prompt has variables `question` and `response`, and your evaluator outputs a `correctness` score, then your few-shot prompt should have the variables `question`, `response`, `few_shot_explanation`, and `correctness`.
 
 ### 2. Specify the number of few-shot examples to use
 


### PR DESCRIPTION
## Description
Fixes a typo on the few-shot evaluators page where "vartiables" was misspelled instead of "variables".

Resolves DOC-852

## Test Plan
- [ ] Verify the corrected text on the preview deployment