### PR TITLE
docs: Add AgentPhone integration

### DIFF
--- a/src/oss/python/integrations/providers/agentphone.mdx
+++ b/src/oss/python/integrations/providers/agentphone.mdx
@@ -1,0 +1,28 @@
+---
+title: "AgentPhone integrations"
+description: "Integrate with AgentPhone using LangChain Python."
+---
+
+[AgentPhone](https://agentphone.to) is a telephony platform for AI agents, providing messaging, voice calls, phone number management, and contact management through a simple API.
+
+## Installation and setup
+
+<CodeGroup>
+```bash pip
+pip install langchain-agentphone
+```
+
+```bash uv
+uv add langchain-agentphone
+```
+</CodeGroup>
+
+Get your API key from [agentphone.to](https://agentphone.to) and set it as an environment variable:
+
+```bash
+export AGENTPHONE_API_KEY="your-api-key"
+```
+
+## Tools
+
+See the [AgentPhone Toolkit](/oss/integrations/tools/agentphone) guide for details on available tools including messaging, voice calls, phone number management, and more.

--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -58,6 +58,14 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
+        title="AgentPhone"
+        href="/oss/integrations/providers/agentphone"
+        icon="link"
+    >
+        Telephony platform for AI agents with messaging, voice calls, and phone number management.
+    </Card>
+
+    <Card
         title="AgentQL"
         href="/oss/integrations/providers/agentql"
         icon="link"

--- a/src/oss/python/integrations/tools/agentphone.mdx
+++ b/src/oss/python/integrations/tools/agentphone.mdx
@@ -1,0 +1,134 @@
+---
+title: "AgentPhone Toolkit"
+description: "Integrate with the AgentPhone toolkit using LangChain Python."
+---
+
+[AgentPhone](https://agentphone.to) is a telephony platform for AI agents. The `langchain-agentphone` package provides LangChain tools for sending messages, making AI-powered phone calls, managing phone numbers, and more.
+
+## Overview
+
+### Integration details
+
+| Class | Package | Serializable | [JS support](https://js.langchain.com) |  Version |
+|:------|:--------| :---: | :---: | :---: |
+| `AgentPhoneToolkit` | [`langchain-agentphone`](https://pypi.org/project/langchain-agentphone/) | ❌ | ❌ | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-agentphone?style=flat-square&label=%20) |
+
+### Available tools
+
+| Tool | Description |
+|:-----|:------------|
+| `AgentPhoneSendSMS` | Send a text message |
+| `AgentPhoneMakeCall` | Make an AI-powered outbound phone call |
+| `AgentPhoneGetTranscript` | Get the transcript of a phone call |
+| `AgentPhoneListCalls` | List phone calls with optional filters |
+| `AgentPhoneListConversations` | List conversations |
+| `AgentPhoneGetConversation` | Get a conversation with its messages |
+| `AgentPhoneBuyNumber` | Buy a new phone number |
+| `AgentPhoneListNumbers` | List phone numbers on the account |
+| `AgentPhoneCreateAgent` | Create a new AI phone agent |
+| `AgentPhoneListAgents` | List AI phone agents |
+| `AgentPhoneCreateContact` | Create a new contact |
+| `AgentPhoneListContacts` | List contacts |
+
+## Setup
+
+Install the package:
+
+```bash
+pip install -qU langchain-agentphone
+```
+
+### Credentials
+
+You need an AgentPhone API key. Sign up at [agentphone.to](https://agentphone.to) to get one.
+
+```python
+import getpass
+import os
+
+if not os.environ.get("AGENTPHONE_API_KEY"):
+    os.environ["AGENTPHONE_API_KEY"] = getpass.getpass("AgentPhone API key:\n")
+```
+
+## Instantiation
+
+Use the toolkit to get all tools at once, or select specific ones:
+
+```python
+from langchain_agentphone import AgentPhoneToolkit
+
+# All tools
+toolkit = AgentPhoneToolkit()
+tools = toolkit.get_tools()
+
+# Or select specific tools
+toolkit = AgentPhoneToolkit(selected_tools=["send_sms", "list_numbers", "make_call"])
+tools = toolkit.get_tools()
+```
+
+You can also instantiate individual tools directly:
+
+```python
+from langchain_agentphone import AgentPhoneSendSMS, AgentPhoneListNumbers
+
+send_sms = AgentPhoneSendSMS()
+list_numbers = AgentPhoneListNumbers()
+```
+
+## Invocation
+
+### Invoke directly with args
+
+```python
+from langchain_agentphone import AgentPhoneSendSMS
+
+tool = AgentPhoneSendSMS()
+result = tool.invoke({
+    "number_id": "num_abc123",
+    "to_number": "+14155551234",
+    "body": "Hello from LangChain!"
+})
+print(result)
+```
+
+### Invoke with ToolCall
+
+```python
+model_generated_tool_call = {
+    "args": {
+        "number_id": "num_abc123",
+        "to_number": "+14155551234",
+        "body": "Meeting at 3pm confirmed."
+    },
+    "id": "1",
+    "name": "agentphone_send_sms",
+    "type": "tool_call",
+}
+tool_msg = tool.invoke(model_generated_tool_call)
+print(tool_msg.content)
+```
+
+## Use within an agent
+
+```python
+from langchain_agentphone import AgentPhoneToolkit
+from langchain.chat_models import init_chat_model
+from langgraph.prebuilt import create_react_agent
+
+model = init_chat_model(model="claude-sonnet-4-6", model_provider="anthropic")
+
+toolkit = AgentPhoneToolkit(
+    selected_tools=["send_sms", "list_numbers", "list_contacts"]
+)
+agent = create_react_agent(model, toolkit.get_tools())
+
+response = agent.invoke({
+    "messages": [("user", "List my phone numbers, then send a message to +14155551234 saying 'Hello!'")]
+})
+```
+
+---
+
+## API reference
+
+For detailed documentation of the AgentPhone API, visit [docs.agentphone.to](https://docs.agentphone.to).

--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -57,6 +57,7 @@ The following table shows tools that can be used to automate tasks in productivi
 | [Jira Toolkit](/oss/integrations/tools/jira) | Free, with [rate limits](https://developer.atlassian.com/cloud/jira/platform/rate-limiting/) |
 | [Office365 Toolkit](/oss/integrations/tools/office365) | Free with Office365, includes [rate limits](https://learn.microsoft.com/en-us/graph/throttling-limits) |
 | [Slack Toolkit](/oss/integrations/tools/slack) | Free |
+| [AgentPhone Toolkit](/oss/integrations/tools/agentphone) | Free tier available, with [pay-as-you-go pricing](https://agentphone.to) after |
 | [Twilio Tool](/oss/integrations/tools/twilio) | Free trial, with [pay-as-you-go pricing](https://www.twilio.com/en-us/pricing) after |
 
 ## Web browsing
@@ -110,6 +111,7 @@ The following platforms provide access to multiple tools and services through a 
 
 <Columns cols={3}>
 <Card title="ADS4GPTs" icon="link" href="/oss/integrations/tools/ads4gpts" arrow="true" cta="View guide" />
+<Card title="AgentPhone Toolkit" icon="link" href="/oss/integrations/tools/agentphone" arrow="true" cta="View guide" />
 <Card title="AgentQL" icon="link" href="/oss/integrations/tools/agentql" arrow="true" cta="View guide" />
 <Card title="AINetwork Toolkit" icon="link" href="/oss/integrations/tools/ainetwork" arrow="true" cta="View guide" />
 <Card title="Alpha Vantage" icon="link" href="/oss/integrations/tools/alpha_vantage" arrow="true" cta="View guide" />


### PR DESCRIPTION
## Summary
- Add AgentPhone provider page and toolkit tool page for `langchain-agentphone`
- Add AgentPhone to the tools index (Productivity section) and all providers list
- Package: [langchain-agentphone](https://pypi.org/project/langchain-agentphone/)

[AgentPhone](https://agentphone.to) is a telephony platform for AI agents with messaging, voice calls, and phone number management. The `langchain-agentphone` package provides 12 LangChain tools via `AgentPhoneToolkit`.

## Files changed
- `src/oss/python/integrations/providers/agentphone.mdx` — new provider page
- `src/oss/python/integrations/tools/agentphone.mdx` — new toolkit tool page
- `src/oss/python/integrations/tools/index.mdx` — added to Productivity table and All tools cards
- `src/oss/python/integrations/providers/all_providers.mdx` — added to provider card list