### PR TITLE
docs(js): add @betterdb/agent-cache LLM cache integration

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -718,3 +718,10 @@ javascript:
     docs_url: https://toolstem.com
   - name: Browserless
     docs_url: https://browserless.io
+  llm_caching:
+  - name: BetterDB Agent Cache
+    npm: "@betterdb/agent-cache"
+    docs_url: https://www.betterdb.com/ai
+  - name: BetterDB Semantic Cache
+    npm: "@betterdb/semantic-cache"
+    docs_url: https://www.betterdb.com/ai

--- a/src/oss/javascript/integrations/providers/all_providers.mdx
+++ b/src/oss/javascript/integrations/providers/all_providers.mdx
@@ -872,6 +872,14 @@ Connect LangGraph agents to front ends.
   >
     Cache LLM responses in Azure Cosmos DB.
   </Card>
+
+  <Card
+    title="BetterDB Agent Cache"
+    href="https://www.betterdb.com/ai"
+    icon="link"
+  >
+    Multi-tier cache for AI agents backed by Valkey or Redis.
+  </Card>
 </Columns>
 
 ## Callbacks

--- a/src/snippets/oss/javascript-llm_caching-downloads.mdx
+++ b/src/snippets/oss/javascript-llm_caching-downloads.mdx
@@ -4,6 +4,8 @@
 
 | Integration | Downloads |
 | :--- | :--- |
+| [`BetterDB Agent Cache`](https://www.betterdb.com/ai) | <span data-sort-value="2940"><a href="https://www.npmjs.com/package/@betterdb/agent-cache" target="_blank"><img src="https://img.shields.io/npm/dm/@betterdb/agent-cache?style=flat-square&label=%20&" alt="Downloads per month" noZoom class="rounded not-prose" /></a></span> |
 | [`Azure Cosmos DB NoSQL semantic`](/oss/integrations/llm_caching/azure_cosmosdb_nosql) | <span data-sort-value="2592"><a href="https://www.npmjs.com/package/@langchain/azure-cosmosdb" target="_blank"><img src="https://img.shields.io/npm/dm/@langchain/azure-cosmosdb?style=flat-square&label=%20&" alt="Downloads per month" noZoom class="rounded not-prose" /></a></span> |
+| [`BetterDB Semantic Cache`](https://www.betterdb.com/ai) | <span data-sort-value="1269"><a href="https://www.npmjs.com/package/@betterdb/semantic-cache" target="_blank"><img src="https://img.shields.io/npm/dm/@betterdb/semantic-cache?style=flat-square&label=%20&" alt="Downloads per month" noZoom class="rounded not-prose" /></a></span> |
 
 </div>


### PR DESCRIPTION
## Summary

Adds LangChain.js documentation for `@betterdb/agent-cache`, a multi-tier cache for AI agent workloads backed by Valkey or Redis.

This PR scope is limited to the LLM cache integration (`BetterDBLlmCache` → LangChain `BaseCache`). The LangGraph  checkpointer piece is tracked separately in #3603 and will be a follow-up PR pending the structural questions raised there.

## Changes

1. **New**: `src/oss/javascript/integrations/llm_caching/betterdb.mdx`
   Integration page following the `azure_cosmosdb_nosql.mdx` template.

2. **Modified**: `src/oss/javascript/integrations/llm_caching/index.mdx`
   Added a card for the new page inside the existing `<Columns>` block.

3. **Modified**: `src/oss/javascript/integrations/providers/all_providers.mdx`
   Added a card in the "LLM caching" section.

## Package info

- npm: https://www.npmjs.com/package/@betterdb/agent-cache
- The package is JavaScript/TypeScript only, no Python equivalent.
- Works on vanilla Valkey 7+, Redis 6.2+, and managed equivalents 
  (ElastiCache, Memorystore, MemoryDB) with no module requirements.

## Nav

No `docs.json` changes. The new page is discoverable via the index card, matching the pattern used by every other category under the JS "General integrations" group (each lists only the index, individual pages are reached from the index card grid).

## Related

- #3603 — tracking issue for the companion LangGraph checkpointer work.