### PR TITLE
ABAC_GA.mdx

### DIFF
--- a/src/langsmith/abac.mdx
+++ b/src/langsmith/abac.mdx
@@ -8,10 +8,6 @@ This reference explains LangSmith's Attribute-Based Access Control (ABAC) system
 ABAC complements [Role-Based Access Control (RBAC)](/langsmith/rbac) by adding tag-based conditions to access decisions. While RBAC grants blanket permissions based on a user's role (e.g., "can read all projects"), ABAC lets you restrict or grant access based on resource tags (e.g., "can only read projects tagged with Environment=Development").
 
 <Note>
-ABAC (Attribute-Based Access Control) is an Enterprise feature in private beta. If you are interested in upgrading to Enterprise, [contact our sales team](https://www.langchain.com/contact-sales).
-</Note>
-
-<Note>
 Roles and resource tags can be managed via the UI or API. ABAC policies are configurable via the [API](https://api.smith.langchain.com/docs#/access_policies). Once configured, policies are automatically enforced in both the API and the UI.
 </Note>
 


### PR DESCRIPTION
This is the version of ABAC Docs which remove the note about the feature being in private beta / private preview. This is the version that should appear for General Access (GA).

## Overview
We are releasing ABAC as a feature to 100% of Enterprise users by noon ET on Friday, March 26, 2026. 

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!--

-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x ] I have tested my changes locally using `docs dev`
- [x ] All code examples have been tested and work correctly
- [ x] I have used **root relative** paths for internal links
- [x ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
I just started this week -- please feel free to be extensive in any feedback on how I handled this -- I want to make sure to get it right. 
