### PR TITLE
fix: reorder checkpointer backends - postgres before mongo [closes DOC-912]

### DIFF
--- a/src/langsmith/configure-checkpointer.mdx
+++ b/src/langsmith/configure-checkpointer.mdx
@@ -18,6 +18,10 @@ Regardless of the checkpointer backend, LangSmith always requires PostgreSQL for
 | `mongo` | MongoDB | `langgraph.json` or `LS_DEFAULT_CHECKPOINTER_BACKEND` env var | Teams with existing MongoDB infrastructure |
 | `custom` | User-provided | `langgraph.json` | Custom storage backends (see [custom checkpointer](/langsmith/custom-checkpointer)) |
 
+## Default (PostgreSQL)
+
+PostgreSQL is the default checkpointer backend. No configuration is needed. To use a custom PostgreSQL instance, set the [`POSTGRES_URI_CUSTOM`](/langsmith/env-var#postgres_uri_custom) environment variable.
+
 ## Set up MongoDB checkpointing
 
 <Info>
@@ -151,10 +155,6 @@ mongodb+srv://user:password@cluster.example.net/langgraph
   PostgreSQL is still auto-provisioned for non-checkpoint data.
   </Tab>
 </Tabs>
-
-## Default (PostgreSQL)
-
-PostgreSQL is the default checkpointer backend. No configuration is needed. To use a custom PostgreSQL instance, set the [`POSTGRES_URI_CUSTOM`](/langsmith/env-var#postgres_uri_custom) environment variable.
 
 ## Custom checkpointer
 


### PR DESCRIPTION
## Description
Moves the "Default (PostgreSQL)" section above "Set up MongoDB checkpointing" on the configure-checkpointer page. Since PostgreSQL is the default/recommended backend, it should be listed first to match user expectations.

Resolves DOC-912

## Test Plan
- [ ] Verify the configure-checkpointer page shows PostgreSQL section before MongoDB section

## Preview

https://langchain-5e9cc07a-preview-opensw-1774360645-bf2eec8.mintlify.app/langsmith/configure-checkpointer#default-postgresql