### PR TITLE
feat: add structured output page link to quickstart [closes DOC-813]

### DIFF
--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -85,7 +85,7 @@ Next, build a practical weather forecasting agent that demonstrates key producti
 1. **Detailed system prompts** for better agent behavior
 2. **Create tools** that integrate with external data
 3. **Model configuration** for consistent responses
-4. **Structured output** for predictable results
+4. **[Structured output](/oss/langchain/structured-output)** for predictable results
 5. **Conversational memory** for chat-like interactions
 6. **Create and run the agent** to test the fully functional agent
 
@@ -249,7 +249,7 @@ Let's walk through each step:
     </Step>
     <Step title="Define response format">
         :::python
-        Optionally, define a structured response format if you need the agent responses to match
+        Optionally, define a [structured response format](/oss/langchain/structured-output) if you need the agent responses to match
         a specific schema.
 
         ```python
@@ -267,7 +267,7 @@ Let's walk through each step:
         :::
 
         :::js
-        Optionally, define a structured response format if you need the agent responses to match
+        Optionally, define a [structured response format](/oss/langchain/structured-output) if you need the agent responses to match
         a specific schema.
 
         ```ts


### PR DESCRIPTION
## Description
Adds a link to the structured output page (`/oss/langchain/structured-output`) in the LangChain quickstart. The link is added in three places: the numbered overview list, the Python step description, and the JS step description for the "Define response format" step. This matches the pattern used by other quickstart steps (e.g., tools, memory) that cross-link to their dedicated pages.

Resolves DOC-813

## Test Plan
- [ ] Verify the structured output links render correctly in the quickstart page and navigate to the correct page