### PR TITLE
Shared skills

### DIFF
--- a/src/langsmith/fleet/skills.mdx
+++ b/src/langsmith/fleet/skills.mdx
@@ -125,10 +125,10 @@ Deleting a skill removes it from the workspace and from all agents that use it. 
 
 Download skills from your Fleet workspace with the LangSmith CLI and install them locally for use in coding agents like Claude Code, Cursor, or Codex.
 
-By default, files are saved to `~/.agents/skills/<skill-name>/` and symlinked into `~/.claude/skills/<skill-name>/`.
+By default, files are saved to `~/.agents/skills/[skill-name]/` and symlinked into `~/.claude/skills/[skill-name]/`.
 
 ```bash
-langsmith fleet skills pull <skill-name> [flags]
+langsmith fleet skills pull [skill-name] [flags]
 ```
 
 | Flag | Description |


### PR DESCRIPTION
Adding shared skills support: skills can now be private to an agent or shared across a workspace

Preview: https://langchain-5e9cc07a-preview-shared-1774401882-b55bb96.mintlify.app/langsmith/fleet/skills

Fixes DOC-920