### PR TITLE
docs(langgraph): add graph version pinning for breaking changes

### DIFF
--- a/src/oss/langgraph/graph-api.mdx
+++ b/src/oss/langgraph/graph-api.mdx
@@ -1361,7 +1361,7 @@ LangGraph can easily handle migrations of graph definitions (nodes, edges, and s
 
 ### Pin graph versions for breaking changes
 
-When you make a drastic change to the graph's logic — rewriting the tool set, changing the prompting strategy, or restructuring conversation flow — you may want existing threads to keep running the old behavior while new threads pick up the latest version.
+When you make a drastic change to the graph's logic, such as rewriting the tool set, changing the prompting strategy, or restructuring conversation flow, you may want existing threads to keep running the old behavior while new threads pick up the latest version.
 
 To do this, store a version identifier in the graph's state. On the first run for a thread, an entry node stamps the current version. Because state is [checkpointed](/oss/langgraph/persistence), the version persists across runs. A conditional edge then routes to the correct implementation:
 
@@ -1391,7 +1391,7 @@ workflow.add_conditional_edges("set_version", route_by_version)
 
 :::
 
-Callers don't need to pass anything special — the graph handles version routing transparently. When you ship v3, update `CURRENT_VERSION` and add a new node and route. Only new threads pick it up.
+Callers don't need to pass anything special because the graph handles version routing transparently. When you ship v3, update `CURRENT_VERSION` and add a new node and route. Only new threads pick it up.
 
 <Tip>
 There are different approaches to managing these types of breaking changes. As an alternative to the strategy outlined above, you can route old threads through a migration node that transforms their state to match the new graph, instead of maintaining multiple versions. This avoids code accumulation but the migration logic can grow complex across multiple version transitions.

--- a/src/oss/langgraph/graph-api.mdx
+++ b/src/oss/langgraph/graph-api.mdx
@@ -1359,49 +1359,9 @@ LangGraph can easily handle migrations of graph definitions (nodes, edges, and s
 - State keys that are renamed lose their saved state in existing threads
 - State keys whose types change in incompatible ways could currently cause issues in threads with state from before the change -- if this is a blocker please reach out and we can prioritize a solution.
 
-### Pin graph versions for breaking changes
-
-When you make a drastic change to the graph's logic, such as rewriting the tool set, changing the prompting strategy, or restructuring conversation flow, you may want existing threads to keep running the old behavior while new threads pick up the latest version.
-
-To do this, store a version identifier in the graph's state. On the first run for a thread, an entry node stamps the current version. Because state is [checkpointed](/oss/langgraph/persistence), the version persists across runs. A conditional edge then routes to the correct implementation:
-
-:::python
-
-```python
-CURRENT_VERSION = "v2"
-
-class State(MessagesState):
-    graph_version: Optional[str] = None
-
-def set_version(state: State):
-    if state["graph_version"] is None:
-        return {"graph_version": CURRENT_VERSION}
-    return {}
-
-def route_by_version(state: State):
-    if state["graph_version"] == "v1":
-        return "v1_agent"
-    return "v2_agent"
-
-workflow = StateGraph(State)
-workflow.add_edge(START, "set_version")
-workflow.add_conditional_edges("set_version", route_by_version)
-# ... add version-specific nodes, edges to END
-```
-
-:::
-
-Callers don't need to pass anything special because the graph handles version routing transparently. When you ship v3, update `CURRENT_VERSION` and add a new node and route. Only new threads pick it up.
-
 <Tip>
-There are different approaches to managing these types of breaking changes. As an alternative to the strategy outlined above, you can route old threads through a migration node that transforms their state to match the new graph, instead of maintaining multiple versions. This avoids code accumulation but the migration logic can grow complex across multiple version transitions.
+For changes that are technically compatible but alter business logic, such as rewriting the tool set or restructuring conversation flow, see [Business compatibility](/oss/langgraph/backward-compatibility#business-compatibility). That page covers pinning a behavioral version in state so existing threads keep the old path while new threads pick up the latest version.
 </Tip>
-
-**Considerations:**
-
-- All version-specific nodes coexist in a single graph. Structure your code with clear separation between versions.
-- The state schema is shared across all versions. Use optional fields with defaults so existing threads remain compatible.
-- Once all threads on an old version have ended, you can retire that version's code.
 
 ## Runtime context
 

--- a/src/oss/langgraph/graph-api.mdx
+++ b/src/oss/langgraph/graph-api.mdx
@@ -1359,6 +1359,50 @@ LangGraph can easily handle migrations of graph definitions (nodes, edges, and s
 - State keys that are renamed lose their saved state in existing threads
 - State keys whose types change in incompatible ways could currently cause issues in threads with state from before the change -- if this is a blocker please reach out and we can prioritize a solution.
 
+### Pin graph versions for breaking changes
+
+When you make a drastic change to the graph's logic — rewriting the tool set, changing the prompting strategy, or restructuring conversation flow — you may want existing threads to keep running the old behavior while new threads pick up the latest version.
+
+To do this, store a version identifier in the graph's state. On the first run for a thread, an entry node stamps the current version. Because state is [checkpointed](/oss/langgraph/persistence), the version persists across runs. A conditional edge then routes to the correct implementation:
+
+:::python
+
+```python
+CURRENT_VERSION = "v2"
+
+class State(MessagesState):
+    graph_version: Optional[str] = None
+
+def set_version(state: State):
+    if state["graph_version"] is None:
+        return {"graph_version": CURRENT_VERSION}
+    return {}
+
+def route_by_version(state: State):
+    if state["graph_version"] == "v1":
+        return "v1_agent"
+    return "v2_agent"
+
+workflow = StateGraph(State)
+workflow.add_edge(START, "set_version")
+workflow.add_conditional_edges("set_version", route_by_version)
+# ... add version-specific nodes, edges to END
+```
+
+:::
+
+Callers don't need to pass anything special — the graph handles version routing transparently. When you ship v3, update `CURRENT_VERSION` and add a new node and route. Only new threads pick it up.
+
+<Tip>
+There are different approaches to managing these types of breaking changes. As an alternative to the strategy outlined above, you can route old threads through a migration node that transforms their state to match the new graph, instead of maintaining multiple versions. This avoids code accumulation but the migration logic can grow complex across multiple version transitions.
+</Tip>
+
+**Considerations:**
+
+- All version-specific nodes coexist in a single graph. Structure your code with clear separation between versions.
+- The state schema is shared across all versions. Use optional fields with defaults so existing threads remain compatible.
+- Once all threads on an old version have ended, you can retire that version's code.
+
 ## Runtime context
 
 :::python


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
Updating our graph migration docs to provide some recommendations for handling breaking changes in graph's logic. This includes pinning a graph's version in the graph's internal state, or migrating state from older threads to updated state logic. 

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

<!-- For LangChain employees, if applicable: -->
- Slack thread: https://langchain.slack.com/archives/C09ET5XJDMY/p1774976626622869

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
