### PR TITLE
docs(deepagents): add JS changelog for deepagents v1.9.0-alpha.0

### DIFF
--- a/src/oss/deepagents/async-subagents.mdx
+++ b/src/oss/deepagents/async-subagents.mdx
@@ -15,7 +15,7 @@ For Python, install the `0.5.0a1` prerelease with `--pre` or `--allow-prerelease
 :::
 
 :::js
-For JavaScript, install the prerelease version explicitly, for example `deepagents@0.5.0-alpha.1`.
+For JavaScript, install the prerelease version explicitly, for example `deepagents@1.9.0-alpha.0`.
 :::
 </Warning>
 
@@ -182,7 +182,7 @@ Each tracked task records the task ID, agent name, thread ID, run ID, status, an
 :::
 
 :::js
-Task metadata is stored in a dedicated state channel (`asyncSubAgentTasks`) on the supervisor's graph, separate from the message history. This is critical because deep agents [compact their message history](/oss/deepagents/customization#summarization) when the context window fills up -- if task IDs were only in tool messages, they would be lost during compaction. The dedicated channel ensures the supervisor can always recall its tasks through `list_async_tasks`, even after multiple rounds of summarization.
+Task metadata is stored in a dedicated state channel (`asyncTasks`) on the supervisor's graph, separate from the message history. This is critical because deep agents [compact their message history](/oss/deepagents/customization#summarization) when the context window fills up -- if task IDs were only in tool messages, they would be lost during compaction. The dedicated channel ensures the supervisor can always recall its tasks through `list_async_tasks`, even after multiple rounds of summarization.
 
 Each tracked task records the task ID, agent name, thread ID, run ID, status, and timestamps (`createdAt`, `lastCheckedAt`, `lastUpdatedAt`).
 :::

--- a/src/oss/javascript/releases/changelog.mdx
+++ b/src/oss/javascript/releases/changelog.mdx
@@ -9,6 +9,19 @@ rss: true
 **Subscribe**: Our changelog includes an [RSS feed](https://docs.langchain.com/oss/javascript/releases/changelog/rss.xml) that can integrate with [Slack](https://slack.com/help/articles/218688467-Add-RSS-feeds-to-Slack), [email](https://zapier.com/apps/email/integrations/rss/1441/send-new-rss-feed-entries-via-email), Discord bots like [Readybot](https://readybot.io/) or [RSS Feeds to Discord Bot](https://rss.app/en/bots/rssfeeds-discord-bot), and other subscription tools.
 </Callout>
 
+<Update label="Mar 24, 2026" tags={["deepagents"]} rss={{ title: "Mar 24, 2026 - deepagents" }}>
+    ## `deepagents` v1.9.0-alpha.0
+
+    Alpha release of `deepagents` v1.9.0.
+
+    - **[Async subagents](/oss/deepagents/async-subagents)**: Deep Agents can launch non-blocking background tasks, so users can continue interacting with the agent while subagents work concurrently. Requires [LangSmith Deployment](/langsmith/deployment) for sub-agents.
+
+    - **[Backend](/oss/deepagents/backends) protocol v2**: We've introduced a new v2 backend protocol (`BackendProtocolV2`) with backward-compatible changes to the Deep Agents backend interface. Key changes:
+      - **Structured result types**: All methods now return structured `Result` objects (e.g., `ReadResult`, `LsResult`, `GrepResult`, `GlobResult`) with consistent error handling via an `error` field, instead of returning raw values or throwing exceptions.
+      - **Multi-modal file support**: `read()` returns a `ReadResult` with a `.content` field instead of a plain string. For binary files (images, PDFs, audio, video), the full raw `Uint8Array` content is returned via `readRaw()`, enabling agents to work with multi-modal files natively.
+      - **Simplified method names**: `lsInfo` -> `ls`, `grepRaw` -> `grep`, `globInfo` -> `glob`.
+      - **Backward compatible**: Existing v1 backends can be adapted to the v2 interface using `adaptBackendProtocol`. The v1 interfaces (`BackendProtocolV1`, `SandboxBackendProtocolV1`) are deprecated but retained for compatibility.
+</Update>
 <Update label="Jan 14, 2026" tags={["langgraph"]} rss={{ title: "Jan 14, 2026 - langgraph" }}>
     ## v1.1.0
 


### PR DESCRIPTION
## Summary

Adds a JavaScript changelog entry for the `deepagents` v1.9.0-alpha.0 release and updates the async subagents doc to reflect JS-specific naming changes.

## Changes

**JavaScript changelog** (`src/oss/javascript/releases/changelog.mdx`):
- New `<Update>` entry for `deepagents` v1.9.0-alpha.0 covering:
  - Async subagents support for non-blocking background tasks via remote LangGraph servers
  - Backend protocol v2 (`BackendProtocolV2`) with structured result types, multi-modal file support, simplified method names (`lsInfo` -> `ls`, `grepRaw` -> `grep`, `globInfo` -> `glob`), and backward compatibility via `adaptBackendProtocol`

**Async subagents doc** (`src/oss/deepagents/async-subagents.mdx`):
- Updated JS install example to `deepagents@1.9.0-alpha.0`
- Updated state channel name from `asyncSubAgentTasks` to `asyncTasks`
