### PR TITLE
fix: replace Python str type with z.string() in TypeScript example

### DIFF
--- a/src/oss/langchain/models.mdx
+++ b/src/oss/langchain/models.mdx
@@ -1211,7 +1211,7 @@ It can be useful to return the raw @[`AIMessage`] object alongside the parsed re
     import * as z from "zod";
 
     const Actor = z.object({
-      name: str
+      name: z.string(),
       role: z.string(),
     });
 

--- a/src/oss/langchain/models.mdx
+++ b/src/oss/langchain/models.mdx
@@ -1223,7 +1223,6 @@ It can be useful to return the raw @[`AIMessage`] object alongside the parsed re
       budget: z.number().nullable().describe("Budget in millions USD"),
     });
 
-    const model = await initChatModel("openai:gpt-4.1-mini");
     const modelWithStructure = model.withStructuredOutput(MovieDetails);
     ```
     :::

--- a/src/oss/langchain/models.mdx
+++ b/src/oss/langchain/models.mdx
@@ -1223,6 +1223,7 @@ It can be useful to return the raw @[`AIMessage`] object alongside the parsed re
       budget: z.number().nullable().describe("Budget in millions USD"),
     });
 
+    const model = await initChatModel("openai:gpt-4.1-mini");
     const modelWithStructure = model.withStructuredOutput(MovieDetails);
     ```
     :::


### PR DESCRIPTION
In the nested structures TypeScript example, `name: str` uses  Python syntax instead of TypeScript/Zod syntax.

Fixed `name: str` → `name: z.string()` to match the correct  Zod schema definition used throughout the rest of the file.

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
