### PR TITLE
ci: auto-remove needs-title label on descriptive title

### DIFF
--- a/.github/workflows/check-default-title.yml
+++ b/.github/workflows/check-default-title.yml
@@ -33,6 +33,19 @@ jobs:
 
             if (!hasDefaultTitle) {
               console.log(`Title is descriptive: "${title}"`);
+
+              // Remove needs-title label if present
+              try {
+                await github.rest.issues.removeLabel({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: itemNumber,
+                  name: 'needs-title',
+                });
+                console.log(`Removed 'needs-title' label from ${itemType} #${itemNumber}`);
+              } catch (error) {
+                // Label not present, that's fine
+              }
               return;
             }
 


### PR DESCRIPTION
When an issue or PR title is updated from a default placeholder to something descriptive, the `needs-title` label was left behind. This adds cleanup logic so the label is automatically removed once the title passes validation.