### PR TITLE
docs(contributing): add Middleware to encouraged integrations

### DIFF
--- a/src/oss/contributing/integrations-langchain.mdx
+++ b/src/oss/contributing/integrations-langchain.mdx
@@ -28,6 +28,7 @@ While any component can be integrated into LangChain, there are specific types o
 **Integrate these ✅**:
 
 - [**Chat Models**](/oss/integrations/chat): Most actively used component type
+- [**Middleware**](/oss/langchain/middleware/custom): Customize agent behavior
 - [**Tools/Toolkits**](/oss/integrations/tools): Enable agent capabilities
 - [**Retrievers**](/oss/integrations/retrievers): Core to RAG applications
 - [**Embedding Models**](/oss/integrations/embeddings): Foundation for vector operations


### PR DESCRIPTION
Add Middleware to the list of integrations we encourage contributors to build. Reorder the list to prioritize Chat Models, Middleware, and Tools/Toolkits at the top.

Created with [Deep Agents CLI](https://docs.langchain.com/oss/python/deepagents/cli/overview) using zai-org/GLM-5 (provider: baseten).