### PR TITLE
fix: correct similarity score description for Supabase vector store

### DIFF
--- a/src/oss/python/integrations/vectorstores/supabase.mdx
+++ b/src/oss/python/integrations/vectorstores/supabase.mdx
@@ -168,7 +168,7 @@ And I did that 4 days ago, when I nominated Circuit Court of Appeals Judge Ketan
 
 ## Similarity search with score
 
-The returned distance score is cosine distance. Therefore, a lower score is better.
+The returned score is cosine similarity. Therefore, a higher score is better.
 
 ```python
 matched_docs = vector_store.similarity_search_with_relevance_scores(query)


### PR DESCRIPTION
## Overview
Fix incorrect score description in the Supabase vector store documentation. The doc states the returned score is cosine distance (lower = better), but it is actually cosine similarity (higher = better).

## Type of change
**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue: N/A
- Feature PR: N/A

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes
The documentation under **Similarity search with score** states:
> "The returned distance score is cosine distance. Therefore, a lower score is better."

This is incorrect. The returned score is **cosine similarity**, not cosine distance. Therefore, a **higher score is better**.

**Evidence:**

**1. The SQL function computes cosine similarity, not cosine distance**

The `match_documents` function defined in the docs computes:
```sql
1 - (documents.embedding <=> query_embedding) as similarity
```
The `<=>` operator in pgvector returns cosine **distance**. Subtracting it from 1 converts it to cosine **similarity**, where:
- `1.0` = identical vectors (best match)
- `0.0` = orthogonal vectors (no similarity)
- `-1.0` = opposite vectors (worst match)

The column is even explicitly named `similarity`, not `distance`.

**2. The Python source code filters with `>=`**

In `langchain_community/vectorstores/supabase.py`, the `similarity_search_by_vector_with_relevance_scores` method (which is called internally by `similarity_search_with_relevance_scores`) filters results using:
```python
if similarity >= score_threshold
```
This confirms higher scores are better — if it were cosine distance, the filter would use `<=`.

**3. The example output is consistent with cosine similarity**

The example output in the same doc shows a top result score of `0.802509746274066`, which is consistent with cosine similarity (closer to 1.0 = better match), not cosine distance.

**Change:**

Before:
> The returned distance score is cosine distance. Therefore, a lower score is better.

After:
> The returned score is cosine similarity. Therefore, a higher score is better.