### PR TITLE
docs: fix boolean values in interrupts.mdx documentation

### DIFF
--- a/src/oss/langgraph/interrupts.mdx
+++ b/src/oss/langgraph/interrupts.mdx
@@ -400,9 +400,8 @@ const approvalNode: typeof State.Node = (state) => {
 ```
 :::
 
-When you resume the graph, pass `true` to approve or `false` to reject:
-
 :::python
+When you resume the graph, pass `True` to approve or `False` to reject:
 ```python
 # To approve
 graph.invoke(Command(resume=True), config=config)
@@ -413,6 +412,7 @@ graph.invoke(Command(resume=False), config=config)
 :::
 
 :::js
+When you resume the graph, pass `true` to approve or `false` to reject:
 ```typescript
 // To approve
 await graph.invoke(new Command({ resume: true }), config);


### PR DESCRIPTION
Fix boolean values in interrupts.mdx documentation.
- Python example now use `True` and `False`
- JS example continue to use `true` and `false`

This aligns the documentation with the correct boolean value for each language.