### PR TITLE
docs: deprecate Docker support for self-hosted LangSmith

### DIFF
--- a/src/langsmith/docker.mdx
+++ b/src/langsmith/docker.mdx
@@ -1,17 +1,18 @@
 ---
-title: Self-host LangSmith with Docker
-sidebarTitle: Install on Docker
+title: Self-host LangSmith with Docker (Deprecated)
+sidebarTitle: Install on Docker (Deprecated)
+description: Docker-based self-hosting for LangSmith is deprecated. Use Kubernetes powered infrastructure instead.
 ---
+
+<Warning>
+**Docker support for self-hosted LangSmith has been deprecated.** For all self-hosted deployments, use [Kubernetes powered infrastructure](/langsmith/kubernetes) instead. The instructions below are preserved for reference only and will be removed in a future release.
+</Warning>
 
 <Info>
 Self-hosting LangSmith is an add-on to the Enterprise Plan designed for our largest, most security-conscious customers. See our [pricing page](https://www.langchain.com/pricing) for more detail, and [contact our sales team](https://www.langchain.com/contact-sales) if you want to get a license key to trial LangSmith in your environment.
 </Info>
 
-This guide provides instructions for running the **LangSmith platform** locally using Docker for development and testing purposes.
-
-<Warning>
-**For development/testing only until v0.11**. Do not use Docker Compose for production. For production deployments or newer versions of LangSmith (after v0.11), please use [Kubernetes](/langsmith/kubernetes).
-</Warning>
+This guide previously provided instructions for running the **LangSmith platform** locally using Docker for development and testing purposes.
 
 <Note>
 This page describes how to install the base [LangSmith platform](/langsmith/self-hosted#langsmith) for local testing. It does **not** include deployment management features. For more details, review the [self-hosted options](/langsmith/self-hosted).


### PR DESCRIPTION
## Summary
- Deprecate Docker-based self-hosting for LangSmith in favor of Kubernetes powered infrastructure
- Add a prominent deprecation warning banner at the top of the Docker page
- Update page title and sidebar to indicate deprecated status
- Direct users to Kubernetes deployment docs for all self-hosted deployments

## Test plan
- [ ] Verify the deprecation warning renders correctly on the Docker page
- [ ] Confirm the link to the Kubernetes page resolves properly
- [ ] Check that the sidebar displays the updated "(Deprecated)" label