### PR TITLE
docs: Add pdfmux PDF document loader integration

### DIFF
--- a/src/oss/python/integrations/document_loaders/index.mdx
+++ b/src/oss/python/integrations/document_loaders/index.mdx
@@ -71,6 +71,7 @@ The below document loaders allow you to load PDF documents.
 | [Docling](/oss/integrations/document_loaders/docling) | Load PDF files using Docling | Package |
 | [UnDatasIO](/oss/integrations/document_loaders/undatasio) | Load PDF files using UnDatasIO | Package |
 | [OpenDataLoader PDF](/oss/integrations/document_loaders/opendataloader_pdf) | Load PDF files using OpenDataLoader PDF | Package |
+| [PDFMux](/oss/integrations/document_loaders/pdfmux) | Smart-routing PDF extraction with confidence scoring and self-healing | Package |
 
 
 ### Cloud providers

--- a/src/oss/python/integrations/document_loaders/pdfmux.mdx
+++ b/src/oss/python/integrations/document_loaders/pdfmux.mdx
@@ -1,0 +1,103 @@
+---
+title: "PDFMux integration"
+description: "Integrate with the PDFMux document loader using LangChain Python."
+---
+
+[PDFMux](https://pdfmux.com) is a self-healing PDF extraction orchestrator that routes each page to the best extraction pipeline automatically. Instead of relying on a single parser, PDFMux selects the optimal extractor per page based on content type (text-heavy, scanned, tables, mixed) and retries with alternative extractors when quality is low.
+
+## Overview
+
+### Integration details
+
+| Class | Package | Local | Serializable | JS support |
+| :--- | :--- | :---: | :---: | :---: |
+| [PDFMuxLoader](https://github.com/NameetP/langchain-pdfmux) | [langchain-pdfmux](https://pypi.org/project/langchain-pdfmux/) | ✅ | ❌ | ❌ |
+
+### Loader features
+
+| Source | Document Lazy Loading | Native Async Support |
+| :---: | :---: | :---: |
+| PDFMuxLoader | ✅ | ❌ |
+
+## Setup
+
+### Credentials
+
+No credentials are needed to use this loader. PDFMux runs entirely locally.
+
+### Installation
+
+```bash
+pip install -U langchain-pdfmux
+```
+
+## Initialization
+
+```python
+from langchain_pdfmux import PDFMuxLoader
+
+loader = PDFMuxLoader("./example_data/report.pdf")
+```
+
+## Load
+
+```python
+docs = loader.load()
+docs[0]
+```
+
+```text
+Document(metadata={'source': './example_data/report.pdf', 'title': 'Q4 Results', 'page_start': 1, 'page_end': 3, 'tokens': 820, 'confidence': 0.94}, page_content='...')
+```
+
+Each document includes a `confidence` score (0.0--1.0) indicating extraction quality. Use this to filter or re-rank chunks in your RAG pipeline:
+
+```python
+# Only keep high-confidence extractions
+high_quality_docs = [doc for doc in docs if doc.metadata.get("confidence", 0) >= 0.8]
+```
+
+## Quality modes
+
+PDFMux supports three quality presets that control the extraction strategy:
+
+```python
+# Fast -- single-pass extraction, best for clean digital PDFs
+loader = PDFMuxLoader("report.pdf", quality="fast")
+
+# Standard (default) -- smart routing with fallback
+loader = PDFMuxLoader("report.pdf", quality="standard")
+
+# High -- multi-extractor with consensus, best for complex layouts
+loader = PDFMuxLoader("report.pdf", quality="high")
+```
+
+## Load a directory
+
+```python
+# Load all PDFs in a directory
+loader = PDFMuxLoader("./papers/")
+
+# Custom glob pattern
+loader = PDFMuxLoader("./papers/", glob="**/*.pdf")
+```
+
+## Lazy load
+
+```python
+for doc in PDFMuxLoader("large.pdf").lazy_load():
+    print(doc.metadata["confidence"])
+    # Process each chunk individually
+```
+
+## Why PDFMux?
+
+Most PDF loaders use a single extraction method and silently fail on complex layouts. PDFMux solves this with:
+
+- **Smart routing** -- automatically selects the optimal parser per page (text-heavy, scanned, tables, mixed)
+- **Confidence scoring** -- every chunk includes a quality score so your RAG pipeline can filter or re-rank
+- **Self-healing** -- retries with alternative extractors when the primary one returns low-quality output
+
+## API reference
+
+For full documentation and source code, see the [langchain-pdfmux GitHub repository](https://github.com/NameetP/langchain-pdfmux).


### PR DESCRIPTION
## Summary

Adds documentation for [PDFMux](https://pdfmux.com), a PDF extraction orchestrator available as [`langchain-pdfmux`](https://pypi.org/project/langchain-pdfmux/) (v0.2.0) on PyPI.

**What is PDFMux?**

Most PDF loaders use a single extraction method and silently fail on complex layouts. PDFMux solves this by automatically routing each page to the optimal extractor based on content type (text-heavy, scanned, tables, mixed). Key features:

- **Smart routing** — selects the best parser per page automatically
- **Confidence scoring** — every document chunk includes a quality score (0.0–1.0), enabling RAG pipelines to filter or re-rank by extraction quality
- **Self-healing** — retries with alternative extractors when the primary one returns low-quality output
- **Quality presets** — fast, standard, and high modes for different use cases

**Changes:**
- Added `src/oss/python/integrations/document_loaders/pdfmux.mdx` — full integration page following the existing loader doc pattern
- Updated `src/oss/python/integrations/document_loaders/index.mdx` — added PDFMux to the PDFs category table

**Links:**
- PyPI: https://pypi.org/project/langchain-pdfmux/
- Source: https://github.com/NameetP/langchain-pdfmux
- Website: https://pdfmux.com

## Test plan

- [ ] Verify the new page renders correctly at `/oss/python/integrations/document_loaders/pdfmux`
- [ ] Verify the PDFs table on the index page includes the new PDFMux entry with working link
- [ ] Confirm `pip install langchain-pdfmux` installs successfully and the code examples work