### PR TITLE
docs: fix model identifier format for Google agent

### DIFF
--- a/src/oss/deepagents/quickstart.mdx
+++ b/src/oss/deepagents/quickstart.mdx
@@ -307,7 +307,7 @@ Pick a model from your provider. By default, `createDeepAgent` uses `claude-sonn
     <Tab title="Google">
         ```typescript
         const agent = createDeepAgent({
-          model: "google_genai:gemini-3.1-pro-preview",
+          model: "google-genai:gemini-3.1-pro-preview",
           tools: [internetSearch],
           systemPrompt: researchInstructions,
         });


### PR DESCRIPTION
## Overview

Fixes a wrong model provider name (I assume just for TS):

I get: 

```
Unable to infer model provider for { model: google_genai:gemini-3.1-pro-preview }, please specify modelProvider directly.","name":"Error"}
```

Dug into it, and the key is wrong: https://github.com/langchain-ai/langchainjs/blob/main/libs/langchain/src/chat_models/universal.ts#L78
