### PR TITLE
[Human In The Loop Middleware] Rename email tool functions to match its consumption in create_agent

### DIFF
--- a/src/oss/langchain/middleware/built-in.mdx
+++ b/src/oss/langchain/middleware/built-in.mdx
@@ -376,11 +376,11 @@ from langchain.agents.middleware import HumanInTheLoopMiddleware
 from langgraph.checkpoint.memory import InMemorySaver
 
 
-def read_email_tool(email_id: str) -> str:
+def your_read_email_tool(email_id: str) -> str:
     """Mock function to read an email by its ID."""
     return f"Email content for ID: {email_id}"
 
-def send_email_tool(recipient: str, subject: str, body: str) -> str:
+def your_send_email_tool(recipient: str, subject: str, body: str) -> str:
     """Mock function to send an email."""
     return f"Email sent to {recipient} with subject '{subject}'"
 


### PR DESCRIPTION
## Overview
There is a syntax error in the section of Human in the Loop Middleware example.

The tool methods were named as: `read_email_tool`, `send_email_tool`
However, in the `create_agent` call, these tools were being registered as `your_read_email_tool` and `your_send_email_tool` which is syntax error in the code.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
N/A

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
