### PR TITLE
fix: document 2-character minimum token length for search indexing [closes DOC-854]

### DIFF
--- a/src/langsmith/filter-traces-in-application.mdx
+++ b/src/langsmith/filter-traces-in-application.mdx
@@ -89,7 +89,11 @@ You can also specify multiple to match all terms provided, either by:
 - Including multiple terms separated by whitespace with the **Full-Text Search**.
 - Adding multiple filters with the <Icon icon="plus"/> button after you've added the first filter.
 
-LangSmith completes keyword search by splitting the text and finding any partial matches on the search keywords, so it is not done in specific order. LangSmith excludes common stop words from the search (from the nltk stop word list along with a few other common JSON keywords). Tokens must be at least 2 characters long to be indexed. Single-character tokens (for example, `a`, `x`) are excluded from search.
+LangSmith completes keyword search by splitting the text and finding any partial matches on the search keywords, so it is not done in specific order. LangSmith excludes common stop words from the search (from the nltk stop word list along with a few other common JSON keywords).
+
+<Note>
+Tokens must be at least 2 characters long to be indexed. Single-character tokens (for example, `a`, `x`) are excluded from search.
+</Note>
 
 <img
     className="block dark:hidden"


### PR DESCRIPTION
## Description
Adds a note to the "Filter traces" page that tokens must be at least 2 characters long to be indexed for full-text search. This was an undocumented behavior that affects both the trace filter bar and alert rule filters.

Resolves DOC-854

## Test Plan
- [ ] Verify the updated paragraph reads clearly on the docs site