### PR TITLE
docs(fleet): replace GitHub OAuth setup with GitHub App instructions

### DIFF
--- a/src/langsmith/fleet/self-hosted.mdx
+++ b/src/langsmith/fleet/self-hosted.mdx
@@ -67,13 +67,16 @@ You can store the encryption key in a predefined Kubernetes secret using the `fl
 
 ## Enable OAuth tools and triggers (optional)
 
-To enable OAuth-based tools (like Gmail, Slack, GitHub), configure the `oauthProviderOrgId` and add provider IDs for each integration you want to enable. You can enable any combination of providers.
+To enable OAuth-based tools (like Gmail, Slack, Linear), configure the `oauthProviderOrgId` and add provider IDs for each integration you want to enable. You can enable any combination of providers.
+
+<Note>
+GitHub tools are no longer configured through an OAuth provider. Fleet now integrates with GitHub via a dedicated GitHub App. See [Enable GitHub App for Fleet](#enable-github-app-for-fleet) below.
+</Note>
 
 ### Available providers
 
 | Provider | Tools enabled | Trigger enabled | Setup guide |
 |----------|--------------|-----------------|---------------------|
-| `githubOAuthProvider` | GitHub | - | [See below](#github-oauth-provider)
 | `googleOAuthProvider` | Gmail, Google Calendar, Google Sheets, BigQuery | Gmail | [See below](#google-oauth-provider)
 | `linearOAuthProvider` | Linear | - | [See below](#linear-oauth-provider)
 | `linkedinOAuthProvider` | LinkedIn | - | [See below](#linkedin-oauth-provider)
@@ -103,7 +106,6 @@ config:
       linkedinOAuthProvider: "<provider-id>"
       linearOAuthProvider: "<provider-id>"
       microsoftOAuthProvider: "<provider-id>"
-      githubOAuthProvider: "<provider-id>"
 ```
 
 <Warning>
@@ -113,69 +115,6 @@ The provider ID must be unique and cannot end with `-agent-builder` or `-oauth-p
 ### Provider setup guides
 
 <AccordionGroup>
-<Accordion title="GitHub OAuth provider" id="github-oauth-provider">
-
-To enable GitHub OAuth for Fleet, you need to create a GitHub OAuth app and configure it with the required permissions.
-
-<Steps>
-  <Step title="Create a GitHub OAuth app">
-    Go to [GitHub Settings > Developer settings > OAuth Apps](https://github.com/settings/developers) and click **New OAuth App**.
-  </Step>
-
-  <Step title="Configure the app">
-    Fill in the application details. You can name it whatever you like and leave the default checkbox settings.
-  </Step>
-
-  <Step title="Set permissions">
-    Give the app read/write permissions to **Pull Requests** and **Issues**.
-  </Step>
-
-  <Step title="Add callback URL">
-    Set the callback URL, replacing `<hostname>` with your LangSmith hostname and `<provider-id>` with your provider ID:
-
-    ```
-    https://<hostname>/host-oauth-callback/<provider-id>
-    ```
-  </Step>
-
-  <Step title="Generate client secret">
-    Click **Generate a new client secret** and copy both the **Client ID** (shown at the top of the app page) and the **Client Secret**.
-  </Step>
-
-  <Step title="Configure OAuth provider in LangSmith">
-    In LangSmith, go to **Settings > OAuth Providers** and add a new provider:
-    - **Client ID**: from GitHub app
-    - **Client Secret**: from GitHub app
-    - **Authorization URL**: `https://github.com/login/oauth/authorize`
-    - **Token URL**: `https://github.com/login/oauth/access_token`
-    - **Provider ID**: Unique string, for example: `github`
-  </Step>
-
-  <Step title="Deploy">
-    Add the following to your `values.yaml` and deploy:
-
-    ```yaml
-    config:
-      agentBuilder:
-        oauthProviderOrgId: "<your-org-id>"
-        oauth:
-          githubOAuthProvider: "<provider-id>"
-    ```
-  </Step>
-
-  <Step title="Install the app on repositories">
-    After creating the app, you need to:
-    1. Authenticate the app to your GitHub account.
-    2. Go to **Settings > Applications > Installed GitHub Apps** and install the app on the repositories you want it to access.
-
-    <Note>
-    For private repositories, you must explicitly install the app on each repository you want Fleet to access.
-    </Note>
-  </Step>
-</Steps>
-
-</Accordion>
-
 <Accordion title="Google OAuth provider" id="google-oauth-provider">
 
 To enable Google OAuth for Fleet, you need to create an OAuth client in GCP and configure it with the required URLs and credentials.
