### PR TITLE
Fix typo in setup instructions for pgvector.mdx

### DIFF
--- a/src/oss/python/integrations/vectorstores/pgvector.mdx
+++ b/src/oss/python/integrations/vectorstores/pgvector.mdx
@@ -20,7 +20,7 @@ If this is a concern, please use a different vectorstore. If not, this implement
 
 ## Setup
 
-First donwload the partner package:
+First download the partner package:
 
 ```python
 pip install -qU langchain-postgres


### PR DESCRIPTION
## Overview

Noticed a simple typo in these docs :)

## Type of change

**Type:** Fix typo

## Related issues/PRs

None

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
