### PR TITLE
docs: add Linkup Search to tools comparison table

### DIFF
--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -22,6 +22,7 @@ The following table shows tools that execute online searches in some shape or fo
 | [Google Search](/oss/integrations/tools/google_search) | Paid | URL, Snippet, Title |
 | [Google Serper](/oss/integrations/tools/google_serper) | Free | URL, Snippet, Title, Search Rank, Site Links |
 | [Jina Search](/oss/integrations/tools/jina_search) | 1M Response Tokens Free | URL, Snippet, Title, Page Content |
+| [Linkup Search](/oss/integrations/tools/linkup_search) | 2000 free searches/month | URL, Content, Sources |
 | [Mojeek Search](/oss/integrations/tools/mojeek_search) | Paid | URL, Snippet, Title |
 | [Nia Toolkit](/oss/integrations/tools/nia) | Free tier available | Code, Docs, Metadata, Sources |
 | [Nimble Search](/oss/integrations/tools/nimble_search) | Free trial available | URL, Content, Title |


### PR DESCRIPTION
## Summary

Adds **Linkup Web Search API** to the Search tools comparison table in `src/oss/python/integrations/tools/index.mdx`, inserted alphabetically between Jina Search and Mojeek Search.

## Why

The integration page at `/oss/integrations/tools/linkup_search` already exists and Linkup already appears in the "All tools and toolkits" card grid at the bottom of the same page, but it is missing from the comparison table at the top — which is the first reference developers see when picking a web-search tool. This one-line addition makes the integration discoverable from the comparison view alongside the other web-search tools.

## Change

Single line added to the Markdown table:

```markdown
| [Linkup Search](/oss/integrations/tools/linkup_search) | 2000 free searches/month | URL, Content, Sources |
```

## Review focus
- Column values accuracy (Free/Paid, Return Data): these reflect Linkup's current offering.
- Alphabetical position (J → **L** → M).
