### PR TITLE
docs(messages): add serialization section with dump/load examples

### DIFF
--- a/src/code-samples/langchain/message-serialization.py
+++ b/src/code-samples/langchain/message-serialization.py
@@ -1,0 +1,20 @@
+# :snippet-start: message-serialization-py
+from langchain.messages import HumanMessage
+from langchain_core.load import dumpd, load
+
+message = HumanMessage("What is the capital of France?")
+
+# Serialize to a plain dict
+serialized = dumpd(message)
+
+# Deserialize back to a message object
+restored = load(serialized)
+# :snippet-end:
+
+# :remove-start:
+if __name__ == "__main__":
+    assert isinstance(serialized, dict)
+    assert isinstance(restored, HumanMessage)
+    assert restored.content == message.content
+    print("✓ Message serialization round-trip works")
+# :remove-end:

--- a/src/code-samples/langchain/message-serialization.ts
+++ b/src/code-samples/langchain/message-serialization.ts
@@ -1,0 +1,30 @@
+// :snippet-start: message-serialization-js
+import { HumanMessage } from "@langchain/core/messages";
+import { load } from "@langchain/core/load";
+
+const message = new HumanMessage("What is the capital of France?");
+
+// Serialize to a plain object
+const serialized = message.toJSON();
+
+// Deserialize back to a message object
+const restored = await load<HumanMessage>(JSON.stringify(serialized));
+// :snippet-end:
+
+// :remove-start:
+async function main() {
+  if (typeof serialized !== "object" || serialized === null) {
+    throw new Error(`Expected plain object, got ${typeof serialized}`);
+  }
+  if (!(restored instanceof HumanMessage)) {
+    throw new Error(`Expected HumanMessage, got ${restored?.constructor?.name}`);
+  }
+  if (restored.content !== message.content) {
+    throw new Error(
+      `Expected content "${message.content}", got "${restored.content}"`,
+    );
+  }
+  console.log("✓ Message serialization round-trip works");
+}
+main();
+// :remove-end:

