### PR TITLE
fix: clarify redis tls is enabled by default in self-hosted docs [closes DOC-924]

### DIFF
--- a/src/langsmith/self-host-external-redis.mdx
+++ b/src/langsmith/self-host-external-redis.mdx
@@ -144,7 +144,7 @@ redis://redis-node-2:6379
 Do not include a password in these URIs, and do not use `rediss` here. For Redis Cluster:
 
 - Provide the password separately via `redis.external.cluster.password` or through a Secret using `passwordSecretKey`.
-- Enable TLS separately with `redis.external.cluster.tlsEnabled: true`.
+- TLS is enabled by default for Redis Cluster (`redis.external.cluster.tlsEnabled: true`). Set `tlsEnabled: false` if your cluster does not use TLS.
 
 ### Configuration
 
@@ -168,7 +168,7 @@ redis:
         - "redis://redis-node-2:6379"
       # Optional. If your cluster requires auth, set a password or use a Secret (recommended).
       password: "your_redis_password"
-      # Enable if your cluster uses TLS.
+      # TLS is enabled by default. Set to false if your cluster does not use TLS.
       tlsEnabled: true
 ```
 
@@ -217,7 +217,7 @@ To validate the Redis server certificate:
 
 - Provide a CA bundle using `config.customCa.secretName` and `config.customCa.secretKey`.
 - For Standalone Redis, use `rediss://` in the connection URL.
-- For Redis Cluster, set `redis.external.cluster.tlsEnabled: true`.
+- For Redis Cluster, `redis.external.cluster.tlsEnabled` defaults to `true`. Ensure it is not set to `false`.
 
 <Warning>
 Mount a custom CA only when your Redis server uses an internal or private CA. Publicly trusted CAs do not require this configuration.
@@ -279,7 +279,7 @@ If your Redis server requires client certificate authentication:
 - Provide a Secret with your client certificate and key.
 - Reference it via `redis.external.clientCert.secretName` and specify the keys with `certSecretKey` and `keySecretKey`.
 - For Standalone Redis, keep using `rediss://` in the connection URL.
-- For Redis Cluster, set `redis.external.cluster.tlsEnabled: true`.
+- For Redis Cluster, `redis.external.cluster.tlsEnabled` defaults to `true`. Ensure it is not set to `false`.
 
 <CodeGroup>
 


### PR DESCRIPTION
## Description
Updates the self-hosted external Redis documentation to clarify that TLS is enabled by default for Redis Cluster (`tlsEnabled: true`), and explains how to disable it for clusters that don't use TLS. The previous wording implied TLS was disabled by default, which confused customers who needed to explicitly disable it.

Resolves DOC-924

## Test Plan
- [ ] Verify the updated page at `/langsmith/self-host-external-redis` renders correctly and the TLS default behavior is clear