### PR TITLE
docs(langchain): fix incorrect agent imports in ArXiv tool integration docs

### DIFF
--- a/src/oss/python/integrations/tools/arxiv.mdx
+++ b/src/oss/python/integrations/tools/arxiv.mdx
@@ -12,8 +12,8 @@ pip install -qU  langchain-community arxiv
 ```
 
 ```python
-from langchain_classic import hub
-from langchain.agents import AgentExecutor, create_agent, load_tools
+from langchain import hub
+from langchain.agents import AgentExecutor, create_react_agent, load_tools
 from langchain_openai import ChatOpenAI
 
 llm = ChatOpenAI(temperature=0.0)
@@ -22,7 +22,7 @@ tools = load_tools(
 )
 prompt = hub.pull("hwchase17/react")
 
-agent = create_agent(llm, tools, prompt)
+agent = create_react_agent(llm, tools, prompt)
 agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
 ```
 


### PR DESCRIPTION
## Summary

Fixes #2956

The ArXiv tool integration docs contained two incorrect imports that 
would cause immediate errors for any user following the guide.

## Changes

| File | Change |
|------|--------|
| `src/oss/python/integrations/tools/arxiv.mdx` | Fixed 2 incorrect imports |

## What was wrong

**1. Non-existent package `langchain_classic`:**
```python
# ❌ Before (throws ModuleNotFoundError)
from langchain_classic import hub

# ✅ After
from langchain import hub
```

**2. Non-existent function `create_agent`:**
```python
# ❌ Before (throws ImportError)
from langchain.agents import AgentExecutor, create_agent, load_tools
agent = create_agent(llm, tools, prompt)

# ✅ After
from langchain.agents import AgentExecutor, create_react_agent, load_tools
agent = create_react_agent(llm, tools, prompt)
```

## Why this matters

Any developer following this guide would hit these errors immediately,
making the ArXiv tool completely unusable from the docs alone.

## Testing

Verified correct imports against the official LangChain source:
- `from langchain import hub` ✅
- `create_react_agent` exists in `langchain.agents` ✅

No code logic was changed — documentation fix only.