### PR TITLE
Update Docker Compose warning for v0.11 cutoff

### DIFF
--- a/src/langsmith/docker.mdx
+++ b/src/langsmith/docker.mdx
@@ -10,7 +10,7 @@ Self-hosting LangSmith is an add-on to the Enterprise Plan designed for our larg
 This guide provides instructions for running the **LangSmith platform** locally using Docker for development and testing purposes.
 
 <Warning>
-**For development/testing only**. Do not use Docker Compose for production. For production deployments, use [Kubernetes](/langsmith/kubernetes).
+**For development/testing only until v0.11**. Do not use Docker Compose for production. For production deployments or newer versions of LangSmith (after v0.11), please use [Kubernetes](/langsmith/kubernetes).
 </Warning>
 
 <Note>


### PR DESCRIPTION
## Summary
- Updates the Docker Compose warning in the self-hosted Docker docs to clarify that Docker Compose is supported for development/testing only **until v0.11**
- Directs users to Kubernetes for production deployments or any LangSmith version after v0.11

## Test plan
- [ ] Verify the warning renders correctly on the docs site
- [ ] Confirm the Kubernetes link still resolves