### PR TITLE
Update Azure AI integration for API key and model

### DIFF
--- a/src/oss/python/integrations/providers/azure_ai.mdx
+++ b/src/oss/python/integrations/providers/azure_ai.mdx
@@ -29,14 +29,14 @@ uv add langchain-azure-ai
 Configure your API key and Endpoint.
 
 ```bash
-export AZURE_AI_CREDENTIAL=your-api-key
-export AZURE_AI_ENDPOINT=your-endpoint
+export OPENAI_API_KEY=your-api-key
+export AZURE_OPENAI_ENDPOINT=your-endpoint
 ```
 
 ```python
-from langchain_azure_ai.chat_models import AzureAIChatCompletionsModel
+from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 
-llm = AzureAIChatCompletionsModel(
+llm = AzureAIOpenAIApiChatModel(
     model_name="gpt-4.1",
     api_version="2024-05-01-preview",
 )


### PR DESCRIPTION
 ---                                                                                                                                                     
  Overview                                                                                                                                                                                                                                                                                                          
  Updated Azure AI chat model integration documentation to use the current recommended AzureAIOpenAIApiChatModel class instead of the deprecated          
  AzureAIChatCompletionsModel, and updated environment variable references accordingly.

  Type of change

  Type: Update existing documentation / Fix outdated content

  Related issues/PRs

  - GitHub issue: (if applicable)
  - Feature PR: (if applicable)

  - Linear issue:
  - Slack thread:

  Checklist

  - I have read the README.md, including the https://docs.langchain.com/oss/python/contributing/overview#language-policy
  - I have tested my changes locally using docs dev
  - All code examples have been tested and work correctly
  - I have used root relative paths for internal links
  - I have updated navigation in src/docs.json if needed

  (Internal team members only / optional): Create a preview deployment as necessary using the
  https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml

  Additional notes

  Summary of Changes:

  - Replaced deprecated class: Changed AzureAIChatCompletionsModel to AzureAIOpenAIApiChatModel
    - The old class uses Azure AI Inference beta SDK which is deprecated and will be retired on May 30, 2026
    - The new class uses the stable OpenAI-compatible API with OpenAI SDK
  - Updated environment variables: Aligned environment variable references with the new class requirements
  - Import statements: Updated import paths to reflect the current recommended approach

  Rationale:

  The AzureAIChatCompletionsModel class is deprecated (as of version 1.1.0) and users should migrate to AzureAIOpenAIApiChatModel. This update ensures    
  documentation reflects current best practices and prevents users from implementing code that will break after May 30, 2026.

  ---