### PR TITLE
docs: update ibm_watsonx_sql to use create_agent (LangGraph v1 migration)

### DIFF
--- a/src/oss/python/integrations/tools/ibm_watsonx_sql.mdx
+++ b/src/oss/python/integrations/tools/ibm_watsonx_sql.mdx
@@ -142,7 +142,7 @@ llm = ChatWatsonx(
 ```
 
 ```python
-from langgraph.prebuilt import create_react_agent
+from langchain.agents import create_agent
 
 # Use one of the prompt from langchain hub
 from langchain import hub
@@ -150,7 +150,7 @@ from langchain import hub
 prompt_template = hub.pull("langchain-ai/sql-agent-system-prompt")
 system_message = prompt_template.format(dialect="PostgreSQL", top_k=5)
 
-agent_executor = create_react_agent(llm, wx_sql_toolkit.get_tools(), prompt=system_message, debug=True)
+agent_executor = create_agent(llm, wx_sql_toolkit.get_tools(), system_prompt=system_message)
 ```
 
 ```python


### PR DESCRIPTION
## Summary
Updates the IBM watsonx SQL integration example to align with LangGraph v1.0 API changes.

## Changes
- Replaces deprecated `langgraph.prebuilt.create_react_agent`
- Uses `langchain.agents.create_agent` for agent construction
- Updates `prompt=` argument to `system_prompt=` per new API
- Removes `debug=True` (not supported in create_agent)

## Why
`create_react_agent` was deprecated in LangGraph v1.0. The replacement
`create_agent` uses `system_prompt=` instead of `prompt=`.

Ref: https://docs.langchain.com/oss/python/migrate/langgraph-v1

## Type of change
**Type:** Update existing documentation

## Checklist
- [x] I have read the contributing guidelines