### PR TITLE
fix: add tools page link to quickstart @tool callout [closes DOC-818]

### DIFF
--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -152,6 +152,7 @@ Let's walk through each step:
         <Tip>
             Tools should be well-documented: their name, description, and argument names become part of the model's prompt.
             LangChain's @[`@tool` decorator][@tool] adds metadata and enables runtime injection with the `ToolRuntime` parameter.
+            Learn more in the [tools guide](/oss/langchain/tools).
         </Tip>
         :::
 


### PR DESCRIPTION
## Description
Adds a link to the tools guide (`/oss/langchain/tools`) in the `<Tip>` callout about the `@tool` decorator in step 2 of the LangChain quickstart. Previously the callout only linked to the API reference for `@tool` but not the conceptual tools page.

## Test Plan
- [ ] Verify the tools guide link renders correctly in the quickstart tip callout