### PR TITLE
fix: bump chat-langchain integration component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "docs",
       "version": "1.0.0",
       "dependencies": {
-        "@langchain/docs-sandbox": "^0.0.20"
+        "@langchain/docs-sandbox": "^0.0.21"
       }
     },
     "node_modules/@langchain/docs-sandbox": {
-      "version": "0.0.20",
-      "resolved": "https://registry.npmjs.org/@langchain/docs-sandbox/-/docs-sandbox-0.0.20.tgz",
-      "integrity": "sha512-M84uLFSkS8cweMNe+Kej5tH+G3/RTrCPT0qCGOxNaGYdYgXOBd2d9gxAA1HLBhNeyXXkztY9q6B2O5JcQbdesA==",
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@langchain/docs-sandbox/-/docs-sandbox-0.0.21.tgz",
+      "integrity": "sha512-lAAJvLP6fqrL2kKGbcIOVbvt0EzjafGqCg0cvEC4KLCHNy351wQtumlJ2oeu6aD+KK/fmVa+goTtgVYC3FPgkQ==",
       "peerDependencies": {
         "@langchain/playground-preview-protocol": "workspace:*",
         "react": "^18 || ^19",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "description": "Docs for the project",
   "private": true,
   "dependencies": {
-    "@langchain/docs-sandbox": "^0.0.20"
+    "@langchain/docs-sandbox": "^0.0.21"
   }
 }


### PR DESCRIPTION
This update hides the "On this page" section when someone opens the Chat LangChain integration (for a browser size smaller than 1800px).