### PR TITLE
ci: cache mintlify cli in check-links workflow

### DIFF
--- a/.github/workflows/_check-links.yml
+++ b/.github/workflows/_check-links.yml
@@ -57,11 +57,12 @@ jobs:
         with:
           node-version: '22'
 
-      - name: Resolve npm global paths
+      - name: Resolve npm global prefix
         id: npm-paths
         run: |
-          echo "root=$(npm root -g)" >> "$GITHUB_OUTPUT"
-          echo "bin=$(npm bin -g)" >> "$GITHUB_OUTPUT"
+          PREFIX="$(npm prefix -g)"
+          echo "root=${PREFIX}/lib/node_modules" >> "$GITHUB_OUTPUT"
+          echo "bin=${PREFIX}/bin" >> "$GITHUB_OUTPUT"
 
       - name: Cache Mintlify CLI
         id: cache-mint


### PR DESCRIPTION
Cache the Mintlify CLI global install in the `_check-links` workflow. The `npm i -g mint@latest` step and its KaTeX patch are slow — caching the installed binaries and skipping both steps on cache hit saves a chunk of wall time on every link-check run.

## Changes
- Add an `actions/cache@v4` step keyed on `runner.os`, Node 22, and a hash of `_check-links.yml` to cache `/usr/local/lib/node_modules/mint` and `/usr/local/bin/mint`
- Gate the `Install Mintlify CLI` and `Patch KaTeX __VERSION__ bug` steps behind `steps.cache-mint.outputs.cache-hit != 'true'`