### PR TITLE
docs(agents): add warning for JS runtime tool registration limitation

### DIFF
--- a/src/oss/langchain/agents.mdx
+++ b/src/oss/langchain/agents.mdx
@@ -651,6 +651,19 @@ There are two approaches depending on whether tools are known ahead of time:
 
     :::js
 
+    <Warning>
+    **Known limitation (JS/TS):** Adding new tools at runtime via `wrapModelCall`
+    is currently not supported in JavaScript/TypeScript and will throw:
+
+    ```
+    Error: You have added a new tool in "wrapModelCall" hook of middleware "...".
+    This is not supported.
+    ```
+
+    Until this is resolved, use the **"Filtering pre-registered tools"** tab instead.
+    Tracking issue: [langchain-ai/langgraphjs#1934](https://github.com/langchain-ai/langgraphjs/issues/1934)
+    </Warning>
+
     ```typescript
     import { createAgent, createMiddleware, tool } from "langchain";
     import * as z from "zod";


### PR DESCRIPTION
## Problem
The "Runtime tool registration" tab in the agents docs shows a JS/TS
example using wrapModelCall to add new tools at runtime. This throws:

  Error: You have added a new tool in "wrapModelCall" hook of middleware "...".
  This is not supported.

Reproduced in @langchain/core@1.2.26 and @langchain/langgraph@^1.0.14.
The Python version works via AgentMiddleware. The JS version does not.

## Fix
Added a <Warning> callout in the JS tab explaining the limitation and
pointing users to the working "Filtering pre-registered tools" approach.

## References
- langchain-ai/langgraphjs#1934