### PR TITLE
docs: update API reference redirect for AzureOpenAIEmbeddings

### DIFF
--- a/src/oss/python/integrations/embeddings/azure_openai.mdx
+++ b/src/oss/python/integrations/embeddings/azure_openai.mdx
@@ -3,7 +3,7 @@ title: "AzureOpenAIEmbeddings integration"
 description: "Integrate with the AzureOpenAIEmbeddings embedding model using LangChain Python."
 ---
 
-This will help you get started with AzureOpenAI embedding models using LangChain. For detailed documentation on `AzureOpenAIEmbeddings` features and configuration options, please refer to the [API reference](https://python.langchain.com/api_reference/openai/embeddings/langchain_openai.embeddings.azure.AzureOpenAIEmbeddings.html).
+This will help you get started with AzureOpenAI embedding models using LangChain. For detailed documentation on `AzureOpenAIEmbeddings` features and configuration options, please refer to the [API reference](https://reference.langchain.com/python/langchain-openai/embeddings/azure/AzureOpenAIEmbeddings).
 
 ## Overview
 


### PR DESCRIPTION
Adds a redirect from the legacy python.langchain.com API reference page for `AzureOpenAIEmbeddings` to the new reference.langchain.com documentation page.

Old URL:
...AzureOpenAIEmbeddings.html

New URL:
.../langchain-openai/embeddings/azure/AzureOpenAIEmbeddings