### PR TITLE
oss: clarify that new integrations must be independent packages

### DIFF
--- a/pipeline/tools/partner_pkg_table.py
+++ b/pipeline/tools/partner_pkg_table.py
@@ -224,7 +224,7 @@ To see a full list of integrations by component type, refer to the categories in
 Community integrations can be found in [`langchain-community`](https://github.com/langchain-ai/langchain-community).
 
 <Info>
-    If you'd like to contribute an integration, see the [contributing guide](/oss/contributing).
+    Want to build your own integration? See [how to create a custom integration package](/oss/contributing/integrations).
 </Info>
 
 """  # noqa: E501

--- a/src/oss/contributing/integrations-langchain.mdx
+++ b/src/oss/contributing/integrations-langchain.mdx
@@ -7,6 +7,10 @@ sidebarTitle: Guide
 
 LangChain provides standard interfaces for several different components (language models, vector stores, etc) that are crucial when building LLM applications. Implementing a new integration helps expand LangChain's ecosystem and makes your service discoverable to millions of developers.
 
+<Warning>
+    New integrations are **not accepted as PRs** to any `langchain-ai` repository. All new integrations must be published as independent packages to PyPI (e.g., `langchain-yourprovider`). The only PR you should open to a `langchain-ai` repo is to add documentation for your published package.
+</Warning>
+
 ## Why implement a LangChain integration?
 
 <Card title="Discoverability" icon="search">

--- a/src/oss/contributing/overview.mdx
+++ b/src/oss/contributing/overview.mdx
@@ -108,9 +108,11 @@ LangChain has helped form the largest developer community in generative AI, and 
         </Columns>
         :::
     </Accordion>
-    <Accordion title="Add a new integration" icon="plug-connected">
-        <Card title="LangChain" icon="link" href="/oss/contributing/integrations-langchain" arrow>Guide to adding a new LangChain integration</Card>
-        <Card title="Deep Agents sandboxes" icon="cube" href="/oss/contributing/integrations-langchain" arrow>Guide to contributing a sandbox integration</Card>
+    <Accordion title="Build a new integration" icon="plug-connected">
+        Anyone can build and publish their own LangChain integration package. New integrations are not accepted as PRs to `langchain-ai` repos — they must be published independently to PyPI or npm.
+
+        <Card title="LangChain" icon="link" href="/oss/contributing/integrations-langchain" arrow>Guide to building a LangChain integration</Card>
+        <Card title="Deep Agents sandboxes" icon="cube" href="/oss/contributing/integrations-langchain" arrow>Guide to building a sandbox integration</Card>
     </Accordion>
 </AccordionGroup>
 


### PR DESCRIPTION
Clarify across contributing docs and the integrations landing page that `langchain-ai` repos don't accept new integration PRs.