### PR TITLE
feat: add ContextOverflowError to link map for API reference [closes DOC-910]

### DIFF
--- a/pipeline/preprocessors/link_map.py
+++ b/pipeline/preprocessors/link_map.py
@@ -211,6 +211,9 @@ LINK_MAPS: list[LinkMap] = [
             "InMemoryStore": "langchain-core/stores/InMemoryStore",
             # Callbacks
             "on_llm_new_token": "langchain-core/callbacks/base/AsyncCallbackHandler/on_llm_new_token",
+            # Exceptions
+            "ContextOverflowError": "langchain-core/exceptions/ContextOverflowError",
+            "OutputParserException": "langchain-core/exceptions/OutputParserException",
             # Rate limiters
             "InMemoryRateLimiter": "langchain-core/rate_limiters/InMemoryRateLimiter",
             # LangSmith SDK

--- a/src/oss/deepagents/context-engineering.mdx
+++ b/src/oss/deepagents/context-engineering.mdx
@@ -327,7 +327,7 @@ This dual approach ensures the agent maintains awareness of its goals and progre
 - Triggers at 85% of the model's `max_input_tokens` from its [model profile](/oss/langchain/models#model-profiles)
 - Keeps 10% of tokens as recent context
 - Falls back to 170,000-token trigger / 6 messages kept if model profile is unavailable
-- If any model call raises a standard `ContextOverflowError`, Deep Agents immediately falls back to summarization and retries with summary + recent preserved messages
+- If any model call raises a standard @[ContextOverflowError], Deep Agents immediately falls back to summarization and retries with summary + recent preserved messages
 - Older messages are summarized by the model
 
 :::python

--- a/src/oss/python/releases/changelog.mdx
+++ b/src/oss/python/releases/changelog.mdx
@@ -43,7 +43,7 @@ rss: true
     * Changes to [conversation history summarization](/oss/deepagents/harness#conversation-history-summarization):
       * Summarization now happens in the model node via `wrap_model_call` events. Due to this we retain the full message history in the graph state.
       * More accurate token counting.
-      * Summarization will now automatically trigger if a chat model raises a `ContextOverflowError` (defined in `langchain-core`). Currently `langchain-anthropic` and `langchain-openai` support this.
+      * Summarization will now automatically trigger if a chat model raises a @[ContextOverflowError] (defined in `langchain-core`). Currently `langchain-anthropic` and `langchain-openai` support this.
     * We now default to the Responses API for model strings prefixed with `"openai:"`.
         <Accordion
             title="Disable data retention with the Responses API"


### PR DESCRIPTION
## Description
Adds `ContextOverflowError` and `OutputParserException` to the link map so docs can reference them with `@[ContextOverflowError]` and `@[OutputParserException]` syntax, linking to the API reference at `reference.langchain.com`. Also updates existing mentions of `ContextOverflowError` in the Deep Agents and changelog docs to use the auto-link syntax.

Resolves DOC-910

## Test Plan
- [ ] Verify `@[ContextOverflowError]` resolves to `https://reference.langchain.com/python/langchain-core/exceptions/ContextOverflowError` in built docs
- [ ] Verify links render correctly on the Deep Agents context-engineering page and changelog page