### PR TITLE
docs: add Salesforce integration page for Fleet

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -978,7 +978,8 @@
                 "langsmith/fleet/slack-app",
                 "langsmith/fleet/teams-app",
                 "langsmith/fleet/remote-mcp-servers",
-                "langsmith/fleet/arcade"
+                "langsmith/fleet/arcade",
+                "langsmith/fleet/salesforce"
               ]
             },
             {

--- a/src/langsmith/fleet/salesforce.mdx
+++ b/src/langsmith/fleet/salesforce.mdx
@@ -1,0 +1,134 @@
+---
+title: Salesforce integration
+sidebarTitle: Salesforce
+description: Connect LangSmith Fleet to Salesforce so your agents can query records, navigate schemas, and read custom fields.
+---
+
+The Salesforce integration gives your agents read-only access to data in your Salesforce org. Once connected, an agent can:
+
+- Query records across standard and custom objects.
+- Navigate your Salesforce data schema, including relationships and custom fields.
+- Pull live context from Salesforce into any thread or scheduled run.
+
+<Note>
+Connecting Salesforce is a one-time setup per Salesforce org. A Salesforce System Administrator (or a user with the **Approve Uninstalled Connected Apps** permission) must install the connector before other users can authenticate.
+</Note>
+
+## Prerequisites
+
+- A LangSmith workspace with access to [Fleet](https://smith.langchain.com/agents).
+- A Salesforce org and user account.
+- A Salesforce System Administrator to complete the install (or the **Approve Uninstalled Connected Apps** permission on your own user).
+
+## Register the connector
+
+The first connection attempt registers the **LangChain Fleet Connector** in your Salesforce org so that an administrator can install it. This initial attempt is expected to fail with an authentication error.
+
+<Steps>
+  <Step title="Open the Integrations page">
+    In the [LangSmith UI](https://smith.langchain.com), navigate to the [**Fleet** > **Integrations**](https://smith.langchain.com/agents/tools) tab.
+  </Step>
+  <Step title="Start the Salesforce connection">
+    Find the **Salesforce** tool and click **Connect**.
+  </Step>
+  <Step title="Sign in with your Salesforce domain">
+    1. On the Salesforce login page, click **Use Custom Domain**.
+    1. Enter your Salesforce domain and continue.
+    1. Sign in with your Salesforce credentials and click **Allow**.
+  </Step>
+</Steps>
+
+<Info>
+The first attempt fails by design. The failed request registers the **LangChain Fleet Connector** in your Salesforce org so an administrator can install it in the next step.
+</Info>
+
+<Tip>
+If you are not a Salesforce administrator, stop here and share this page with your Salesforce admin.
+</Tip>
+
+## Install the connector
+
+<Note>
+This step must be completed by a Salesforce System Administrator.
+</Note>
+
+<Steps>
+  <Step title="Open Salesforce Setup">
+    In Salesforce, click the <Icon icon="settings"/> gear icon and select **Setup**.
+  </Step>
+  <Step title="Open Connected Apps OAuth Usage">
+    In the **Quick Find** box, type `Connected Apps OAuth Usage` and open the page.
+  </Step>
+  <Step title="Install the connector">
+    1. Find **LangChain Fleet Connector** in the list.
+    1. Click **Install**.
+    1. Confirm the installation on the next page.
+  </Step>
+</Steps>
+
+## Grant user access
+
+Granting access through a permission set is the recommended way to control which users can authenticate with Fleet.
+
+<Note>
+This step must be completed by a Salesforce System Administrator.
+</Note>
+
+<Steps>
+  <Step title="Open the app policies">
+    From **Connected Apps OAuth Usage**, click **Manage App Policies** next to **LangChain Fleet Connector**.
+  </Step>
+  <Step title="Pre-authorize admin-approved users">
+    Under **OAuth Policies** > **Permitted Users**, select **Admin approved users are pre-authorized**, then click **Save**.
+  </Step>
+  <Step title="Assign a permission set">
+    Use **Manage Permission Sets** to grant access to the users who need to connect the Salesforce tool in Fleet.
+  </Step>
+</Steps>
+
+## Connect from Fleet
+
+Once your administrator has installed the connector and granted access, return to Fleet to complete the connection.
+
+1. In the [LangSmith UI](https://smith.langchain.com), navigate to the [**Fleet** > **Integrations**](https://smith.langchain.com/agents/tools) tab.
+1. Find the **Salesforce** tool and click **Connect**.
+1. Sign in with your Salesforce credentials and click **Allow**.
+
+The connection now succeeds and Salesforce tools become available to agents in your workspace.
+
+## Use Salesforce with an agent
+
+After connecting, add Salesforce tools to a specific agent:
+
+1. Open your agent in [Fleet](https://smith.langchain.com/agents) and click the <Icon icon="pencil"/> **Edit Agent** icon.
+1. In the **Toolbox** section, click **+ Add**.
+1. Search for **Salesforce Query** and add it to the agent.
+1. Click **Save changes**.
+
+## Troubleshooting
+
+### Connection fails with an authentication error
+
+The first connection attempt is expected to fail. It registers the **LangChain Fleet Connector** in your Salesforce org so an administrator can install it. If the connection still fails after the connector is installed, confirm that:
+
+- The administrator completed both **Install the connector** and **Grant user access**.
+- Your Salesforce user is assigned to a permission set that grants access to the connector.
+- You signed in through **Use Custom Domain** with the correct Salesforce domain.
+
+### Agent cannot see an object or field
+
+Salesforce tools run with the permissions of the connected user. If an agent cannot read an object or custom field, verify that the user's Salesforce profile and permission sets grant read access to that object.
+
+## Next steps
+
+<CardGroup cols={3}>
+  <Card title="Add more tools" icon="puzzle" href="/langsmith/fleet/tools">
+    Connect additional services to your agent
+  </Card>
+  <Card title="Agent identity" icon="user" href="/langsmith/fleet/agent-identity">
+    Choose whether the agent uses shared or per-user credentials
+  </Card>
+  <Card title="Human-in-the-loop" icon="check" href="/langsmith/fleet/essentials#human-in-the-loop">
+    Require approval before the agent takes sensitive actions
+  </Card>
+</CardGroup>

--- a/src/langsmith/fleet/salesforce.mdx
+++ b/src/langsmith/fleet/salesforce.mdx
@@ -31,10 +31,8 @@ The first connection attempt registers the **LangChain Fleet Connector** in your
   <Step title="Start the Salesforce connection">
     Find the **Salesforce** tool and click **Connect**.
   </Step>
-  <Step title="Sign in with your Salesforce domain">
-    1. On the Salesforce login page, click **Use Custom Domain**.
-    1. Enter your Salesforce domain and continue.
-    1. Sign in with your Salesforce credentials and click **Allow**.
+  <Step title="Sign in to Salesforce">
+    Sign in with your Salesforce credentials. If your org requires a custom domain or SSO, click **Use Custom Domain** and enter your org's My Domain before signing in. Then click **Allow** to authorize the connection.
   </Step>
 </Steps>
 
@@ -43,7 +41,7 @@ The first attempt fails by design. The failed request registers the **LangChain 
 </Info>
 
 <Tip>
-If you are not a Salesforce administrator, stop here and share this page with your Salesforce admin.
+If you are not a Salesforce administrator, stop here and send your admin the link to this page. They need to follow the **Install the connector** and **Grant user access** steps below before you can complete the connection.
 </Tip>
 
 ## Install the connector


### PR DESCRIPTION
## Summary

- New page at `src/langsmith/fleet/salesforce.mdx` documenting the Salesforce tool integration for Fleet.
- Walks through the four-phase setup: register the connector (expected first-attempt failure), Salesforce admin install via Connected Apps OAuth Usage, granting user access via permission sets, and completing the connection from Fleet.
- Adds a short "Use Salesforce with an agent" section pointing users to the `Salesforce Query` tool, plus troubleshooting entries for the failed-auth-on-first-attempt case and missing-object permissions.
- Sidebar entry added to `Fleet > Tools and automation` in `src/docs.json`, after `arcade`.

## Test plan

- [x] Local Mintlify preview renders the page at `/langsmith/fleet/salesforce`.
- [x] Sidebar shows **Salesforce** under **Tools and automation**.
- [x] Internal links resolve (`/langsmith/fleet/tools`, `/langsmith/fleet/agent-identity`, `/langsmith/fleet/essentials#human-in-the-loop`).