### PR TITLE
docs: add Doubleword integration provider

### DIFF
--- a/src/oss/python/integrations/chat/doubleword.mdx
+++ b/src/oss/python/integrations/chat/doubleword.mdx
@@ -71,7 +71,7 @@ Now we can instantiate our model object and generate chat completions:
 from langchain_doubleword import ChatDoubleword
 
 model = ChatDoubleword(
-    model="gpt-4o",
+    model="Qwen/Qwen3-30B-A3B",
     temperature=0,
     max_tokens=1024,
     max_retries=2,
@@ -142,19 +142,29 @@ For more on binding tools and tool call outputs, head to the [tool calling](/oss
 
 ## Batch processing
 
-`ChatDoublewordBatch` uses Doubleword's batch API to transparently collect concurrent calls into batch submissions at reduced cost. This is useful for high-throughput workloads where real-time responses are not required.
+`ChatDoublewordBatch` uses Doubleword's batch API to transparently collect concurrent calls into batch submissions with up to 90% cost savings. This is useful for high-throughput workloads where real-time responses are not required.
+
+**Note:** `ChatDoublewordBatch` is async-only. Sync methods like `invoke()` will raise `NotImplementedError`. Use `ainvoke()` instead.
 
 ```python
+import asyncio
 from langchain_doubleword import ChatDoublewordBatch
 
 batch_model = ChatDoublewordBatch(
-    model="gpt-4o",
+    model="Qwen/Qwen3-30B-A3B",
     temperature=0,
 )
 
+
 # Calls are automatically batched behind the scenes
-result = batch_model.invoke("Summarize the theory of relativity in one sentence.")
-result.content
+async def main():
+    result = await batch_model.ainvoke(
+        "Summarize the theory of relativity in one sentence."
+    )
+    print(result.content)
+
+
+asyncio.run(main())
 ```
 
 ---

--- a/src/oss/python/integrations/chat/doubleword.mdx
+++ b/src/oss/python/integrations/chat/doubleword.mdx
@@ -29,7 +29,7 @@ The `ChatDoubleword` class itself supports:
 | :---: | :---: | :---: | :---: | :---: |
 | ✅ | ✅ | ✅ | ✅ | ✅ |
 
-Multimodal capabilities (image, audio, video) depend on the underlying model — Doubleword passes these through to models that support them.
+Multimodal capabilities (image, audio, video) depend on the underlying model—Doubleword passes these through to models that support them.
 
 ## Setup
 

--- a/src/oss/python/integrations/chat/doubleword.mdx
+++ b/src/oss/python/integrations/chat/doubleword.mdx
@@ -21,7 +21,7 @@ The `langchain-doubleword` package provides two chat model classes:
 
 ### Model features
 
-Feature support depends on the model you route through Doubleword. See the [available models](https://docs.doubleword.ai/inference-api/models) page for a full list with capabilities, or visit the [Doubleword console](https://doubleword.ai) for detailed model cards and API examples.
+Feature support depends on the model you route through Doubleword. See the [available models](https://docs.doubleword.ai/inference-api/models) page for a full list with capabilities, or visit the [Doubleword console](https://doubleword.ai) for detailed model cards.
 
 The `ChatDoubleword` class itself supports:
 

--- a/src/oss/python/integrations/chat/doubleword.mdx
+++ b/src/oss/python/integrations/chat/doubleword.mdx
@@ -21,13 +21,19 @@ The `langchain-doubleword` package provides two chat model classes:
 
 ### Model features
 
-| [Tool calling](/oss/langchain/tools) | [Structured output](/oss/langchain/structured-output) | [Image input](/oss/langchain/messages#multimodal) | Audio input | Video input | [Token-level streaming](/oss/langchain/streaming/) | Native async | [Token usage](/oss/langchain/models#token-usage) | [Logprobs](/oss/langchain/models#log-probabilities) |
-| :---: | :---: | :---: |  :---: | :---: | :---: | :---: | :---: | :---: |
-| ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ |
+Feature support depends on the model you route through Doubleword. See the [available models](https://docs.doubleword.ai/inference-api/models) page for a full list with capabilities, or visit the [Doubleword console](https://doubleword.ai) for detailed model cards and API examples.
+
+The `ChatDoubleword` class itself supports:
+
+| [Tool calling](/oss/langchain/tools) | [Structured output](/oss/langchain/structured-output) | [Token-level streaming](/oss/langchain/streaming/) | Native async | [Token usage](/oss/langchain/models#token-usage) |
+| :---: | :---: | :---: | :---: | :---: |
+| ✅ | ✅ | ✅ | ✅ | ✅ |
+
+Multimodal capabilities (image, audio, video) depend on the underlying model — Doubleword passes these through to models that support them.
 
 ## Setup
 
-To access models via Doubleword you'll need a Doubleword account and an API key. Visit the [Doubleword documentation](https://docs.doubleword.ai) to get started.
+To access models via Doubleword you'll need a Doubleword account and an API key. Sign up at [doubleword.ai](https://doubleword.ai) and generate an API key from the console.
 
 ### Installation
 

--- a/src/oss/python/integrations/chat/doubleword.mdx
+++ b/src/oss/python/integrations/chat/doubleword.mdx
@@ -1,0 +1,164 @@
+---
+title: "ChatDoubleword integration"
+sidebarTitle: Doubleword
+description: "Integrate with the ChatDoubleword chat model using LangChain Python."
+---
+
+This will help you get started with Doubleword [chat models](/oss/langchain/models). [Doubleword](https://doubleword.ai/) is an AI model gateway and control layer that provides unified routing, management, and security for inference across multiple model providers.
+
+The `langchain-doubleword` package provides two chat model classes:
+
+- **`ChatDoubleword`**: Real-time chat completions via the Doubleword gateway.
+- **`ChatDoublewordBatch`**: Cost-optimized batched completions using Doubleword's batch API. Uses `autobatcher` to transparently collect concurrent calls into batch submissions.
+
+## Overview
+
+### Integration details
+
+| Class | Package | Serializable | JS/TS Support | Downloads | Latest Version |
+| :--- | :--- | :---: |  :---: | :---: | :---: |
+| `ChatDoubleword` | `langchain-doubleword` | beta | ❌ | <a href="https://pypi.org/project/langchain-doubleword/" target="_blank"><img src="https://static.pepy.tech/badge/langchain-doubleword/month" alt="Downloads per month" noZoom height="100" class="rounded" /></a> | <a href="https://pypi.org/project/langchain-doubleword/" target="_blank"><img src="https://img.shields.io/pypi/v/langchain-doubleword?style=flat-square&label=%20&color=orange" alt="PyPI - Latest version" noZoom height="100" class="rounded" /></a> |
+
+### Model features
+
+| [Tool calling](/oss/langchain/tools) | [Structured output](/oss/langchain/structured-output) | [Image input](/oss/langchain/messages#multimodal) | Audio input | Video input | [Token-level streaming](/oss/langchain/streaming/) | Native async | [Token usage](/oss/langchain/models#token-usage) | [Logprobs](/oss/langchain/models#log-probabilities) |
+| :---: | :---: | :---: |  :---: | :---: | :---: | :---: | :---: | :---: |
+| ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ |
+
+## Setup
+
+To access models via Doubleword you'll need a Doubleword account and an API key. Visit the [Doubleword documentation](https://docs.doubleword.ai) to get started.
+
+### Installation
+
+The LangChain Doubleword integration lives in the `langchain-doubleword` package:
+
+<CodeGroup>
+    ```bash pip
+    pip install -U langchain-doubleword
+    ```
+    ```bash uv
+    uv add langchain-doubleword
+    ```
+</CodeGroup>
+
+### Credentials
+
+Generate an API key from your Doubleword dashboard and set the `DOUBLEWORD_API_KEY` environment variable:
+
+```python
+import getpass
+import os
+
+if not os.getenv("DOUBLEWORD_API_KEY"):
+    os.environ["DOUBLEWORD_API_KEY"] = getpass.getpass("Enter your Doubleword API key: ")
+```
+
+You can also pass the key directly via the `api_key` parameter or configure it in `~/.dw/credentials.toml`.
+
+To enable automated tracing of your model calls, set your [LangSmith](/langsmith/home) API key:
+
+```python
+os.environ["LANGSMITH_API_KEY"] = getpass.getpass("Enter your LangSmith API key: ")
+os.environ["LANGSMITH_TRACING"] = "true"
+```
+
+## Instantiation
+
+Now we can instantiate our model object and generate chat completions:
+
+```python
+from langchain_doubleword import ChatDoubleword
+
+model = ChatDoubleword(
+    model="gpt-4o",
+    temperature=0,
+    max_tokens=1024,
+    max_retries=2,
+    # api_key="...",  # if not using DOUBLEWORD_API_KEY env var
+)
+```
+
+---
+
+## Invocation
+
+```python
+messages = [
+    (
+        "system",
+        "You are a helpful assistant that translates English to French. Translate the user sentence.",
+    ),
+    ("human", "I love programming."),
+]
+ai_msg = model.invoke(messages)
+ai_msg.content
+```
+
+```text
+"J'adore la programmation."
+```
+
+---
+
+## Streaming
+
+```python
+for chunk in model.stream("Write a short poem about the sea."):
+    print(chunk.text, end="", flush=True)
+```
+
+---
+
+## Tool calling
+
+Doubleword supports OpenAI-compatible tool calling. You can use `bind_tools` to pass Pydantic classes, dict schemas, LangChain tools, or functions.
+
+```python
+from pydantic import BaseModel, Field
+
+
+class GetWeather(BaseModel):
+    """Get the current weather in a given location"""
+
+    location: str = Field(description="The city and state, e.g. San Francisco, CA")
+
+
+model_with_tools = model.bind_tools([GetWeather])
+ai_msg = model_with_tools.invoke("What is the weather like in San Francisco?")
+ai_msg.tool_calls
+```
+
+```text
+[{'name': 'GetWeather',
+  'args': {'location': 'San Francisco, CA'},
+  'id': 'call_abc123',
+  'type': 'tool_call'}]
+```
+
+For more on binding tools and tool call outputs, head to the [tool calling](/oss/langchain/tools) docs.
+
+---
+
+## Batch processing
+
+`ChatDoublewordBatch` uses Doubleword's batch API to transparently collect concurrent calls into batch submissions at reduced cost. This is useful for high-throughput workloads where real-time responses are not required.
+
+```python
+from langchain_doubleword import ChatDoublewordBatch
+
+batch_model = ChatDoublewordBatch(
+    model="gpt-4o",
+    temperature=0,
+)
+
+# Calls are automatically batched behind the scenes
+result = batch_model.invoke("Summarize the theory of relativity in one sentence.")
+result.content
+```
+
+---
+
+## API reference
+
+For detailed documentation and source code, visit the [`langchain-doubleword` GitHub repository](https://github.com/doublewordai/langchain-doubleword).

--- a/src/oss/python/integrations/chat/doubleword.mdx
+++ b/src/oss/python/integrations/chat/doubleword.mdx
@@ -71,7 +71,7 @@ Now we can instantiate our model object and generate chat completions:
 from langchain_doubleword import ChatDoubleword
 
 model = ChatDoubleword(
-    model="Qwen/Qwen3-30B-A3B",
+    model="Qwen/Qwen3.5-35B-A3B-FP8",
     temperature=0,
     max_tokens=1024,
     max_retries=2,
@@ -151,7 +151,7 @@ import asyncio
 from langchain_doubleword import ChatDoublewordBatch
 
 batch_model = ChatDoublewordBatch(
-    model="Qwen/Qwen3-30B-A3B",
+    model="Qwen/Qwen3.5-35B-A3B-FP8",
     temperature=0,
 )
 

--- a/src/oss/python/integrations/chat/doubleword.mdx
+++ b/src/oss/python/integrations/chat/doubleword.mdx
@@ -175,6 +175,11 @@ asyncio.run(main())
 
 ---
 
+## End-to-end examples
+
+- [`examples/langgraph-basic/`](https://github.com/doublewordai/langchain-doubleword/tree/master/examples/langgraph-basic)—minimal LangGraph agent with a calculator tool, in both real-time and batched variants
+- [`examples/async-agents-langgraph/`](https://github.com/doublewordai/langchain-doubleword/tree/master/examples/async-agents-langgraph)—recursive multi-agent research orchestrator that spawns parallel sub-agents, searches the web, reads pages, and compiles a report—all LLM calls batched via `ChatDoublewordBatch`
+
 ## API reference
 
 For detailed documentation and source code, visit the [`langchain-doubleword` GitHub repository](https://github.com/doublewordai/langchain-doubleword).

--- a/src/oss/python/integrations/embeddings/doubleword.mdx
+++ b/src/oss/python/integrations/embeddings/doubleword.mdx
@@ -34,7 +34,7 @@ if not os.getenv("DOUBLEWORD_API_KEY"):
 ```python
 from langchain_doubleword import DoublewordEmbeddings
 
-embeddings = DoublewordEmbeddings(model="text-embedding-3-small")
+embeddings = DoublewordEmbeddings(model="Qwen/Qwen3-Embedding-8B")
 
 # Embed a single query
 query_embedding = embeddings.embed_query("What is the meaning of life?")
@@ -47,15 +47,25 @@ doc_embeddings = embeddings.embed_documents(
 
 ## Batch embeddings
 
-For high-throughput workloads, use `DoublewordEmbeddingsBatch` to automatically batch concurrent embedding requests at reduced cost:
+For high-throughput workloads, use `DoublewordEmbeddingsBatch` to automatically batch concurrent embedding requests with up to 90% cost savings.
+
+**Note:** `DoublewordEmbeddingsBatch` is async-only. Sync methods like `embed_documents()` will raise `NotImplementedError`. Use `aembed_documents()` instead.
 
 ```python
+import asyncio
 from langchain_doubleword import DoublewordEmbeddingsBatch
 
-batch_embeddings = DoublewordEmbeddingsBatch(model="text-embedding-3-small")
-doc_embeddings = batch_embeddings.embed_documents(
-    ["Document one.", "Document two.", "Document three."]
-)
+batch_embeddings = DoublewordEmbeddingsBatch(model="Qwen/Qwen3-Embedding-8B")
+
+
+async def main():
+    doc_embeddings = await batch_embeddings.aembed_documents(
+        ["Document one.", "Document two.", "Document three."]
+    )
+    print(f"Generated {len(doc_embeddings)} embeddings")
+
+
+asyncio.run(main())
 ```
 
 ## API reference

--- a/src/oss/python/integrations/embeddings/doubleword.mdx
+++ b/src/oss/python/integrations/embeddings/doubleword.mdx
@@ -1,0 +1,63 @@
+---
+title: "Doubleword Embeddings integration"
+description: "Integrate with the Doubleword embedding model using LangChain Python."
+---
+
+[Doubleword](https://doubleword.ai/) is an AI model gateway that provides unified routing across multiple model providers. The `langchain-doubleword` package provides two embedding classes:
+
+- **`DoublewordEmbeddings`**: Real-time embedding generation via the Doubleword gateway.
+- **`DoublewordEmbeddingsBatch`**: Cost-optimized batched embeddings using Doubleword's batch API.
+
+## Setup
+
+Install the package and set your API key:
+
+<CodeGroup>
+    ```bash pip
+    pip install -U langchain-doubleword
+    ```
+    ```bash uv
+    uv add langchain-doubleword
+    ```
+</CodeGroup>
+
+```python
+import getpass
+import os
+
+if not os.getenv("DOUBLEWORD_API_KEY"):
+    os.environ["DOUBLEWORD_API_KEY"] = getpass.getpass("Enter your Doubleword API key: ")
+```
+
+## Usage
+
+```python
+from langchain_doubleword import DoublewordEmbeddings
+
+embeddings = DoublewordEmbeddings(model="text-embedding-3-small")
+
+# Embed a single query
+query_embedding = embeddings.embed_query("What is the meaning of life?")
+
+# Embed multiple documents
+doc_embeddings = embeddings.embed_documents(
+    ["Document one.", "Document two.", "Document three."]
+)
+```
+
+## Batch embeddings
+
+For high-throughput workloads, use `DoublewordEmbeddingsBatch` to automatically batch concurrent embedding requests at reduced cost:
+
+```python
+from langchain_doubleword import DoublewordEmbeddingsBatch
+
+batch_embeddings = DoublewordEmbeddingsBatch(model="text-embedding-3-small")
+doc_embeddings = batch_embeddings.embed_documents(
+    ["Document one.", "Document two.", "Document three."]
+)
+```
+
+## API reference
+
+For detailed documentation and source code, visit the [`langchain-doubleword` GitHub repository](https://github.com/doublewordai/langchain-doubleword).

--- a/src/oss/python/integrations/providers/doubleword.mdx
+++ b/src/oss/python/integrations/providers/doubleword.mdx
@@ -1,0 +1,23 @@
+---
+title: "Doubleword integrations"
+description: "Route AI inference through Doubleword's unified gateway using LangChain Python."
+sidebarTitle: "Doubleword"
+---
+
+[Doubleword](https://doubleword.ai/) is an AI model gateway and control layer that provides unified routing, management, and security for inference across multiple model providers. It exposes an OpenAI-compatible API with features like per-key rate limiting, request logging, and cost-optimized batch processing.
+
+## Chat models
+
+<Columns cols={2}>
+    <Card title="ChatDoubleword" href="/oss/integrations/chat/doubleword" cta="Get started" icon="message" arrow>
+        Real-time chat completions routed through the Doubleword gateway.
+    </Card>
+</Columns>
+
+## Embeddings
+
+<Columns cols={2}>
+    <Card title="DoublewordEmbeddings" href="/oss/integrations/embeddings/doubleword" cta="Get started" icon="grid" arrow>
+        Generate embeddings through the Doubleword gateway.
+    </Card>
+</Columns>

--- a/src/oss/python/integrations/providers/doubleword.mdx
+++ b/src/oss/python/integrations/providers/doubleword.mdx
@@ -4,7 +4,7 @@ description: "Route AI inference through Doubleword's unified gateway using Lang
 sidebarTitle: "Doubleword"
 ---
 
-[Doubleword](https://doubleword.ai/) is an AI model gateway and control layer that provides unified routing, management, and security for inference across multiple model providers. It exposes an OpenAI-compatible API with features like per-key rate limiting, request logging, and cost-optimized batch processing.
+[Doubleword](https://doubleword.ai/) is an AI model gateway and control layer that provides unified routing, management, and security for inference across multiple model providers. It exposes an OpenAI-compatible API with features like per-key rate limiting, request logging, and cost-optimized batch processing with up to 90% cost savings.
 
 ## Chat models
 


### PR DESCRIPTION
## Summary

- Adds a **provider overview page** for [Doubleword](https://doubleword.ai/) at `src/oss/python/integrations/providers/doubleword.mdx`
- Adds a **chat model integration page** (`ChatDoubleword`, `ChatDoublewordBatch`) at `src/oss/python/integrations/chat/doubleword.mdx`
- Adds an **embeddings integration page** (`DoublewordEmbeddings`, `DoublewordEmbeddingsBatch`) at `src/oss/python/integrations/embeddings/doubleword.mdx`

Doubleword is an AI model gateway / control layer providing unified routing, management, and security for inference across multiple model providers. The `langchain-doubleword` package ([PyPI](https://pypi.org/project/langchain-doubleword/), [GitHub](https://github.com/doublewordai/langchain-doubleword)) provides OpenAI-compatible chat and embedding classes with both real-time and cost-optimized batch variants.

## Areas requiring review

- Page format follows the pattern established by existing integrations (e.g., OpenRouter, DeepSeek)
- Feature support flags in the model features table should be verified against the latest `langchain-doubleword` release

## AI disclosure

This PR was authored with assistance from Claude (Anthropic AI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)