### PR TITLE
ci(pipeline): disable tqdm progress bars in CI

### DIFF
--- a/pipeline/core/builder.py
+++ b/pipeline/core/builder.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import os
 import re
 import shutil
 from pathlib import Path
@@ -11,6 +12,8 @@ import yaml
 from tqdm import tqdm
 
 from pipeline.preprocessors import preprocess_markdown
+
+_IS_CI = os.environ.get("CI", "").lower() in ("true", "1")
 
 logger = logging.getLogger(__name__)
 
@@ -503,6 +506,7 @@ class DocumentationBuilder:
             bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}]",
             dynamic_ncols=True,
             leave=False,
+            disable=_IS_CI,
         ) as pbar:
             for file_path in existing_files:
                 result = self._build_file_with_progress(file_path, pbar)
@@ -552,6 +556,7 @@ class DocumentationBuilder:
             bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}]",
             dynamic_ncols=True,
             leave=False,
+            disable=_IS_CI,
         ) as pbar:
             for file_path in all_files:
                 # Calculate relative path from oss/ directory
@@ -630,6 +635,7 @@ class DocumentationBuilder:
             bar_format="{l_bar}{bar}| {n_fmt}/{total_fmt} [{elapsed}<{remaining}]",
             dynamic_ncols=True,
             leave=False,
+            disable=_IS_CI,
         ) as pbar:
             for file_path in all_files:
                 # Calculate relative path from source directory


### PR DESCRIPTION
Disable `tqdm` progress bars when `CI=true` is set. GitHub Actions sets this automatically, and the per-line bar updates produce thousands of lines of noise in CI logs — only the final `INFO` summary lines matter.