### PR TITLE
docs: fix interrupt handling example in SQL agent tutorial

### DIFF
--- a/src/oss/langchain/sql-agent.mdx
+++ b/src/oss/langchain/sql-agent.mdx
@@ -521,7 +521,7 @@ for step in agent.stream(
 ):
     if "messages" in step:
         step["messages"][-1].pretty_print()
-    elif "__interrupt__" in step:
+    if "__interrupt__" in step:
         print("INTERRUPTED:")
         interrupt = step["__interrupt__"][0]
         for request in interrupt.value["action_requests"]:


### PR DESCRIPTION
## Summary
Fixes the interrupt-handling example in the SQL agent tutorial.

## Changes
- Replaced `elif "__interrupt__" in step:` with `if "__interrupt__" in step:`
- Preserved the rest of the example logic

## Why
When a step contains both `"messages"` and `"__interrupt__"`, the previous `elif` branch can skip interrupt handling. This update matches the issue report and makes the example work correctly for multiple interruptions.

Fixes #3208