### PR TITLE
Add Hashlock integration documentation

### DIFF
--- a/src/oss/python/integrations/tools/hashlock.mdx
+++ b/src/oss/python/integrations/tools/hashlock.mdx
@@ -1,0 +1,126 @@
+---
+title: Hashlock
+description: Integrate with the Hashlock toolkit using LangChain Python. Swap any asset — crypto, RWA, stablecoins — with private sealed bids and verified counterparties.
+---
+
+# Hashlock
+
+This guide provides a quick overview for getting started with the Hashlock [toolkit](/docs/concepts/tools). For detailed documentation, head to the [GitHub repository](https://github.com/Hashlock-Tech/langchain-hashlock).
+
+## Overview
+
+### Details
+
+| Class | Package | Serializable | JS support | Downloads | Version |
+| :--- | :--- | :---: | :---: | :---: | :---: |
+| HashlockToolkit | [langchain-hashlock](https://pypi.org/project/langchain-hashlock/) | ❌ | ❌ | ![PyPI Downloads](https://img.shields.io/pypi/dm/langchain-hashlock) | ![PyPI Version](https://img.shields.io/pypi/v/langchain-hashlock) |
+
+### Features
+
+- **Create trading intents** — exchange any asset (crypto, RWA, stablecoins) across any chain
+- **Sealed-bid commitments** — control what you reveal and what stays private
+- **Natural language parsing** — convert everyday language like "sell 10 ETH for USDC above 4000" into structured intents
+- **Intent validation** — catch missing fields, invalid amounts, and chain mismatches before submitting
+- **Cross-chain support** — Ethereum, Arbitrum, Base, Polygon, and more
+
+## Setup
+
+To access Hashlock tools, you'll need to create a [Hashlock](https://hashlock.ai) account, get an API key, and install the `langchain-hashlock` integration package.
+
+### Credentials
+
+```python
+import getpass
+import os
+
+if "HASHLOCK_API_KEY" not in os.environ:
+    os.environ["HASHLOCK_API_KEY"] = getpass.getpass("Enter your Hashlock API key: ")
+if "HASHLOCK_API_URL" not in os.environ:
+    os.environ["HASHLOCK_API_URL"] = "https://api.hashlock.ai"
+```
+
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability/tracing of your tool calls.
+
+```python
+os.environ["LANGSMITH_API_KEY"] = getpass.getpass("Enter your LangSmith API key: ")
+os.environ["LANGSMITH_TRACING"] = "true"
+```
+
+### Installation
+
+The Hashlock toolkit lives in the `langchain-hashlock` package:
+
+```python pip
+pip install -U langchain-hashlock
+```
+
+```python uv
+uv add langchain-hashlock
+```
+
+## Instantiation
+
+```python
+from langchain_hashlock import HashlockToolkit
+
+toolkit = HashlockToolkit(
+    api_url="https://api.hashlock.ai",
+    api_key=os.environ["HASHLOCK_API_KEY"],
+)
+
+tools = toolkit.get_tools()
+```
+
+The toolkit provides 5 tools:
+
+| Tool | Description |
+| :--- | :--- |
+| `CreateIntentTool` | Create a trading intent to exchange any asset across any chain |
+| `CommitIntentTool` | Submit a sealed-bid commitment with privacy controls |
+| `ParseNaturalLanguageTool` | Convert everyday language into structured intents |
+| `ExplainIntentTool` | Get plain-language explanation of an intent |
+| `ValidateIntentTool` | Check intent validity before submitting |
+
+## Invocation
+
+### Directly
+
+```python
+from langchain_hashlock import ParseNaturalLanguageTool
+
+parser = ParseNaturalLanguageTool(
+    api_url="https://api.hashlock.ai",
+    api_key=os.environ["HASHLOCK_API_KEY"],
+)
+
+result = parser.invoke({"text": "sell 10 ETH for USDC above 4000"})
+print(result)
+```
+
+### Within an agent
+
+We can use the Hashlock toolkit in an agent:
+
+```python
+# pip install -qU "langchain[anthropic]"
+from langchain.agents import create_agent
+
+tools = toolkit.get_tools()
+
+agent = create_agent(
+    model="claude-sonnet-4-6",
+    tools=tools,
+)
+
+agent.invoke(
+    {"messages": [{"role": "user", "content": "I want to swap 5 ETH for USDC on Arbitrum"}]}
+)
+```
+
+## What is Hashlock?
+
+[Hashlock](https://hashlock.ai) is the universal asset exchange protocol — one address to swap crypto, RWA, and stablecoins with private sealed bids and verified counterparties. It supports cross-chain trading across Ethereum, Arbitrum, Base, Polygon, and more.
+
+## API reference
+
+For detailed documentation, see the [langchain-hashlock GitHub repository](https://github.com/Hashlock-Tech/langchain-hashlock).


### PR DESCRIPTION
## Overview

Add integration documentation for Hashlock — a universal asset exchange protocol for swapping crypto, RWA, and stablecoins with private sealed bids and verified counterparties.

The `langchain-hashlock` package is published on PyPI: https://pypi.org/project/langchain-hashlock/

## Type of change

**Type:** New documentation page

## Related issues/PRs

N/A — this is the initial integration documentation for the new `langchain-hashlock` package.

## Documentation page

Adds `src/oss/python/integrations/tools/hashlock.mdx` following the tools template.

The page covers:
- Setup and credentials
- Installation
- Toolkit instantiation with all 5 tools
- Direct invocation examples
- Agent usage example

## Package info

- **Package**: `langchain-hashlock` (https://pypi.org/project/langchain-hashlock/)
- **GitHub**: https://github.com/Hashlock-Tech/langchain-hashlock
- **Version**: 0.1.0