@@ -494,6 +433,183 @@ To enable Slack OAuth for Fleet, you need to create a Slack app and configure it
 
 </Accordion>
 </AccordionGroup>
+
+## Enable GitHub App for Fleet
+
+Fleet integrates with GitHub through a dedicated **GitHub App** (not an OAuth app). The GitHub App provides repository access for Fleet's GitHub tools and supports the user authorization flow required for private repository access.
+
+Setup involves creating a GitHub App, gathering its credentials, storing them as Kubernetes secrets, and referencing them from `values.yaml`.
+
+<Steps>
+  <Step title="Create a GitHub App">
+    Go to [GitHub Settings > Developer settings > GitHub Apps](https://github.com/settings/apps) and click **New GitHub App**.
+
+    <Note>
+    You can create the app under a personal account or an organization. If multiple people will manage the integration, an organization-owned app is recommended.
+    </Note>
+  </Step>
+
+  <Step title="Fill in basic details">
+    - **GitHub App name**: Any unique name, for example `acme-langsmith-fleet`. Make a note of the slug GitHub generates (the lowercased, hyphenated form of the name — this is the value you'll use for `FLEET_GITHUB_APP_SLUG`).
+    - **Homepage URL**: Your LangSmith hostname, for example `https://langsmith.acme.com`.
+    - Uncheck **Active** under **Webhook** for now — you'll enable it in a later step after generating a webhook secret.
+  </Step>
+
+  <Step title="Set callback URLs">
+    Under **Identifying and authorizing users**, add the following **Callback URL**, replacing `<hostname>` with your LangSmith hostname:
+
+    ```
+    https://<hostname>/v1/platform/fleet/providers/github-app/auth/callback
+    ```
+
+    Leave **Request user authorization (OAuth) during installation** unchecked. Check **Redirect on update**.
+
+    Under **Post installation**, add the following **Setup URL**:
+
+    ```
+    https://<hostname>/v1/platform/fleet/providers/github-app/callback
+    ```
+
+    Check **Redirect on update**.
+  </Step>
+
+  <Step title="Set webhook URL and generate a webhook secret">
+    Generate a random webhook secret:
+
+    ```bash
+    python3 -c "import secrets; print(secrets.token_urlsafe(48))"
+    ```
+
+    Under **Webhook**:
+    - Check **Active**.
+    - Set the **Webhook URL** to:
+
+      ```
+      https://<hostname>/v1/platform/fleet/providers/github-app/webhooks
+      ```
+
+    - Paste the generated value into **Webhook secret**. Save it — you'll need the same value when configuring LangSmith.
+  </Step>
+
+  <Step title="Set repository permissions">
+    Under **Permissions > Repository permissions**, grant the following:
+
+    - **Contents**: Read and write
+    - **Issues**: Read and write
+    - **Pull requests**: Read and write
+    - **Metadata**: Read-only (automatically selected)
+
+    Under **Permissions > Account permissions**, grant **Email addresses: Read-only**.
+
+    <Note>
+    These are the minimum permissions required for Fleet's built-in GitHub tools (issue management, pull request creation, repository content access). Adjust if you need additional tool capabilities.
+    </Note>
+  </Step>
+
+  <Step title="Choose install visibility">
+    Under **Where can this GitHub App be installed?**, select whichever option matches your distribution needs. For most self-hosted deployments, **Only on this account** is correct.
+  </Step>
+
+  <Step title="Create the app">
+    Click **Create GitHub App**. You'll be taken to the app's settings page, where several values are now available:
+
+    - **App ID** (numeric, at the top of the page) → `FLEET_GITHUB_APP_ID`
+    - **Public link** (for example, `https://github.com/apps/acme-langsmith-fleet`) → `FLEET_GITHUB_APP_PUBLIC_LINK`
+    - App slug (the last path segment of the public link) → `FLEET_GITHUB_APP_SLUG`
+    - **Client ID** (under **About**) → `FLEET_GITHUB_APP_CLIENT_ID`
+  </Step>
+
+  <Step title="Generate a client secret">
+    Under **Client secrets**, click **Generate a new client secret** and copy the value. This is `FLEET_GITHUB_APP_CLIENT_SECRET`. GitHub only shows it once.
+  </Step>
+
+  <Step title="Generate a private key">
+    Scroll to **Private keys** and click **Generate a private key**. GitHub will download a `.pem` file. Keep this file secure — it grants full access to the GitHub App. The PEM contents are `FLEET_GITHUB_APP_PRIVATE_KEY`.
+  </Step>
+
+  <Step title="Generate a state JWT secret">
+    The backend signs short-lived OAuth state tokens with an HMAC key. Generate one:
+
+    ```bash
+    python3 -c "import secrets; print(secrets.token_urlsafe(48))"
+    ```
+
+    This is `FLEET_GITHUB_APP_STATE_JWT_SECRET`.
+  </Step>
+
+  <Step title="Create a Kubernetes secret">
+    Store the sensitive values in a Kubernetes secret. For example:
+
+    ```bash
+    kubectl create secret generic fleet-github-app \
+      --namespace <your-langsmith-namespace> \
+      --from-literal=client_secret="<client-secret>" \
+      --from-literal=webhook_secret="<webhook-secret>" \
+      --from-literal=state_jwt_secret="<state-jwt-secret>" \
+      --from-file=private_key=/path/to/fleet-app.private-key.pem
+    ```
+
+    For production deployments, we recommend managing this secret through your existing secrets workflow (for example, [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) or [External Secrets Operator](https://external-secrets.io/)). See [Use an existing secret](/langsmith/self-host-using-an-existing-secret) for more on managing LangSmith secrets.
+  </Step>
+
+  <Step title="Configure values.yaml">
+    Add the following to your `values.yaml`, replacing the placeholder values with the non-sensitive values gathered above:
+
+    ```yaml
+    commonEnv:
+      - name: FLEET_GITHUB_APP_ID
+        value: "<app-id>"
+      - name: FLEET_GITHUB_APP_SLUG
+        value: "<app-slug>"
+      - name: FLEET_GITHUB_APP_PUBLIC_LINK
+        value: "https://github.com/apps/<app-slug>"
+      - name: FLEET_GITHUB_APP_CLIENT_ID
+        value: "<client-id>"
+      - name: FLEET_GITHUB_APP_CLIENT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: fleet-github-app
+            key: client_secret
+      - name: FLEET_GITHUB_APP_PRIVATE_KEY
+        valueFrom:
+          secretKeyRef:
+            name: fleet-github-app
+            key: private_key
+      - name: FLEET_GITHUB_APP_WEBHOOK_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: fleet-github-app
+            key: webhook_secret
+      - name: FLEET_GITHUB_APP_STATE_JWT_SECRET
+        valueFrom:
+          secretKeyRef:
+            name: fleet-github-app
+            key: state_jwt_secret
+
+    agentBuilderToolServer:
+      deployment:
+        extraEnv:
+          - name: FLEET_GITHUB_APP_ENABLED
+            value: "true"
+    ```
+
+    <Note>
+    `FLEET_GITHUB_APP_ENABLED` must be set on the tool server so the GitHub tools are registered. The remaining `FLEET_GITHUB_APP_*` variables are consumed by the platform backend and so live under `commonEnv`.
+    </Note>
+  </Step>
+
+  <Step title="Deploy and install the app on repositories">
+    Upgrade your LangSmith release to apply the new configuration. Once pods are healthy:
+
+    1. In LangSmith, open a Fleet agent and go to the GitHub integration in the agent editor.
+    2. Click **Connect GitHub** to install the app on the repositories Fleet should access.
+    3. For private repositories, you must explicitly select each repository during installation.
+
+    <Note>
+    Users must also authorize the app against their own GitHub account (via the re-auth flow in LangSmith) so Fleet can resolve per-user tokens for tools that act on behalf of a user.
+    </Note>
+  </Step>
+</Steps>
 
 ## Disable Fleet
 


### PR DESCRIPTION
## Summary

Fleet now integrates with GitHub via a dedicated **GitHub App** instead of an OAuth app (see [langchainplus#22022](https://github.com/langchain-ai/langchainplus/pull/22022) and [deployments#27739](https://github.com/langchain-ai/deployments/pull/27739)).

This PR updates the self-hosted Fleet docs to match:

- Removes the old "GitHub OAuth provider" accordion and all references to `githubOAuthProvider` in the OAuth providers table and general config example.
- Adds a new top-level "Enable GitHub App for Fleet" section with end-to-end setup: creating the GitHub App, configuring permissions / callback URLs / webhook URL, generating the private key, webhook secret, state JWT secret, and client secret, storing everything in a Kubernetes secret, and wiring the `FLEET_GITHUB_APP_*` env vars into `values.yaml` via `commonEnv` and `agentBuilderToolServer.deployment.extraEnv`.

## Test plan

- [x] Preview the page in Mintlify and confirm the new section renders correctly and the anchor link from the OAuth providers note resolves.

[Enable OAuth tools and triggers (optional)](https://langchain-5e9cc07a-preview-docsfl-1776371397-e812a24.mintlify.app/langsmith/fleet/self-hosted#enable-oauth-tools-and-triggers-optional)