--- a/src/oss/langchain/messages.mdx
+++ b/src/oss/langchain/messages.mdx
@@ -1804,6 +1804,54 @@ const imageBlock: ContentBlock.Multimodal.Image = {
     Content blocks are not a replacement for the @[`content`][BaseMessage(content)] property, but rather a new property that can be used to access the content of a message in a standardized format.
 </Info>
 
+## Serialization
+
+Messages can be serialized to plain objects for storage and deserialized back to message instances. This is useful for persisting conversation history and resuming sessions.
+
+:::python
+```python
+from langchain_core.messages import HumanMessage
+from langchain_core.load import dumpd, load
+
+message = HumanMessage("What is the capital of France?")
+
+# Serialize to a plain dict
+serialized = dumpd(message)
+
+# Deserialize back to a message object
+restored = load(serialized)
+```
+:::
+
+:::js
+```typescript
+import { HumanMessage } from "@langchain/core/messages";
+import { dump, load } from "@langchain/core/load";
+
+const message = new HumanMessage("What is the capital of France?");
+
+// Serialize to a plain object
+const serialized = dump(message);
+
+// Deserialize back to a message object
+const restored = await load<HumanMessage>(serialized);
+```
+:::
+
+:::python
+<Warning>
+**`load()` instantiates Python objects and can trigger side effects during deserialization. Never call `load()` on data from an untrusted or unauthenticated source.**
+</Warning>
+:::
+
+:::js
+<Warning>
+**`load()` deserializes data by instantiating classes and invoking constructors. Never call `load()` on untrusted or user-supplied input.** Only deserialize data that originates from a source you control, such as your own database.
+</Warning>
+:::
+
+---
+
 ## Use with chat models
 
 [Chat models](/oss/langchain/models) accept a sequence of message objects as input and return an @[`AIMessage`] as output. Interactions are often stateless, so that a simple conversational loop involves invoking a model with a growing list of messages.

--- a/src/oss/langchain/messages.mdx
+++ b/src/oss/langchain/messages.mdx
@@ -1810,8 +1810,8 @@ Messages can be serialized to plain objects for storage and deserialized back to
 
 :::python
 ```python
-from langchain_core.messages import HumanMessage
-from langchain_core.load import dumpd, load
+from langchain.messages import HumanMessage
+from langchain.load import dumpd, load
 
 message = HumanMessage("What is the capital of France?")
 

--- a/src/oss/langchain/messages.mdx
+++ b/src/oss/langchain/messages.mdx
@@ -1813,7 +1813,7 @@ const imageBlock: ContentBlock.Multimodal.Image = {
 
 ## Serialization
 
-Messages can be serialized to plain objects for storage and deserialized back to message instances. This is useful for persisting conversation history and resuming sessions.
+You can serialize messages to plain objects for storage and deserialized back to message instances. This is useful for persisting conversation history and resuming sessions.
 
 :::python
 ```python
@@ -1856,8 +1856,6 @@ const restored = await load<HumanMessage>(serialized);
 **`load()` deserializes data by instantiating classes and invoking constructors. Never call `load()` on untrusted or user-supplied input.** Only deserialize data that originates from a source you control, such as your own database.
 </Warning>
 :::
-
----
 
 ## Use with chat models
 

--- a/src/oss/langchain/messages.mdx
+++ b/src/oss/langchain/messages.mdx
@@ -1817,8 +1817,8 @@ Messages can be serialized to plain objects for storage and deserialized back to
 
 :::python
 ```python
-from langchain_core.messages import HumanMessage
-from langchain_core.load import dumpd, load
+from langchain.messages import HumanMessage
+from langchain.load import dumpd, load
 
 message = HumanMessage("What is the capital of France?")
 

--- a/src/oss/langchain/messages.mdx
+++ b/src/oss/langchain/messages.mdx
@@ -2,6 +2,9 @@
 title: Messages
 ---
 
+import MessageSerializationPy from '/snippets/code-samples/message-serialization-py.mdx';
+import MessageSerializationJs from '/snippets/code-samples/message-serialization-js.mdx';
+
 {/* TODO: section on metadata types (response and usage) */}
 
 Messages are the fundamental unit of context for models in LangChain. They represent the input and output of models, carrying both the content and metadata needed to represent the state of a conversation when interacting with an LLM.
@@ -1813,36 +1816,18 @@ const imageBlock: ContentBlock.Multimodal.Image = {
 
 ## Serialization
 
-You can serialize messages to plain objects for storage and deserialized back to message instances. This is useful for persisting conversation history and resuming sessions.
+You can serialize messages to plain objects for storage and deserialize back to message instances. This is useful for persisting conversation history and resuming sessions.
 
 :::python
-```python
-from langchain.messages import HumanMessage
-from langchain.load import dumpd, load
 
-message = HumanMessage("What is the capital of France?")
+<MessageSerializationPy />
 
-# Serialize to a plain dict
-serialized = dumpd(message)
-
-# Deserialize back to a message object
-restored = load(serialized)
-```
 :::
 
 :::js
-```typescript
-import { HumanMessage } from "@langchain/core/messages";
-import { dump, load } from "@langchain/core/load";
 
-const message = new HumanMessage("What is the capital of France?");
+<MessageSerializationJs />
 
-// Serialize to a plain object
-const serialized = dump(message);
-
-// Deserialize back to a message object
-const restored = await load<HumanMessage>(serialized);
-```
 :::
 
 :::python

--- a/src/oss/langchain/messages.mdx
+++ b/src/oss/langchain/messages.mdx
@@ -1811,6 +1811,54 @@ const imageBlock: ContentBlock.Multimodal.Image = {
     Content blocks are not a replacement for the @[`content`][BaseMessage(content)] property, but rather a new property that can be used to access the content of a message in a standardized format.
 </Info>
 
+## Serialization
+
+Messages can be serialized to plain objects for storage and deserialized back to message instances. This is useful for persisting conversation history and resuming sessions.
+
+:::python
+```python
+from langchain_core.messages import HumanMessage
+from langchain_core.load import dumpd, load
+
+message = HumanMessage("What is the capital of France?")
+
+# Serialize to a plain dict
+serialized = dumpd(message)
+
+# Deserialize back to a message object
+restored = load(serialized)
+```
+:::
+
+:::js
+```typescript
+import { HumanMessage } from "@langchain/core/messages";
+import { dump, load } from "@langchain/core/load";
+
+const message = new HumanMessage("What is the capital of France?");
+
+// Serialize to a plain object
+const serialized = dump(message);
+
+// Deserialize back to a message object
+const restored = await load<HumanMessage>(serialized);
+```
+:::
+
+:::python
+<Warning>
+**`load()` instantiates Python objects and can trigger side effects during deserialization. Never call `load()` on data from an untrusted or unauthenticated source.**
+</Warning>
+:::
+
+:::js
+<Warning>
+**`load()` deserializes data by instantiating classes and invoking constructors. Never call `load()` on untrusted or user-supplied input.** Only deserialize data that originates from a source you control, such as your own database.
+</Warning>
+:::
+
+---
+
 ## Use with chat models
 
 [Chat models](/oss/langchain/models) accept a sequence of message objects as input and return an @[`AIMessage`] as output. Interactions are often stateless, so that a simple conversational loop involves invoking a model with a growing list of messages.

--- a/src/snippets/code-samples/message-serialization-js.mdx
+++ b/src/snippets/code-samples/message-serialization-js.mdx
@@ -1,0 +1,12 @@
+```ts
+import { HumanMessage } from "@langchain/core/messages";
+import { load } from "@langchain/core/load";
+
+const message = new HumanMessage("What is the capital of France?");
+
+// Serialize to a plain object
+const serialized = message.toJSON();
+
+// Deserialize back to a message object
+const restored = await load<HumanMessage>(JSON.stringify(serialized));
+```

--- a/src/snippets/code-samples/message-serialization-py.mdx
+++ b/src/snippets/code-samples/message-serialization-py.mdx
@@ -1,0 +1,12 @@
+```python
+from langchain.messages import HumanMessage
+from langchain_core.load import dumpd, load
+
+message = HumanMessage("What is the capital of France?")
+
+# Serialize to a plain dict
+serialized = dumpd(message)
+
+# Deserialize back to a message object
+restored = load(serialized)
+```


### PR DESCRIPTION
## Overview
Adds a "Serialization" section to the messages guide covering how to serialize and deserialize LangChain message objects using `dump()`/`load()` (JS) and `dumpd()`/`load()` (Python). This addresses a long-standing gap where there was no documentation on persisting messages to a database and restoring them.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: langchain-ai/langchainjs#10472
- Feature PR: langchain-ai/langchainjs#10542

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed