### PR TITLE
Fix encryption docs: stop steering users toward custom encryption when basic suffices

### DIFF
--- a/src/langsmith/encryption.mdx
+++ b/src/langsmith/encryption.mdx
@@ -9,8 +9,8 @@ Agent Server supports encryption at rest for checkpoint data and metadata. You c
 
 | Method | What's encrypted | Use case |
 |--------|------------------|----------|
-| **Basic encryption** | Checkpoint blobs, optionally JSON fields | Single static key, automatic AES encryption |
-| **Custom encryption** | Checkpoints, threads, runs, assistants, crons and stores | Per-tenant keys, KMS integration, selective field encryption |
+| **Basic encryption** | Checkpoint blobs, optionally JSON fields | Single static key, automatic AES encryption, selective field encryption |
+| **Custom encryption** | Checkpoints, threads, runs, assistants, crons and stores | Per-tenant keys, KMS integration |
 
 ## Basic encryption
 
@@ -55,11 +55,14 @@ Requires Agent Server version 0.6.22+ and Python SDK version `langgraph-sdk>=0.3
 Agent Server versions 0.5.34–0.6.21 included a pre-release version of custom encryption. Data encrypted with these versions will be corrupted when upgrading to 0.6.22+. Do not use custom encryption on these versions.
 </Warning>
 
+<Warning>
+Only use custom encryption if basic encryption doesn't meet your needs. Custom encryption requires you to implement and maintain encryption handlers, and adds operational complexity. If you only need a single static key with optional selective field encryption, use [basic encryption](#basic-encryption) instead.
+</Warning>
+
 Use custom encryption when you need:
 
 - **Per-tenant key isolation** — different encryption keys for different customers
 - **KMS integration** — AWS KMS, Google Cloud KMS, or HashiCorp Vault for key management, rotation, and audit logging
-- **Selective field encryption** — encrypt sensitive metadata fields while keeping others searchable
 
 ### How it works
 


### PR DESCRIPTION
- Moves "selective field encryption" to the basic encryption row in the comparison table — `LANGGRAPH_AES_JSON_KEYS` already handles this use case, so listing it as a reason to use custom encryption was misleading
- Removes the "Selective field encryption" bullet from the custom encryption use-case list
- Adds a prominent `<Warning>` box at the top of the custom encryption section making it explicit that custom encryption should only be used when basic encryption doesn't meet your needs

## Why

The doc was implicitly directing users toward custom encryption (more complex, requires implementing/maintaining handlers) for a use case (selective field encryption) that basic encryption already covers natively. This increases operational burden unnecessarily.

I've already jumped on one random customer call to Shepard folks in the right direction, this should prevent that from repeating.