### PR TITLE
docs: add langchain-collapse to community middleware

### DIFF
--- a/src/oss/python/integrations/middleware/index.mdx
+++ b/src/oss/python/integrations/middleware/index.mdx
@@ -33,3 +33,4 @@ Middleware enables context engineering, harness customization, and runtime safet
 |-----------|-------------|--------|
 | [Cisco AI Defense](https://github.com/cisco-ai-defense/ai-defense-langchain-middleware) | Runtime security inspection | [`cisco-ai-defense/ai-defense-langchain-middleware`](https://github.com/cisco-ai-defense/ai-defense-langchain-middleware) |
 | [compact-middleware](https://github.com/emanueleielo/compact-middleware) | Claude Code's compaction engine as LangChain middleware. Multi-level context compaction for long-running agents. | [`emanueleielo/compact-middleware`](https://github.com/emanueleielo/compact-middleware) |
+| [langchain-collapse](https://github.com/johanity/langchain-collapse) | Preventive context management. Collapses consecutive tool-call groups before they fill the context window. | [`johanity/langchain-collapse`](https://github.com/johanity/langchain-collapse) |


### PR DESCRIPTION
Adds [langchain-collapse](https://github.com/johanity/langchain-collapse) to the community middleware integrations table.

## What it does

Preventive context management middleware that collapses consecutive read/search tool-call groups into a short placeholder, keeping only the most recent result. Reduces context usage before `SummarizationMiddleware` needs to fire.

- 92% token reduction on realistic coding sessions
- `SummarizationMiddleware` triggers 4.2x later when `CollapseMiddleware` runs first
- Stateless, no LLM calls
- [PyPI](https://pypi.org/project/langchain-collapse/) · [Source](https://github.com/johanity/langchain-collapse) · [CI](https://github.com/johanity/langchain-collapse/actions)