### PR TITLE
chore: bump playground integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "docs",
       "version": "1.0.0",
       "dependencies": {
-        "@langchain/docs-sandbox": "0.0.5"
+        "@langchain/docs-sandbox": "0.0.9"
       }
     },
     "node_modules/@langchain/docs-sandbox": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/@langchain/docs-sandbox/-/docs-sandbox-0.0.5.tgz",
-      "integrity": "sha512-clMxDpWqVUaIgs2u3Nj4uGpQD1dEDYO+Lva9qmo8HSQucwfnyGjFGE9nSuvDfdf/or+/2asApu8QB8WvRPruOA==",
+      "version": "0.0.9",
+      "resolved": "https://registry.npmjs.org/@langchain/docs-sandbox/-/docs-sandbox-0.0.9.tgz",
+      "integrity": "sha512-1uUHqPF4Vy8zIWP2L0xoMUtfwcvi2/wudYdPWFkLgyEqXFHDJ8jWr1YwFdb2McKz5Cmqw7f9eakzjGOgaNHdGw==",
       "peerDependencies": {
         "@langchain/playground-preview-protocol": "workspace:*",
         "react": "^18 || ^19",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "description": "Docs for the project",
   "private": true,
   "dependencies": {
-    "@langchain/docs-sandbox": "0.0.5"
+    "@langchain/docs-sandbox": "0.0.9"
   }
 }


### PR DESCRIPTION
Made some tweaks to the playground integration. This bumps the version of the component we are integrating.