### PR TITLE
fix: remove outdated saas-only callout from insights page

### DIFF
--- a/src/langsmith/insights.mdx
+++ b/src/langsmith/insights.mdx
@@ -8,7 +8,7 @@ The Insights Agent automatically analyzes your traces to detect usage patterns, 
 Insights uses hierarchical categorization to make sense of your data and highlight actionable trends.
 
 <Note>
-    Insights is available for LangSmith Plus and Enterprise [plans](https://www.langchain.com/pricing) and is only available for LangSmith SaaS deployments.
+    Insights is available for LangSmith Plus and Enterprise [plans](https://www.langchain.com/pricing).
 </Note>
 
 ## Prerequisites


### PR DESCRIPTION
## Description
Insights is now available on self-hosted deployments, so the callout incorrectly stating it was only available for SaaS has been removed.

## Test Plan
- [x] Verify the callout on https://docs.langchain.com/langsmith/insights no longer mentions SaaS-only availability
