### PR TITLE
Add SidClaw governance integration

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -793,3 +793,10 @@ packages:
   provider_page: oracleai
   downloads: 645
   downloads_updated_at: "2026-01-19T00:06:43.844774+00:00"
+- name: langchain-sidclaw
+  name_title: SidClaw
+  repo: sidclawhq/platform
+  path: integrations/langchain-python
+  js: "@sidclaw/sdk"
+  downloads: 0
+  downloads_updated_at: "2026-03-23T00:00:00.000000+00:00"

--- a/src/oss/python/integrations/providers/sidclaw.mdx
+++ b/src/oss/python/integrations/providers/sidclaw.mdx
@@ -1,0 +1,24 @@
+---
+title: "SidClaw integrations"
+description: "Add governance, human approval, and audit trails to LangChain tool calls with SidClaw."
+---
+
+[SidClaw](https://github.com/sidclawhq/platform) is an open-source approval and accountability layer for AI agents. It wraps tool calls with policy evaluation, human approval workflows, and tamper-evident audit trails.
+
+## Installation and setup
+
+```bash
+pip install langchain-sidclaw
+```
+
+You'll also need a SidClaw instance. Use the free hosted tier at [app.sidclaw.com](https://app.sidclaw.com) or self-host with Docker.
+
+## Tool governance
+
+SidClaw provides a `governTools()` wrapper that intercepts LangChain tool calls before execution:
+
+- **Policy evaluation**: each tool call is checked against priority-ordered policies
+- **Human approval**: high-risk actions are held for reviewer approval before executing
+- **Audit trail**: every action, approval, and denial is recorded in a hash-chain trace
+
+See the [SidClaw LangChain integration guide](https://docs.sidclaw.com/docs/integrations/langchain) for usage details.


### PR DESCRIPTION
## Summary

Adds [`langchain-sidclaw`](https://pypi.org/project/langchain-sidclaw/) to `packages.yml` — governance for LangChain AI agent tools.

**What SidClaw does:** IAM-style governance for AI agents — policy evaluation, human-in-the-loop approval, and tamper-evident audit trails. It lets teams enforce rules like "require human approval before any agent writes to production databases" or "deny all PII-classified actions outside business hours."

**What the integration provides:**
- `govern_tools()` — wraps LangChain tools with policy checks and approval gates
- `GovernanceCallbackHandler` — emits audit events to SidClaw's trace pipeline

## Package details

| | |
|---|---|
| **Python package** | [`langchain-sidclaw`](https://pypi.org/project/langchain-sidclaw/) |
| **JS/TS package** | [`@sidclaw/sdk`](https://www.npmjs.com/package/@sidclaw/sdk) (includes `@sidclaw/sdk/langchain` export) |
| **Documentation** | [docs.sidclaw.com/docs/integrations/langchain](https://docs.sidclaw.com/docs/integrations/langchain) |
| **Source** | [github.com/sidclawhq/platform](https://github.com/sidclawhq/platform) (`integrations/langchain-python/`) |
| **Website** | [sidclaw.com](https://sidclaw.com) |

## Changes

- Added `langchain-sidclaw` entry to `packages.yml` with `name`, `name_title`, `repo`, `path`, `js`, and `downloads` fields