### PR TITLE
docs: replace deprecated RetrievalQA with LCEL in bedrock retriever

### DIFF
--- a/src/oss/python/integrations/retrievers/bedrock.mdx
+++ b/src/oss/python/integrations/retrievers/bedrock.mdx
@@ -59,18 +59,25 @@ retriever.invoke(query)
 
 ```python
 from botocore.client import Config
-from langchain_classic.chains import RetrievalQA
 from langchain_aws import Bedrock
+from langchain.chains import create_retrieval_chain
+from langchain.chains.combine_documents import create_stuff_documents_chain
+from langchain_core.prompts import ChatPromptTemplate
 
 model_kwargs_claude = {"temperature": 0, "top_k": 10, "max_tokens_to_sample": 3000}
 
 llm = Bedrock(model_id="anthropic.claude-v2", model_kwargs=model_kwargs_claude)
 
-qa = RetrievalQA.from_chain_type(
-    llm=llm, retriever=retriever, return_source_documents=True
-)
+prompt = ChatPromptTemplate.from_messages([
+    ("system", "Answer based on the context:\n\n{context}"),
+    ("human", "{input}"),
+])
 
-qa(query)
+doc_chain = create_stuff_documents_chain(llm, prompt)
+chain = create_retrieval_chain(retriever, doc_chain)
+
+result = chain.invoke({"input": query})
+print(result["answer"])
 ```
 
 ---


### PR DESCRIPTION
## Overview
Replaces deprecated `RetrievalQA.from_chain_type()` with the modern LCEL pattern using `create_retrieval_chain` in the Bedrock retriever integration page(lines 60-74).

## Type of change
Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue: Closes #3427
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
This replaces the deprecated `RetrievalQA.from_chain_type()` pattern  (from `langchain_classic`) with the modern LCEL equivalent using `create_retrieval_chain` + `create_stuff_documents_chain`, consistent 
with LangChain v1.0 migration guidelines.
