### PR TITLE
docs: Add a note for ChatOCIGenAI about the expensive initialization

### DIFF
--- a/src/oss/python/integrations/providers/oci.mdx
+++ b/src/oss/python/integrations/providers/oci.mdx
@@ -20,6 +20,10 @@ uv add langchain-oci oci
 
 ## Authentication
 
+<Note>
+    Initializing [ChatOCIGenAI](#chatocigenai) is resource-intensive. For optimal performance, it is recommended to treat this client as a singleton and reuse the instance across your application.
+</Note>
+
 Four authentication methods are supported for OCI services. All methods follow the [standard OCI SDK authentication](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdk_authentication_methods.htm).
 
 ### API Key (Default)


### PR DESCRIPTION
## Overview
- Adding a note about the expensive initialization (In order of 5-10s seconds) for cases for customers
- The expensive initialization is due to setting Retry strategy, loading SDK configurations, loading private keys in the signer.

## Type of change

Update existing documentation 

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Testing

<img width="762" height="308" alt="Screenshot 2026-03-27 at 1 03 17 AM" src="https://github.com/user-attachments/assets/12c23f80-2d22-4cc1-8490-5e920cd5f3cf" />
