### PR TITLE
docs(ollama): add dimensions parameter example to OllamaEmbeddings instantiation

### DIFF
--- a/src/oss/python/integrations/embeddings/ollama.mdx
+++ b/src/oss/python/integrations/embeddings/ollama.mdx
@@ -58,6 +58,17 @@ embeddings = OllamaEmbeddings(
 )
 ```
 
+If your model supports configurable output dimensions (e.g., `qwen3-embedding`), you can specify them via the `dimensions` parameter:
+
+```python
+from langchain_ollama import OllamaEmbeddings
+
+embeddings = OllamaEmbeddings(
+    model="qwen3-embedding:8b",
+    dimensions=1024,
+)
+```
+
 ## Indexing and retrieval
 
 Embedding models are often used in retrieval-augmented generation (RAG) flows, both as part of indexing data as well as later retrieving it. For more detailed instructions, please see our [RAG tutorials](/oss/langchain/rag/).


### PR DESCRIPTION
## Overview
Adds a `dimensions` parameter example to the `OllamaEmbeddings` instantiation 
section, reflecting the new parameter introduced in `langchain-ollama` 1.1.0.

## Type of change
**Type:** Update existing documentation

## Related issues/PRs
- Feature PR: langchain-ai/langchain#36543

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed