### PR TITLE
Fix GH action for generated partner package table

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -32,16 +32,13 @@
 #     - To run manually: uv run scripts/packages_yml_get_downloads.py
 #     - Runs automatically weekly on Sundays at 11:59 PM UTC via GitHub Actions
 #       workflow: .github/workflows/update-package-downloads.yml
+# - has_reference_docs: Optional boolean. Set to true for third-party packages
+#     (type != monorepo/langchain-org) that have reference docs hosted on
+#     reference.langchain.com. Without this, the package URL falls back to PyPI.
 # - downloads_updated_at: Automatically calculated (ISO 8601 timestamp)
 
 packages:
   # monorepo (alphabetical by path)
-- name: langchain-cli
-  integration: false
-  repo: langchain-ai/langchain
-  path: libs/cli
-  downloads: 45000
-  downloads_updated_at: "2026-01-19T00:06:43.844774+00:00"
 - name: langchain-core
   integration: false
   repo: langchain-ai/langchain

--- a/pipeline/tools/partner_pkg_table.py
+++ b/pipeline/tools/partner_pkg_table.py
@@ -117,6 +117,13 @@ def _enrich_package(p: dict) -> dict | None:
     # Handling for package URLs
     ref_doc_name = p["name"].replace("-", "_")
 
+    if p.get("has_reference_docs") and p.get("integration") == "false":
+        msg = (
+            f"{p['name']}: has_reference_docs=true and integration=false "
+            "is not a supported combination"
+        )
+        raise ValueError(msg)
+
     if p["type"] in ("monorepo", "langchain-org") or p.get("has_reference_docs"):
         if p.get("integration") == "false":
             p["package_url"] = f"https://reference.langchain.com/python/{p['name']}/"


### PR DESCRIPTION
Fix GH action for checking the generated partner package table now that ref docs are in `references` repo