### PR TITLE
fix: improve code quality across pipeline and scripts

### DIFF
--- a/pipeline/cli.py
+++ b/pipeline/cli.py
@@ -166,7 +166,7 @@ def migrate_command(args) -> None:  # noqa: ANN001
 
     # Determine if the path is a file or a directory
     if not input_path.exists():
-        logger.exception("Path %s does not exist", input_path)
+        logger.error("Path %s does not exist", input_path)
         sys.exit(1)
 
     # Find all files to migrate

--- a/pipeline/core/builder.py
+++ b/pipeline/core/builder.py
@@ -445,35 +445,13 @@ class DocumentationBuilder:
         Returns:
             True if the file was copied, False if it was skipped.
         """
-        # Skip template files
-        if file_path.name == "TEMPLATE.mdx":
-            return False
-
         relative_path = file_path.absolute().relative_to(self.src_dir.absolute())
         output_path = self.build_dir / relative_path
 
         # Update progress bar description with current file
         pbar.set_postfix_str(f"{relative_path}")
 
-        # Create output directory if needed
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Handle special case for docs.yml files
-        if file_path.name == "docs.yml" and file_path.suffix.lower() in {
-            ".yml",
-            ".yaml",
-        }:
-            self._convert_yaml_to_json(file_path, output_path)
-            return True
-        # Copy other supported files directly
-        if file_path.suffix.lower() in self.copy_extensions:
-            # Handle markdown files with preprocessing
-            if file_path.suffix.lower() in {".md", ".mdx"}:
-                self._process_markdown_file(file_path, output_path)
-                return True
-            shutil.copy2(file_path, output_path)
-            return True
-        return False
+        return self._build_single_file_to_path(file_path, output_path, None)
 
     def build_files(self, file_paths: list[Path]) -> None:
         """Build specific files by copying them to the build directory.
@@ -684,32 +662,10 @@ class DocumentationBuilder:
         Returns:
             True if the file was copied, False if it was skipped.
         """
-        # Skip template files
-        if file_path.name == "TEMPLATE.mdx":
-            return False
-
         # Update progress bar description with current file
         pbar.set_postfix_str(display_path)
 
-        # Create output directory if needed
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Handle special case for docs.yml files
-        if file_path.name == "docs.yml" and file_path.suffix.lower() in {
-            ".yml",
-            ".yaml",
-        }:
-            self._convert_yaml_to_json(file_path, output_path)
-            return True
-        # Copy other supported files
-        if file_path.suffix.lower() in self.copy_extensions:
-            # Handle markdown files with preprocessing
-            if file_path.suffix.lower() in {".md", ".mdx"}:
-                self._process_markdown_file(file_path, output_path, target_language)
-                return True
-            shutil.copy2(file_path, output_path)
-            return True
-        return False
+        return self._build_single_file_to_path(file_path, output_path, target_language)
 
     def _build_version_file_with_progress(
         self, file_path: Path, version_dir: str, target_language: str, pbar: tqdm
@@ -732,25 +688,7 @@ class DocumentationBuilder:
         # Update progress bar description with current file
         pbar.set_postfix_str(f"{version_dir}/{relative_path}")
 
-        # Create output directory if needed
-        output_path.parent.mkdir(parents=True, exist_ok=True)
-
-        # Handle special case for docs.yml files
-        if file_path.name == "docs.yml" and file_path.suffix.lower() in {
-            ".yml",
-            ".yaml",
-        }:
-            self._convert_yaml_to_json(file_path, output_path)
-            return True
-        # Copy other supported files
-        if file_path.suffix.lower() in self.copy_extensions:
-            # Handle markdown files with preprocessing
-            if file_path.suffix.lower() in {".md", ".mdx"}:
-                self._process_markdown_file(file_path, output_path, target_language)
-                return True
-            shutil.copy2(file_path, output_path)
-            return True
-        return False
+        return self._build_single_file_to_path(file_path, output_path, target_language)
 
     def is_shared_file(self, file_path: Path) -> bool:
         """Check if a file should be shared between versions rather than duplicated.

--- a/scripts/convert_pip_to_codegroup.py
+++ b/scripts/convert_pip_to_codegroup.py
@@ -193,8 +193,8 @@ def convert_file(file_path: str, *, dry_run: bool = False) -> bool:
             if not dry_run:
                 file_obj.write_text(converted_content, encoding="utf-8")
             return True
-    except Exception:  # noqa: BLE001, S110
-        pass
+    except Exception as e:  # noqa: BLE001
+        print(f"Error converting {file_path}: {e}")
     return False
 
 
@@ -228,15 +228,22 @@ def main() -> None:
         files = [str(f) for f in search_path.rglob("*.mdx")]
 
     if not files:
+        print("No MDX files found.")
         return
-
-    if args.dry_run:
-        pass
 
     converted_count = 0
     for file_path in files:
         if convert_file(file_path, dry_run=args.dry_run):
             converted_count += 1
+            if args.dry_run:
+                print(f"Would convert: {file_path}")
+            else:
+                print(f"Converted: {file_path}")
+
+    print(
+        f"\n{converted_count} of {len(files)} file(s) "
+        f"{'would be converted' if args.dry_run else 'converted'}."
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Three targeted code quality fixes:

1. **pipeline/cli.py** — `logger.exception()` was called outside an exception handler in `migrate_command()`. Replaced with `logger.error()` since there's no traceback to attach.

2. **scripts/convert_pip_to_codegroup.py** — `convert_file()` silently swallowed all exceptions (`except: pass`), and `main()` produced zero output (including `--dry-run` being a literal no-op `pass`). Now reports errors, prints per-file status, and shows a summary.

3. **pipeline/core/builder.py** — Deduplicated the file-build logic that was copy-pasted across 4 methods (`_build_single_file_to_path`, `_build_file_with_progress`, `_build_single_file`, `_build_version_file_with_progress`). The latter 3 now delegate to `_build_single_file_to_path`, removing ~60 lines of duplicated code.

All 134 existing tests pass. Ruff clean.
