### PR TITLE
oss(deepagents-cli): prefer short flags in CLI examples

### DIFF
--- a/src/oss/deepagents/cli/overview.mdx
+++ b/src/oss/deepagents/cli/overview.mdx
@@ -48,11 +48,11 @@ The Deep Agents CLI has the following built-in capabilities:
     <sup>1</sup>: Potentially destructive operations require user approval before execution. To bypass human approval, you can toggle auto-approve or start the deep agent with the `auto-approve` option:
 
     ```bash
-    deepagents --auto-approve
+    deepagents -y
     ```
 
     <Note>
-        When running the CLI non-interactively (via `-n` or piped stdin), shell execution is disabled by default even with `--auto-approve`. Use `--shell-allow-list` to allowlist specific commands (e.g., `--shell-allow-list "pytest,git,make"`), `recommended` for safe defaults, or `all` to permit any command. The `DEEPAGENTS_SHELL_ALLOW_LIST` environment variable is also supported. See [Non-interactive mode and piping](#non-interactive-mode-and-piping) for more details.
+        When running the CLI non-interactively (via `-n` or piped stdin), shell execution is disabled by default even with `-y`/`--auto-approve`. Use `-S`/`--shell-allow-list` to allowlist specific commands (e.g., `-S "pytest,git,make"`), `recommended` for safe defaults, or `all` to permit any command. The `DEEPAGENTS_SHELL_ALLOW_LIST` environment variable is also supported. See [Non-interactive mode and piping](#non-interactive-mode-and-piping) for more details.
     </Note>
 
     <sup>2</sup>: The CLI automatically offloads the conversation in the background when token usage exceeds a model-aware threshold. Offloading summarizes older messages via the LLM, and ejects originals to backend storage (`/conversation_history/{thread_id}.md`), replacing them in context with the summary. The agent can still retrieve the full history from the offloaded file if needed. The `compact_conversation` tool lets the agent (or you) trigger offloading on demand. When called as a tool, it requires user approval by default.
@@ -206,7 +206,7 @@ When piped input is combined with `-n` or `-m`, the piped content is prepended t
     The maximum piped input size is 10 MiB.
 </Note>
 
-Shell execution is disabled by default in non-interactive mode. Use `--shell-allow-list` to enable specific commands (e.g., `--shell-allow-list "pytest,git,make"`), `recommended` for safe defaults, or `all` to permit any command.
+Shell execution is disabled by default in non-interactive mode. Use `-S`/`--shell-allow-list` to enable specific commands (e.g., `-S "pytest,git,make"`), `recommended` for safe defaults, or `all` to permit any command.
 
 <AccordionGroup>
     <Accordion title="Clean output and buffering" icon="buffer">
@@ -223,19 +223,19 @@ Shell execution is disabled by default in non-interactive mode. Use `--shell-all
     <Accordion title="Shell execution examples" icon="shield-check">
         ```bash
         # Allow specific commands (validated against the list)
-        deepagents -n "Run the tests and fix failures" --shell-allow-list "pytest,git,make"
+        deepagents -n "Run the tests and fix failures" -S "pytest,git,make"
 
         # Use the curated safe-command list
-        deepagents -n "Build the project" --shell-allow-list recommended
+        deepagents -n "Build the project" -S recommended
 
         # Allow any shell command
-        deepagents -n "Fix the build" --shell-allow-list all
+        deepagents -n "Fix the build" -S all
         ```
     </Accordion>
 </AccordionGroup>
 
 <Warning>
-    `--shell-allow-list all` lets the agent execute arbitrary shell commands with no human confirmation. Use with caution.
+    `-S all` / `--shell-allow-list all` lets the agent execute arbitrary shell commands with no human confirmation. Use with caution.
 </Warning>
 
 ## Switch models
@@ -663,7 +663,7 @@ deepagents --model anthropic:claude-sonnet-4-5
 deepagents --model gpt-4o
 
 # Auto-approve tool usage (skip human-in-the-loop prompts)
-deepagents --auto-approve
+deepagents -y
 ```
 
 <AccordionGroup>
@@ -680,8 +680,8 @@ deepagents --auto-approve
         | `-n`, `--non-interactive TEXT` | Run a single task non-interactively and exit. Shell is disabled unless `--shell-allow-list` is set |
         | `-q`, `--quiet`        | Clean output for piping—only the agent's response goes to stdout. Requires `-n` or piped stdin |
         | `--no-stream`          | Buffer the full response and write to stdout at once instead of streaming. Requires `-n` or piped stdin |
-        | `--auto-approve`       | Auto-approve all tool calls without prompting (disables human-in-the-loop). Toggle with `Shift+Tab` during an interactive session |
-        | `--shell-allow-list LIST` | Comma-separated shell commands to auto-approve, `'recommended'` for safe defaults, or `'all'` to allow any command. Applies to both `-n` and interactive modes |
+        | `-y`, `--auto-approve` | Auto-approve all tool calls without prompting (disables human-in-the-loop). Toggle with `Shift+Tab` during an interactive session |
+        | `-S`, `--shell-allow-list LIST` | Comma-separated shell commands to auto-approve, `'recommended'` for safe defaults, or `'all'` to allow any command. Applies to both `-n` and interactive modes |
         | `--json`               | Emit machine-readable JSON from management subcommands (`list`, `reset`, `threads`, `skills`). Output envelope: `{"schema_version": 1, "command": "...", "data": ...}` |
         | `--sandbox TYPE`       | Remote sandbox for code execution: `none` (default), `modal`, `daytona`, `runloop`, `langsmith` |
         | `--sandbox-id ID`      | Reuse an existing sandbox (skips creation and cleanup)      |


### PR DESCRIPTION
Update the Deep Agents CLI docs to prefer short flags (`-y`, `-S`) over long-form equivalents (`--auto-approve`, `--shell-allow-list`) in examples and inline references. The long forms are still documented in the flags table — this just makes the examples less noisy and closer to real-world usage.

## Changes
- Replace `--auto-approve` with `-y` in code examples and inline prose throughout `cli/overview.mdx`
- Replace `--shell-allow-list` with `-S` in shell examples and explanatory text; long forms retained in the flags reference table as `| -y, --auto-approve |` / `| -S, --shell-allow-list |`
- Update the warning callout for unrestricted shell access to lead with `-S all` alongside the existing `--shell-allow-list all`