### PR TITLE
docs: Add Usage Telemetry section to self-hosted egress documentation

### DIFF
--- a/src/langsmith/self-host-egress.mdx
+++ b/src/langsmith/self-host-egress.mdx
@@ -11,6 +11,7 @@ Self-hosted LangSmith instances store all information locally and never send sen
 
 - **Billing telemetry** — License verification and subscription/usage reporting (required)
 - **Operational telemetry** — Logs, metrics, and traces for support diagnostics (optional, can be disabled)
+- **Usage telemetry** — Anonymized usage snapshots for product insights (optional, can be disabled)
 
 <Warning>
 **Egress to `https://beacon.langchain.com` is required.** Refer to the [allowlisting IP section](/langsmith/cloud#allowlisting-ip-addresses) for static IP addresses, if needed.
@@ -393,6 +394,72 @@ We only export error log messages from self-hosted LangSmith instances. This all
   ]
 }
 ```
+
+## Usage telemetry
+
+Usage telemetry collects anonymized snapshots of your LangSmith instance's usage metrics. This data helps LangChain understand platform adoption patterns and inform product development decisions.
+
+<Info>
+Usage telemetry is **optional** and can be disabled. Unlike billing telemetry, you have full control over whether these snapshots are sent to LangChain.
+</Info>
+
+### What it does
+
+- Captures aggregated usage metrics at regular intervals
+- Provides insight into feature adoption and platform growth
+- Helps LangChain prioritize improvements and new features based on real-world usage
+
+### What we collect
+
+- **Platform metrics**: Counts of workspaces, projects, experiments, datasets, evaluators, and other platform resources
+- **Feature usage**: Counts of run rules, annotation queues, prompts, and prompt-related activity
+- **Active users**: Count of active PATs (Personal Access Tokens) in the last 30 days
+- **Timestamps**: Time range for the snapshot (from/to timestamps in UTC)
+
+<Info>
+All metrics are **aggregated counts only**. No individual resource data, identifiers, or usage patterns are collected. We do not collect any information that could identify your end users or customers.
+</Info>
+
+### Example payloads
+
+**Endpoint:** `POST /v1/beacon/usage-snapshot`
+
+**Request:**
+
+```json
+{
+  "license_key": "<YOUR_LICENSE_KEY>",
+  "from_timestamp": "2026-03-25T02:00:00+00:00",
+  "to_timestamp": "2026-03-26T02:00:00+00:00",
+  "measures": {
+    "workspaces": 12,
+    "projects": 87,
+    "experiments": 34,
+    "datasets": 15,
+    "evaluators": 8,
+    "run_rules": 5,
+    "annotation_queues": 3,
+    "prompts": 22,
+    "prompt_commits": 156,
+    "prompt_pulls": 1043,
+    "active_pats_30d": 47
+  }
+}
+```
+
+### How to disable
+
+You can disable usage telemetry by setting the following environment variable in your deployment configuration:
+
+```yaml
+PHONE_HOME_USAGE_REPORTING_ENABLED: false
+```
+
+Add this to the `commonEnv` section of your Helm configuration to permanently disable usage telemetry reporting.
+
+<Warning>
+Disabling usage telemetry does **not** affect billing or operational telemetry. License verification and subscription/usage reporting will continue to function normally.
+</Warning>
 
 ## Our commitment
 


### PR DESCRIPTION
## Summary

This PR adds a new **Usage Telemetry** section to the self-hosted egress configuration documentation.

## Changes

- Added comprehensive Usage Telemetry section documenting optional telemetry for anonymized usage snapshots
- Includes what it does, what we collect, example JSON payload, and how to disable
- Documents the `PHONE_HOME_USAGE_REPORTING_ENABLED` environment variable for Helm configuration
- Updated the introduction to list usage telemetry alongside billing and operational telemetry

## Details

The new section follows the existing documentation pattern for billing and operational telemetry, with:
- Clear explanation of purpose and scope
- Privacy guarantees (aggregated counts only, no PII)
- Complete example payload with the `POST /v1/beacon/usage-snapshot` endpoint
- Configuration instructions for disabling the feature
- Warning note clarifying that disabling usage telemetry doesn't affect other telemetry types

## File Modified
- `src/langsmith/self-host-egress.mdx`