### PR TITLE
Add using replicas for tracing to log to project

### DIFF
--- a/src/langsmith/log-traces-to-project.mdx
+++ b/src/langsmith/log-traces-to-project.mdx
@@ -643,7 +643,7 @@ await myPipeline("What is LangSmith?");
 
 </CodeGroup>
 
-You can also use the `updates` field to merge additional fields (such as [metadata or tags](/langsmith/metadata-parameters-reference)) into a run for a specific replica only—the primary trace is unchanged. Replica errors are non-fatal: if a replica endpoint is unavailable, LangSmith logs the error without affecting the primary trace.
+You can also use the `updates` field to merge additional fields (such as [metadata or tags](/langsmith/ls-metadata-parameters)) into a run for a specific replica only—the primary trace is unchanged. Replica errors are non-fatal: if a replica endpoint is unavailable, LangSmith logs the error without affecting the primary trace.
 
 <Warning>
 Auth does not propagate in distributed traces. When a trace spans multiple services, LangSmith forwards replica `project_name` and `updates` to downstream services automatically, but not API keys or credentials. Each service must configure its own credentials for replica destinations.
@@ -690,4 +690,3 @@ await myPipeline("What is LangSmith?");
 ```
 
 </CodeGroup>
-


### PR DESCRIPTION
Fixes DOC-588

https://langchain-5e9cc07a-preview-replic-1774372525-f24c745.mintlify.app/langsmith/log-traces-to-project#write-traces-to-multiple-destinations-with-replicas