### PR TITLE
fix link styling in tables

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -211,6 +211,11 @@ a code {
   line-height: 1.5 !important;
 }
 
+/* Hide page description subtitle (kept in frontmatter for SEO) */
+.prose-gray.text-lg.mt-2 {
+  display: none !important;
+}
+
 /* Hide pagination */
 #pagination {
   display: none;
@@ -483,17 +488,37 @@ body:has(.home-page) .source-links,
   background-color: transparent !important;
 }
 
-/* Style links in tables to match regular content links (light blue underline) */
-table a {
-  color: var(--color-light, #7FC8FF) !important;
+/* Make card and dropdown borders visible in dark mode (WCAG 1.4.11: 3:1 min for UI components) */
+.dark .card,
+.dark [data-component="card"] {
+  border-color: #4f5d73 !important;
+}
+.dark [data-radix-popper-content-wrapper] *,
+.dark [data-radix-collection-item],
+.dark [role="listbox"],
+.dark [role="menu"],
+.dark [role="combobox"],
+.dark details,
+.dark details > summary,
+.dark button[class*="border"],
+.dark [class*="border-"][class*="rounded"] {
+  border-color: #4f5d73 !important;
+}
+
+/* Style links in tables to match regular content links */
+.dark table a {
+  color: #7FC8FF !important;
+  text-decoration: none !important;
+}
+.dark table a:hover {
   text-decoration: underline !important;
-  text-decoration-color: var(--color-light, #7FC8FF) !important;
+  text-decoration-color: #7FC8FF !important;
   text-underline-offset: 2px;
 }
 
 /* Make table borders visible in dark mode */
 .dark table * {
-  border-color: #3b4557 !important;
+  border-color: #4f5d73 !important;
 }
 
 /* Force vertical alignment to top for table cells on products page */


### PR DESCRIPTION
Fixes DOC-865

- Hide page descriptions site-wide 
- Fixed light mode table links
- Improved dark mode border contrast