### PR TITLE
ci: shallow clone in all workflows

### DIFF
--- a/.github/workflows/_check-links.yml
+++ b/.github/workflows/_check-links.yml
@@ -39,6 +39,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
 
       - name: Configure Python ${{ inputs.python-version }} with uv package manager
         uses: "./.github/actions/uv_setup"

--- a/.github/workflows/_lint.yml
+++ b/.github/workflows/_lint.yml
@@ -27,6 +27,8 @@ jobs:
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
 
       - name: Set up Python ${{ inputs.python-version }} + uv
         uses: "./.github/actions/uv_setup"

--- a/.github/workflows/_test.yml
+++ b/.github/workflows/_test.yml
@@ -26,6 +26,8 @@ jobs:
     name: "make test #${{ inputs.python-version }}"
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
 
       - name: Set up Python ${{ inputs.python-version }} + uv
         uses: "./.github/actions/uv_setup"

--- a/.github/workflows/check-agents-sync.yml
+++ b/.github/workflows/check-agents-sync.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: "📋 Checkout Code"
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
 
       - name: "🔍 Check CLAUDE.md and AGENTS.md are in sync"
         run: |

--- a/.github/workflows/check-import-mappings.yml
+++ b/.github/workflows/check-import-mappings.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          fetch-depth: 1
           persist-credentials: false
 
       - name: Set up Python 3.13 + uv
@@ -112,6 +113,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
+          fetch-depth: 1
           persist-credentials: false
 
       - name: Download updated files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - uses: "./.github/actions/uv_setup"
         with:
           python-version: "3.13"
@@ -82,6 +84,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
       - name: Skip check for automated updates
         env:
           PR_TITLE: ${{ github.event.pull_request.title }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,8 @@ jobs:
       contents: write
     steps:
     - uses: actions/checkout@v6
+      with:
+        fetch-depth: 1
     - name: Set up Python 3.13 + uv
       uses: "./.github/actions/uv_setup"
       id: setup-python

--- a/.github/workflows/update-package-downloads.yml
+++ b/.github/workflows/update-package-downloads.yml
@@ -16,6 +16,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
 
       - name: Set up Python 3.13 + uv
         uses: "./.github/actions/uv_setup"
@@ -56,6 +58,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
 
       - name: Download updated files
         uses: actions/download-artifact@v7


### PR DESCRIPTION
Add `fetch-depth: 1` to all `actions/checkout@v6` steps across CI workflows. Full git history isn't needed for any of these jobs — shallow clones cut checkout time and reduce runner disk/network usage.