### PR TITLE
docs: add Perplexity web search to Agent Builder tool integrations

### DIFF
--- a/src/langsmith/agent-builder-tools.mdx
+++ b/src/langsmith/agent-builder-tools.mdx
@@ -141,13 +141,14 @@ To view a comprehensive list of all tool integrations, navigate to the [Agent Bu
   <div style={{ position: 'relative', margin: 0, padding: 0 }}>
     <Card title="Search" icon="search">
       <ul>
+        <li>Perplexity web search (ranked results with domain/language filtering)</li>
         <li>Exa web search (optionally fetch page contents)</li>
         <li>Exa LinkedIn profile search</li>
         <li>Tavily web search</li>
       </ul>
     </Card>
     <div style={{ position: 'absolute', top: 16, right: 16 }}>
-      <Tooltip tip="Exa: EXA_API_KEY; Tavily: TAVILY_API_KEY">
+      <Tooltip tip="Perplexity: PPLX_API_KEY; Exa: EXA_API_KEY; Tavily: TAVILY_API_KEY">
         <Icon icon="key" size={16} />
       </Tooltip>
     </div>


### PR DESCRIPTION
Adds Perplexity web search to the Search tool integrations list in the Agent Builder tools page.

Perplexity provides ranked web search results with domain and language filtering via the `langchain-perplexity` partner package (`PerplexitySearchResults` tool). The integration is already available as a [LangChain partner package](https://github.com/langchain-ai/langchain/tree/master/libs/partners/perplexity/langchain_perplexity) and documented in the [LangChain providers list](https://docs.langchain.com/oss/python/integrations/providers/perplexity).

**Changes:**
- Added Perplexity web search to the Search card
- Added `PPLX_API_KEY` to the API key tooltip