### PR TITLE
update OSS changelog

### DIFF
--- a/src/oss/python/releases/changelog.mdx
+++ b/src/oss/python/releases/changelog.mdx
@@ -10,7 +10,7 @@ rss: true
 </Callout>
 
 
-<Update label="Mar 23, 2026" tags={["deepagents"]} rss={{ title: "Mar 23, 2026 - deepagents" }}>
+<Update label="Mar 24, 2026" tags={["deepagents"]} rss={{ title: "Mar 24, 2026 - deepagents" }}>
     ## `deepagents` v0.5.0a1
 
     Alpha release of `deepagents` v0.5.0.


### PR DESCRIPTION
<img width="631" height="395" alt="Screenshot 2026-03-24 at 2 53 23 PM" src="https://github.com/user-attachments/assets/34520d9c-5690-413d-bdb5-d640fa170dfe" />

(I fixed the date to March 24 already)