### PR TITLE
Set RecursiveCharacterTextSplitter chunk count to 516

### DIFF
--- a/src/oss/langchain/knowledge-base.mdx
+++ b/src/oss/langchain/knowledge-base.mdx
@@ -296,7 +296,7 @@ console.log(allSplits.length);
 :::
 
 ```text
-514
+516
 ```
 
 


### PR DESCRIPTION
In the latest langchain_text_splitters, the number of segments after splitting using RecursiveCharacteristTextSplitter is 516

## Overview
<!-- Brief description of what documentation is being added/updated -->
In the latest langchain_text_splitters, the number of segments after splitting using RecursiveCharacteristTextSplitter is 516

## Type of change

**Update existing documentation**

Examples:
<img width="1338" height="469" alt="image" src="https://github.com/user-attachments/assets/c2d239a7-74c0-4cfc-89eb-b0cc1f1aa572" />



## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed


## Additional notes

