### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.7.68

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -4186,6 +4186,11 @@
             "title": "Schedule",
             "description": "The cron schedule to execute this job on."
           },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone",
+            "description": "IANA timezone for the cron schedule (e.g. 'America/New_York'). Defaults to null, which is treated as UTC."
+          },
           "end_time": {
             "type": "string",
             "format": "date-time",
@@ -4376,6 +4381,11 @@
             "type": "string",
             "title": "Schedule",
             "description": "The cron schedule to execute this job on."
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone",
+            "description": "IANA timezone for the cron schedule (e.g. 'America/New_York'). Defaults to null, which is treated as UTC."
           },
           "end_time": {
             "type": "string",
@@ -4610,6 +4620,7 @@
                 "on_run_completed",
                 "end_time",
                 "schedule",
+                "timezone",
                 "created_at",
                 "updated_at",
                 "user_id",
@@ -6235,6 +6246,11 @@
             "type": "string",
             "title": "Schedule",
             "description": "The cron schedule to execute this job on."
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone",
+            "description": "IANA timezone for the cron schedule (e.g. 'America/New_York'). Defaults to null, which is treated as UTC."
           },
           "end_time": {
             "type": "string",


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.7.68**

This update was automatically generated by the sync workflow in the langgraph-api repository.