### PR TITLE
DOC-574 Document pushing StructuredPrompts to PromptHub

### DIFF
--- a/src/langsmith/manage-prompts-programmatically.mdx
+++ b/src/langsmith/manage-prompts-programmatically.mdx
@@ -233,38 +233,6 @@ url = client.push_prompt("sentiment-evaluator-with-model", object=chain)
 print(url)
 ```
 
-```typescript TypeScript
-import * as hub from "langchain/hub";
-import { StructuredPrompt } from "@langchain/core/prompts";
-import { ChatOpenAI } from "@langchain/openai";
-
-const schema = {
-  title: "ResponseSchema",
-  type: "object",
-  properties: {
-    positive_sentiment: {
-      type: "boolean",
-      description: "Was the user sentiment positive?",
-    },
-  },
-  required: ["positive_sentiment"],
-};
-
-const prompt = StructuredPrompt.fromMessagesAndSchema(
-  [
-    ["system", "Evaluate the sentiment of the following conversation."],
-    ["human", "{conversation}"],
-  ],
-  schema
-);
-
-const model = new ChatOpenAI({ model: "gpt-4o-mini" });
-const chain = prompt.pipe(model);
-
-const url = await hub.push("sentiment-evaluator-with-model", chain);
-console.log(url);
-```
-
 </CodeGroup>
 
 ## Pull a prompt


### PR DESCRIPTION
In manage-prompts-programmatically.mdx, added section for Push a StructuredPrompt.

Fixes DOC-574

**Preview**
[Push a StructuredPrompt](https://langchain-5e9cc07a-preview-fjmorr-1773927942-1177053.mintlify.app/langsmith/manage-prompts-programmatically#push-a-structuredprompt)