### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.7.70

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -1136,16 +1136,6 @@
             },
             "name": "thread_id",
             "in": "path"
-          },
-          {
-            "required": false,
-            "schema": {
-              "type": "boolean",
-              "title": "Subgraphs",
-              "description": "If true, includes subgraph states."
-            },
-            "name": "subgraphs",
-            "in": "query"
           }
         ],
         "requestBody": {
@@ -1909,7 +1899,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/RunCreateStateful"
+                "$ref": "#/components/schemas/RunCreateStreamingStateful"
               }
             }
           },
@@ -1992,7 +1982,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/RunCreateStateful"
+                "$ref": "#/components/schemas/RunCreateStreamingStateful"
               }
             }
           },
@@ -2589,7 +2579,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/RunCreateStateless"
+                "$ref": "#/components/schemas/RunCreateStreamingStateless"
               }
             }
           },
@@ -2715,7 +2705,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/RunCreateStateless"
+                "$ref": "#/components/schemas/RunCreateStreamingStateless"
               }
             }
           },
@@ -5061,13 +5051,6 @@
             "description": "Whether to persist the stream chunks in order to resume the stream later.",
             "default": false
           },
-          "on_disconnect": {
-            "type": "string",
-            "enum": ["cancel", "continue"],
-            "title": "On Disconnect",
-            "description": "The disconnect mode to use. Must be one of 'cancel' or 'continue'.",
-            "default": "continue"
-          },
           "feedback_keys": {
             "items": {
               "type": "string"
@@ -5280,13 +5263,6 @@
             "title": "On Completion",
             "description": "Whether to delete or keep the thread created for a stateless run. Must be one of 'delete' or 'keep'.",
             "default": "delete"
-          },
-          "on_disconnect": {
-            "type": "string",
-            "enum": ["cancel", "continue"],
-            "title": "On Disconnect",
-            "description": "The disconnect mode to use. Must be one of 'cancel' or 'continue'.",
-            "default": "continue"
           },
           "after_seconds": {
             "type": "number",
@@ -6025,9 +6001,19 @@
           },
           "index": {
             "oneOf": [
-              { "type": "boolean", "enum": [false] },
-              { "type": "array", "items": { "type": "string" } },
-              { "type": "null" }
+              {
+                "type": "boolean",
+                "enum": [false]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+              {
+                "type": "null"
+              }
             ],
             "default": null,
             "title": "Index",
@@ -6454,6 +6440,46 @@
         },
         "title": "Interrupt",
         "required": ["value"]
+      },
+      "RunCreateStreamingStateful": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RunCreateStateful"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "on_disconnect": {
+                "type": "string",
+                "enum": ["cancel", "continue"],
+                "title": "On Disconnect",
+                "description": "The disconnect mode to use. Must be one of 'cancel' or 'continue'.",
+                "default": "continue"
+              }
+            }
+          }
+        ],
+        "title": "RunCreateStreamingStateful"
+      },
+      "RunCreateStreamingStateless": {
+        "allOf": [
+          {
+            "$ref": "#/components/schemas/RunCreateStateless"
+          },
+          {
+            "type": "object",
+            "properties": {
+              "on_disconnect": {
+                "type": "string",
+                "enum": ["cancel", "continue"],
+                "title": "On Disconnect",
+                "description": "The disconnect mode to use. Must be one of 'cancel' or 'continue'.",
+                "default": "continue"
+              }
+            }
+          }
+        ],
+        "title": "RunCreateStreamingStateless"
       }
     },
     "responses": {


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.7.70**

This update was automatically generated by the sync workflow in the langgraph-api repository.