### PR TITLE
fix: update BG_JOB_TIMEOUT_SECS default to 86400 [closes DOC-887]

### DIFF
--- a/src/langsmith/env-var.mdx
+++ b/src/langsmith/env-var.mdx
@@ -32,7 +32,7 @@ The timeout of a background run can be increased. However, the infrastructure fo
 
 A background run can execute for longer than 1 hour, but a client must reconnect to the server (e.g. join stream via `POST /threads/{thread_id}/runs/{run_id}/stream`) to retrieve output from the run if the run is taking longer than 1 hour.
 
-Defaults to `3600`.
+Defaults to `86400`.
 
 ## `CORS_ALLOW_ORIGINS`
 


### PR DESCRIPTION
## Description
Updates the documented default value for `BG_JOB_TIMEOUT_SECS` from `3600` to `86400` (24 hours) on the environment variables page, reflecting a recent change confirmed by the team.

Resolves DOC-887

## Test Plan
- [ ] Verify the env-var page shows the updated default of `86400` for `BG_JOB_TIMEOUT_SECS`