### PR TITLE
docs: add langchain-strale integration — business data & compliance

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -796,3 +796,7 @@ packages:
   js: "@oracle/langchain-oracledb"
   downloads: 20000
   downloads_updated_at: "2026-03-30T00:11:49.141587+00:00"
+- name: langchain-strale
+  name_title: Strale
+  repo: strale-io/strale
+  path: packages/langchain-strale

--- a/src/oss/python/integrations/providers/strale.mdx
+++ b/src/oss/python/integrations/providers/strale.mdx
@@ -1,0 +1,28 @@
+---
+title: "Strale integrations"
+description: "Integrate with Strale using LangChain Python."
+---
+
+[Strale](https://strale.io) is a capability marketplace that lets AI agents buy and execute capabilities at runtime — company data lookups, compliance checks, web scraping, document extraction, and more — via a single API call.
+
+## Installation and setup
+
+- Get an API key from [strale.io](https://strale.io) and set it in environment variables (`STRALE_API_KEY`).
+- Install the `langchain-strale` package:
+
+```bash
+pip install langchain-strale
+```
+
+## Tools
+
+The `StraleToolkit` provides LangChain tools for all 200+ Strale capabilities.
+
+```python
+from langchain_strale import StraleToolkit
+
+toolkit = StraleToolkit(api_key="your-api-key")
+tools = toolkit.get_tools()
+```
+
+Each tool maps to a Strale capability (e.g., `vat-validate`, `swedish-company-data`, `invoice-extract`) and can be used directly with LangChain agents.


### PR DESCRIPTION
Adds langchain-strale as a third-party integration for business data and compliance capabilities.

- Provider page at `src/oss/python/integrations/providers/strale.mdx`
- Package entry in `packages.yml`

langchain-strale provides 271 quality-scored capabilities: company verification across 27 countries, sanctions screening, IBAN/VAT validation, web intelligence, and more.

- PyPI: https://pypi.org/project/langchain-strale/
- Docs: https://strale.dev/docs
- GitHub: https://github.com/strale-io/strale