### PR TITLE
docs: update DuckDuckGo Python integration installs to use ddgs

### DIFF
--- a/src/oss/python/integrations/providers/duckduckgo_search.mdx
+++ b/src/oss/python/integrations/providers/duckduckgo_search.mdx
@@ -3,7 +3,7 @@ title: "DuckDuckGo search integrations"
 description: "Integrate with DuckDuckGo search using LangChain Python."
 ---
 
->[DuckDuckGo Search](https://github.com/deedy5/duckduckgo_search) is a package that
+>[DuckDuckGo Search](https://github.com/deedy5/ddgs) is a package that
 > searches for words, documents, images, videos, news, maps and text
 > translation using the `DuckDuckGo.com` search engine. It is downloading files
 > and images to a local hard drive.
@@ -14,11 +14,11 @@ You have to install a python package:
 
 <CodeGroup>
 ```bash pip
-pip install duckduckgo-search
+pip install ddgs
 ```
 
 ```bash uv
-uv add duckduckgo-search
+uv add ddgs
 ```
 </CodeGroup>
 

--- a/src/oss/python/integrations/tools/ddg.mdx
+++ b/src/oss/python/integrations/tools/ddg.mdx
@@ -8,7 +8,7 @@ This guide shows over how to use the DuckDuckGo search component.
 ## Usage
 
 ```python
-pip install -qU duckduckgo-search langchain-community
+pip install -qU ddgs langchain-community
 ```
 
 ```python


### PR DESCRIPTION
## Overview
Update DuckDuckGo Python docs to use `ddgs` in install commands.

## Type of change
**Type:** Update existing documentation

## Related issues/PRs
N/A

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed


## Additional notes
Reason: `duckduckgo-search` has been renamed to `ddgs`, so install commands were updated accordingly.
Reference: https://pypi.org/project/duckduckgo-search/
