### PR TITLE
Add new CLI commands: `deploy list`, `deploy delete`, `deploy logs`

### DIFF
--- a/src/langsmith/cli.mdx
+++ b/src/langsmith/cli.mdx
@@ -657,9 +657,9 @@ To build and run a valid application, the LangGraph CLI requires a JSON configur
     | `--start-time TEXT` |  | ISO8601 start time. Example: `2026-03-08T00:00:00Z`. |
     | `-q, --query TEXT` |  | Search string filter. |
     | `--limit INTEGER` | `100` | Max log entries to fetch. |
-    | `--level [DEBUG|INFO|WARNING|ERROR|CRITICAL]` |  | Filter by log level. |
+    | `--level [DEBUG\|INFO\|WARNING\|ERROR\|CRITICAL]` |  | Filter by log level. |
     | `--revision-id TEXT` |  | Specific revision ID. For build logs, defaults to the latest revision. |
-    | `--type [deploy|build]` | `deploy` | Log stream to fetch. `deploy` shows agent server runtime logs. `build` shows remote build logs. |
+    | `--type [deploy\|build]` | `deploy` | Log stream to fetch. `deploy` shows agent server runtime logs. `build` shows remote build logs. |
     | `--deployment-id TEXT` |  | Deployment ID. If omitted, `--name` is used to find the deployment. |
     | `--name TEXT` | Current directory name | Deployment name. Can also be set via `LANGSMITH_DEPLOYMENT_NAME` environment variable or `.env` file. Used when `--deployment-id` is not provided. |
     | `--api-key TEXT` |  | API key. Can also be set via `LANGGRAPH_HOST_API_KEY`, `LANGSMITH_API_KEY`, or `LANGCHAIN_API_KEY` environment variable or `.env` file. |


### PR DESCRIPTION
## Overview
Add new reference sections for `deploy list`, `deploy delete`, `deploy logs`.

Indented in right-side navigation (subcommand):
<img width="614" height="620" alt="image" src="https://github.com/user-attachments/assets/76ce234f-26ca-41bf-a289-004cc295b997" />

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
n/a

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
n/a
