### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.7.69

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -1667,7 +1667,14 @@
             "required": false,
             "schema": {
               "type": "string",
-              "enum": ["pending", "error", "success", "timeout", "interrupted"]
+              "enum": [
+                "pending",
+                "running",
+                "error",
+                "success",
+                "timeout",
+                "interrupted"
+              ]
             },
             "name": "status",
             "in": "query"


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.7.69**

This update was automatically generated by the sync workflow in the langgraph-api repository.