### PR TITLE
 update type hint from dict to MessagesState in tool_node

### DIFF
--- a/src/oss/langgraph/workflows-agents.mdx
+++ b/src/oss/langgraph/workflows-agents.mdx
@@ -1883,7 +1883,7 @@ def llm_call(state: MessagesState):
     }
 
 
-def tool_node(state: dict):
+def tool_node(state: MessagesState):
     """Performs the tool call"""
 
     result = []


### PR DESCRIPTION
## Overview
 update type hint from dict to MessagesState in tool_node

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed


