### PR TITLE
DOC-403 Link studio eval docs from playground eval page

### DIFF
--- a/src/langsmith/run-evaluation-from-playground.mdx
+++ b/src/langsmith/run-evaluation-from-playground.mdx
@@ -7,7 +7,7 @@ LangSmith allows you to run evaluations directly in the UI. The [**Playground**]
 
 Before you run an evaluation, you need to have an [existing dataset](/langsmith/evaluation-concepts#datasets). Learn how to [create a dataset from the UI](/langsmith/manage-datasets-in-application#set-up-your-dataset).
 
-If you prefer to run experiments in code, visit [run an evaluation using the SDK](/langsmith/evaluate-llm-application).
+To run evaluations from Studio instead, see [run experiments over a dataset in Studio](/langsmith/observability-studio#run-experiments-over-a-dataset). If you prefer to run experiments in code, see [run an evaluation using the SDK](/langsmith/evaluate-llm-application).
 
 ![Playground experiment](/langsmith/images/playground-experiment.gif)
 


### PR DESCRIPTION
## Overview
In run-evaluation-from-playground.mdx, added link to observability-studio.mdx

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Linear issue: Fixes DOC-403