### PR TITLE
docs: Add CRW document loader integration

### DIFF
--- a/src/oss/python/integrations/document_loaders/crw.mdx
+++ b/src/oss/python/integrations/document_loaders/crw.mdx
@@ -1,0 +1,153 @@
+---
+title: "CRW"
+description: "Integrate with the CRW document loader using LangChain Python."
+---
+
+[CRW](https://github.com/us/crw) is an open-source, high-performance web scraper built for AI agents. Written in Rust, it crawls and converts any website into clean markdown with JS rendering support. Self-hosted (free) or managed cloud at [fastcrw.com](https://fastcrw.com).
+
+## Overview
+
+### Integration details
+
+| Class | Package | Local | Serializable | JS support |
+| :--- | :--- | :---: | :---: | :---: |
+| CrwLoader | [langchain-crw](https://pypi.org/project/langchain-crw/) | ✅ | ❌ | ❌ |
+
+### Loader features
+
+| Source | Document Lazy Loading | Native Async Support |
+| :---: | :---: | :---: |
+| CrwLoader | ✅ | ❌ |
+
+## Setup
+
+```bash
+pip install langchain-crw
+```
+
+### Self-hosted (no API key needed)
+
+```bash
+# Install and run CRW locally
+curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | bash
+crw
+```
+
+### Cloud
+
+Set environment variables for [fastcrw.com](https://fastcrw.com):
+
+```bash
+export CRW_API_URL=https://fastcrw.com/api
+export CRW_API_KEY=crw_live_...
+```
+
+## Usage
+
+### Scrape a single page
+
+```python
+from langchain_crw import CrwLoader
+
+loader = CrwLoader(url="https://example.com", mode="scrape")
+docs = loader.load()
+
+print(docs[0].page_content[:200])
+print(docs[0].metadata)
+```
+
+### Lazy loading
+
+```python
+pages = []
+for doc in loader.lazy_load():
+    pages.append(doc)
+    if len(pages) >= 10:
+        # do some paged operation, e.g.
+        # index.upsert(pages)
+        pages = []
+```
+
+## Modes
+
+- `scrape`: Scrape a single URL and return clean markdown.
+- `crawl`: Crawl the URL and all accessible subpages, return markdown for each.
+- `map`: Discover all URLs on a website via sitemap and link discovery.
+
+### Crawl
+
+```python
+loader = CrwLoader(
+    url="https://docs.example.com",
+    mode="crawl",
+    params={"max_depth": 3, "max_pages": 50},
+)
+
+docs = loader.load()
+print(f"Crawled {len(docs)} pages")
+```
+
+### Map
+
+```python
+loader = CrwLoader(url="https://example.com", mode="map")
+docs = loader.load()
+
+urls = [doc.page_content for doc in docs]
+print(f"Found {len(urls)} URLs")
+```
+
+## Scrape with options
+
+```python
+loader = CrwLoader(
+    url="https://spa-app.example.com",
+    mode="scrape",
+    params={
+        "render_js": True,
+        "wait_for": 3000,
+        "css_selector": "article.main-content",
+        "only_main_content": True,
+    },
+)
+docs = loader.load()
+```
+
+## RAG pipeline example
+
+```python
+from langchain_crw import CrwLoader
+from langchain_openai import OpenAIEmbeddings
+from langchain_community.vectorstores import FAISS
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+# Crawl documentation site
+loader = CrwLoader(
+    url="https://docs.example.com",
+    mode="crawl",
+    params={"max_depth": 3, "max_pages": 50},
+)
+docs = loader.load()
+
+# Split and embed
+splitter = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
+chunks = splitter.split_documents(docs)
+vectorstore = FAISS.from_documents(chunks, OpenAIEmbeddings())
+
+# Query
+results = vectorstore.similarity_search("how to authenticate")
+```
+
+## Migrating from FireCrawlLoader
+
+CrwLoader supports the same scrape, crawl, and map modes with a similar interface. CrwLoader defaults to `mode="scrape"` while FireCrawlLoader defaults to `mode="crawl"`.
+
+```python
+# Before
+from langchain_community.document_loaders import FireCrawlLoader
+loader = FireCrawlLoader(url="https://example.com", api_key="fc-...", mode="scrape")
+
+# After — self-hosted, no SDK dependency needed
+from langchain_crw import CrwLoader
+loader = CrwLoader(url="https://example.com", mode="scrape")
+```

--- a/src/oss/python/integrations/providers/crw.mdx
+++ b/src/oss/python/integrations/providers/crw.mdx
@@ -1,0 +1,54 @@
+---
+title: "CRW integrations"
+description: "Integrate with CRW using LangChain Python."
+---
+
+>[CRW](https://github.com/us/crw) is an open-source, high-performance web scraper built for AI agents.
+> Written in Rust, it crawls and converts any website into clean markdown. 
+> Self-hosted (free) or managed cloud at [fastcrw.com](https://fastcrw.com).
+
+## Installation and setup
+
+Install the LangChain integration package:
+
+<CodeGroup>
+```bash pip
+pip install langchain-crw
+```
+
+```bash uv
+uv add langchain-crw
+```
+</CodeGroup>
+
+### Self-hosted (free)
+
+Run CRW locally — no API key, no account, no limits:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/us/crw/main/install.sh | bash
+crw
+```
+
+Or use Docker:
+
+```bash
+docker run -p 3000:3000 ghcr.io/us/crw:latest
+```
+
+### Cloud
+
+Get an API key from [fastcrw.com](https://fastcrw.com) and set environment variables:
+
+```bash
+export CRW_API_URL=https://fastcrw.com/api
+export CRW_API_KEY=crw_live_...
+```
+
+## Document loader
+
+See a [usage example](/oss/integrations/document_loaders/crw).
+
+```python
+from langchain_crw import CrwLoader
+```


### PR DESCRIPTION
## Summary

Adds documentation for [CRW](https://github.com/us/crw), an open-source web scraper built for AI agents, as a LangChain document loader integration.

**Files added:**
- `src/oss/python/integrations/providers/crw.mdx` — Provider page with installation and setup
- `src/oss/python/integrations/document_loaders/crw.mdx` — Document loader page with usage examples

**PyPI package:** [`langchain-crw`](https://pypi.org/project/langchain-crw/)

### What CRW provides

- `CrwLoader` — Document loader with three modes: `scrape`, `crawl`, and `map`
- Self-hosted (free, no API key) or managed cloud ([fastcrw.com](https://fastcrw.com))
- High-performance Rust-based scraper with JS rendering support
- Firecrawl-compatible API — includes migration guide from `FireCrawlLoader`

### Documentation follows existing patterns

Modeled after the existing FireCrawl integration docs, including:
- Overview tables (integration details + loader features)
- Setup instructions (self-hosted + cloud)
- Usage examples for all three modes (scrape, crawl, map)
- RAG pipeline example
- Migration guide from FireCrawlLoader