### PR TITLE
feat: add dynamic model selection guidance to deep agents models page

### DIFF
--- a/src/oss/deepagents/models.mdx
+++ b/src/oss/deepagents/models.mdx
@@ -91,9 +91,9 @@ To configure model-specific parameters, use @[`init_chat_model`] or instantiate 
 
 ## Select a model at runtime
 
-If your application lets users choose a model (e.g., via a dropdown in the UI), use [middleware](/oss/langchain/middleware) to swap the model at runtime without rebuilding the agent.
+If your application lets users choose a model (for example using a dropdown in the UI), use [middleware](/oss/langchain/middleware) to swap the model at runtime without rebuilding the agent.
 
-Pass the user's model selection through [runtime context](/oss/langchain/agents#dynamic-model), then use a `wrap_model_call` middleware to override the model on each invocation:
+Pass the user's model selection through [runtime context](/oss/langchain/agents#dynamic-model), then use a `wrap_model_call` middleware to override the model on each invocation using the @[`@wrap_model_call`] decorator:
 
 :::python
 ```python
@@ -165,7 +165,7 @@ const result = await agent.invoke(
 :::
 
 <Tip>
-For more dynamic model patterns (e.g., routing based on conversation complexity or cost optimization), see [Dynamic model](/oss/langchain/agents#dynamic-model) in the LangChain agents guide.
+For more dynamic model patterns (foe example routing based on conversation complexity or cost optimization), see [Dynamic model](/oss/langchain/agents#dynamic-model) in the LangChain agents guide.
 </Tip>
 
 ## Supported models


### PR DESCRIPTION
## Description
Adds a "Select a model at runtime" section to the Deep Agents models page, addressing the need for guidance on dynamically selecting models at runtime (e.g., via a model selector dropdown in a client UI). The section shows how to use `wrap_model_call` middleware with runtime context to swap models per invocation without rebuilding the agent, with examples for both Python and TypeScript.

Resolves DOC-914

## Test Plan
- [ ] Verify the new section renders correctly in preview deployment
- [ ] Verify internal links to middleware and dynamic model docs resolve correctly