### PR TITLE
bump gpt-4.1 model references to gpt-5.4

### DIFF
--- a/src/code-samples/langchain/middleware-dynamic-prompt.ts
+++ b/src/code-samples/langchain/middleware-dynamic-prompt.ts
@@ -12,7 +12,7 @@ const addContextMiddleware = createMiddleware({
 });
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   systemPrompt: "You are a helpful assistant.",
   middleware: [addContextMiddleware],
 });

--- a/src/langsmith/access-current-span.mdx
+++ b/src/langsmith/access-current-span.mdx
@@ -42,7 +42,7 @@ from openai import Client
         print(f"invoke_llm Trace Id: {run.trace_id}")
         print(f"invoke_llm Parent Run Id: {run.parent_run.id}")
         return openai.chat.completions.create(
-            messages=messages, model="gpt-4.1-mini", temperature=0
+            messages=messages, model="gpt-5.4-mini", temperature=0
         )
 
     @traceable
@@ -95,7 +95,7 @@ import OpenAI from "openai";
             console.log("invokeLLM Trace ID", run.trace_id)
             console.log("invokeLLM Parent Run ID", run.parent_run.id)
             return openai.chat.completions.create({
-                model: "gpt-4.1-mini",
+                model: "gpt-5.4-mini",
                 messages: messages,
                 temperature: 0,
             });

--- a/src/langsmith/add-metadata-tags.mdx
+++ b/src/langsmith/add-metadata-tags.mdx
@@ -32,7 +32,7 @@ messages = [
         metadata={"my-key": "my-value"}
     )
     def call_openai(
-        messages: list[dict], model: str = "gpt-4.1-mini"
+        messages: list[dict], model: str = "gpt-5.4-mini"
     ) -> str:
         # You can also dynamically set metadata on the parent run:
         rt = ls.get_current_run_tree()
@@ -66,7 +66,7 @@ messages = [
         metadata={"my-key": "my-value"},
     ) as rt:
         chat_completion = client.chat.completions.create(
-            model="gpt-4.1-mini",
+            model="gpt-5.4-mini",
             messages=messages,
         )
         rt.metadata["some-conditional-key"] = "some-val"
@@ -77,7 +77,7 @@ patched_client = wrap_openai(
     client, tracing_extra={"metadata": {"my-key": "my-value"}, "tags": ["a-tag"]}
 )
 chat_completion = patched_client.chat.completions.create(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     messages=messages,
     langsmith_extra={
         "tags": ["my-other-tag"],
@@ -100,7 +100,7 @@ import { wrapOpenAI } from "langsmith/wrappers";
     const traceableCallOpenAI = traceable(
         async (messages: OpenAI.Chat.ChatCompletionMessageParam[]) => {
             const completion = await client.chat.completions.create({
-                model: "gpt-4.1-mini",
+                model: "gpt-5.4-mini",
                 messages,
             });
             const runTree = getCurrentRunTree();

--- a/src/langsmith/analyze-an-experiment.mdx
+++ b/src/langsmith/analyze-an-experiment.mdx
@@ -139,7 +139,7 @@ results = client.evaluate(
     data="my-dataset",
     evaluators=[...],
     metadata={
-        "models": "openai:gpt-4.1-mini",
+        "models": "openai:gpt-5.4-mini",
         "prompts": ["my-org/my-prompt:abc12345"],
         "tools": [{"name": "web_search", "description": "Search the web for information"}],
     },
@@ -196,6 +196,6 @@ You can rename an experiment in the LangSmith UI in the following places:
 
   ![Edit name in experiment view](/langsmith/images/rename-in-experiment-view.png)
 
-- **Playground**: A default name with the format `pg::prompt-name::model::uuid` (eg. `pg::gpt-4.1-mini::897ee630`) is automatically assigned. You can rename an experiment immediately after running it by editing its name in the Playground table header.
+- **Playground**: A default name with the format `pg::prompt-name::model::uuid` (eg. `pg::gpt-5.4-mini::897ee630`) is automatically assigned. You can rename an experiment immediately after running it by editing its name in the Playground table header.
 
   ![Edit name in playground](/langsmith/images/rename-in-playground.png)

--- a/src/langsmith/annotate-code.mdx
+++ b/src/langsmith/annotate-code.mdx
@@ -60,7 +60,7 @@ def format_prompt(subject):
 @traceable(run_type="llm")
 def invoke_llm(messages):
   return openai.chat.completions.create(
-      messages=messages, model="gpt-4.1-mini", temperature=0
+      messages=messages, model="gpt-5.4-mini", temperature=0
   )
 
 @traceable
@@ -98,7 +98,7 @@ const formatPrompt = traceable((subject: string) => {
 const invokeLLM = traceable(
   async ({ messages }: { messages: { role: string; content: string }[] }) => {
       return openai.chat.completions.create({
-          model: "gpt-4.1-mini",
+          model: "gpt-5.4-mini",
           messages: messages,
           temperature: 0,
       });
@@ -164,7 +164,7 @@ def chat_pipeline(question: str):
         { "role": "user", "content": f"Question: {question}\nContext: {context}"}
     ]
     chat_completion = client.chat.completions.create(
-        model="gpt-4.1-mini", messages=messages
+        model="gpt-5.4-mini", messages=messages
     )
     return chat_completion.choices[0].message.content
 
@@ -216,7 +216,7 @@ child_llm_run.post()
 # Generate a completion
 client = openai.Client()
 chat_completion = client.chat.completions.create(
-  model="gpt-4.1-mini", messages=messages
+  model="gpt-5.4-mini", messages=messages
 )
 
 # End the runs and log them
@@ -258,7 +258,7 @@ await childRun.postRun();
 // Generate a completion
 const client = new OpenAI();
 const chatCompletion = await client.chat.completions.create({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   messages: messages,
 });
 

--- a/src/langsmith/code-evaluator-sdk.mdx
+++ b/src/langsmith/code-evaluator-sdk.mdx
@@ -109,7 +109,7 @@ answer is logically valid and consistent with question and the answer."""
 
     msg = f"Question: {inputs['question']}\nAnswer: {outputs['answer']}\nReasoning: {outputs['reasoning']}"
     response = await oai_client.beta.chat.completions.parse(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         messages=[{"role": "system", "content": instructions,}, {"role": "user", "content": msg}],
         response_format=Response
     )

--- a/src/langsmith/cost-tracking.mdx
+++ b/src/langsmith/cost-tracking.mdx
@@ -379,7 +379,7 @@ total_cost = input_cost + output_cost  # 6.5e-5
 When using a custom model, the following fields need to be specified in a [run's metadata](/langsmith/add-metadata-tags) in order to associate token counts with costs. It's also helpful to provide these metadata fields to identify the model when viewing traces and when filtering.
 
 - `ls_provider`: The provider of the model, e.g., “openai”, “anthropic”
-- `ls_model_name`: The name of the model, e.g., “gpt-4.1-mini”, “claude-3-opus-20240229”
+- `ls_model_name`: The name of the model, e.g., “gpt-5.4-mini”, “claude-3-opus-20240229”
 
 
 **3. Set model prices**

--- a/src/langsmith/define-target-function.mdx
+++ b/src/langsmith/define-target-function.mdx
@@ -61,7 +61,7 @@ def target(inputs: dict) -> dict:
   messages = inputs["messages"]
   response = oai_client.chat.completions.create(
       messages=messages,
-      model="gpt-4.1-mini",
+      model="gpt-5.4-mini",
   )
   return {"answer": response.choices[0].message.content}
 ```
@@ -78,7 +78,7 @@ const target = async(inputs) => {
   const messages = inputs.messages;
   const response = await client.chat.completions.create({
       messages: messages,
-      model: 'gpt-4.1-mini',
+      model: 'gpt-5.4-mini',
   });
   return { answer: response.choices[0].message.content };
 }
@@ -87,7 +87,7 @@ const target = async(inputs) => {
 ```python Python (LangChain)
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model("gpt-4.1-mini")
+model = init_chat_model("gpt-5.4-mini")
 
 def target(inputs: dict) -> dict:
   # This assumes your dataset has inputs with a `messages` key
@@ -103,7 +103,7 @@ import { ChatOpenAI } from '@langchain/openai';
 const target = async(inputs) => {
   // This assumes your dataset has inputs with a `messages` key
   const messages = inputs.messages;
-  const model = new ChatOpenAI({ model: "gpt-4.1-mini" });
+  const model = new ChatOpenAI({ model: "gpt-5.4-mini" });
   const response = await model.invoke(messages);
   return {"answer": response.content};
 }

--- a/src/langsmith/evaluate-chatbot-tutorial.mdx
+++ b/src/langsmith/evaluate-chatbot-tutorial.mdx
@@ -126,7 +126,7 @@ You are grading the following predicted answer:
 Respond with CORRECT or INCORRECT:
 Grade:"""
     response = openai_client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         temperature=0,
         messages=[
             {"role": "system", "content": eval_instructions},
@@ -150,7 +150,7 @@ Great! Now how do we run evaluations? Now that we have a dataset and evaluators,
 ```python
 default_instructions = "Respond to the users question in a short, concise manner (one short sentence)."
 
-def my_app(question: str, model: str = "gpt-4.1-mini", instructions: str = default_instructions) -> str:
+def my_app(question: str, model: str = "gpt-5.4-mini", instructions: str = default_instructions) -> str:
     return openai_client.chat.completions.create(
         model=model,
         temperature=0,
@@ -291,7 +291,7 @@ openai_client = wrappers.wrap_openai(openai.OpenAI())
 
 default_instructions = "Respond to the users question in a short, concise manner (one short sentence)."
 
-def my_app(question: str, model: str = "gpt-4.1-mini", instructions: str = default_instructions) -> str:
+def my_app(question: str, model: str = "gpt-5.4-mini", instructions: str = default_instructions) -> str:
     return openai_client.chat.completions.create(
         model=model,
         temperature=0,
@@ -346,7 +346,7 @@ You are grading the following predicted answer:
 Respond with CORRECT or INCORRECT:
 Grade:"""
     response = openai_client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         temperature=0,
         messages=[
             {"role": "system", "content": eval_instructions},

--- a/src/langsmith/evaluate-complex-agent.mdx
+++ b/src/langsmith/evaluate-complex-agent.mdx
@@ -196,7 +196,7 @@ class PurchaseInformation(TypedDict):
     ]
 
 # Model for performing extraction.
-info_llm = init_chat_model("gpt-4.1-mini").with_structured_output(
+info_llm = init_chat_model("gpt-5.4-mini").with_structured_output(
     PurchaseInformation, method="json_schema", include_raw=True
 )
 
@@ -344,7 +344,7 @@ class UserIntent(TypedDict):
     intent: Literal["refund", "question_answering"]
 
 # Routing model with structured output
-router_llm = init_chat_model("gpt-4.1-mini").with_structured_output(
+router_llm = init_chat_model("gpt-5.4-mini").with_structured_output(
     UserIntent, method="json_schema", strict=True
 )
 
@@ -534,7 +534,7 @@ class Grade(TypedDict):
     is_correct: Annotated[bool, ..., "True if the student response is mostly or exactly correct, otherwise False."]
 
 # Judge LLM
-grader_llm = init_chat_model("gpt-4.1-mini", temperature=0).with_structured_output(Grade, method="json_schema", strict=True)
+grader_llm = init_chat_model("gpt-5.4-mini", temperature=0).with_structured_output(Grade, method="json_schema", strict=True)
 
 # Evaluator function
 async def final_answer_correct(inputs: dict, outputs: dict, reference_outputs: dict) -> bool:
@@ -995,7 +995,7 @@ class PurchaseInformation(TypedDict):
 
 
 # Model for performing extraction.
-info_llm = init_chat_model("gpt-4.1-mini").with_structured_output(
+info_llm = init_chat_model("gpt-5.4-mini").with_structured_output(
     PurchaseInformation, method="json_schema", include_raw=True
 )
 
@@ -1272,7 +1272,7 @@ class UserIntent(TypedDict):
 
 
 # Routing model with structured output
-router_llm = init_chat_model("gpt-4.1-mini").with_structured_output(
+router_llm = init_chat_model("gpt-5.4-mini").with_structured_output(
     UserIntent, method="json_schema", strict=True
 )
 
@@ -1419,7 +1419,7 @@ class Grade(TypedDict):
 
 
 # Judge LLM
-grader_llm = init_chat_model("gpt-4.1-mini", temperature=0).with_structured_output(
+grader_llm = init_chat_model("gpt-5.4-mini", temperature=0).with_structured_output(
     Grade, method="json_schema", strict=True
 )
 

--- a/src/langsmith/evaluate-graph.mdx
+++ b/src/langsmith/evaluate-graph.mdx
@@ -130,7 +130,7 @@ And a simple evaluator:
 Requires `langsmith>=0.2.0`
 
 ```python
-judge_llm = init_chat_model("gpt-4.1")
+judge_llm = init_chat_model("gpt-5.4")
 
 async def correct(outputs: dict, reference_outputs: dict) -> bool:
     instructions = (
@@ -385,7 +385,7 @@ ls_client.create_examples(
 
 # Define evaluators
 
-judge_llm = init_chat_model("gpt-4.1")
+judge_llm = init_chat_model("gpt-5.4")
 
 async def correct(outputs: dict, reference_outputs: dict) -> bool:
     instructions = (

--- a/src/langsmith/evaluate-llm-application.mdx
+++ b/src/langsmith/evaluate-llm-application.mdx
@@ -45,7 +45,7 @@ def toxicity_classifier(inputs: dict) -> dict:
         {"role": "user", "content": inputs["text"]},
     ]
     result = oai_client.chat.completions.create(
-        messages=messages, model="gpt-4.1-mini", temperature=0
+        messages=messages, model="gpt-5.4-mini", temperature=0
     )
     return {"class": result.choices[0].message.content}
 ```
@@ -69,7 +69,7 @@ const toxicityClassifier = traceable(
         },
         { role: "user", content: text },
       ],
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       temperature: 0,
     });
 
@@ -227,12 +227,12 @@ Python: Requires `langsmith>=0.3.13`
 # optional metadata, used to populate model/prompt/tool columns in UI
 EXPERIMENT_METADATA = {
     "models": [
-        "openai:gpt-4.1-mini",
+        "openai:gpt-5.4-mini",
         {
             "id": ["langchain", "chat_models", "openai", "ChatOpenAI"],
             "lc": 1,
             "type": "constructor",
-            "kwargs": {"model_name": "gpt-4.1", "temperature": 0.2},
+            "kwargs": {"model_name": "gpt-5.4", "temperature": 0.2},
         },
     ],
     "prompts": ["my-org/my-eval-prompt:abc12345"],
@@ -255,7 +255,7 @@ results = ls_client.evaluate(
     toxicity_classifier,
     data=dataset.name,
     evaluators=[correct],
-    experiment_prefix="gpt-4.1-mini, baseline",  # optional, experiment name prefix
+    experiment_prefix="gpt-5.4-mini, baseline",  # optional, experiment name prefix
     description="Testing the baseline system.",  # optional, experiment description
     max_concurrency=4,  # optional, add concurrency
     metadata=EXPERIMENT_METADATA,  # optional, used to populate model/prompt/tool columns in UI
@@ -268,12 +268,12 @@ import { evaluate } from "langsmith/evaluation";
 // optional metadata, used to populate model/prompt/tool columns in UI
 const EXPERIMENT_METADATA = {
   models: [
-    "openai:gpt-4.1-mini",
+    "openai:gpt-5.4-mini",
     {
       id: ["langchain", "chat_models", "openai", "ChatOpenAI"],
       lc: 1,
       type: "constructor",
-      kwargs: { model_name: "gpt-4.1", temperature: 0.2 },
+      kwargs: { model_name: "gpt-5.4", temperature: 0.2 },
     },
   ],
   prompts: ["my-org/my-eval-prompt:abc12345"],
@@ -293,7 +293,7 @@ const EXPERIMENT_METADATA = {
 await evaluate((inputs) => toxicityClassifier(inputs["input"]), {
   data: datasetName,
   evaluators: [correct],
-  experimentPrefix: "gpt-4.1-mini, baseline",  // optional, experiment name prefix
+  experimentPrefix: "gpt-5.4-mini, baseline",  // optional, experiment name prefix
   maxConcurrency: 4, // optional, add concurrency
   metadata: EXPERIMENT_METADATA,  // optional, used to populate model/prompt/tool columns in UI
 });
@@ -406,7 +406,7 @@ def toxicity_classifier(inputs: dict) -> str:
         {"role": "user", "content": inputs["text"]},
     ]
     result = oai_client.chat.completions.create(
-        messages=messages, model="gpt-4.1-mini", temperature=0
+        messages=messages, model="gpt-5.4-mini", temperature=0
     )
     return result.choices[0].message.content
 
@@ -453,12 +453,12 @@ def correct(inputs: dict, outputs: dict, reference_outputs: dict) -> bool:
 # optional metadata, used to populate model/prompt/tool columns in UI
 EXPERIMENT_METADATA = {
     "models": [
-        "openai:gpt-4.1-mini",
+        "openai:gpt-5.4-mini",
         {
             "id": ["langchain", "chat_models", "openai", "ChatOpenAI"],
             "lc": 1,
             "type": "constructor",
-            "kwargs": {"model_name": "gpt-4.1", "temperature": 0.2},
+            "kwargs": {"model_name": "gpt-5.4", "temperature": 0.2},
         },
     ],
     "prompts": ["my-org/my-eval-prompt:abc12345"],
@@ -480,7 +480,7 @@ results = ls_client.evaluate(
     toxicity_classifier,
     data=dataset.name,
     evaluators=[correct],
-    experiment_prefix="gpt-4.1-mini, simple",  # optional, experiment name prefix
+    experiment_prefix="gpt-5.4-mini, simple",  # optional, experiment name prefix
     description="Testing the baseline system.",  # optional, experiment description
     max_concurrency=4,  # optional, add concurrency
     metadata=EXPERIMENT_METADATA,  # optional, used to populate model/prompt/tool columns in UI
@@ -507,7 +507,7 @@ const toxicityClassifier = traceable(
         },
         { role: "user", content: text },
       ],
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       temperature: 0,
     });
     return result.choices[0].message.content;
@@ -556,12 +556,12 @@ function correct({
 // optional metadata, used to populate model/prompt/tool columns in UI
 const EXPERIMENT_METADATA = {
   models: [
-    "openai:gpt-4.1-mini",
+    "openai:gpt-5.4-mini",
     {
       id: ["langchain", "chat_models", "openai", "ChatOpenAI"],
       lc: 1,
       type: "constructor",
-      kwargs: { model_name: "gpt-4.1", temperature: 0.2 },
+      kwargs: { model_name: "gpt-5.4", temperature: 0.2 },
     },
   ],
   prompts: ["my-org/my-eval-prompt:abc12345"],
@@ -581,7 +581,7 @@ const EXPERIMENT_METADATA = {
 await evaluate((inputs) => toxicityClassifier(inputs["input"]), {
   data: datasetName,
   evaluators: [correct],
-  experimentPrefix: "gpt-4.1-mini, simple",  // optional, experiment name prefix
+  experimentPrefix: "gpt-5.4-mini, simple",  // optional, experiment name prefix
   maxConcurrency: 4, // optional, add concurrency
   metadata: EXPERIMENT_METADATA,  // optional, used to populate model/prompt/tool columns in UI
 });

--- a/src/langsmith/evaluate-on-intermediate-steps.mdx
+++ b/src/langsmith/evaluate-on-intermediate-steps.mdx
@@ -55,7 +55,7 @@ def generate_wiki_search(question: str) -> str:
     ]
     result = oai_client.chat.completions.create(
         messages=messages,
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         temperature=0,
     )
     return result.choices[0].message.content
@@ -87,7 +87,7 @@ def generate_answer(question: str, context: str) -> str:
     ]
     result = oai_client.chat.completions.create(
         messages=messages,
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         temperature=0
     )
     return result.choices[0].message.content
@@ -120,7 +120,7 @@ const generateWikiSearch = traceable(
       { role: "user" as const, content: input.question },
     ];
     const chatCompletion = await openai.chat.completions.create({
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       messages: messages,
       temperature: 0,
     });
@@ -165,7 +165,7 @@ const generateAnswer = traceable(
       { role: "user" as const, content: input.question },
     ];
     const chatCompletion = await openai.chat.completions.create({
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       messages: messages,
       temperature: 0,
     });
@@ -276,7 +276,7 @@ class GradeHallucinations(BaseModel):
 
 # LLM with structured output for grading hallucinations
 # For more see: https://docs.langchain.com/oss/python/langchain/structured-output
-grader_llm= init_chat_model("gpt-4.1-mini", temperature=0).with_structured_output(
+grader_llm= init_chat_model("gpt-5.4-mini", temperature=0).with_structured_output(
     GradeHallucinations,
     method="json_schema",
     strict=True,
@@ -367,7 +367,7 @@ async function hallucination(
   ]);
 
   const llm = new ChatOpenAI({
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-mini",
     temperature: 0,
   }).withStructuredOutput(
     z

--- a/src/langsmith/evaluate-pairwise.mdx
+++ b/src/langsmith/evaluate-pairwise.mdx
@@ -95,7 +95,7 @@ from langsmith import evaluate
 
 # See the prompt: https://smith.langchain.com/hub/langchain-ai/pairwise-evaluation-2
 prompt = hub.pull("langchain-ai/pairwise-evaluation-2")
-model = init_chat_model("gpt-4.1")
+model = init_chat_model("gpt-5.4")
 chain = prompt | model
 
 def ranked_preference(inputs: dict, outputs: list[dict]) -> list:

--- a/src/langsmith/evaluate-rag-tutorial.mdx
+++ b/src/langsmith/evaluate-rag-tutorial.mdx
@@ -164,7 +164,7 @@ We can now define the generative pipeline.
 from langchain_openai import ChatOpenAI
 from langsmith import traceable
 
-llm = ChatOpenAI(model="gpt-4.1", temperature=1)
+llm = ChatOpenAI(model="gpt-5.4", temperature=1)
 
 # Add decorator so this function is traced in LangSmith
 @traceable()
@@ -193,7 +193,7 @@ import { ChatOpenAI } from "@langchain/openai";
 import { traceable } from "langsmith/traceable";
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 1,
 })
 
@@ -358,7 +358,7 @@ A correctness value of False means that the student's answer does not meet all o
 Explain your reasoning in a step-by-step manner to ensure your reasoning and conclusion are correct. Avoid simply stating the correct answer at the outset."""
 
 # Grader LLM
-grader_llm = ChatOpenAI(model="gpt-4.1", temperature=0).with_structured_output(
+grader_llm = ChatOpenAI(model="gpt-5.4", temperature=0).with_structured_output(
     CorrectnessGrade, method="json_schema", strict=True
 )
 
@@ -392,7 +392,7 @@ A correctness value of False means that the student's answer does not meet all o
 Explain your reasoning in a step-by-step manner to ensure your reasoning and conclusion are correct. Avoid simply stating the correct answer at the outset.`
 
 const graderLLM = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
 }).withStructuredOutput(
   z
@@ -454,7 +454,7 @@ A relevance value of False means that the student's answer does not meet all of 
 Explain your reasoning in a step-by-step manner to ensure your reasoning and conclusion are correct. Avoid simply stating the correct answer at the outset."""
 
 # Grader LLM
-relevance_llm = ChatOpenAI(model="gpt-4.1", temperature=0).with_structured_output(
+relevance_llm = ChatOpenAI(model="gpt-5.4", temperature=0).with_structured_output(
     RelevanceGrade, method="json_schema", strict=True
 )
 
@@ -485,7 +485,7 @@ A relevance value of False means that the student's answer does not meet all of 
 Explain your reasoning in a step-by-step manner to ensure your reasoning and conclusion are correct. Avoid simply stating the correct answer at the outset.`
 
 const relevanceLLM = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
 }).withStructuredOutput(
   z
@@ -543,7 +543,7 @@ A grounded value of False means that the student's answer does not meet all of t
 Explain your reasoning in a step-by-step manner to ensure your reasoning and conclusion are correct. Avoid simply stating the correct answer at the outset."""
 
 # Grader LLM
-grounded_llm = ChatOpenAI(model="gpt-4.1", temperature=0).with_structured_output(
+grounded_llm = ChatOpenAI(model="gpt-5.4", temperature=0).with_structured_output(
     GroundedGrade, method="json_schema", strict=True
 )
 
@@ -574,7 +574,7 @@ A grounded value of False means that the student's answer does not meet all of t
 Explain your reasoning in a step-by-step manner to ensure your reasoning and conclusion are correct. Avoid simply stating the correct answer at the outset.`
 
 const groundedLLM = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
 }).withStructuredOutput(
   z
@@ -636,7 +636,7 @@ Explain your reasoning in a step-by-step manner to ensure your reasoning and con
 
 # Grader LLM
 retrieval_relevance_llm = ChatOpenAI(
-    model="gpt-4.1", temperature=0
+    model="gpt-5.4", temperature=0
 ).with_structured_output(RetrievalRelevanceGrade, method="json_schema", strict=True)
 
 def retrieval_relevance(inputs: dict, outputs: dict) -> bool:
@@ -668,7 +668,7 @@ A relevance value of False means that the FACTS are completely unrelated to the 
 Explain your reasoning in a step-by-step manner to ensure your reasoning and conclusion are correct. Avoid simply stating the correct answer at the outset.`
 
 const retrievalRelevanceLLM = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
 }).withStructuredOutput(
   z
@@ -784,7 +784,7 @@ vectorstore = InMemoryVectorStore.from_documents(
 # With langchain we can easily turn any vector store into a retrieval component:
 retriever = vectorstore.as_retriever(k=6)
 
-llm = ChatOpenAI(model="gpt-4.1", temperature=1)
+llm = ChatOpenAI(model="gpt-5.4", temperature=1)
 
 # Add decorator so this function is traced in LangSmith
 @traceable()
@@ -854,7 +854,7 @@ A correctness value of False means that the student's answer does not meet all o
 Explain your reasoning in a step-by-step manner to ensure your reasoning and conclusion are correct. Avoid simply stating the correct answer at the outset."""
 
 # Grader LLM
-grader_llm = ChatOpenAI(model="gpt-4.1", temperature=0).with_structured_output(
+grader_llm = ChatOpenAI(model="gpt-5.4", temperature=0).with_structured_output(
     CorrectnessGrade, method="json_schema", strict=True
 )
 
@@ -891,7 +891,7 @@ A relevance value of False means that the student's answer does not meet all of 
 Explain your reasoning in a step-by-step manner to ensure your reasoning and conclusion are correct. Avoid simply stating the correct answer at the outset."""
 
 # Grader LLM
-relevance_llm = ChatOpenAI(model="gpt-4.1", temperature=0).with_structured_output(
+relevance_llm = ChatOpenAI(model="gpt-5.4", temperature=0).with_structured_output(
     RelevanceGrade, method="json_schema", strict=True
 )
 
@@ -924,7 +924,7 @@ A grounded value of False means that the student's answer does not meet all of t
 Explain your reasoning in a step-by-step manner to ensure your reasoning and conclusion are correct. Avoid simply stating the correct answer at the outset."""
 
 # Grader LLM
-grounded_llm = ChatOpenAI(model="gpt-4.1", temperature=0).with_structured_output(
+grounded_llm = ChatOpenAI(model="gpt-5.4", temperature=0).with_structured_output(
     GroundedGrade, method="json_schema", strict=True
 )
 
@@ -963,7 +963,7 @@ Explain your reasoning in a step-by-step manner to ensure your reasoning and con
 
 # Grader LLM
 retrieval_relevance_llm = ChatOpenAI(
-    model="gpt-4.1", temperature=0
+    model="gpt-5.4", temperature=0
 ).with_structured_output(RetrievalRelevanceGrade, method="json_schema", strict=True)
 
 def retrieval_relevance(inputs: dict, outputs: dict) -> bool:
@@ -1029,7 +1029,7 @@ const vectorStore = new MemoryVectorStore(embeddings);  // Index chunks
 await vectorStore.addDocuments(allSplits)
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 1,
 })
 
@@ -1104,7 +1104,7 @@ A correctness value of False means that the student's answer does not meet all o
 Explain your reasoning in a step-by-step manner to ensure your reasoning and conclusion are correct. Avoid simply stating the correct answer at the outset.`
 
 const graderLLM = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
 }).withStructuredOutput(
   z
@@ -1149,7 +1149,7 @@ A relevance value of False means that the student's answer does not meet all of 
 Explain your reasoning in a step-by-step manner to ensure your reasoning and conclusion are correct. Avoid simply stating the correct answer at the outset.`
 
 const relevanceLLM = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
 }).withStructuredOutput(
   z
@@ -1190,7 +1190,7 @@ A grounded value of False means that the student's answer does not meet all of t
 Explain your reasoning in a step-by-step manner to ensure your reasoning and conclusion are correct. Avoid simply stating the correct answer at the outset.`
 
 const groundedLLM = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
 }).withStructuredOutput(
   z
@@ -1234,7 +1234,7 @@ A relevance value of False means that the FACTS are completely unrelated to the 
 Explain your reasoning in a step-by-step manner to ensure your reasoning and conclusion are correct. Avoid simply stating the correct answer at the outset.`
 
 const retrievalRelevanceLLM = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
 }).withStructuredOutput(
   z

--- a/src/langsmith/evaluate-with-attachments.mdx
+++ b/src/langsmith/evaluate-with-attachments.mdx
@@ -321,7 +321,7 @@ def file_qa(inputs, attachments):
     # You can pipe the image pre-signed URL directly to the model
     image_url = attachments["my_img"]["presigned_url"]
     image_completion = client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         messages=[
           {
             "role": "user",
@@ -399,7 +399,7 @@ async function fileQA(inputs: Record<string, any>, config?: Record<string, any>)
 
   const imageUrl = config?.attachments?.["my_img"]?.presigned_url
   const imageCompletion = await client.chat.completions.create({
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-mini",
     messages: [
       {
         role: "user",
@@ -449,7 +449,7 @@ def valid_image_description(outputs: dict, attachments: dict) -> bool:
 
   image_url = attachments["my_img"]["presigned_url"]
   response = client.beta.chat.completions.parse(
-      model="gpt-4.1",
+      model="gpt-5.4",
       messages=[
           {
               "role": "system",
@@ -495,7 +495,7 @@ Please carefully review the image and the description to determine if the descri
 
   const imageUrl = attachments?.["my_img"]?.presigned_url
   const completion = await client.beta.chat.completions.parse({
-      model: "gpt-4.1",
+      model: "gpt-5.4",
       messages: [
           {
               role: "system",

--- a/src/langsmith/evaluation-async.mdx
+++ b/src/langsmith/evaluation-async.mdx
@@ -33,7 +33,7 @@ async def researcher_app(inputs: dict) -> str:
 list 5 concrete questions that should be investigated to determine if the idea is worth pursuing."""
 
     response = await oai_client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         messages=[
             {"role": "system", "content": instructions},
             {"role": "user", "content": inputs["idea"]},
@@ -67,7 +67,7 @@ results = await ls_client.aevaluate(
     evaluators=[concise],
     # Optional, add concurrency.
     max_concurrency=2,  # Optional, add concurrency.
-    experiment_prefix="gpt-4.1-mini-baseline"  # Optional, random by default.
+    experiment_prefix="gpt-5.4-mini-baseline"  # Optional, random by default.
 )
 ```
 

--- a/src/langsmith/filter-experiments-ui.mdx
+++ b/src/langsmith/filter-experiments-ui.mdx
@@ -14,8 +14,8 @@ In our example, we are going to attach metadata to our experiment around the mod
 
 ```python
 models = {
-    "openai-gpt-4.1": ChatOpenAI(model="gpt-4.1", temperature=0),
-    "openai-gpt-4.1-mini": ChatOpenAI(model="gpt-4.1-mini", temperature=0),
+    "openai-gpt-5.4": ChatOpenAI(model="gpt-5.4", temperature=0),
+    "openai-gpt-5.4-mini": ChatOpenAI(model="gpt-5.4-mini", temperature=0),
     "anthropic-claude-3-sonnet-20240229": ChatAnthropic(temperature=0, model_name="claude-3-sonnet-20240229")
 }
 
@@ -26,7 +26,7 @@ prompts = {
 }
 
 def answer_evaluator(run, example) -> dict:
-    llm = ChatOpenAI(model="gpt-4.1", temperature=0)
+    llm = ChatOpenAI(model="gpt-5.4", temperature=0)
     answer_grader = hub.pull("langchain-ai/rag-answer-vs-reference") | llm
     score = answer_grader.invoke(
         {

--- a/src/langsmith/generative-ui-react.mdx
+++ b/src/langsmith/generative-ui-react.mdx
@@ -98,7 +98,7 @@ CSS and Tailwind 4.x is also supported out of the box, so you can freely use Tai
             city: str
 
         weather: WeatherOutput = (
-            await ChatOpenAI(model="gpt-4.1-mini")
+            await ChatOpenAI(model="gpt-5.4-mini")
             .with_structured_output(WeatherOutput)
             .with_config({"tags": ["nostream"]})
             .ainvoke(state["messages"])
@@ -154,7 +154,7 @@ CSS and Tailwind 4.x is also supported out of the box, so you can freely use Tai
         // pushing the messages to the `ui` and sending a custom event as well.
         const ui = typedUi<typeof ComponentMap>(config);
 
-        const weather = await new ChatOpenAI({ model: "gpt-4.1-mini" })
+        const weather = await new ChatOpenAI({ model: "gpt-5.4-mini" })
           .withStructuredOutput(z.object({ city: z.string() }))
           .withConfig({ tags: ["nostream"] })
           .invoke(state.messages);

--- a/src/langsmith/langchain-runnable.mdx
+++ b/src/langsmith/langchain-runnable.mdx
@@ -45,7 +45,7 @@ prompt = ChatPromptTemplate(
     [("system", instructions), ("user", "{text}")],
 )
 
-model = init_chat_model("gpt-4.1")
+model = init_chat_model("gpt-5.4")
 chain = prompt | model | StrOutputParser()
 ```
 
@@ -96,8 +96,8 @@ async def main():
         chain,
         data=dataset,
         evaluators=[correct],
-        experiment_prefix="gpt-4.1, baseline",
-        metadata={"models": "openai:gpt-4.1"},  # optional, used to populate model/prompt/tool columns in UI
+        experiment_prefix="gpt-5.4, baseline",
+        metadata={"models": "openai:gpt-5.4"},  # optional, used to populate model/prompt/tool columns in UI
     )
     print(results)
 
@@ -117,8 +117,8 @@ const dataset = await client.clonePublicDataset(
 await evaluate(chain, {
   data: dataset.name,
   evaluators: [correct],
-  experimentPrefix: "gpt-4.1, baseline",
-  metadata: { models: "openai:gpt-4.1" },  // optional, used to populate model/prompt/tool columns in UI
+  experimentPrefix: "gpt-5.4, baseline",
+  metadata: { models: "openai:gpt-5.4" },  // optional, used to populate model/prompt/tool columns in UI
 });
 ```
 

--- a/src/langsmith/legacy-trace-with-vercel-ai-sdk.mdx
+++ b/src/langsmith/legacy-trace-with-vercel-ai-sdk.mdx
@@ -87,7 +87,7 @@ import { openai } from "@ai-sdk/openai";
 let result;
 try {
   result = await generateText({
-    model: openai("gpt-4.1-nano"),
+    model: openai("gpt-5.4-nano"),
     prompt: "Write a vegetarian lasagna recipe for 4 people.",
     experimental_telemetry: {
       isEnabled: true,
@@ -108,7 +108,7 @@ import { openai } from "@ai-sdk/openai";
 import { z } from "zod";
 
 await generateText({
-  model: openai("gpt-4.1-nano"),
+  model: openai("gpt-5.4-nano"),
   messages: [
     {
       role: "user",
@@ -158,7 +158,7 @@ const client = new Client();
 const wrappedText = traceable(
   async (content: string) => {
     const { text } = await generateText({
-      model: openai("gpt-4.1-nano"),
+      model: openai("gpt-5.4-nano"),
       messages: [{ role: "user", content }],
       tools: {
         listOrders: tool({
@@ -246,7 +246,7 @@ initializeOTEL();
 
 export async function GET() {
   const { text } = await generateText({
-    model: openai("gpt-4.1-nano"),
+    model: openai("gpt-5.4-nano"),
     messages: [{ role: "user", content: "Why is the sky blue?" }],
     experimental_telemetry: {
       isEnabled: true,
@@ -310,7 +310,7 @@ initializeOTEL({
 const wrappedText = traceable(
   async (content: string) => {
     const { text } = await generateText({
-      model: openai("gpt-4.1-nano"),
+      model: openai("gpt-5.4-nano"),
       messages: [{ role: "user", content }],
       experimental_telemetry: {
         isEnabled: true,
@@ -340,7 +340,7 @@ import { generateText } from "ai";
 import { openai } from "@ai-sdk/openai";
 
 await generateText({
-  model: openai("gpt-4.1-nano"),
+  model: openai("gpt-5.4-nano"),
   prompt: "Write a vegetarian lasagna recipe for 4 people.",
   experimental_telemetry: {
     isEnabled: true,
@@ -361,7 +361,7 @@ import { generateText } from "ai";
 import { openai } from "@ai-sdk/openai";
 
 await generateText({
-  model: openai("gpt-4.1-mini"),
+  model: openai("gpt-5.4-mini"),
   prompt: "Write a vegetarian lasagna recipe for 4 people.",
   experimental_telemetry: {
     isEnabled: true,

--- a/src/langsmith/log-llm-trace.mdx
+++ b/src/langsmith/log-llm-trace.mdx
@@ -397,7 +397,7 @@ def chat_model(inputs: dict) -> dict:
 When using a custom model, it is recommended to also provide the following `metadata` fields to identify the model when viewing traces and when filtering.
 
 * `ls_provider`: The provider of the model, e.g. "openai", "anthropic", etc.
-* `ls_model_name`: The name of the model, e.g. "gpt-4.1-mini", "claude-3-opus-20240229", etc.
+* `ls_model_name`: The name of the model, e.g. "gpt-5.4-mini", "claude-3-opus-20240229", etc.
 
 <CodeGroup>
 

--- a/src/langsmith/log-traces-to-project.mdx
+++ b/src/langsmith/log-traces-to-project.mdx
@@ -53,7 +53,7 @@ messages = [
   project_name="My Project"
 )
 def call_openai(
-  messages: list[dict], model: str = "gpt-4.1-mini"
+  messages: list[dict], model: str = "gpt-5.4-mini"
 ) -> str:
   return client.chat.completions.create(
       model=model,
@@ -76,7 +76,7 @@ call_openai(
 from langsmith import wrappers
 wrapped_client = wrappers.wrap_openai(client)
 wrapped_client.chat.completions.create(
-  model="gpt-4.1-mini",
+  model="gpt-5.4-mini",
   messages=messages,
   langsmith_extra={"project_name": "My Project"},
 )
@@ -90,7 +90,7 @@ rt = RunTree(
   project_name="My Project"
 )
 chat_completion = client.chat.completions.create(
-  model="gpt-4.1-mini",
+  model="gpt-5.4-mini",
   messages=messages,
 )
 # End and submit the run
@@ -123,7 +123,7 @@ const traceableCallOpenAI = traceable(async (messages: {role: string, content: s
 });
 
 // Call the traceable function
-await traceableCallOpenAI(messages, "gpt-4.1-mini");
+await traceableCallOpenAI(messages, "gpt-5.4-mini");
 
 // Create and use a RunTree object
 const rt = new RunTree({

--- a/src/langsmith/ls-metadata-parameters.mdx
+++ b/src/langsmith/ls-metadata-parameters.mdx
@@ -64,7 +64,7 @@ For more comprehensive tracking, you can include additional configuration parame
     run_type="llm",
     metadata={
         "ls_provider": "openai",
-        "ls_model_name": "gpt-4.1",
+        "ls_model_name": "gpt-5.4",
         "ls_temperature": 0.7,
         "ls_max_tokens": 4096,
         "ls_stop": ["END"],
@@ -87,7 +87,7 @@ const myConfiguredLlm = traceable(
     run_type: "llm",
     metadata: {
       ls_provider: "openai",
-      ls_model_name: "gpt-4.1",
+      ls_model_name: "gpt-5.4",
       ls_temperature: 0.7,
       ls_max_tokens: 4096,
       ls_stop: ["END"],
@@ -164,7 +164,7 @@ When you want [automatic cost tracking](/langsmith/cost-tracking) for custom mod
     run_type="llm",
     metadata={
         "ls_provider": "openai",
-        "ls_model_name": "gpt-4.1"
+        "ls_model_name": "gpt-5.4"
     }
 )
 def my_llm_call(prompt: str):
@@ -184,7 +184,7 @@ def my_llm_call(prompt: str):
 Identifies the specific model. Combined with `ls_provider`, matches against pricing database for automatic cost calculation.
 
 **Common values:**
-- OpenAI: `"gpt-4.1"`, `"gpt-4.1-mini"`, `"gpt-3.5-turbo"`
+- OpenAI: `"gpt-5.4"`, `"gpt-5.4-mini"`, `"gpt-3.5-turbo"`
 - Anthropic: `"claude-3-5-sonnet-20241022"`, `"claude-3-opus-20240229"`
 - Custom: Any model identifier
 
@@ -223,7 +223,7 @@ When you want to track model configuration for experiments or debugging.
 ```python
 metadata={
     "ls_provider": "openai",
-    "ls_model_name": "gpt-4.1",
+    "ls_model_name": "gpt-5.4",
     "ls_temperature": 0.7
 }
 ```
@@ -247,7 +247,7 @@ When you want to track model configuration for experiments or debugging.
 ```python
 metadata={
     "ls_provider": "openai",
-    "ls_model_name": "gpt-4.1",
+    "ls_model_name": "gpt-5.4",
     "ls_max_tokens": 4096
 }
 ```
@@ -271,7 +271,7 @@ When you want to track model configuration for experiments or debugging.
 ```python
 metadata={
     "ls_provider": "openai",
-    "ls_model_name": "gpt-4.1",
+    "ls_model_name": "gpt-5.4",
     "ls_stop": ["END", "STOP", "\n\n"]
 }
 ```
@@ -297,7 +297,7 @@ When you need to track additional configuration beyond the standard parameters.
 ```python
 metadata={
     "ls_provider": "openai",
-    "ls_model_name": "gpt-4.1",
+    "ls_model_name": "gpt-5.4",
     "ls_invocation_params": {
         "top_p": 0.9,
         "frequency_penalty": 0.5,
@@ -465,7 +465,7 @@ runs = client.list_runs(
 # Filter by specific model
 runs = client.list_runs(
     project_name="my-app",
-    filter='metadata_key = "ls_model_name" AND metadata_value = "gpt-4.1"'
+    filter='metadata_key = "ls_model_name" AND metadata_value = "gpt-5.4"'
 )
 
 # Filter root runs only (top-level traces)
@@ -499,7 +499,7 @@ for await (const run of client.listRuns({
 const runsByModel: any[] = [];
 for await (const run of client.listRuns({
   projectName: "my-app",
-  filter: 'metadata_key = "ls_model_name" AND metadata_value = "gpt-4.1"'
+  filter: 'metadata_key = "ls_model_name" AND metadata_value = "gpt-5.4"'
 })) {
   runsByModel.push(run);
 }
@@ -536,7 +536,7 @@ In the [LangSmith UI](https://smith.langchain.com), use the filter/search bar wi
 
 ```
 metadata_key = 'ls_provider' AND metadata_value = 'openai'
-metadata_key = 'ls_model_name' AND metadata_value = 'gpt-4.1'
+metadata_key = 'ls_model_name' AND metadata_value = 'gpt-5.4'
 metadata_key = 'ls_run_depth' AND metadata_value = 0
 ```
 

--- a/src/langsmith/manage-prompts-programmatically.mdx
+++ b/src/langsmith/manage-prompts-programmatically.mdx
@@ -107,7 +107,7 @@ from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 
 client = Client()
-model = ChatOpenAI(model="gpt-4.1-mini")
+model = ChatOpenAI(model="gpt-5.4-mini")
 prompt = ChatPromptTemplate.from_template("tell me a joke about {topic}")
 chain = prompt | model
 client.push_prompt("joke-generator-with-model", object=chain)
@@ -118,7 +118,7 @@ from langchain_classic import hub as prompts
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 
-model = ChatOpenAI(model="gpt-4.1-mini")
+model = ChatOpenAI(model="gpt-5.4-mini")
 prompt = ChatPromptTemplate.from_template("tell me a joke about {topic}")
 chain = prompt | model
 url = prompts.push("joke-generator-with-model", chain)
@@ -131,7 +131,7 @@ import * as hub from "langchain/hub";
 import { ChatPromptTemplate } from "@langchain/core/prompts";
 import { ChatOpenAI } from "@langchain/openai";
 
-const model = new ChatOpenAI({ model: "gpt-4.1-mini" });
+const model = new ChatOpenAI({ model: "gpt-5.4-mini" });
 const prompt = ChatPromptTemplate.fromTemplate("tell me a joke about {topic}");
 const chain = prompt.pipe(model);
 await hub.push("joke-generator-with-model", {
@@ -251,7 +251,7 @@ from langchain_openai import ChatOpenAI
 
 client = Client()
 prompt = client.pull_prompt("joke-generator")
-model = ChatOpenAI(model="gpt-4.1-mini")
+model = ChatOpenAI(model="gpt-5.4-mini")
 chain = prompt | model
 chain.invoke({"topic": "cats"})
 ```
@@ -261,7 +261,7 @@ from langchain_classic import hub as prompts
 from langchain_openai import ChatOpenAI
 
 prompt = prompts.pull("joke-generator")
-model = ChatOpenAI(model="gpt-4.1-mini")
+model = ChatOpenAI(model="gpt-5.4-mini")
 chain = prompt | model
 chain.invoke({"topic": "cats"})
 ```
@@ -271,7 +271,7 @@ import * as hub from "langchain/hub";
 import { ChatOpenAI } from "@langchain/openai";
 
 const prompt = await hub.pull("joke-generator");
-const model = new ChatOpenAI({ model: "gpt-4.1-mini" });
+const model = new ChatOpenAI({ model: "gpt-5.4-mini" });
 const chain = prompt.pipe(model);
 await chain.invoke({"topic": "cats"});
 ```
@@ -730,7 +730,7 @@ const { messages } = convertPromptToOpenAI(formattedPrompt);
 
 const openAIClient = new OpenAI();
 const openAIResponse = await openAIClient.chat.completions.create({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   messages,
 });
 ```

--- a/src/langsmith/mask-inputs-outputs.mdx
+++ b/src/langsmith/mask-inputs-outputs.mdx
@@ -45,7 +45,7 @@ langsmith_client = Client(
 
 # The trace produced will have its metadata present, but the inputs will be hidden
 openai_client.chat.completions.create(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Hello!"},
@@ -55,7 +55,7 @@ openai_client.chat.completions.create(
 
 # The trace produced will not have hidden inputs and outputs
 openai_client.chat.completions.create(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "Hello!"},
@@ -78,7 +78,7 @@ const filteredOAIClient = wrapOpenAI(new OpenAI(), {
     client: langsmithClient,
 });
 await filteredOAIClient.chat.completions.create({
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-mini",
     messages: [
         { role: "system", content: "You are a helpful assistant." },
         { role: "user", content: "Hello!" },
@@ -88,7 +88,7 @@ await filteredOAIClient.chat.completions.create({
 const openaiClient = wrapOpenAI(new OpenAI());
 // The trace produced will not have hidden inputs and outputs
 await openaiClient.chat.completions.create({
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-mini",
     messages: [
         { role: "system", content: "You are a helpful assistant." },
         { role: "user", content: "Hello!" },
@@ -480,7 +480,7 @@ langsmith_client = Client(
 
 # The trace produced will have its metadata present, but the inputs and outputs will be anonymized
 response_with_anonymization = openai_client.chat.completions.create(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "My name is John Doe, my SSN is 123-45-6789, my credit card number is 4111 1111 1111 1111, my email is john.doe@example.com, and my phone number is (123) 456-7890."},
@@ -490,7 +490,7 @@ response_with_anonymization = openai_client.chat.completions.create(
 
 # The trace produced will not have anonymized inputs and outputs
 response_without_anonymization = openai_client.chat.completions.create(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     messages=[
         {"role": "system", "content": "You are a helpful assistant."},
         {"role": "user", "content": "My name is John Doe, my SSN is 123-45-6789, my credit card number is 4111 1111 1111 1111, my email is john.doe@example.com, and my phone number is (123) 456-7890."},
@@ -590,7 +590,7 @@ langsmith_client = Client(
 
 # The trace produced will have its metadata present, but the inputs and outputs will be anonymized
 response_with_anonymization = openai_client.chat.completions.create(
-  model="gpt-4.1-mini",
+  model="gpt-5.4-mini",
   messages=[
       {"role": "system", "content": "You are a helpful assistant."},
       {"role": "user", "content": "My name is Slim Shady, call me at 313-666-7440 or email me at real.slim.shady@gmail.com"},
@@ -600,7 +600,7 @@ response_with_anonymization = openai_client.chat.completions.create(
 
 # The trace produced will not have anonymized inputs and outputs
 response_without_anonymization = openai_client.chat.completions.create(
-  model="gpt-4.1-mini",
+  model="gpt-5.4-mini",
   messages=[
       {"role": "system", "content": "You are a helpful assistant."},
       {"role": "user", "content": "My name is Slim Shady, call me at 313-666-7440 or email me at real.slim.shady@gmail.com"},
@@ -732,7 +732,7 @@ langsmith_client = Client(
 
 # The trace produced will have its metadata present, but the inputs and outputs will be anonymized
 response_with_anonymization = openai_client.chat.completions.create(
-  model="gpt-4.1-mini",
+  model="gpt-5.4-mini",
   messages=[
       {"role": "system", "content": "You are a helpful assistant."},
       {"role": "user", "content": "My name is Slim Shady, call me at 313-666-7440 or email me at real.slim.shady@gmail.com"},
@@ -742,7 +742,7 @@ response_with_anonymization = openai_client.chat.completions.create(
 
 # The trace produced will not have anonymized inputs and outputs
 response_without_anonymization = openai_client.chat.completions.create(
-  model="gpt-4.1-mini",
+  model="gpt-5.4-mini",
   messages=[
       {"role": "system", "content": "You are a helpful assistant."},
       {"role": "user", "content": "My name is Slim Shady, call me at 313-666-7440 or email me at real.slim.shady@gmail.com"},

--- a/src/langsmith/multi-turn-simulation.mdx
+++ b/src/langsmith/multi-turn-simulation.mdx
@@ -75,7 +75,7 @@ def app(inputs: ChatCompletionMessage, *, thread_id: str, **kwargs):
     history[thread_id].append(inputs)
     # inputs is a message object with role and content
     res = client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         messages=[
             {
                 "role": "system",
@@ -89,7 +89,7 @@ def app(inputs: ChatCompletionMessage, *, thread_id: str, **kwargs):
 
 user = create_llm_simulated_user(
     system="You are an aggressive and hostile customer who wants a refund for their car.",
-    model="openai:gpt-4.1-mini",
+    model="openai:gpt-5.4-mini",
 )
 
 # Run the simulation directly with the new function
@@ -121,7 +121,7 @@ const app = async ({ inputs, threadId }: { inputs: ChatCompletionMessage, thread
   }
   history[threadId].push(inputs);
   const res = await client.chat.completions.create({
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-mini",
     messages: [
       {
         role: "system",
@@ -138,7 +138,7 @@ const app = async ({ inputs, threadId }: { inputs: ChatCompletionMessage, thread
 
 const user = createLLMSimulatedUser({
   system: "You are an aggressive and hostile customer who wants a refund for their car.",
-  model: "openai:gpt-4.1-mini",
+  model: "openai:gpt-5.4-mini",
 });
 
 const result = await runMultiturnSimulation({
@@ -236,7 +236,7 @@ def test_multiturn_message_with_openai():
             history[thread_id] = []
         history[thread_id] = history[thread_id] + [inputs]
         res = client.chat.completions.create(
-            model="gpt-4.1-nano",
+            model="gpt-5.4-nano",
             messages=[
                 {
                     "role": "system",
@@ -251,7 +251,7 @@ def test_multiturn_message_with_openai():
 
     user = create_llm_simulated_user(
         system="You are a nice customer who wants a refund for their car.",
-        model="openai:gpt-4.1-nano",
+        model="openai:gpt-5.4-nano",
         fixed_responses=[
             inputs,
         ],
@@ -308,7 +308,7 @@ ls.describe("Multiturn demo", () => {
         }
         history[threadId].push(inputs);
         const res = await client.chat.completions.create({
-          model: "gpt-4.1-nano",
+          model: "gpt-5.4-nano",
           messages: [
             {
               role: "system",
@@ -326,7 +326,7 @@ ls.describe("Multiturn demo", () => {
       const user = createLLMSimulatedUser({
         system:
           "You are a nice customer who wants a refund for their car.",
-        model: "openai:gpt-4.1-nano",
+        model: "openai:gpt-5.4-nano",
         fixedResponses: inputs.messages,
       });
 
@@ -409,7 +409,7 @@ def target(inputs: dict):
             history[thread_id] = []
         history[thread_id] = history[thread_id] + [next_message]
         res = client.chat.completions.create(
-            model="gpt-4.1-nano",
+            model="gpt-5.4-nano",
             messages=[
                 {
                     "role": "system",
@@ -424,7 +424,7 @@ def target(inputs: dict):
 
     user = create_llm_simulated_user(
         system="You are a nice customer who wants a refund for their car.",
-        model="openai:gpt-4.1-nano",
+        model="openai:gpt-5.4-nano",
         fixed_responses=inputs["messages"],
     )
     res = run_multiturn_simulation(
@@ -486,7 +486,7 @@ const target = async (inputs: { messages: ChatCompletionMessage[]}) => {
     }
     history[threadId].push(nextMessage);
     const res = await client.chat.completions.create({
-      model: "gpt-4.1-nano",
+      model: "gpt-5.4-nano",
       messages: [
         {
           role: "system",
@@ -504,7 +504,7 @@ const target = async (inputs: { messages: ChatCompletionMessage[]}) => {
   const user = createLLMSimulatedUser({
     system:
       "You are a nice customer who wants a refund for their car.",
-    model: "openai:gpt-4.1-nano",
+    model: "openai:gpt-5.4-nano",
     fixedResponses: inputs.messages,
   });
 
@@ -574,7 +574,7 @@ def target(inputs: dict):
             history[thread_id] = []
         history[thread_id] = history[thread_id] + [next_message]
         res = client.chat.completions.create(
-            model="gpt-4.1-nano",
+            model="gpt-5.4-nano",
             messages=[
                 {
                     "role": "system",
@@ -589,7 +589,7 @@ def target(inputs: dict):
 
     user = create_llm_simulated_user(
         system=inputs["simulated_user_prompt"],
-        model="openai:gpt-4.1-nano",
+        model="openai:gpt-5.4-nano",
         fixed_responses=inputs["messages"],
     )
     res = run_multiturn_simulation(
@@ -669,7 +669,7 @@ const target = async (inputs: {
     }
     history[threadId].push(nextMessage);
     const res = await client.chat.completions.create({
-      model: "gpt-4.1-nano",
+      model: "gpt-5.4-nano",
       messages: [
         {
           role: "system",
@@ -686,7 +686,7 @@ const target = async (inputs: {
 
   const user = createLLMSimulatedUser({
     system: inputs.simulated_user_prompt,
-    model: "openai:gpt-4.1-nano",
+    model: "openai:gpt-5.4-nano",
     fixedResponses: inputs.messages,
   });
 

--- a/src/langsmith/observability-llm-tutorial.mdx
+++ b/src/langsmith/observability-llm-tutorial.mdx
@@ -93,7 +93,7 @@ def support_bot(question: str) -> str:
         + "\n".join(context)
     )
     response = client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         messages=[
             {"role": "system", "content": system_message},
             {"role": "user", "content": question},
@@ -128,7 +128,7 @@ async function supportBot(question: string): Promise<string> {
         "Answer using only the information provided below:\n\n" +
         context.join("\n");
     const response = await client.chat.completions.create({
-        model: "gpt-4.1-mini",
+        model: "gpt-5.4-mini",
         messages: [
             { role: "system", content: systemMessage },
             { role: "user", content: question },
@@ -177,7 +177,7 @@ def support_bot(question: str) -> str:
         + "\n".join(context)
     )
     response = client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         messages=[
             {"role": "system", "content": system_message},
             {"role": "user", "content": question},
@@ -213,7 +213,7 @@ const supportBot = traceable(async function supportBot(question: string): Promis
         "Answer using only the information provided below:\n\n" +
         context.join("\n");
     const response = await client.chat.completions.create({
-        model: "gpt-4.1-mini",
+        model: "gpt-5.4-mini",
         messages: [
             { role: "system", content: systemMessage },
             { role: "user", content: question },
@@ -292,7 +292,7 @@ def support_bot(question: str) -> str:
         + "\n".join(context)
     )
     response = client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         messages=[
             {"role": "system", "content": system_message},
             {"role": "user", "content": question},
@@ -338,7 +338,7 @@ const supportBot = traceable(async function supportBot(question: string): Promis
         "Answer using only the information provided below:\n\n" +
         context.join("\n");
     const response = await client.chat.completions.create({
-        model: "gpt-4.1-mini",
+        model: "gpt-5.4-mini",
         messages: [
             { role: "system", content: systemMessage },
             { role: "user", content: question },
@@ -388,7 +388,7 @@ docs = [
 def retriever(query: str) -> list[str]:
     return docs
 
-@traceable(metadata={"llm": "gpt-4.1-mini"})  # [!code highlight]
+@traceable(metadata={"llm": "gpt-5.4-mini"})  # [!code highlight]
 def support_bot(question: str) -> str:
     context = retriever(question)
     system_message = (
@@ -397,7 +397,7 @@ def support_bot(question: str) -> str:
         + "\n".join(context)
     )
     response = client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         messages=[
             {"role": "system", "content": system_message},
             {"role": "user", "content": question},
@@ -437,7 +437,7 @@ const supportBot = traceable(
             "Answer using only the information provided below:\n\n" +
             context.join("\n");
         const response = await client.chat.completions.create({
-            model: "gpt-4.1-mini",
+            model: "gpt-5.4-mini",
             messages: [
                 { role: "system", content: systemMessage },
                 { role: "user", content: question },
@@ -445,7 +445,7 @@ const supportBot = traceable(
         });
         return response.choices[0].message?.content ?? "";
     },
-    { metadata: { llm: "gpt-4.1-mini" } }  // [!code highlight]
+    { metadata: { llm: "gpt-5.4-mini" } }  // [!code highlight]
 );
 
 (async () => {

--- a/src/langsmith/observability-quickstart.mdx
+++ b/src/langsmith/observability-quickstart.mdx
@@ -89,7 +89,7 @@ def get_context(question: str) -> str:
 def assistant(question: str) -> str:
     context = get_context(question)
     response = client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         messages=[
             {
                 "role": "system",
@@ -122,7 +122,7 @@ const getContext = traceable(
 const assistant = traceable(async function assistant(question: string) { // capture the full pipeline as a single trace
     const context = await getContext(question);
     const response = await client.chat.completions.create({
-        model: "gpt-4.1-mini",
+        model: "gpt-5.4-mini",
         messages: [
             {
                 role: "system",

--- a/src/langsmith/observability-studio.mdx
+++ b/src/langsmith/observability-studio.mdx
@@ -81,13 +81,13 @@ class Configuration(BaseModel):
             "anthropic/claude-sonnet-4-6",
             "anthropic/claude-haiku-4-5-20251001",
             "openai/o1",
-            "openai/gpt-4.1-mini",
+            "openai/gpt-5.4-mini",
             "openai/o1-mini",
             "openai/o3-mini",
         ],
         {"__template_metadata__": {"kind": "llm"}},
     ] = Field(
-        default="openai/gpt-4.1-mini",
+        default="openai/gpt-5.4-mini",
         description="The name of the language model to use for the agent's main interactions. "
         "Should be in the form: provider/model-name.",
         json_schema_extra={"langgraph_nodes": ["call_model"]},

--- a/src/langsmith/online-evaluations-multi-turn.mdx
+++ b/src/langsmith/online-evaluations-multi-turn.mdx
@@ -38,7 +38,7 @@ The first time you configure a thread level evaluator, you'll define the idle ti
 When first testing your evaluator, use a short idle time so you can see results quickly. Once validated, increase it to match the expected length of user interactions.
 </Tip>
 6. **Configure your model.**<br />
-Select the provider and model you want to use for your evaluator. Threads tend to get long, so you should use a model with a higher context window in order to avoid running into limits. For example, OpenAI's GPT-4.1 mini or Gemini 2.5 Flash are good options as they both have 1M+ token context windows.
+Select the provider and model you want to use for your evaluator. Threads tend to get long, so you should use a model with a higher context window in order to avoid running into limits. For example, OpenAI's GPT-5.4 mini or Gemini 2.5 Flash are good options as they both have 1M+ token context windows.
 
 7. **Configure your LLM-as-a-judge prompt.**<br />
 Define what you want to evaluate. This prompt will be used to evaluate the thread. You can also configure which parts of the `messages` list are passed to the evaluator to control the content it receives:

--- a/src/langsmith/optimize-classifier.mdx
+++ b/src/langsmith/optimize-classifier.mdx
@@ -45,7 +45,7 @@ Issue: {text}"""
 def topic_classifier(
     topic: str):
     return client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         temperature=0,
         messages=[
             {
@@ -163,7 +163,7 @@ def topic_classifier(
     examples = list(ls_client.list_examples(dataset_name="classifier-github-issues"))  # <- New Code
     example_string = create_example_string(examples)
     return client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         temperature=0,
         messages=[
             {
@@ -247,7 +247,7 @@ def topic_classifier(
     examples = find_similar(examples, topic)
     example_string = create_example_string(examples)
     return client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         temperature=0,
         messages=[
             {

--- a/src/langsmith/prompt-commit.mdx
+++ b/src/langsmith/prompt-commit.mdx
@@ -130,7 +130,7 @@ The webhook will send a JSON payload containing the new **prompt manifest**.
                 "top_p": 1,
                 "presence_penalty": 0,
                 "frequency_penalty": 0,
-                "model": "gpt-4.1-mini",
+                "model": "gpt-5.4-mini",
                 "extra_headers": {},
                 "openai_api_key": {
                   "id": ["OPENAI_API_KEY"],

--- a/src/langsmith/prompt-engineering-quickstart.mdx
+++ b/src/langsmith/prompt-engineering-quickstart.mdx
@@ -224,7 +224,7 @@ Then, you'll iterate on the prompt by creating a new version. Members of your wo
     formatted_prompt = prompt.invoke({"question": "What is the color of the sky?"})
 
     response = oai_client.chat.completions.create(
-        model="gpt-4.1",
+        model="gpt-5.4",
         messages=convert_to_openai_messages(formatted_prompt.messages),
     )
     ```
@@ -242,7 +242,7 @@ Then, you'll iterate on the prompt by creating a new version. Members of your wo
     const formattedPrompt = await prompt.invoke({ question: "What is the color of the sky?" });
 
     const response = await oaiClient.chat.completions.create({
-        model: "gpt-4.1",
+        model: "gpt-5.4",
         messages: convertPromptToOpenAI(formattedPrompt).messages,
     });
     ```

--- a/src/langsmith/pytest.mdx
+++ b/src/langsmith/pytest.mdx
@@ -50,7 +50,7 @@ oai_client = wrappers.wrap_openai(openai.OpenAI())
 @traceable
 def generate_sql(user_query: str) -> str:
     result = oai_client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         messages=[
             {"role": "system", "content": "Convert the user query to a SQL query."},
             {"role": "user", "content": user_query},
@@ -185,7 +185,7 @@ def test_offtopic_input() -> None:
         )
 
         grade = oai_client.chat.completions.create(
-            model="gpt-4.1-mini",
+            model="gpt-5.4-mini",
             messages=[
                 {"role": "system", "content": instructions},
                 {"role": "user", "content": f"ACTUAL: {sql}\nEXPECTED: {expected}"},

--- a/src/langsmith/rate-limiting.mdx
+++ b/src/langsmith/rate-limiting.mdx
@@ -19,7 +19,7 @@ rate_limiter = InMemoryRateLimiter(
     max_bucket_size=10,  # Controls the maximum burst size.
 )
 
-model = init_chat_model("gpt-4.1", rate_limiter=rate_limiter)
+model = init_chat_model("gpt-5.4", rate_limiter=rate_limiter)
 
 def app(inputs: dict) -> dict:
     response = model.invoke(...)
@@ -45,13 +45,13 @@ If you're using `langchain` components you can add retries to all model calls wi
 ```python Python
 from langchain import init_chat_model
 
-model_with_retry = init_chat_model("gpt-4.1-mini").with_retry(stop_after_attempt=6)
+model_with_retry = init_chat_model("gpt-5.4-mini").with_retry(stop_after_attempt=6)
 ```
 
 ```typescript TypeScript
 import { initChatModel } from "langchain";
 
-const model = await initChatModel("gpt-4.1", {
+const model = await initChatModel("gpt-5.4", {
     modelProvider: "openai",
 });
 

--- a/src/langsmith/run-backtests-new-agent.mdx
+++ b/src/langsmith/run-backtests-new-agent.mdx
@@ -203,7 +203,7 @@ grounded_instructions = f"""You have given somebody some contextual information 
 Grade whether their response is fully supported by the context you have provided. \
 If any meaningful part of their statement is not backed up directly by the context you provided, then their response is not grounded. \
 Otherwise it is grounded."""
-grounded_model = init_chat_model(model="gpt-4.1").with_structured_output(Grade)
+grounded_model = init_chat_model(model="gpt-5.4").with_structured_output(Grade)
 
 def lt_280_chars(outputs: dict) -> bool:
     messages = convert_to_openai_messages(outputs["messages"])
@@ -252,10 +252,10 @@ Now, let's define and evaluate our new system. In this example our new system wi
 
 ```python
 candidate_results = await client.aevaluate(
-    agent.with_config(model="gpt-4.1"),
+    agent.with_config(model="gpt-5.4"),
     data=dataset_name,
     evaluators=[lt_280_chars, gte_3_emojis, is_grounded],
-    experiment_prefix="candidate-gpt-4.1",
+    experiment_prefix="candidate-gpt-5.4",
 )
 # If you have pandas installed can easily explore results as df:
 # candidate_results.to_pandas()

--- a/src/langsmith/run-evals-api-only.mdx
+++ b/src/langsmith/run-evals-api-only.mdx
@@ -179,7 +179,7 @@ Now create the experiments and run completions on all examples. In the API, an "
 #  An experiment is a collection of runs with a reference to the dataset used
 #  API Reference: https://api.smith.langchain.com/redoc#tag/tracer-sessions/operation/create_tracer_session_api_v1_sessions_post
 
-model_names = ("gpt-3.5-turbo", "gpt-4.1-mini")
+model_names = ("gpt-3.5-turbo", "gpt-5.4-mini")
 experiment_ids = []
 for model_name in model_names:
     resp = requests.post(

--- a/src/langsmith/server-mcp.mdx
+++ b/src/langsmith/server-mcp.mdx
@@ -154,7 +154,7 @@ Use an MCP-compliant client to connect to the Agent Server. The following exampl
                 tools = await load_mcp_tools(session)
 
                 # Create and run a react agent with the tools
-                agent = create_agent("gpt-4.1", tools)
+                agent = create_agent("gpt-5.4", tools)
 
                 # Invoke the agent with a message
                 agent_response = await agent.ainvoke({"messages": "What can the finance agent do for me?"})

--- a/src/langsmith/setup-javascript.mdx
+++ b/src/langsmith/setup-javascript.mdx
@@ -108,7 +108,7 @@ async function callModel(state: typeof MessagesAnnotation.State) {
    * Feel free to customize the prompt, model, and other logic!
    */
   const model = new ChatOpenAI({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
   }).bindTools(tools);
 
   const response = await model.invoke([

--- a/src/langsmith/streaming.mdx
+++ b/src/langsmith/streaming.mdx
@@ -650,7 +650,7 @@ The streamed output from [`messages-tuple` mode](#supported-stream-modes) is a t
         topic: str
         joke: str = ""
 
-    model = init_chat_model(model="gpt-4.1-mini")
+    model = init_chat_model(model="gpt-5.4-mini")
 
     def call_model(state: MyState):
         """Call the LLM to generate a joke about a topic"""

--- a/src/langsmith/test-react-agent-pytest.mdx
+++ b/src/langsmith/test-react-agent-pytest.mdx
@@ -194,7 +194,7 @@ class AgentOutputFormat(TypedDict):
     reasoning: Annotated[str, ..., "The reasoning behind the answer"]
 
 agent = create_agent(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     tools=[code_tool, search_tool, polygon_aggregates],
     response_format=AgentOutputFormat,
     system_prompt="You are a financial expert. Respond to the users query accurately",
@@ -215,7 +215,7 @@ const AgentOutputFormatSchema = z.object({
 const tools = [codeTool, searchTool, tickerTool];
 
 const agent = createReactAgent({
-  llm: new ChatOpenAI({ model: "gpt-4.1" }),
+  llm: new ChatOpenAI({ model: "gpt-5.4" }),
   tools: tools,
   responseFormat: AgentOutputFormatSchema,
   stateModifier: "You are a financial expert. Respond to the users query accurately",
@@ -535,7 +535,7 @@ class Grade(TypedDict):
       "Return True if the answer is fully grounded in the source documents, otherwise False.",
   ]
 
-judge_llm = init_chat_model("gpt-4.1").with_structured_output(Grade)
+judge_llm = init_chat_model("gpt-5.4").with_structured_output(Grade)
 
 @pytest.mark.langsmith
 def test_grounded_in_source_info() -> None:
@@ -581,7 +581,7 @@ def test_grounded_in_source_info() -> None:
 
 ```typescript Vitest
 // THIS CODE GOES OUTSIDE THE TEST - IT IS JUST A HELPER FUNCTION
-const judgeLLM = new ChatOpenAI({ model: "gpt-4.1" });
+const judgeLLM = new ChatOpenAI({ model: "gpt-5.4" });
 const groundedEvaluator = async (params: {
   answer: string;
   referenceDocuments: string,
@@ -623,7 +623,7 @@ ls.test(
 
 ```typescript Jest
 // THIS CODE GOES OUTSIDE THE TEST - IT IS JUST A HELPER FUNCTION
-const judgeLLM = new ChatOpenAI({ model: "gpt-4.1" });
+const judgeLLM = new ChatOpenAI({ model: "gpt-5.4" });
 const groundedEvaluator = async (params: {
   answer: string;
   referenceDocuments: string,
@@ -768,7 +768,7 @@ Remember to also add the config files for Vitest and Jest to your project.
         reasoning: Annotated[str, ..., "The reasoning behind the answer"]
 
     agent = create_agent(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         tools=[code_tool, search_tool, polygon_aggregates],
         response_format=AgentOutputFormat,
         system_prompt="You are a financial expert. Respond to the users query accurately",
@@ -842,7 +842,7 @@ Remember to also add the config files for Vitest and Jest to your project.
     const tools = [codeTool, searchTool, tickerTool];
 
     const agent = createReactAgent({
-        llm: new ChatOpenAI({ model: "gpt-4.1" }),
+        llm: new ChatOpenAI({ model: "gpt-5.4" }),
         tools: tools,
         responseFormat: AgentOutputFormatSchema,
         stateModifier: "You are a financial expert. Respond to the users query accurately",
@@ -946,7 +946,7 @@ Remember to also add the config files for Vitest and Jest to your project.
         "Return True if the answer is fully grounded in the source documents, otherwise False.",
     ]
 
-  judge_llm = init_chat_model("gpt-4.1").with_structured_output(Grade)
+  judge_llm = init_chat_model("gpt-5.4").with_structured_output(Grade)
 
   @pytest.mark.langsmith
   def test_grounded_in_source_info() -> None:
@@ -997,7 +997,7 @@ Remember to also add the config files for Vitest and Jest to your project.
   import { AIMessage, ToolMessage } from "@langchain/core/messages";
   import { ChatOpenAI } from "@langchain/openai";
 
-  const judgeLLM = new ChatOpenAI({ model: "gpt-4.1" });
+  const judgeLLM = new ChatOpenAI({ model: "gpt-5.4" });
 
   const groundedEvaluator = async (params: {
     answer: string;
@@ -1105,7 +1105,7 @@ Remember to also add the config files for Vitest and Jest to your project.
   import { AIMessage } from "@langchain/core/messages";
   import { ChatOpenAI } from "@langchain/openai";
 
-  const judgeLLM = new ChatOpenAI({ model: "gpt-4.1" });
+  const judgeLLM = new ChatOpenAI({ model: "gpt-5.4" });
 
   const groundedEvaluator = async (params: {
     answer: string;

--- a/src/langsmith/threads.mdx
+++ b/src/langsmith/threads.mdx
@@ -90,7 +90,7 @@ def chat_pipeline(messages: list, get_chat_history: bool = False):
 
     # Invoke the model
     chat_completion = client.chat.completions.create(
-        model="gpt-4.1-mini", messages=all_messages
+        model="gpt-5.4-mini", messages=all_messages
     )
 
     response_message = chat_completion.choices[0].message
@@ -166,7 +166,7 @@ const chatPipeline = traceable(
 
     // Invoke the model
     const chatCompletion = await client.chat.completions.create({
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       messages,
     });
 

--- a/src/langsmith/trace-with-api.mdx
+++ b/src/langsmith/trace-with-api.mdx
@@ -96,7 +96,7 @@ post_run(child_run_id, "OpenAI Call", "llm", {"messages": messages}, parent_run_
 # Generate a completion
 client = openai.Client()
 chat_completion = client.chat.completions.create(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     messages=messages
 )
 

--- a/src/langsmith/trace-with-instructor.mdx
+++ b/src/langsmith/trace-with-instructor.mdx
@@ -54,7 +54,7 @@ class UserDetail(BaseModel):
 
 
 user = client.chat.completions.create(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     response_model=UserDetail,
     messages=[
         {"role": "user", "content": "Extract Jason is 25 years old"},
@@ -71,7 +71,7 @@ Please see [Custom instrumentation](/langsmith/annotate-code) for more informati
 @traceable(name="Extract User Details")
 def my_function(text: str) -> UserDetail:
     return client.chat.completions.create(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         response_model=UserDetail,
         messages=[
             {"role": "user", "content": f"Extract {text}"},

--- a/src/langsmith/trace-with-langchain.mdx
+++ b/src/langsmith/trace-with-langchain.mdx
@@ -70,7 +70,7 @@ prompt = ChatPromptTemplate.from_messages([
     ("user", "Question: {question}\nContext: {context}")
 ])
 
-model = ChatOpenAI(model="gpt-4.1-mini")
+model = ChatOpenAI(model="gpt-5.4-mini")
 output_parser = StrOutputParser()
 chain = prompt | model | output_parser
 
@@ -90,7 +90,7 @@ const prompt = ChatPromptTemplate.fromMessages([
   ["user", "Question: {question}\nContext: {context}"],
 ]);
 
-const model = new ChatOpenAI({ modelName: "gpt-4.1-mini" });
+const model = new ChatOpenAI({ modelName: "gpt-5.4-mini" });
 const outputParser = new StringOutputParser();
 const chain = prompt.pipe(model).pipe(outputParser);
 
@@ -274,7 +274,7 @@ await chain.invoke({ input: "What is the meaning of life?" }, {runName: "MyCusto
 </CodeGroup>
 
 <Note>
-The `run_name` parameter only changes the name of the runnable you invoke (e.g., a chain, function). It does not rename the nested run automatically created when you invoke an LLM object like @[`ChatOpenAI`] (`gpt-4.1-mini`). In the example, the enclosing run will appear in LangSmith as `MyCustomChain`, while the nested LLM run still shows the model’s default name.
+The `run_name` parameter only changes the name of the runnable you invoke (e.g., a chain, function). It does not rename the nested run automatically created when you invoke an LLM object like @[`ChatOpenAI`] (`gpt-5.4-mini`). In the example, the enclosing run will appear in LangSmith as `MyCustomChain`, while the nested LLM run still shows the model’s default name.
 
 To give the LLM run a more meaningful name, you can either:
 
@@ -307,15 +307,15 @@ llm = ChatOllama(
 
 # Or with OpenAI to distinguish configurations
 llm_creative = ChatOpenAI(
-    model="gpt-4.1",
+    model="gpt-5.4",
     temperature=0.9,
-    metadata={"ls_model_name": "gpt-4.1-creative"}
+    metadata={"ls_model_name": "gpt-5.4-creative"}
 )
 
 llm_factual = ChatOpenAI(
-    model="gpt-4.1",
+    model="gpt-5.4",
     temperature=0.1,
-    metadata={"ls_model_name": "gpt-4.1-factual"}
+    metadata={"ls_model_name": "gpt-5.4-factual"}
 )
 
 # The metadata is inherited when the model is used in a chain
@@ -334,15 +334,15 @@ const llm = new ChatOllama({
 
 // Or with OpenAI to distinguish configurations
 const llmCreative = new ChatOpenAI({
-  modelName: "gpt-4.1",
+  modelName: "gpt-5.4",
   temperature: 0.9,
-  metadata: { ls_model_name: "gpt-4.1-creative" }
+  metadata: { ls_model_name: "gpt-5.4-creative" }
 });
 
 const llmFactual = new ChatOpenAI({
-  modelName: "gpt-4.1",
+  modelName: "gpt-5.4",
   temperature: 0.1,
-  metadata: { ls_model_name: "gpt-4.1-factual" }
+  metadata: { ls_model_name: "gpt-5.4-factual" }
 });
 
 // The metadata is inherited when the model is used in a chain
@@ -408,7 +408,7 @@ prompt = ChatPromptTemplate.from_messages([
     ("system", "You are a helpful assistant. Please respond to the user's request only based on the given context."),
     ("user", "Question: {question}\n\nContext: {context}")
 ])
-model = ChatOpenAI(model="gpt-4.1-mini")
+model = ChatOpenAI(model="gpt-5.4-mini")
 output_parser = StrOutputParser()
 
 chain = prompt | model | output_parser
@@ -430,7 +430,7 @@ const prompt = ChatPromptTemplate.fromMessages([
   ["system", "You are a helpful assistant. Please respond to the user's request only based on the given context."],
   ["user", "Question: {question}\n\nContext: {context}"],
 ]);
-const model = new ChatOpenAI({ modelName: "gpt-4.1-mini" });
+const model = new ChatOpenAI({ modelName: "gpt-5.4-mini" });
 const outputParser = new StringOutputParser();
 
 const chain = prompt.pipe(model).pipe(outputParser);
@@ -585,7 +585,7 @@ prompt = ChatPromptTemplate.from_messages([
     ("user", "Question: {question}\nContext: {context}")
 ])
 
-model = ChatOpenAI(model="gpt-4.1-mini")
+model = ChatOpenAI(model="gpt-5.4-mini")
 output_parser = StrOutputParser()
 chain = prompt | model | output_parser
 
@@ -625,7 +625,7 @@ const prompt = ChatPromptTemplate.fromMessages([
   ["user", "Question: {question}\nContext: {context}"],
 ]);
 
-const model = new ChatOpenAI({ modelName: "gpt-4.1-mini" });
+const model = new ChatOpenAI({ modelName: "gpt-5.4-mini" });
 const outputParser = new StringOutputParser();
 const chain = prompt.pipe(model).pipe(outputParser);
 

--- a/src/langsmith/trace-with-langgraph.mdx
+++ b/src/langsmith/trace-with-langgraph.mdx
@@ -84,7 +84,7 @@ def search(query: str):
 tools = [search]
 tool_node = ToolNode(tools)
 
-model = ChatOpenAI(model="gpt-4.1", temperature=0).bind_tools(tools)
+model = ChatOpenAI(model="gpt-5.4", temperature=0).bind_tools(tools)
 
 def should_continue(state: MessagesState) -> Literal["tools", "__end__"]:
     messages = state['messages']
@@ -155,7 +155,7 @@ const tools = [searchTool];
 const toolNode = new ToolNode<AgentState>(tools);
 
 const model = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
 }).bindTools(tools);
 
@@ -325,7 +325,7 @@ def call_model(state: State):
     messages = state["messages"]
     # Calling the wrapped client will automatically infer the correct tracing context
     response = wrapped_client.chat.completions.create(
-        messages=messages, model="gpt-4.1-mini", tools=[tool_schema]
+        messages=messages, model="gpt-5.4-mini", tools=[tool_schema]
     )
     raw_tool_calls = response.choices[0].message.tool_calls
     tool_calls = [tool_call.to_dict() for tool_call in raw_tool_calls] if raw_tool_calls else []
@@ -422,7 +422,7 @@ const callModel = async ({ messages }: GraphState) => {
   // Calling the wrapped client will automatically infer the correct tracing context
   const response = await wrappedClient.chat.completions.create({
     messages,
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-mini",
     tools: [toolSchema],
   });
   const responseMessage = {

--- a/src/langsmith/trace-with-livekit.mdx
+++ b/src/langsmith/trace-with-livekit.mdx
@@ -128,7 +128,7 @@ async def my_agent(ctx: agents.JobContext):
     # Create agent session with STT, LLM, TTS, and VAD
     session = AgentSession(
         stt="deepgram/nova-2:en",
-        llm="openai/gpt-4.1-mini",
+        llm="openai/gpt-5.4-mini",
         tts=openai.TTS(model="tts-1", voice="alloy"),
         vad=silero.VAD.load(),
         turn_detection=MultilingualModel(),

--- a/src/langsmith/trace-with-opentelemetry.mdx
+++ b/src/langsmith/trace-with-opentelemetry.mdx
@@ -138,7 +138,7 @@ For non-LangChain applications or custom instrumentation, you can trace your app
    tracer = trace.get_tracer(__name__)
 
    def call_openai():
-       model = "gpt-4.1-mini"
+       model = "gpt-5.4-mini"
        with tracer.start_as_current_span("call_open_ai") as span:
            span.set_attribute("langsmith.span.kind", "LLM")
            span.set_attribute("langsmith.metadata.user_id", "user_123")

--- a/src/langsmith/trace-with-pipecat.mdx
+++ b/src/langsmith/trace-with-pipecat.mdx
@@ -106,7 +106,7 @@ async def main():
 
     # Initialize AI services
     stt = WhisperSTTService()
-    llm = OpenAILLMService(model="gpt-4.1-mini")
+    llm = OpenAILLMService(model="gpt-5.4-mini")
     tts = OpenAITTSService(voice="alloy")
 
     # Set up conversation context with system prompt
@@ -334,7 +334,7 @@ If you're getting import errors:
 
 If responses are slow:
 
-1. **Use faster models**: Switch to `gpt-4.1-mini` for the LLM (already in the tutorial).
+1. **Use faster models**: Switch to `gpt-5.4-mini` for the LLM (already in the tutorial).
 2. **Check network**: Ensure stable internet connection for API calls.
 3. **Local STT**: Consider using local Whisper instead of API-based services.
 

--- a/src/langsmith/trace-with-pydantic-ai.mdx
+++ b/src/langsmith/trace-with-pydantic-ai.mdx
@@ -71,7 +71,7 @@ configure(project_name="pydantic-ai-demo")
 Agent.instrument_all()
 
 # Create and run an agent
-agent = Agent('openai:gpt-4.1')
+agent = Agent('openai:gpt-5.4')
 result = agent.run_sync('What is the capital of France?')
 print(result.output)
 #> Paris
@@ -93,7 +93,7 @@ Agent.instrument_all()
 
 tracer = trace.get_tracer(__name__)
 
-agent = Agent('openai:gpt-4.1')
+agent = Agent('openai:gpt-5.4')
 
 with tracer.start_as_current_span("pydantic_ai_workflow") as span:
     span.set_attribute("langsmith.metadata.user_id", "user_123")

--- a/src/langsmith/trace-with-vercel-ai-sdk.mdx
+++ b/src/langsmith/trace-with-vercel-ai-sdk.mdx
@@ -327,7 +327,7 @@ const runId = uuid7();
 const lsConfig = createLangSmithProviderOptions({ id: runId });
 
 await generateText({
-  model: openai("gpt-4.1-mini"),
+  model: openai("gpt-5.4-mini"),
   prompt: "What is the capital of France?",
   providerOptions: {
     langsmith: lsConfig,

--- a/src/langsmith/trace-without-env-vars.mdx
+++ b/src/langsmith/trace-without-env-vars.mdx
@@ -47,7 +47,7 @@ def chat_pipeline(question: str):
       { "role": "user", "content": f"Question: {question}\nContext: {context}"}
   ]
   chat_completion = client.chat.completions.create(
-      model="gpt-4.1-mini", messages=messages
+      model="gpt-5.4-mini", messages=messages
   )
   return chat_completion.choices[0].message.content
 
@@ -79,7 +79,7 @@ const pipeline = traceable(
         const context = await tool(question);
 
         const completion = await openai.chat.completions.create({
-            model: "gpt-4.1-mini",
+            model: "gpt-5.4-mini",
             messages: [
                 { role: "system" as const, content: "You are a helpful assistant. Please respond to the user's request only based on the given context." },
                 { role: "user" as const, content: `Question: ${question}\nContext: ${context}`}

--- a/src/langsmith/trajectory-evals.mdx
+++ b/src/langsmith/trajectory-evals.mdx
@@ -70,7 +70,7 @@ def get_weather(city: str):
     """Get weather information for a city."""
     return f"It's 75 degrees and sunny in {city}."
 
-agent = create_agent("gpt-4.1", tools=[get_weather])
+agent = create_agent("gpt-5.4", tools=[get_weather])
 
 evaluator = create_trajectory_match_evaluator(  # [!code highlight]
     trajectory_match_mode="strict",  # [!code highlight]
@@ -121,7 +121,7 @@ const getWeather = tool(
 );
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [getWeather]
 });
 
@@ -187,7 +187,7 @@ def get_events(city: str):
     """Get events happening in a city."""
     return f"Concert at the park in {city} tonight."
 
-agent = create_agent("gpt-4.1", tools=[get_weather, get_events])
+agent = create_agent("gpt-5.4", tools=[get_weather, get_events])
 
 evaluator = create_trajectory_match_evaluator(  # [!code highlight]
     trajectory_match_mode="unordered",  # [!code highlight]
@@ -249,7 +249,7 @@ const getEvents = tool(
 );
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [getWeather, getEvents]
 });
 
@@ -325,7 +325,7 @@ def get_detailed_forecast(city: str):
     """Get detailed weather forecast for a city."""
     return f"Detailed forecast for {city}: sunny all week."
 
-agent = create_agent("gpt-4.1", tools=[get_weather, get_detailed_forecast])
+agent = create_agent("gpt-5.4", tools=[get_weather, get_detailed_forecast])
 
 evaluator = create_trajectory_match_evaluator(  # [!code highlight]
     trajectory_match_mode="superset",  # [!code highlight]
@@ -388,7 +388,7 @@ const getDetailedForecast = tool(
 );
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [getWeather, getDetailedForecast]
 });
 
@@ -460,7 +460,7 @@ def get_weather(city: str):
     """Get weather information for a city."""
     return f"It's 75 degrees and sunny in {city}."
 
-agent = create_agent("gpt-4.1", tools=[get_weather])
+agent = create_agent("gpt-5.4", tools=[get_weather])
 
 evaluator = create_trajectory_llm_as_judge(  # [!code highlight]
     model="openai:o3-mini",  # [!code highlight]
@@ -502,7 +502,7 @@ const getWeather = tool(
 );
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [getWeather]
 });
 

--- a/src/langsmith/vitest-jest.mdx
+++ b/src/langsmith/vitest-jest.mdx
@@ -212,7 +212,7 @@ const tracedClient = wrapOpenAI(new OpenAI());
 const generateSql = traceable(
   async (userQuery: string) => {
     const result = await tracedClient.chat.completions.create({
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       messages: [
         {
           role: "system",
@@ -306,7 +306,7 @@ const tracedClient = wrapOpenAI(new OpenAI());
 const generateSql = traceable(
   async (userQuery: string) => {
     const result = await tracedClient.chat.completions.create({
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       messages: [
         {
           role: "system",
@@ -334,7 +334,7 @@ const myEvaluator = async (params: {
     "otherwise return 0. Return only 0 or 1 and nothing else.",
   ].join("\n");
   const grade = await tracedClient.chat.completions.create({
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-mini",
     messages: [
       {
         role: "system",

--- a/src/oss/deepagents/going-to-production.mdx
+++ b/src/oss/deepagents/going-to-production.mdx
@@ -946,7 +946,7 @@ agent = create_deep_agent(
         # Retry model calls on rate limits, timeouts, and 5xx errors
         ModelRetryMiddleware(max_retries=3, backoff_factor=2.0, initial_delay=1.0),
         # If the primary model is fully down, fall back to an alternative
-        ModelFallbackMiddleware("gpt-4.1"),
+        ModelFallbackMiddleware("gpt-5.4"),
         # Retry specific tools that hit external APIs (not all tools)
         ToolRetryMiddleware(
             max_retries=2,
@@ -973,7 +973,7 @@ const agent = createAgent({
     // Retry model calls on rate limits, timeouts, and 5xx errors
     modelRetryMiddleware({ maxRetries: 3, backoffFactor: 2.0, initialDelayMs: 1000 }),
     // If the primary model is fully down, fall back to an alternative
-    modelFallbackMiddleware("gpt-4.1"),
+    modelFallbackMiddleware("gpt-5.4"),
     // Retry specific tools that hit external APIs (not all tools)
     toolRetryMiddleware({
       maxRetries: 2,

--- a/src/oss/deepagents/models.mdx
+++ b/src/oss/deepagents/models.mdx
@@ -16,7 +16,7 @@ These models perform well on the [Deep Agents eval suite](https://github.com/lan
 | Provider | Models |
 |----------|--------|
 | [Google](/oss/integrations/providers/google) | `gemini-3.1-pro-preview`, `gemini-3-flash-preview` |
-| [OpenAI](/oss/integrations/providers/openai) | `gpt-5.4`, `gpt-4o`, `gpt-4.1`, `o4-mini`, `gpt-5.2-codex`, `gpt-4o-mini`, `o3` |
+| [OpenAI](/oss/integrations/providers/openai) | `gpt-5.4`, `gpt-4o`, `gpt-5.4`, `o4-mini`, `gpt-5.2-codex`, `gpt-4o-mini`, `o3` |
 | [Anthropic](/oss/integrations/providers/anthropic) | `claude-opus-4-6`, `claude-opus-4-5`, `claude-sonnet-4-6`, `claude-sonnet-4`, `claude-sonnet-4-5`, `claude-haiku-4-5`, `claude-opus-4-1` |
 | Open-weight | `GLM-5`, `Kimi-K2.5`, `MiniMax-M2.5`, `qwen3.5-397B-A17B`, `devstral-2-123B` |
 

--- a/src/oss/javascript/integrations/chat/azure.mdx
+++ b/src/oss/javascript/integrations/chat/azure.mdx
@@ -78,7 +78,7 @@ Now we can instantiate our model object and generate chat completions:
 import { AzureChatOpenAI } from "@langchain/openai"
 
 const llm = new AzureChatOpenAI({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     temperature: 0,
     maxTokens: undefined,
     maxRetries: 2,

--- a/src/oss/javascript/integrations/chat/index.mdx
+++ b/src/oss/javascript/integrations/chat/index.mdx
@@ -39,7 +39,7 @@ description: "Integrate with chat models using LangChain JavaScript."
         ```typescript
         import { ChatOpenAI } from "@langchain/openai";
 
-        const model = new ChatOpenAI({ model: "gpt-4.1-mini" });
+        const model = new ChatOpenAI({ model: "gpt-5.4-mini" });
         ```
         ```javascript
         await model.invoke("Hello, world!")

--- a/src/oss/javascript/integrations/chat/openai.mdx
+++ b/src/oss/javascript/integrations/chat/openai.mdx
@@ -79,7 +79,7 @@ Now we can instantiate our model object and generate chat completions:
 import { ChatOpenAI } from "@langchain/openai"
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
   // other params...
 })
@@ -141,7 +141,7 @@ You can customize the base URL the SDK sends requests to by passing a `configura
 import { ChatOpenAI } from "@langchain/openai";
 
 const llmWithCustomURL = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0.9,
   configuration: {
     baseURL: "https://your_custom_url.com",
@@ -163,7 +163,7 @@ You can specify custom headers in the same `configuration` field:
 import { ChatOpenAI } from "@langchain/openai";
 
 const llmWithCustomHeaders = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0.9,
   configuration: {
     defaultHeaders: {
@@ -183,7 +183,7 @@ Some proxies or third-party providers present largely the same API interface as 
 import { ChatOpenAI } from "@langchain/openai";
 
 const llmWithoutStreamUsage = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0.9,
   streamUsage: false,
   configuration: {
@@ -224,7 +224,7 @@ import { ChatOpenAI } from "@langchain/openai";
 
 // See https://cookbook.openai.com/examples/using_logprobs for details
 const llmWithLogprobs = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   logprobs: true,
   // topLogprobs: 5,
 });
@@ -411,7 +411,7 @@ const weatherTool = tool((_) => "no-op", {
 })
 
 const llmWithStrictTrue = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
 }).bindTools([weatherTool], {
   strict: true,
   tool_choice: weatherTool.name,
@@ -455,7 +455,7 @@ const toolSchema = {
 };
 
 const llmWithStrictTrueTools = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
 }).bindTools([toolSchema], {
   strict: true,
 });
@@ -491,7 +491,7 @@ const traitSchema = z.object({
 });
 
 const structuredLlm = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
 }).withStructuredOutput(traitSchema, {
   name: "extract_traits",
   strict: true,
@@ -540,7 +540,7 @@ llm.invoke("...", { tools: [{ type: "web_search_preview" }] });
 ```typescript
 import { ChatOpenAI } from "@langchain/openai";
 
-const llm = new ChatOpenAI({ model: "gpt-4.1-mini" }).bindTools([
+const llm = new ChatOpenAI({ model: "gpt-5.4-mini" }).bindTools([
   { type: "web_search_preview" },
 ]);
 
@@ -557,7 +557,7 @@ To trigger a file search, pass a [file search tool](https://platform.openai.com/
 ```typescript
 import { ChatOpenAI } from "@langchain/openai";
 
-const llm = new ChatOpenAI({ model: "gpt-4.1-mini" }).bindTools([
+const llm = new ChatOpenAI({ model: "gpt-5.4-mini" }).bindTools([
   { type: "file_search", vector_store_ids: ["vs..."] },
 ]);
 
@@ -753,7 +753,7 @@ ChatOpenAI allows you to bring the built-in [image generation tool](https://plat
 import { ChatOpenAI } from "@langchain/openai";
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   useResponsesApi: true,
 });
 
@@ -1115,7 +1115,7 @@ void 0;
 import { ChatOpenAI } from "@langchain/openai";
 
 const modelWithCaching = new ChatOpenAI({
-  model: "gpt-4.1-mini-2025-04-14",
+  model: "gpt-5.4-mini",
 });
 
 // CACHED_TEXT is some string longer than 1024 tokens
@@ -1177,7 +1177,7 @@ Here's an example:
 import { ChatOpenAI } from "@langchain/openai";
 
 const modelWithPredictions = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
 });
 
 const codeSample = `

--- a/src/oss/javascript/integrations/chat/openrouter.mdx
+++ b/src/oss/javascript/integrations/chat/openrouter.mdx
@@ -188,7 +188,7 @@ For more on binding tools and tool call outputs, head to the [tool calling](/oss
 import { ChatOpenRouter } from "@langchain/openrouter";
 import { z } from "zod";
 
-const model = new ChatOpenRouter({ model: "openai/gpt-4.1" });
+const model = new ChatOpenRouter({ model: "openai/gpt-5.4" });
 
 const movieSchema = z.object({
   title: z.string().describe("The title of the movie"),

--- a/src/oss/javascript/integrations/document_loaders/web_loaders/serpapi.mdx
+++ b/src/oss/javascript/integrations/document_loaders/web_loaders/serpapi.mdx
@@ -29,7 +29,7 @@ import { createRetrievalChain } from "@langchain/classic/chains/retrieval";
 
 // Initialize the necessary components
 const llm = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
 });
 const embeddings = new OpenAIEmbeddings();
 const apiKey = "Your SerpApi API key";

--- a/src/oss/javascript/integrations/llm_caching/azure_cosmosdb_nosql.mdx
+++ b/src/oss/javascript/integrations/llm_caching/azure_cosmosdb_nosql.mdx
@@ -61,7 +61,7 @@ const cache = new AzureCosmosDBNoSQLSemanticCache(
   similarityScoreThreshold
 );
 
-const model = new ChatOpenAI({ model: "gpt-4.1-mini", cache });
+const model = new ChatOpenAI({ model: "gpt-5.4-mini", cache });
 
 // Invoke the model to perform an action
 const response1 = await model.invoke("Do something random!");

--- a/src/oss/javascript/integrations/providers/openai.mdx
+++ b/src/oss/javascript/integrations/providers/openai.mdx
@@ -84,11 +84,11 @@ Moderate agent traffic (user input, model output, and tool results) using OpenAI
 import { createAgent, openAIModerationMiddleware } from "langchain";
 
 const agent = createAgent({
-  model: "openai:gpt-4.1",
+  model: "openai:gpt-5.4",
   tools: [searchTool, databaseTool],
   middleware: [
     openAIModerationMiddleware({
-      model: "openai:gpt-4.1",
+      model: "openai:gpt-5.4",
       moderationModel: "omni-moderation-latest",
       checkInput: true,
       checkOutput: true,
@@ -101,7 +101,7 @@ const agent = createAgent({
 <Accordion title="Configuration options">
 
 <ParamField body="model" type="string | BaseChatModel" required>
-    OpenAI model to use for moderation. Can be either a model name string (e.g., `"openai:gpt-4.1"`) or a `BaseChatModel` instance. The middleware will use this model's client to access the moderation endpoint.
+    OpenAI model to use for moderation. Can be either a model name string (e.g., `"openai:gpt-5.4"`) or a `BaseChatModel` instance. The middleware will use this model's client to access the moderation endpoint.
 </ParamField>
 
 <ParamField body="moderationModel" type="ModerationModel" default="omni-moderation-latest">
@@ -159,11 +159,11 @@ import { createAgent, openAIModerationMiddleware } from "langchain";
 
 // Basic moderation
 const agent = createAgent({
-  model: "openai:gpt-4.1",
+  model: "openai:gpt-5.4",
   tools: [searchTool, customerDataTool],
   middleware: [
     openAIModerationMiddleware({
-      model: "openai:gpt-4.1",
+      model: "openai:gpt-5.4",
       moderationModel: "omni-moderation-latest",
       checkInput: true,
       checkOutput: true,
@@ -173,11 +173,11 @@ const agent = createAgent({
 
 // Strict moderation with custom message
 const agentStrict = createAgent({
-  model: "openai:gpt-4.1",
+  model: "openai:gpt-5.4",
   tools: [searchTool, customerDataTool],
   middleware: [
     openAIModerationMiddleware({
-      model: "openai:gpt-4.1",
+      model: "openai:gpt-5.4",
       moderationModel: "omni-moderation-latest",
       checkInput: true,
       checkOutput: true,
@@ -192,11 +192,11 @@ const agentStrict = createAgent({
 
 // Moderation with replacement behavior
 const agentReplace = createAgent({
-  model: "openai:gpt-4.1",
+  model: "openai:gpt-5.4",
   tools: [searchTool],
   middleware: [
     openAIModerationMiddleware({
-      model: "openai:gpt-4.1",
+      model: "openai:gpt-5.4",
       checkInput: true,
       exitBehavior: "replace",
       violationMessage: "[Content removed due to safety policies]",

--- a/src/oss/javascript/integrations/retrievers/arxiv-retriever.mdx
+++ b/src/oss/javascript/integrations/retrievers/arxiv-retriever.mdx
@@ -69,7 +69,7 @@ import { StringOutputParser } from "@langchain/core/output_parsers";
 import type { Document } from "@langchain/core/documents";
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   temperature: 0,
 });
 

--- a/src/oss/javascript/integrations/retrievers/azion-edgesql.mdx
+++ b/src/oss/javascript/integrations/retrievers/azion-edgesql.mdx
@@ -64,7 +64,7 @@ const embeddingModel = new OpenAIEmbeddings({
 })
 
 const chatModel = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   apiKey: process.env.OPENAI_API_KEY
 })
 

--- a/src/oss/javascript/integrations/tools/aiplugin-tool.mdx
+++ b/src/oss/javascript/integrations/tools/aiplugin-tool.mdx
@@ -19,7 +19,7 @@ export const run = async () => {
   ];
   const executor = await initializeAgentExecutorWithOptions(
     tools,
-    new ChatOpenAI({ model: "gpt-4.1-mini", temperature: 0 }),
+    new ChatOpenAI({ model: "gpt-5.4-mini", temperature: 0 }),
     { agentType: "chat-zero-shot-react-description", verbose: true }
   );
 

--- a/src/oss/javascript/integrations/tools/connery.mdx
+++ b/src/oss/javascript/integrations/tools/connery.mdx
@@ -33,7 +33,7 @@ const manualRunResult = await sendEmailAction.invoke({
 console.log(manualRunResult);
 
 // Run the action using the OpenAI Functions agent.
-const llm = new ChatOpenAI({ model: "gpt-4.1-mini", temperature: 0 });
+const llm = new ChatOpenAI({ model: "gpt-5.4-mini", temperature: 0 });
 const agent = await initializeAgentExecutorWithOptions([sendEmailAction], llm, {
   agentType: "openai-functions",
   verbose: true,

--- a/src/oss/javascript/integrations/tools/connery_toolkit.mdx
+++ b/src/oss/javascript/integrations/tools/connery_toolkit.mdx
@@ -24,7 +24,7 @@ const conneryService = new ConneryService();
 const conneryToolkit = await ConneryToolkit.createInstance(conneryService);
 
 // Use OpenAI Functions agent to execute the prompt using actions from the Connery Toolkit.
-const llm = new ChatOpenAI({ model: "gpt-4.1-mini", temperature: 0 });
+const llm = new ChatOpenAI({ model: "gpt-5.4-mini", temperature: 0 });
 const agent = await initializeAgentExecutorWithOptions(
   conneryToolkit.tools,
   llm,

--- a/src/oss/javascript/integrations/tools/decodo.mdx
+++ b/src/oss/javascript/integrations/tools/decodo.mdx
@@ -53,7 +53,7 @@ const main = async () => {
   const decodoUniversalTool = new DecodoUniversalTool({ username, password });
 
   const model = new ChatOpenAI({
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-mini",
   });
 
   const agent = createAgent({

--- a/src/oss/javascript/integrations/tools/discord_tool.mdx
+++ b/src/oss/javascript/integrations/tools/discord_tool.mdx
@@ -59,7 +59,7 @@ import { DiscordSendMessagesTool } from "@langchain/community/tools/discord";
 import { DadJokeAPI } from "@langchain/community/tools/dadjokeapi";
 
 const model = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   temperature: 0,
 });
 

--- a/src/oss/javascript/integrations/tools/duckduckgo_search.mdx
+++ b/src/oss/javascript/integrations/tools/duckduckgo_search.mdx
@@ -100,7 +100,7 @@ We can use our tool in a chain by first binding it to a [tool-calling model](/os
 import { ChatOpenAI } from "@langchain/openai"
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
 })
 ```
 

--- a/src/oss/javascript/integrations/tools/exa_search.mdx
+++ b/src/oss/javascript/integrations/tools/exa_search.mdx
@@ -118,7 +118,7 @@ We can use our tool in a chain by first binding it to a [tool-calling model](/os
 import { ChatOpenAI } from "@langchain/openai"
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
 })
 ```
 
@@ -204,7 +204,7 @@ Then, define the LLM to use with the agent
 import { ChatOpenAI } from "@langchain/openai";
 
 const llmForAgent = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0
 })
 ```

--- a/src/oss/javascript/integrations/tools/goat.mdx
+++ b/src/oss/javascript/integrations/tools/goat.mdx
@@ -104,7 +104,7 @@ const tools = await getOnChainTools({
 
 // 3. Create the agent
 const model = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
 });
 
 const agent = createAgent({ llm: model, tools: tools });

--- a/src/oss/javascript/integrations/tools/google_calendar.mdx
+++ b/src/oss/javascript/integrations/tools/google_calendar.mdx
@@ -27,7 +27,7 @@ export async function run() {
   const model = new ChatOpenAI({
     temperature: 0,
     apiKey: process.env.OPENAI_API_KEY,
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-mini",
   });
 
   const googleCalendarParams = {

--- a/src/oss/javascript/integrations/tools/jigsawstack.mdx
+++ b/src/oss/javascript/integrations/tools/jigsawstack.mdx
@@ -108,7 +108,7 @@ import {
 } from "@langchain/jigsawstack";
 
 const model = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   temperature: 0,
 });
 

--- a/src/oss/javascript/integrations/tools/openai.mdx
+++ b/src/oss/javascript/integrations/tools/openai.mdx
@@ -18,7 +18,7 @@ The web search tool allows OpenAI models to search the web for up-to-date inform
 import { ChatOpenAI, tools } from "@langchain/openai";
 
 const model = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
 });
 
 // Basic usage
@@ -90,7 +90,7 @@ There are two ways to use MCP tools:
 ```typescript
 import { ChatOpenAI, tools } from "@langchain/openai";
 
-const model = new ChatOpenAI({ model: "gpt-4.1" });
+const model = new ChatOpenAI({ model: "gpt-5.4" });
 
 const response = await model.invoke("Roll 2d4+1", {
   tools: [
@@ -135,7 +135,7 @@ Use Code Interpreter for:
 ```typescript
 import { ChatOpenAI, tools } from "@langchain/openai";
 
-const model = new ChatOpenAI({ model: "gpt-4.1" });
+const model = new ChatOpenAI({ model: "gpt-5.4" });
 
 // Basic usage with auto container (default 1GB memory)
 const response = await model.invoke("Solve the equation 3x + 11 = 14", {
@@ -202,7 +202,7 @@ The File Search tool allows models to search your files for relevant information
 ```typescript
 import { ChatOpenAI, tools } from "@langchain/openai";
 
-const model = new ChatOpenAI({ model: "gpt-4.1" });
+const model = new ChatOpenAI({ model: "gpt-5.4" });
 
 const response = await model.invoke("What is deep research by OpenAI?", {
   tools: [
@@ -238,7 +238,7 @@ Use Image Generation for:
 ```typescript
 import { ChatOpenAI, tools } from "@langchain/openai";
 
-const model = new ChatOpenAI({ model: "gpt-4.1" });
+const model = new ChatOpenAI({ model: "gpt-5.4" });
 
 // Basic usage - generate an image
 const response = await model.invoke(
@@ -336,7 +336,7 @@ const response2 = await model.invoke(
 
 > **Prompting tips**: Use terms like "draw" or "edit" for best results. For combining images, say "edit the first image by adding this element" instead of "combine" or "merge".
 
-Supported models: `gpt-4o`, `gpt-4o-mini`, `gpt-4.1`, `gpt-4.1-mini`, `gpt-4.1-nano`, `o3`
+Supported models: `gpt-4o`, `gpt-4o-mini`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.4-nano`, `o3`
 
 For more information, see [OpenAI's Image Generation Documentation](https://platform.openai.com/docs/guides/tools-image-generation).
 

--- a/src/oss/javascript/integrations/tools/openapi.mdx
+++ b/src/oss/javascript/integrations/tools/openapi.mdx
@@ -62,7 +62,7 @@ Now we can instantiate our toolkit. First, we need to define the LLM we would li
 
 import { ChatOpenAI } from "@langchain/openai";
 const llm = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   temperature: 0,
 })
 ```
@@ -155,7 +155,7 @@ const agentExecutor = createAgent({ llm, tools });
 ```
 
 ```typescript
-const exampleQuery = "Make a POST request to openai /chat/completions. The prompt should be 'tell me a joke.'. Ensure you use the model 'gpt-4.1-mini'."
+const exampleQuery = "Make a POST request to openai /chat/completions. The prompt should be 'tell me a joke.'. Ensure you use the model 'gpt-5.4-mini'."
 
 const events = await agentExecutor.stream(
   { messages: [["user", exampleQuery]]},
@@ -177,7 +177,7 @@ for await (const event of events) {
   {
     name: 'requests_post',
     args: {
-      input: '{"url":"https://api.openai.com/v1/chat/completions","data":{"model":"gpt-4.1-mini","messages":[{"role":"user","content":"tell me a joke."}]}}'
+      input: '{"url":"https://api.openai.com/v1/chat/completions","data":{"model":"gpt-5.4-mini","messages":[{"role":"user","content":"tell me a joke."}]}}'
     },
     type: 'tool_call',
     id: 'call_1HqyZrbYgKFwQRfAtsZA2uL5'
@@ -187,7 +187,7 @@ for await (const event of events) {
   "id": "chatcmpl-9t36IIuRCs0WGMEy69HUqPcKvOc1w",
   "object": "chat.completion",
   "created": 1722906986,
-  "model": "gpt-4.1-mini-2025-04-14",
+  "model": "gpt-5.4-mini",
   "choices": [
     {
       "index": 0,

--- a/src/oss/javascript/integrations/tools/searchapi.mdx
+++ b/src/oss/javascript/integrations/tools/searchapi.mdx
@@ -21,7 +21,7 @@ import { BaseMessageChunk } from "@langchain/core/messages";
 import { SearchApi } from "@langchain/community/tools/searchapi";
 
 const model = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   temperature: 0,
 });
 const tools = [

--- a/src/oss/javascript/integrations/tools/serpapi.mdx
+++ b/src/oss/javascript/integrations/tools/serpapi.mdx
@@ -110,7 +110,7 @@ We can use our tool in a chain by first binding it to a [tool-calling model](/os
 import { ChatOpenAI } from "@langchain/openai"
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   temperature: 0,
 })
 ```

--- a/src/oss/javascript/integrations/tools/sql.mdx
+++ b/src/oss/javascript/integrations/tools/sql.mdx
@@ -53,7 +53,7 @@ First, we need to define our LLM to be used in the toolkit.
 import { ChatOpenAI } from "@langchain/openai";
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   temperature: 0,
 })
 ```

--- a/src/oss/javascript/integrations/tools/tavily_crawl.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_crawl.mdx
@@ -108,7 +108,7 @@ We can use our tool in a chain by first binding it to a [tool-calling model](/os
 import { ChatOpenAI } from "@langchain/openai"
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
 })
 ```

--- a/src/oss/javascript/integrations/tools/tavily_extract.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_extract.mdx
@@ -101,7 +101,7 @@ We can use our tool in a chain by first binding it to a [tool-calling model](/os
 import { ChatOpenAI } from "@langchain/openai"
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
 })
 ```

--- a/src/oss/javascript/integrations/tools/tavily_map.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_map.mdx
@@ -105,7 +105,7 @@ We can use our tool in a chain by first binding it to a [tool-calling model](/os
 import { ChatOpenAI } from "@langchain/openai"
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
 })
 ```

--- a/src/oss/javascript/integrations/tools/tavily_search.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_search.mdx
@@ -113,7 +113,7 @@ We can use our tool in a chain by first binding it to a [tool-calling model](/os
 import { ChatOpenAI } from "@langchain/openai"
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
 })
 ```

--- a/src/oss/javascript/integrations/tools/tavily_search_community.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_search_community.mdx
@@ -106,7 +106,7 @@ We can use our tool in a chain by first binding it to a [tool-calling model](/os
 import { ChatOpenAI } from "@langchain/openai"
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0,
 })
 ```

--- a/src/oss/javascript/integrations/tools/vectorstore.mdx
+++ b/src/oss/javascript/integrations/tools/vectorstore.mdx
@@ -42,7 +42,7 @@ Now we can instantiate our toolkit. First, we need to define the LLM we'll use i
 import { ChatOpenAI } from "@langchain/openai";
 
 const llm = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   temperature: 0,
 })
 ```

--- a/src/oss/javascript/integrations/tools/webbrowser.mdx
+++ b/src/oss/javascript/integrations/tools/webbrowser.mdx
@@ -28,7 +28,7 @@ import { WebBrowser } from "@langchain/classic/tools/webbrowser";
 import { ChatOpenAI, OpenAIEmbeddings } from "@langchain/openai";
 
 export async function run() {
-  const model = new ChatOpenAI({ model: "gpt-4.1-mini", temperature: 0 });
+  const model = new ChatOpenAI({ model: "gpt-5.4-mini", temperature: 0 });
   const embeddings = new OpenAIEmbeddings();
 
   const browser = new WebBrowser({ model, embeddings });

--- a/src/oss/javascript/migrate/langchain-v1.mdx
+++ b/src/oss/javascript/migrate/langchain-v1.mdx
@@ -387,11 +387,11 @@ To better support structured output, `createAgent` should receive a plain model 
 
 ```typescript
 // No longer supported
-// const modelWithTools = new ChatOpenAI({ model: "gpt-4.1-mini" }).bindTools([someTool]);
+// const modelWithTools = new ChatOpenAI({ model: "gpt-5.4-mini" }).bindTools([someTool]);
 // const agent = createAgent({ model: modelWithTools, tools: [] });
 
 // Use instead
-const agent = createAgent({ model: "gpt-4.1-mini", tools: [someTool] });
+const agent = createAgent({ model: "gpt-5.4-mini", tools: [someTool] });
 ```
 
 ### Tools
@@ -475,7 +475,7 @@ const OutputSchema = z.object({
 });
 
 const agent = createAgent({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   tools,
   // explicitly using tool strategy
   responseFormat: toolStrategy(OutputSchema), // [!code highlight]
@@ -491,7 +491,7 @@ const OutputSchema = z.object({
 });
 
 const agent = createReactAgent({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   tools,
   // Structured output was driven primarily via tool-calling with fewer options
   responseFormat: OutputSchema,
@@ -517,7 +517,7 @@ import { createAgent, HumanMessage } from "langchain";
 import * as z from "zod";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools,
   contextSchema: z.object({ userId: z.string(), sessionId: z.string() }),
 });

--- a/src/oss/javascript/releases/langchain-v1.mdx
+++ b/src/oss/javascript/releases/langchain-v1.mdx
@@ -211,7 +211,7 @@ const weatherSchema = z.object({
 });
 
 const agent = createAgent({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   tools: [getWeather],
   responseFormat: weatherSchema,
 });

--- a/src/oss/langchain/agents.mdx
+++ b/src/oss/langchain/agents.mdx
@@ -118,7 +118,7 @@ import { createAgent } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
 
 const model = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   temperature: 0.1,
   maxTokens: 1000,
   timeout: 30
@@ -147,8 +147,8 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import wrap_model_call, ModelRequest, ModelResponse
 
 
-basic_model = ChatOpenAI(model="gpt-4.1-mini")
-advanced_model = ChatOpenAI(model="gpt-4.1")
+basic_model = ChatOpenAI(model="gpt-5.4-mini")
+advanced_model = ChatOpenAI(model="gpt-5.4")
 
 @wrap_model_call
 def dynamic_model_selection(request: ModelRequest, handler) -> ModelResponse:
@@ -183,8 +183,8 @@ To use a dynamic model, create middleware with `wrapModelCall` that modifies the
 import { ChatOpenAI } from "@langchain/openai";
 import { createAgent, createMiddleware } from "langchain";
 
-const basicModel = new ChatOpenAI({ model: "gpt-4.1-mini" });
-const advancedModel = new ChatOpenAI({ model: "gpt-4.1" });
+const basicModel = new ChatOpenAI({ model: "gpt-5.4-mini" });
+const advancedModel = new ChatOpenAI({ model: "gpt-5.4" });
 
 const dynamicModelSelection = createMiddleware({
   name: "DynamicModelSelection",
@@ -200,7 +200,7 @@ const dynamicModelSelection = createMiddleware({
 });
 
 const agent = createAgent({
-  model: "gpt-4.1-mini", // Base model (used when messageCount ≤ 10)
+  model: "gpt-5.4-mini", // Base model (used when messageCount ≤ 10)
   tools,
   middleware: [dynamicModelSelection],
 });
@@ -285,7 +285,7 @@ const getWeather = tool(
 );
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [search, getWeather],
 });
 ```
@@ -338,7 +338,7 @@ There are two approaches depending on whether tools are known ahead of time:
             return handler(request)
 
         agent = create_agent(
-            model="gpt-4.1",
+            model="gpt-5.4",
             tools=[public_search, private_search, advanced_search],
             middleware=[state_based_tools]
         )
@@ -426,7 +426,7 @@ There are two approaches depending on whether tools are known ahead of time:
             return handler(request)
 
         agent = create_agent(
-            model="gpt-4.1",
+            model="gpt-5.4",
             tools=[search_tool, analysis_tool, export_tool],
             middleware=[store_based_tools],
             context_schema=Context,
@@ -533,7 +533,7 @@ There are two approaches depending on whether tools are known ahead of time:
             return handler(request)
 
         agent = create_agent(
-            model="gpt-4.1",
+            model="gpt-5.4",
             tools=[read_data, write_data, delete_data],
             middleware=[context_based_tools],
             context_schema=Context
@@ -745,7 +745,7 @@ def handle_tool_errors(request, handler):
         )
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search, get_weather],
     middleware=[handle_tool_errors]
 )
@@ -788,7 +788,7 @@ const handleToolErrors = createMiddleware({
 });
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [
     /* ... */
   ],
@@ -985,7 +985,7 @@ def user_role_prompt(request: ModelRequest) -> str:
     return base_prompt
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[web_search],
     middleware=[user_role_prompt],
     context_schema=Context
@@ -1009,7 +1009,7 @@ const contextSchema = z.object({
 });
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [/* ... */],
   contextSchema,
   middleware: [
@@ -1124,7 +1124,7 @@ class ContactInfo(BaseModel):
     phone: str
 
 agent = create_agent(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     tools=[search_tool],
     response_format=ToolStrategy(ContactInfo)
 )
@@ -1145,7 +1145,7 @@ result["structured_response"]
 from langchain.agents.structured_output import ProviderStrategy
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     response_format=ProviderStrategy(ContactInfo)
 )
 ```
@@ -1169,7 +1169,7 @@ const ContactInfo = z.object({
 });
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   responseFormat: ContactInfo,
 });
 
@@ -1281,7 +1281,7 @@ const CustomAgentState = new StateSchema({
 });
 
 const customAgent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [],
   stateSchema: CustomAgentState,
 });

--- a/src/oss/langchain/context-engineering.mdx
+++ b/src/oss/langchain/context-engineering.mdx
@@ -130,7 +130,7 @@ The system prompt sets the LLM's behavior and capabilities. Different users, con
         return base
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[...],
         middleware=[state_aware_prompt]
     )
@@ -142,7 +142,7 @@ The system prompt sets the LLM's behavior and capabilities. Different users, con
     import { createAgent } from "langchain";
 
     const agent = createAgent({
-      model: "gpt-4.1",
+      model: "gpt-5.4",
       tools: [...],
       middleware: [
         dynamicSystemPromptMiddleware((state) => {
@@ -195,7 +195,7 @@ The system prompt sets the LLM's behavior and capabilities. Different users, con
         return base
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[...],
         middleware=[store_aware_prompt],
         context_schema=Context,
@@ -216,7 +216,7 @@ The system prompt sets the LLM's behavior and capabilities. Different users, con
     type Context = z.infer<typeof contextSchema>;
 
     const agent = createAgent({
-      model: "gpt-4.1",
+      model: "gpt-5.4",
       tools: [...],
       contextSchema,
       middleware: [
@@ -276,7 +276,7 @@ The system prompt sets the LLM's behavior and capabilities. Different users, con
         return base
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[...],
         middleware=[context_aware_prompt],
         context_schema=Context
@@ -297,7 +297,7 @@ The system prompt sets the LLM's behavior and capabilities. Different users, con
     type Context = z.infer<typeof contextSchema>;
 
     const agent = createAgent({
-      model: "gpt-4.1",
+      model: "gpt-5.4",
       tools: [...],
       contextSchema,
       middleware: [
@@ -376,7 +376,7 @@ Reference these files when answering questions."""
         return handler(request)
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[...],
         middleware=[inject_file_context]
     )
@@ -417,7 +417,7 @@ Reference these files when answering questions.`;
     });
 
     const agent = createAgent({
-      model: "gpt-4.1",
+      model: "gpt-5.4",
       tools: [...],
       middleware: [injectFileContext],
     });
@@ -473,7 +473,7 @@ Reference these files when answering questions.`;
         return handler(request)
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[...],
         middleware=[inject_writing_style],
         context_schema=Context,
@@ -579,7 +579,7 @@ ${style.exampleEmail || ''}`;
         return handler(request)
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[...],
         middleware=[inject_compliance_rules],
         context_schema=Context
@@ -758,7 +758,7 @@ Not every tool is appropriate for every situation. Too many tools may overwhelm 
         return handler(request)
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[public_search, private_search, advanced_search],
         middleware=[state_based_tools]
     )
@@ -830,7 +830,7 @@ Not every tool is appropriate for every situation. Too many tools may overwhelm 
         return handler(request)
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[search_tool, analysis_tool, export_tool],
         middleware=[store_based_tools],
         context_schema=Context,
@@ -911,7 +911,7 @@ Not every tool is appropriate for every situation. Too many tools may overwhelm 
         return handler(request)
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[read_data, write_data, delete_data],
         middleware=[context_based_tools],
         context_schema=Context
@@ -974,8 +974,8 @@ might change during an agent run.
 
     # Initialize models once outside the middleware
     large_model = init_chat_model("claude-sonnet-4-6")
-    standard_model = init_chat_model("gpt-4.1")
-    efficient_model = init_chat_model("gpt-4.1-mini")
+    standard_model = init_chat_model("gpt-5.4")
+    efficient_model = init_chat_model("gpt-5.4-mini")
 
     @wrap_model_call
     def state_based_model(
@@ -1001,7 +1001,7 @@ might change during an agent run.
         return handler(request)
 
     agent = create_agent(
-        model="gpt-4.1-mini",
+        model="gpt-5.4-mini",
         tools=[...],
         middleware=[state_based_model]
     )
@@ -1015,8 +1015,8 @@ might change during an agent run.
 
     // Initialize models once outside the middleware
     const largeModel = initChatModel("claude-sonnet-4-6");
-    const standardModel = initChatModel("gpt-4.1");
-    const efficientModel = initChatModel("gpt-4.1-mini");
+    const standardModel = initChatModel("gpt-5.4");
+    const efficientModel = initChatModel("gpt-5.4-mini");
 
     const stateBasedModel = createMiddleware({
       name: "StateBasedModel",
@@ -1059,8 +1059,8 @@ might change during an agent run.
 
     # Initialize available models once
     MODEL_MAP = {
-        "gpt-4.1": init_chat_model("gpt-4.1"),
-        "gpt-4.1-mini": init_chat_model("gpt-4.1-mini"),
+        "gpt-5.4": init_chat_model("gpt-5.4"),
+        "gpt-5.4-mini": init_chat_model("gpt-5.4-mini"),
         "claude-sonnet": init_chat_model("claude-sonnet-4-6"),
     }
 
@@ -1084,7 +1084,7 @@ might change during an agent run.
         return handler(request)
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[...],
         middleware=[store_based_model],
         context_schema=Context,
@@ -1105,8 +1105,8 @@ might change during an agent run.
 
     // Initialize available models once
     const MODEL_MAP = {
-      "gpt-4.1": initChatModel("gpt-4.1"),
-      "gpt-4.1-mini": initChatModel("gpt-4.1-mini"),
+      "gpt-5.4": initChatModel("gpt-5.4"),
+      "gpt-5.4-mini": initChatModel("gpt-5.4-mini"),
       "claude-sonnet": initChatModel("claude-sonnet-4-6"),
     };
 
@@ -1155,8 +1155,8 @@ might change during an agent run.
 
     # Initialize models once outside the middleware
     premium_model = init_chat_model("claude-sonnet-4-6")
-    standard_model = init_chat_model("gpt-4.1")
-    budget_model = init_chat_model("gpt-4.1-mini")
+    standard_model = init_chat_model("gpt-5.4")
+    budget_model = init_chat_model("gpt-5.4-mini")
 
     @wrap_model_call
     def context_based_model(
@@ -1183,7 +1183,7 @@ might change during an agent run.
         return handler(request)
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[...],
         middleware=[context_based_model],
         context_schema=Context
@@ -1204,8 +1204,8 @@ might change during an agent run.
 
     // Initialize models once outside the middleware
     const premiumModel = initChatModel("claude-sonnet-4-6");
-    const standardModel = initChatModel("gpt-4.1");
-    const budgetModel = initChatModel("gpt-4.1-mini");
+    const standardModel = initChatModel("gpt-5.4");
+    const budgetModel = initChatModel("gpt-5.4-mini");
 
     const contextBasedModel = createMiddleware({
       name: "ContextBasedModel",
@@ -1333,7 +1333,7 @@ Dynamic response format selection adapts schemas based on user preferences, conv
         return handler(request)
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[...],
         middleware=[state_based_output]
     )
@@ -1426,7 +1426,7 @@ Dynamic response format selection adapts schemas based on user preferences, conv
         return handler(request)
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[...],
         middleware=[store_based_output],
         context_schema=Context,
@@ -1524,7 +1524,7 @@ Dynamic response format selection adapts schemas based on user preferences, conv
         return handler(request)
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[...],
         middleware=[context_based_output],
         context_schema=Context
@@ -1612,7 +1612,7 @@ Most real-world tools need more than just the LLM's parameters. They need user I
             return "User is not authenticated"
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[check_authentication]
     )
     ```
@@ -1680,7 +1680,7 @@ Most real-world tools need more than just the LLM's parameters. They need user I
             return "No preferences found"
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[get_preference],
         context_schema=Context,
         store=InMemoryStore()
@@ -1758,7 +1758,7 @@ Most real-world tools need more than just the LLM's parameters. They need user I
         return f"Found {len(results)} results for user {user_id}"
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[fetch_user_data],
         context_schema=Context
     )
@@ -1808,7 +1808,7 @@ Most real-world tools need more than just the LLM's parameters. They need user I
     );
 
     const agent = createAgent({
-      model: "gpt-4.1",
+      model: "gpt-5.4",
       tools: [fetchUserData],
       contextSchema,
     });
@@ -1849,7 +1849,7 @@ and update the memory of the agent to make important context available to future
             return Command(update={"authenticated": False})
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[authenticate_user]
     )
     ```
@@ -1925,7 +1925,7 @@ and update the memory of the agent to make important context available to future
         return f"Saved preference: {preference_key} = {preference_value}"
 
     agent = create_agent(
-        model="gpt-4.1",
+        model="gpt-5.4",
         tools=[save_preference],
         context_schema=Context,
         store=InMemoryStore()
@@ -2001,11 +2001,11 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[...],
     middleware=[
         SummarizationMiddleware(
-            model="gpt-4.1-mini",
+            model="gpt-5.4-mini",
             trigger={"tokens": 4000},
             keep={"messages": 20},
         ),
@@ -2019,11 +2019,11 @@ agent = create_agent(
 import { createAgent, summarizationMiddleware } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [...],
   middleware: [
     summarizationMiddleware({
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       trigger: { tokens: 4000 },
       keep: { messages: 20 },
     }),

--- a/src/oss/langchain/guardrails.mdx
+++ b/src/oss/langchain/guardrails.mdx
@@ -59,7 +59,7 @@ from langchain.agents.middleware import PIIMiddleware
 
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[customer_service_tool, email_tool],
     middleware=[
         # Redact emails in user input before sending to model
@@ -96,7 +96,7 @@ result = agent.invoke({
 import { createAgent, piiRedactionMiddleware } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [customerServiceTool, emailTool],
   middleware: [
     // Redact emails in user input before sending to model
@@ -183,7 +183,7 @@ from langgraph.types import Command
 
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool, send_email_tool, delete_database_tool],
     middleware=[
         HumanInTheLoopMiddleware(
@@ -222,7 +222,7 @@ import { createAgent, humanInTheLoopMiddleware } from "langchain";
 import { MemorySaver, Command } from "@langchain/langgraph";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [searchTool, sendEmailTool, deleteDatabaseTool],
   middleware: [
     humanInTheLoopMiddleware({
@@ -313,7 +313,7 @@ class ContentFilterMiddleware(AgentMiddleware):
 from langchain.agents import create_agent
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool, calculator_tool],
     middleware=[
         ContentFilterMiddleware(
@@ -367,7 +367,7 @@ def content_filter(state: AgentState, runtime: Runtime) -> dict[str, Any] | None
 from langchain.agents import create_agent
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool, calculator_tool],
     middleware=[content_filter],
 )
@@ -430,7 +430,7 @@ const contentFilterMiddleware = (bannedKeywords: string[]) => {
 import { createAgent } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [searchTool, calculatorTool],
   middleware: [
     contentFilterMiddleware(["hack", "exploit", "malware"]),
@@ -464,7 +464,7 @@ class SafetyGuardrailMiddleware(AgentMiddleware):
 
     def __init__(self):
         super().__init__()
-        self.safety_model = init_chat_model("gpt-4.1-mini")
+        self.safety_model = init_chat_model("gpt-5.4-mini")
 
     @hook_config(can_jump_to=["end"])
     def after_agent(self, state: AgentState, runtime: Runtime) -> dict[str, Any] | None:
@@ -493,7 +493,7 @@ class SafetyGuardrailMiddleware(AgentMiddleware):
 from langchain.agents import create_agent
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool, calculator_tool],
     middleware=[SafetyGuardrailMiddleware()],
 )
@@ -510,7 +510,7 @@ from langchain.messages import AIMessage
 from langchain.chat_models import init_chat_model
 from typing import Any
 
-safety_model = init_chat_model("gpt-4.1-mini")
+safety_model = init_chat_model("gpt-5.4-mini")
 
 @after_agent(can_jump_to=["end"])
 def safety_guardrail(state: AgentState, runtime: Runtime) -> dict[str, Any] | None:
@@ -540,7 +540,7 @@ def safety_guardrail(state: AgentState, runtime: Runtime) -> dict[str, Any] | No
 from langchain.agents import create_agent
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool, calculator_tool],
     middleware=[safety_guardrail],
 )
@@ -559,7 +559,7 @@ result = agent.invoke({
 import { createMiddleware, AIMessage, initChatModel } from "langchain";
 
 const safetyGuardrailMiddleware = () => {
-  const safetyModel = initChatModel("gpt-4.1-mini");
+  const safetyModel = initChatModel("gpt-5.4-mini");
 
   return createMiddleware({
     name: "SafetyGuardrailMiddleware",
@@ -607,7 +607,7 @@ const safetyGuardrailMiddleware = () => {
 import { createAgent } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [searchTool, calculatorTool],
   middleware: [safetyGuardrailMiddleware()],
 });
@@ -628,7 +628,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import PIIMiddleware, HumanInTheLoopMiddleware
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool, send_email_tool],
     middleware=[
         # Layer 1: Deterministic input filter (before agent)
@@ -653,7 +653,7 @@ agent = create_agent(
 import { createAgent, piiRedactionMiddleware, humanInTheLoopMiddleware } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [searchTool, sendEmailTool],
   middleware: [
     // Layer 1: Deterministic input filter (before agent)

--- a/src/oss/langchain/human-in-the-loop.mdx
+++ b/src/oss/langchain/human-in-the-loop.mdx
@@ -42,7 +42,7 @@ from langgraph.checkpoint.memory import InMemorySaver # [!code highlight]
 
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[write_file_tool, execute_sql_tool, read_data_tool],
     middleware=[
         HumanInTheLoopMiddleware( # [!code highlight]
@@ -71,7 +71,7 @@ import { createAgent, humanInTheLoopMiddleware } from "langchain"; // [!code hig
 import { MemorySaver } from "@langchain/langgraph"; // [!code highlight]
 
 const agent = createAgent({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     tools: [writeFileTool, executeSQLTool, readDataTool],
     middleware: [
         humanInTheLoopMiddleware({

--- a/src/oss/langchain/mcp.mdx
+++ b/src/oss/langchain/mcp.mdx
@@ -444,7 +444,7 @@ client = MultiServerMCPClient(
     }
 )
 tools = await client.get_tools()
-agent = create_agent("openai:gpt-4.1", tools)
+agent = create_agent("openai:gpt-5.4", tools)
 response = await agent.ainvoke({"messages": "what is the weather in nyc?"})
 ```
 :::
@@ -795,7 +795,7 @@ When MCP tools are used within a LangChain agent (via `create_agent`), intercept
         tool_interceptors=[inject_user_context],
     )
     tools = await client.get_tools()
-    agent = create_agent("gpt-4.1", tools, context_schema=Context)
+    agent = create_agent("gpt-5.4", tools, context_schema=Context)
 
     # Invoke with user context
     result = await agent.ainvoke(
@@ -848,7 +848,7 @@ When MCP tools are used within a LangChain agent (via `create_agent`), intercept
     )
     tools = await client.get_tools()
     agent = create_agent(
-        "gpt-4.1",
+        "gpt-5.4",
         tools,
         context_schema=Context,
         store=InMemoryStore()

--- a/src/oss/langchain/middleware/built-in.mdx
+++ b/src/oss/langchain/middleware/built-in.mdx
@@ -68,11 +68,11 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[your_weather_tool, your_calculator_tool],
     middleware=[
         SummarizationMiddleware(
-            model="gpt-4.1-mini",
+            model="gpt-5.4-mini",
             trigger=("tokens", 4000),
             keep=("messages", 20),
         ),
@@ -86,11 +86,11 @@ agent = create_agent(
 import { createAgent, summarizationMiddleware } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [weatherTool, calculatorTool],
   middleware: [
     summarizationMiddleware({
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       trigger: { tokens: 4000 },
       keep: { messages: 20 },
     }),
@@ -113,12 +113,12 @@ const agent = createAgent({
         "max_input_tokens": 100_000,
         # ...
     }
-    model = init_chat_model("gpt-4.1", profile=custom_profile)
+    model = init_chat_model("gpt-5.4", profile=custom_profile)
     ```
 </Tip>
 
 <ParamField body="model" type="string | BaseChatModel" required>
-    Model for generating summaries. Can be a model identifier string (e.g., `'openai:gpt-4.1-mini'`) or a `BaseChatModel` instance. See @[`init_chat_model`][init_chat_model(model)] for more information.
+    Model for generating summaries. Can be a model identifier string (e.g., `'openai:gpt-5.4-mini'`) or a `BaseChatModel` instance. See @[`init_chat_model`][init_chat_model(model)] for more information.
 </ParamField>
 
 <ParamField body="trigger" type="ContextSize | list[ContextSize] | None">
@@ -188,7 +188,7 @@ const agent = createAgent({
 </Tip>
 
 <ParamField body="model" type="string | BaseChatModel" required>
-    Model for generating summaries. Can be a model identifier string (e.g., `'openai:gpt-4.1-mini'`) or a `BaseChatModel` instance.
+    Model for generating summaries. Can be a model identifier string (e.g., `'openai:gpt-5.4-mini'`) or a `BaseChatModel` instance.
 </ParamField>
 
 <ParamField body="trigger" type="object | object[]">
@@ -262,11 +262,11 @@ from langchain.agents.middleware import SummarizationMiddleware
 
 # Single condition: trigger if tokens >= 4000
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[your_weather_tool, your_calculator_tool],
     middleware=[
         SummarizationMiddleware(
-            model="gpt-4.1-mini",
+            model="gpt-5.4-mini",
             trigger=("tokens", 4000),
             keep=("messages", 20),
         ),
@@ -275,11 +275,11 @@ agent = create_agent(
 
 # Multiple conditions: trigger if number of tokens >= 3000 OR messages >= 6
 agent2 = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[your_weather_tool, your_calculator_tool],
     middleware=[
         SummarizationMiddleware(
-            model="gpt-4.1-mini",
+            model="gpt-5.4-mini",
             trigger=[
                 ("tokens", 3000),
                 ("messages", 6),
@@ -291,11 +291,11 @@ agent2 = create_agent(
 
 # Using fractional limits
 agent3 = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[your_weather_tool, your_calculator_tool],
     middleware=[
         SummarizationMiddleware(
-            model="gpt-4.1-mini",
+            model="gpt-5.4-mini",
             trigger=("fraction", 0.8),
             keep=("fraction", 0.3),
         ),
@@ -310,11 +310,11 @@ import { createAgent, summarizationMiddleware } from "langchain";
 
 // Single condition
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [weatherTool, calculatorTool],
   middleware: [
     summarizationMiddleware({
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       trigger: { tokens: 4000, messages: 10 },
       keep: { messages: 20 },
     }),
@@ -323,11 +323,11 @@ const agent = createAgent({
 
 // Multiple conditions
 const agent2 = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [weatherTool, calculatorTool],
   middleware: [
     summarizationMiddleware({
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       trigger: [
         { tokens: 3000, messages: 6 },
       ],
@@ -338,11 +338,11 @@ const agent2 = createAgent({
 
 // Using fractional limits
 const agent3 = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [weatherTool, calculatorTool],
   middleware: [
     summarizationMiddleware({
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       trigger: { fraction: 0.8 },
       keep: { fraction: 0.3 },
     }),
@@ -385,7 +385,7 @@ def your_send_email_tool(recipient: str, subject: str, body: str) -> str:
     return f"Email sent to {recipient} with subject '{subject}'"
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[your_read_email_tool, your_send_email_tool],
     checkpointer=InMemorySaver(),
     middleware=[
@@ -417,7 +417,7 @@ function sendEmailTool(recipient: string, subject: string, body: string): string
 }
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [readEmailTool, sendEmailTool],
   middleware: [
     humanInTheLoopMiddleware({
@@ -466,7 +466,7 @@ from langchain.agents.middleware import ModelCallLimitMiddleware
 from langgraph.checkpoint.memory import InMemorySaver
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     checkpointer=InMemorySaver(),  # Required for thread limiting
     tools=[],
     middleware=[
@@ -486,7 +486,7 @@ import { createAgent, modelCallLimitMiddleware } from "langchain";
 import { MemorySaver } from "@langchain/langgraph";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   checkpointer: new MemorySaver(), // Required for thread limiting
   tools: [],
   middleware: [
@@ -562,7 +562,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import ToolCallLimitMiddleware
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool, database_tool],
     middleware=[
         # Global limit
@@ -583,7 +583,7 @@ agent = create_agent(
 import { createAgent, toolCallLimitMiddleware } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [searchTool, databaseTool],
   middleware: [
     toolCallLimitMiddleware({ threadLimit: 20, runLimit: 10 }),
@@ -684,7 +684,7 @@ database_limiter = ToolCallLimitMiddleware(tool_name="query_database", thread_li
 strict_limiter = ToolCallLimitMiddleware(tool_name="scrape_webpage", run_limit=2, exit_behavior="error")
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool, database_tool, scraper_tool],
     middleware=[global_limiter, search_limiter, database_limiter, strict_limiter],
 )
@@ -701,7 +701,7 @@ const databaseLimiter = toolCallLimitMiddleware({ toolName: "query_database", th
 const strictLimiter = toolCallLimitMiddleware({ toolName: "scrape_webpage", runLimit: 2, exitBehavior: "error" });
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [searchTool, databaseTool, scraperTool],
   middleware: [globalLimiter, searchLimiter, databaseLimiter, strictLimiter],
 });
@@ -727,11 +727,11 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import ModelFallbackMiddleware
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[],
     middleware=[
         ModelFallbackMiddleware(
-            "gpt-4.1-mini",
+            "gpt-5.4-mini",
             "claude-3-5-sonnet-20241022",
         ),
     ],
@@ -744,11 +744,11 @@ agent = create_agent(
 import { createAgent, modelFallbackMiddleware } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [],
   middleware: [
     modelFallbackMiddleware(
-      "gpt-4.1-mini",
+      "gpt-5.4-mini",
       "claude-3-5-sonnet-20241022"
     ),
   ],
@@ -766,7 +766,7 @@ const agent = createAgent({
 
 :::python
 <ParamField body="first_model" type="string | BaseChatModel" required>
-    First fallback model to try when the primary model fails. Can be a model identifier string (e.g., `'openai:gpt-4.1-mini'`) or a `BaseChatModel` instance.
+    First fallback model to try when the primary model fails. Can be a model identifier string (e.g., `'openai:gpt-5.4-mini'`) or a `BaseChatModel` instance.
 </ParamField>
 
 <ParamField body="*additional_models" type="string | BaseChatModel">
@@ -808,7 +808,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import PIIMiddleware
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[],
     middleware=[
         PIIMiddleware("email", strategy="redact", apply_to_input=True),
@@ -823,7 +823,7 @@ agent = create_agent(
 import { createAgent, piiMiddleware } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [],
   middleware: [
     piiMiddleware("email", { strategy: "redact", applyToInput: true }),
@@ -854,7 +854,7 @@ import re
 
 # Method 1: Regex pattern string
 agent1 = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[],
     middleware=[
         PIIMiddleware(
@@ -867,7 +867,7 @@ agent1 = create_agent(
 
 # Method 2: Compiled regex pattern
 agent2 = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[],
     middleware=[
         PIIMiddleware(
@@ -900,7 +900,7 @@ def detect_ssn(content: str) -> list[dict[str, str | int]]:
     return matches
 
 agent3 = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[],
     middleware=[
         PIIMiddleware(
@@ -919,7 +919,7 @@ import { createAgent, piiMiddleware, type PIIMatch } from "langchain";
 
 // Method 1: Regex pattern string
 const agent1 = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [],
   middleware: [
     piiMiddleware("api_key", {
@@ -931,7 +931,7 @@ const agent1 = createAgent({
 
 // Method 2: RegExp object
 const agent2 = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [],
   middleware: [
     piiMiddleware("phone_number", {
@@ -963,7 +963,7 @@ function detectSSN(content: string): PIIMatch[] {
 }
 
 const agent3 = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [],
   middleware: [
     piiMiddleware("ssn", {
@@ -1107,7 +1107,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import TodoListMiddleware
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[read_file, write_file, run_tests],
     middleware=[TodoListMiddleware()],
 )
@@ -1119,7 +1119,7 @@ agent = create_agent(
 import { createAgent, todoListMiddleware } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [readFile, writeFile, runTests],
   middleware: [todoListMiddleware()],
 });
@@ -1174,11 +1174,11 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import LLMToolSelectorMiddleware
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[tool1, tool2, tool3, tool4, tool5, ...],
     middleware=[
         LLMToolSelectorMiddleware(
-            model="gpt-4.1-mini",
+            model="gpt-5.4-mini",
             max_tools=3,
             always_include=["search"],
         ),
@@ -1192,11 +1192,11 @@ agent = create_agent(
 import { createAgent, llmToolSelectorMiddleware } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [tool1, tool2, tool3, tool4, tool5, ...],
   middleware: [
     llmToolSelectorMiddleware({
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       maxTools: 3,
       alwaysInclude: ["search"],
     }),
@@ -1209,7 +1209,7 @@ const agent = createAgent({
 
 :::python
 <ParamField body="model" type="string | BaseChatModel">
-    Model for tool selection. Can be a model identifier string (e.g., `'openai:gpt-4.1-mini'`) or a `BaseChatModel` instance. See @[`init_chat_model`][init_chat_model(model)] for more information.
+    Model for tool selection. Can be a model identifier string (e.g., `'openai:gpt-5.4-mini'`) or a `BaseChatModel` instance. See @[`init_chat_model`][init_chat_model(model)] for more information.
 
     Defaults to the agent's main model.
 </ParamField>
@@ -1229,7 +1229,7 @@ const agent = createAgent({
 
 :::js
 <ParamField body="model" type="string | BaseChatModel">
-    Model for tool selection. Can be a model identifier string (e.g., `'openai:gpt-4.1-mini'`) or a `BaseChatModel` instance. Defaults to the agent's main model.
+    Model for tool selection. Can be a model identifier string (e.g., `'openai:gpt-5.4-mini'`) or a `BaseChatModel` instance. Defaults to the agent's main model.
 </ParamField>
 
 <ParamField body="systemPrompt" type="string">
@@ -1264,7 +1264,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import ToolRetryMiddleware
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool, database_tool],
     middleware=[
         ToolRetryMiddleware(
@@ -1284,7 +1284,7 @@ agent = create_agent(
 import { createAgent, toolRetryMiddleware } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [searchTool, databaseTool],
   middleware: [
     toolRetryMiddleware({
@@ -1415,7 +1415,7 @@ from langchain.agents.middleware import ToolRetryMiddleware
 
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool, database_tool, api_tool],
     middleware=[
         ToolRetryMiddleware(
@@ -1441,7 +1441,7 @@ import { z } from "zod";
 
 // Basic usage with default settings (2 retries, exponential backoff)
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [searchTool, databaseTool],
   middleware: [toolRetryMiddleware()],
 });
@@ -1529,7 +1529,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import ModelRetryMiddleware
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool, database_tool],
     middleware=[
         ModelRetryMiddleware(
@@ -1549,7 +1549,7 @@ agent = create_agent(
 import { createAgent, modelRetryMiddleware } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [searchTool, databaseTool],
   middleware: [
     modelRetryMiddleware({
@@ -1644,7 +1644,7 @@ from langchain.agents.middleware import ModelRetryMiddleware
 
 # Basic usage with default settings (2 retries, exponential backoff)
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool],
     middleware=[ModelRetryMiddleware()],
 )
@@ -1716,7 +1716,7 @@ import { createAgent, modelRetryMiddleware } from "langchain";
 
 // Basic usage with default settings (2 retries, exponential backoff)
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [searchTool],
   middleware: [modelRetryMiddleware()],
 });
@@ -1802,7 +1802,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import LLMToolEmulator
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[get_weather, search_database, send_email],
     middleware=[
         LLMToolEmulator(),  # Emulate all tools
@@ -1816,7 +1816,7 @@ agent = create_agent(
 import { createAgent, toolEmulatorMiddleware } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [getWeather, searchDatabase, sendEmail],
   middleware: [
     toolEmulatorMiddleware(), // Emulate all tools
@@ -1873,21 +1873,21 @@ def send_email(to: str, subject: str, body: str) -> str:
 
 # Emulate all tools (default behavior)
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[get_weather, send_email],
     middleware=[LLMToolEmulator()],
 )
 
 # Emulate specific tools only
 agent2 = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[get_weather, send_email],
     middleware=[LLMToolEmulator(tools=["get_weather"])],
 )
 
 # Use custom model for emulation
 agent4 = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[get_weather, send_email],
     middleware=[LLMToolEmulator(model="claude-sonnet-4-6")],
 )
@@ -1923,14 +1923,14 @@ const sendEmail = tool(
 
 // Emulate all tools (default behavior)
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [getWeather, sendEmail],
   middleware: [toolEmulatorMiddleware()],
 });
 
 // Emulate specific tools by name
 const agent2 = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [getWeather, sendEmail],
   middleware: [
     toolEmulatorMiddleware({
@@ -1941,7 +1941,7 @@ const agent2 = createAgent({
 
 // Emulate specific tools by passing tool instances
 const agent3 = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [getWeather, sendEmail],
   middleware: [
     toolEmulatorMiddleware({
@@ -1952,7 +1952,7 @@ const agent3 = createAgent({
 
 // Use custom model for emulation
 const agent5 = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [getWeather, sendEmail],
   middleware: [
     toolEmulatorMiddleware({
@@ -1981,7 +1981,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import ContextEditingMiddleware, ClearToolUsesEdit
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[],
     middleware=[
         ContextEditingMiddleware(
@@ -2002,7 +2002,7 @@ agent = create_agent(
 import { createAgent, contextEditingMiddleware, ClearToolUsesEdit } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [],
   middleware: [
     contextEditingMiddleware({
@@ -2107,7 +2107,7 @@ from langchain.agents.middleware import ContextEditingMiddleware, ClearToolUsesE
 
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool, your_calculator_tool, database_tool],
     middleware=[
         ContextEditingMiddleware(
@@ -2131,7 +2131,7 @@ agent = create_agent(
 import { createAgent, contextEditingMiddleware, ClearToolUsesEdit } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [searchTool, calculatorTool, databaseTool],
   middleware: [
     contextEditingMiddleware({
@@ -2180,7 +2180,7 @@ from langchain.agents.middleware import (
 )
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool],
     middleware=[
         ShellToolMiddleware(
@@ -2255,7 +2255,7 @@ from langchain.agents.middleware import (
 
 # Basic shell tool with host execution
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[search_tool],
     middleware=[
         ShellToolMiddleware(
@@ -2267,7 +2267,7 @@ agent = create_agent(
 
 # Docker isolation with startup commands
 agent_docker = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[],
     middleware=[
         ShellToolMiddleware(
@@ -2283,7 +2283,7 @@ agent_docker = create_agent(
 
 # With output redaction (applied post execution)
 agent_redacted = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[],
     middleware=[
         ShellToolMiddleware(
@@ -2314,7 +2314,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import FilesystemFileSearchMiddleware
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[],
     middleware=[
         FilesystemFileSearchMiddleware(
@@ -2361,7 +2361,7 @@ from langchain.messages import HumanMessage
 
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[],
     middleware=[
         FilesystemFileSearchMiddleware(
@@ -2534,7 +2534,7 @@ agent = create_agent(
                     "description": "This subagent can get weather in cities.",
                     "system_prompt": "Use the get_weather tool to get the weather in a city.",
                     "tools": [get_weather],
-                    "model": "gpt-4.1",
+                    "model": "gpt-5.4",
                     "middleware": [],
                 }
             ],
@@ -2576,7 +2576,7 @@ const agent = createAgent({
           description: "This subagent can get weather in cities.",
           systemPrompt: "Use the get_weather tool to get the weather in a city.",
           tools: [getWeather],
-          model: "gpt-4.1",
+          model: "gpt-5.4",
           middleware: [],
         },
       ],
@@ -2649,7 +2649,7 @@ const weatherSubagent: SubAgent = {
   description: "This subagent can get weather in cities.",
   systemPrompt: "Use the get_weather tool to get the weather in a city.",
   tools: [getWeather],
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   middleware: [],
 };
 

--- a/src/oss/langchain/middleware/custom.mdx
+++ b/src/oss/langchain/middleware/custom.mdx
@@ -593,7 +593,7 @@ def retry_model(
             print(f"Retry {attempt + 1}/3 after error: {e}")
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     middleware=[log_before_model, retry_model],
     tools=[...],
 )
@@ -644,7 +644,7 @@ class LoggingMiddleware(AgentMiddleware):
 
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     middleware=[LoggingMiddleware()],
     tools=[...],
 )
@@ -728,7 +728,7 @@ def increment_counter(state: CustomState, runtime: Runtime) -> dict[str, Any] | 
 
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     middleware=[check_call_limit, increment_counter],
     tools=[],
 )
@@ -772,7 +772,7 @@ class CallCounterMiddleware(AgentMiddleware[CustomState]):
 
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     middleware=[CallCounterMiddleware()],
     tools=[],
 )
@@ -821,7 +821,7 @@ const callCounterMiddleware = createMiddleware({
 });
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [...],
   middleware: [callCounterMiddleware],
 });
@@ -913,7 +913,7 @@ const userContextMiddleware = createMiddleware({
 });
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   middleware: [userContextMiddleware],
   tools: [],
   contextSchema,
@@ -949,7 +949,7 @@ When using multiple middleware, understand how they execute:
 :::python
 ```python
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     middleware=[middleware1, middleware2, middleware3],
     tools=[...],
 )
@@ -959,7 +959,7 @@ agent = create_agent(
 :::js
 ```typescript
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   middleware: [middleware1, middleware2, middleware3],
   tools: [...],
 });
@@ -1068,7 +1068,7 @@ class BlockedContentMiddleware(AgentMiddleware):
 import { createAgent, createMiddleware, AIMessage } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   middleware: [
     createMiddleware({
       name: "BlockedContentMiddleware",
@@ -1212,7 +1212,7 @@ def select_tools(
     return handler(request.override(tools=relevant_tools))
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=all_tools,  # All available tools need to be registered upfront
     middleware=[select_tools],
 )
@@ -1240,7 +1240,7 @@ class ToolSelectorMiddleware(AgentMiddleware):
         return handler(request.override(tools=relevant_tools))
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=all_tools,  # All available tools need to be registered upfront
     middleware=[ToolSelectorMiddleware()],
 )
@@ -1267,7 +1267,7 @@ const toolSelectorMiddleware = createMiddleware({
 });
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: allTools,
   middleware: [toolSelectorMiddleware],
 });

--- a/src/oss/langchain/middleware/overview.mdx
+++ b/src/oss/langchain/middleware/overview.mdx
@@ -18,7 +18,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import SummarizationMiddleware, HumanInTheLoopMiddleware
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[...],
     middleware=[
         SummarizationMiddleware(...),
@@ -39,7 +39,7 @@ import {
 } from "langchain";
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [...],
   middleware: [summarizationMiddleware, humanInTheLoopMiddleware],
 });

--- a/src/oss/langchain/models.mdx
+++ b/src/oss/langchain/models.mdx
@@ -641,7 +641,7 @@ const getWeather = tool(
   },
 );
 
-const model = new ChatOpenAI({ model: "gpt-4.1" });
+const model = new ChatOpenAI({ model: "gpt-5.4" });
 const modelWithTools = model.bindTools([getWeather]);  // [!code highlight]
 
 const response = await modelWithTools.invoke("What's the weather like in Boston?");
@@ -1499,7 +1499,7 @@ If a model invokes a tool server-side, the content of the response message will 
 ```python Invoke with server-side tool use
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model("gpt-4.1-mini")
+model = init_chat_model("gpt-5.4-mini")
 
 tool = {"type": "web_search"}
 model_with_tools = model.bind_tools([tool])
@@ -1543,7 +1543,7 @@ print(response.content_blocks)
 ```typescript
 import { initChatModel } from "langchain";
 
-const model = await initChatModel("gpt-4.1-mini");
+const model = await initChatModel("gpt-5.4-mini");
 const modelWithTools = model.bindTools([{ type: "web_search" }])
 
 const message = await modelWithTools.invoke("What was a positive news story from today?");
@@ -1640,7 +1640,7 @@ You can configure a custom base URL for providers that implement the OpenAI Chat
     from langchain_openai import ChatOpenAI
 
     model = ChatOpenAI(
-        model="gpt-4.1",
+        model="gpt-5.4",
         openai_proxy="http://proxy.example.com:8080"
     )
     ```
@@ -1660,7 +1660,7 @@ Certain models can be configured to return token-level log probabilities represe
 :::python
 ```python
 model = init_chat_model(
-    model="gpt-4.1",
+    model="gpt-5.4",
     model_provider="openai"
 ).bind(logprobs=True)
 
@@ -1672,7 +1672,7 @@ print(response.response_metadata["logprobs"])
 :::js
 ```typescript
 const model = new ChatOpenAI({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     logprobs: true,
 });
 
@@ -1701,7 +1701,7 @@ You can track aggregate token counts across models in an application using eithe
         from langchain.chat_models import init_chat_model
         from langchain_core.callbacks import UsageMetadataCallbackHandler
 
-        model_1 = init_chat_model(model="gpt-4.1-mini")
+        model_1 = init_chat_model(model="gpt-5.4-mini")
         model_2 = init_chat_model(model="claude-haiku-4-5-20251001")
 
         callback = UsageMetadataCallbackHandler()
@@ -1711,7 +1711,7 @@ You can track aggregate token counts across models in an application using eithe
         ```
         ```python
         {
-            'gpt-4.1-mini-2025-04-14': {
+            'gpt-5.4-mini': {
                 'input_tokens': 8,
                 'output_tokens': 10,
                 'total_tokens': 18,
@@ -1732,7 +1732,7 @@ You can track aggregate token counts across models in an application using eithe
         from langchain.chat_models import init_chat_model
         from langchain_core.callbacks import get_usage_metadata_callback
 
-        model_1 = init_chat_model(model="gpt-4.1-mini")
+        model_1 = init_chat_model(model="gpt-5.4-mini")
         model_2 = init_chat_model(model="claude-haiku-4-5-20251001")
 
         with get_usage_metadata_callback() as cb:
@@ -1742,7 +1742,7 @@ You can track aggregate token counts across models in an application using eithe
         ```
         ```python
         {
-            'gpt-4.1-mini-2025-04-14': {
+            'gpt-5.4-mini': {
                 'input_tokens': 8,
                 'output_tokens': 10,
                 'total_tokens': 18,
@@ -1892,7 +1892,7 @@ configurable_model.invoke(
 
     ```python
     first_model = init_chat_model(
-            model="gpt-4.1-mini",
+            model="gpt-5.4-mini",
             temperature=0,
             configurable_fields=("model", "model_provider", "temperature", "max_tokens"),
             config_prefix="first",  # Useful when you have a chain with multiple models
@@ -1940,7 +1940,7 @@ configurable_model.invoke(
     model_with_tools = model.bind_tools([GetWeather, GetPopulation])
 
     model_with_tools.invoke(
-        "what's bigger in 2024 LA or NYC", config={"configurable": {"model": "gpt-4.1-mini"}}
+        "what's bigger in 2024 LA or NYC", config={"configurable": {"model": "gpt-5.4-mini"}}
     ).tool_calls
     ```
     ```

--- a/src/oss/langchain/multi-agent/custom-workflow.mdx
+++ b/src/oss/langchain/multi-agent/custom-workflow.mdx
@@ -55,7 +55,7 @@ The core insight is that you can call a LangChain agent directly inside any Lang
 from langchain.agents import create_agent
 from langgraph.graph import StateGraph, START, END
 
-agent = create_agent(model="openai:gpt-4.1", tools=[...])
+agent = create_agent(model="openai:gpt-5.4", tools=[...])
 
 def agent_node(state: State) -> dict:
     """A LangGraph node that invokes a LangChain agent."""
@@ -176,11 +176,11 @@ def get_latest_news(query: str) -> str:
     return "Latest: The WNBA announced expanded playoff format for 2025..."
 
 agent = create_agent(
-    model="openai:gpt-4.1",
+    model="openai:gpt-5.4",
     tools=[get_latest_news],
 )
 
-model = ChatOpenAI(model="gpt-4.1")
+model = ChatOpenAI(model="gpt-5.4")
 
 class RewrittenQuery(BaseModel):
     query: str
@@ -274,11 +274,11 @@ const getLatestNews = tool(
 );
 
 const agent = createAgent({
-  model: "openai:gpt-4.1",
+  model: "openai:gpt-5.4",
   tools: [getLatestNews],
 });
 
-const model = new ChatOpenAI({ model: "gpt-4.1" });
+const model = new ChatOpenAI({ model: "gpt-5.4" });
 
 const RewrittenQuery = z.object({ query: z.string() });
 

--- a/src/oss/langchain/multi-agent/handoffs-customer-support.mdx
+++ b/src/oss/langchain/multi-agent/handoffs-customer-support.mdx
@@ -606,7 +606,7 @@ const allTools = [
 
 // Initialize the model
 const model = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   temperature: 0.7,
 });
 
@@ -839,7 +839,7 @@ agent = create_agent(
     middleware=[
         apply_step_config,
         SummarizationMiddleware(  # [!code highlight]
-            model="gpt-4.1-mini",
+            model="gpt-5.4-mini",
             trigger=("tokens", 4000),
             keep=("messages", 10)
         )
@@ -861,7 +861,7 @@ const agent = createAgent({
   middleware: [
     applyStepMiddleware,
     new SummarizationMiddleware({  // [!code highlight]
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       trigger: { tokens: 4000 },
       keep: { messages: 10 },
     }),
@@ -1206,7 +1206,7 @@ agent = create_agent(
     middleware=[
         apply_step_config,
         SummarizationMiddleware(
-            model="gpt-4.1-mini",
+            model="gpt-5.4-mini",
             trigger=("tokens", 4000),
             keep=("messages", 10)
         )
@@ -1451,7 +1451,7 @@ const allTools = [
 ];
 
 const model = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
 });
 
 // Create the agent with step-based configuration

--- a/src/oss/langchain/multi-agent/router-knowledge-base.mdx
+++ b/src/oss/langchain/multi-agent/router-knowledge-base.mdx
@@ -367,7 +367,7 @@ Create an agent for each vertical. Each agent has domain-specific tools and a pr
 from langchain.agents import create_agent
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model("openai:gpt-4.1")
+model = init_chat_model("openai:gpt-5.4")
 
 github_agent = create_agent(
     model,
@@ -406,7 +406,7 @@ slack_agent = create_agent(
 import { createAgent } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
 
-const llm = new ChatOpenAI({ model: "gpt-4.1" });
+const llm = new ChatOpenAI({ model: "gpt-5.4" });
 
 const githubAgent = createAgent({
   model: llm,
@@ -455,7 +455,7 @@ from pydantic import BaseModel, Field
 from langgraph.graph import StateGraph, START, END
 from langgraph.types import Send
 
-router_llm = init_chat_model("openai:gpt-4.1-mini")
+router_llm = init_chat_model("openai:gpt-5.4-mini")
 
 
 # Define structured output schema for the classifier
@@ -560,7 +560,7 @@ def synthesize_results(state: RouterState) -> dict:
 import { StateGraph, START, END, Send } from "@langchain/langgraph";
 import { z } from "zod";
 
-const routerLlm = new ChatOpenAI({ model: "gpt-4.1-mini" });
+const routerLlm = new ChatOpenAI({ model: "gpt-5.4-mini" });
 
 
 // Define structured output schema for the classifier
@@ -941,8 +941,8 @@ def get_thread(thread_id: str) -> str:
 
 
 # Models and agents
-model = init_chat_model("openai:gpt-4.1")
-router_llm = init_chat_model("openai:gpt-4.1-mini")
+model = init_chat_model("openai:gpt-5.4")
+router_llm = init_chat_model("openai:gpt-5.4-mini")
 
 github_agent = create_agent(
     model,
@@ -1218,7 +1218,7 @@ const getThread = tool(
 import { createAgent } from "langchain";
 import { ChatOpenAI } from "@langchain/openai";
 
-const llm = new ChatOpenAI({ model: "gpt-4.1" });
+const llm = new ChatOpenAI({ model: "gpt-5.4" });
 
 const githubAgent = createAgent({
   model: llm,
@@ -1250,7 +1250,7 @@ shared knowledge and solutions.
   `.trim(),
 });
 
-const routerLlm = new ChatOpenAI({ model: "gpt-4.1-mini" });
+const routerLlm = new ChatOpenAI({ model: "gpt-5.4-mini" });
 
 // Define structured output schema for the classifier
 const ClassificationResultSchema = z.object({

--- a/src/oss/langchain/multi-agent/skills-sql-assistant.mdx
+++ b/src/oss/langchain/multi-agent/skills-sql-assistant.mdx
@@ -1555,7 +1555,7 @@ const skillMiddleware = createMiddleware({
 });
 
 const model = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   temperature: 0,
 });
 

--- a/src/oss/langchain/multi-agent/skills.mdx
+++ b/src/oss/langchain/multi-agent/skills.mdx
@@ -59,7 +59,7 @@ def load_skill(skill_name: str) -> str:
     ...
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[load_skill],
     system_prompt=(
         "You are a helpful assistant. "
@@ -98,7 +98,7 @@ Returns the skill's prompt and context.`,
 );
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [loadSkill],
   systemPrompt: (
     "You are a helpful assistant. " +

--- a/src/oss/langchain/multi-agent/subagents.mdx
+++ b/src/oss/langchain/multi-agent/subagents.mdx
@@ -327,12 +327,12 @@ from langchain.agents import create_agent
 
 # Sub-agents developed by different teams
 research_agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     prompt="You are a research specialist..."
 )
 
 writer_agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     prompt="You are a writing specialist..."
 )
 
@@ -363,7 +363,7 @@ def task(
 
 # Main coordinator agent
 main_agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[task],
     system_prompt=(
         "You coordinate specialized sub-agents. "
@@ -381,12 +381,12 @@ import * as z from "zod";
 
 // Sub-agents developed by different teams
 const researchAgent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   prompt: "You are a research specialist...",
 });
 
 const writerAgent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   prompt: "You are a writing specialist...",
 });
 
@@ -426,7 +426,7 @@ Available agents:
 
 // Main coordinator agent
 const mainAgent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [task],
   prompt: (
     "You coordinate specialized sub-agents. " +

--- a/src/oss/langchain/observability.mdx
+++ b/src/oss/langchain/observability.mdx
@@ -57,7 +57,7 @@ def search_web(query: str):
     return f"Search results for: {query}"
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[send_email, search_web],
     system_prompt="You are a helpful assistant that can send emails and search the web."
 )
@@ -84,7 +84,7 @@ function searchWeb(query: string): string {
 }
 
 const agent = createAgent({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     tools: [sendEmail, searchWeb],
     systemPrompt: "You are a helpful assistant that can send emails and search the web."
 });

--- a/src/oss/langchain/runtime.mdx
+++ b/src/oss/langchain/runtime.mdx
@@ -76,7 +76,7 @@ const contextSchema = z.object({ // [!code highlight]
 }); // [!code highlight]
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [
     /* ... */
   ],
@@ -329,7 +329,7 @@ const loggingMiddleware = createMiddleware({
 });
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [
     /* ... */
   ],

--- a/src/oss/langchain/short-term-memory.mdx
+++ b/src/oss/langchain/short-term-memory.mdx
@@ -304,7 +304,7 @@ const trimMessages = createMiddleware({
 
 const checkpointer = new MemorySaver();
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [],
   middleware: [trimMessages],
   checkpointer,
@@ -454,7 +454,7 @@ const deleteOldMessages = createMiddleware({
 });
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [],
   systemPrompt: "Please be concise and to the point.",
   middleware: [deleteOldMessages],
@@ -521,11 +521,11 @@ from langchain_core.runnables import RunnableConfig
 checkpointer = InMemorySaver()
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=[],
     middleware=[
         SummarizationMiddleware(
-            model="gpt-4.1-mini",
+            model="gpt-5.4-mini",
             trigger=("tokens", 4000),
             keep=("messages", 20)
         )
@@ -559,11 +559,11 @@ import { MemorySaver } from "@langchain/langgraph";
 const checkpointer = new MemorySaver();
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   tools: [],
   middleware: [
     summarizationMiddleware({
-      model: "gpt-4.1-mini",
+      model: "gpt-5.4-mini",
       trigger: { tokens: 4000 },
       keep: { messages: 20 },
     }),

--- a/src/oss/langchain/sql-agent.mdx
+++ b/src/oss/langchain/sql-agent.mdx
@@ -388,7 +388,7 @@ import requests
 
 
 # Initialize an LLM
-model = init_chat_model("gpt-4.1")
+model = init_chat_model("gpt-5.4")
 
 # Get the database, store it locally
 url = "https://storage.googleapis.com/benchmarks-artifacts/chinook/Chinook.db"

--- a/src/oss/langchain/streaming.mdx
+++ b/src/oss/langchain/streaming.mdx
@@ -323,7 +323,7 @@ const getWeather = tool(
 );
 
 const agent = createAgent({
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-mini",
     tools: [getWeather],
 });
 
@@ -405,7 +405,7 @@ const getWeather = tool(
 );
 
 const agent = createAgent({
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-mini",
     tools: [getWeather],
 });
 
@@ -511,7 +511,7 @@ const getWeather = tool(
 );
 
 const agent = createAgent({
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-mini",
     tools: [getWeather],
 });
 
@@ -1124,7 +1124,7 @@ Set `streaming=False` when initializing the model.
 from langchain_openai import ChatOpenAI
 
 model = ChatOpenAI(
-    model="gpt-4.1",
+    model="gpt-5.4",
     streaming=False  # [!code highlight]
 )
 ```
@@ -1137,7 +1137,7 @@ Set `streaming: false` when initializing the model.
 import { ChatOpenAI } from "@langchain/openai";
 
 const model = new ChatOpenAI({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   streaming: false,  // [!code highlight]
 });
 ```

--- a/src/oss/langchain/tools.mdx
+++ b/src/oss/langchain/tools.mdx
@@ -336,7 +336,7 @@ def get_account_info(runtime: ToolRuntime[UserContext]) -> str:
         return f"Account holder: {user['name']}\nType: {user['account_type']}\nBalance: ${user['balance']}"
     return "User not found"
 
-model = ChatOpenAI(model="gpt-4.1")
+model = ChatOpenAI(model="gpt-5.4")
 agent = create_agent(
     model,
     tools=[get_account_info],
@@ -376,7 +376,7 @@ const contextSchema = z.object({
 });
 
 const agent = createAgent({
-  model: new ChatOpenAI({ model: "gpt-4.1" }),
+  model: new ChatOpenAI({ model: "gpt-5.4" }),
   tools: [getUserName],
   contextSchema,
 });
@@ -427,7 +427,7 @@ def save_user_info(user_id: str, user_info: dict[str, Any], runtime: ToolRuntime
     store.put(("users",), user_id, user_info)
     return "Successfully saved user info."
 
-model = ChatOpenAI(model="gpt-4.1")
+model = ChatOpenAI(model="gpt-5.4")
 
 store = InMemoryStore()
 agent = create_agent(
@@ -500,7 +500,7 @@ const saveUserInfo = tool(
 );
 
 const agent = createAgent({
-  model: new ChatOpenAI({ model: "gpt-4.1" }),
+  model: new ChatOpenAI({ model: "gpt-5.4" }),
   tools: [getUserInfo, saveUserInfo],
   store,
 });

--- a/src/oss/langgraph/add-memory.mdx
+++ b/src/oss/langgraph/add-memory.mdx
@@ -1107,7 +1107,7 @@ const items = await store.search(["user_123", "memories"], {
     from langgraph.graph import START, MessagesState, StateGraph
     from langgraph.runtime import Runtime  # [!code highlight]
 
-    model = init_chat_model("gpt-4.1-mini")
+    model = init_chat_model("gpt-5.4-mini")
 
     # Create store with semantic search enabled
     embeddings = init_embeddings("openai:text-embedding-3-small")
@@ -1160,7 +1160,7 @@ const items = await store.search(["user_123", "memories"], {
       messages: MessagesValue,
     });
 
-    const model = new ChatOpenAI({ model: "gpt-4.1-mini" });
+    const model = new ChatOpenAI({ model: "gpt-5.4-mini" });
 
     // Create store with semantic search enabled
     const embeddings = new OpenAIEmbeddings({ model: "text-embedding-3-small" });

--- a/src/oss/langgraph/agentic-rag.mdx
+++ b/src/oss/langgraph/agentic-rag.mdx
@@ -209,7 +209,7 @@ Note that the components will operate on the [`MessagesState`](/oss/langgraph/gr
   from langgraph.graph import MessagesState
   from langchain.chat_models import init_chat_model
 
-  response_model = init_chat_model("gpt-4.1", temperature=0)
+  response_model = init_chat_model("gpt-5.4", temperature=0)
 
 
   def generate_query_or_respond(state: MessagesState):
@@ -264,7 +264,7 @@ Note that the components will operate on the [`MessagesState`](/oss/langgraph/gr
 
   const generateQueryOrRespond: GraphNode<typeof State> = async (state) => {
     const model = new ChatOpenAI({
-      model: "gpt-4.1",
+      model: "gpt-5.4",
       temperature: 0,
     }).bindTools(tools);  // [!code highlight]
 
@@ -340,7 +340,7 @@ Note that the components will operate on the [`MessagesState`](/oss/langgraph/gr
       )
 
 
-  grader_model = init_chat_model("gpt-4.1", temperature=0)
+  grader_model = init_chat_model("gpt-5.4", temperature=0)
 
 
   def grade_documents(
@@ -452,7 +452,7 @@ Note that the components will operate on the [`MessagesState`](/oss/langgraph/gr
 
   const gradeDocuments: GraphNode<typeof State> = async (state) => {
     const model = new ChatOpenAI({
-      model: "gpt-4.1",
+      model: "gpt-5.4",
       temperature: 0,
     }).withStructuredOutput(gradeDocumentsSchema);
 
@@ -596,7 +596,7 @@ Note that the components will operate on the [`MessagesState`](/oss/langgraph/gr
     const question = state.messages.at(0)?.content;
 
     const model = new ChatOpenAI({
-      model: "gpt-4.1",
+      model: "gpt-5.4",
       temperature: 0,
     });
 
@@ -721,7 +721,7 @@ Note that the components will operate on the [`MessagesState`](/oss/langgraph/gr
     );
 
     const llm = new ChatOpenAI({
-      model: "gpt-4.1",
+      model: "gpt-5.4",
       temperature: 0,
     });
 

--- a/src/oss/langgraph/streaming.mdx
+++ b/src/oss/langgraph/streaming.mdx
@@ -338,7 +338,7 @@ class MyState:
     joke: str = ""
 
 
-model = init_chat_model(model="gpt-4.1-mini")
+model = init_chat_model(model="gpt-5.4-mini")
 
 def call_model(state: MyState):
     """Call the LLM to generate a joke about a topic"""
@@ -389,7 +389,7 @@ const MyState = new StateSchema({
   joke: z.string().default(""),
 });
 
-const model = new ChatOpenAI({ model: "gpt-4.1-mini" });
+const model = new ChatOpenAI({ model: "gpt-5.4-mini" });
 
 const callModel: GraphNode<typeof MyState> = async (state) => {
   // Call the LLM to generate a joke about a topic
@@ -428,9 +428,9 @@ You can associate `tags` with LLM invocations to filter the streamed tokens by L
 from langchain.chat_models import init_chat_model
 
 # model_1 is tagged with "joke"
-model_1 = init_chat_model(model="gpt-4.1-mini", tags=['joke'])
+model_1 = init_chat_model(model="gpt-5.4-mini", tags=['joke'])
 # model_2 is tagged with "poem"
-model_2 = init_chat_model(model="gpt-4.1-mini", tags=['poem'])
+model_2 = init_chat_model(model="gpt-5.4-mini", tags=['poem'])
 
 graph = ... # define a graph that uses these LLMs
 
@@ -456,12 +456,12 @@ import { ChatOpenAI } from "@langchain/openai";
 
 // model1 is tagged with "joke"
 const model1 = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   tags: ['joke']
 });
 // model2 is tagged with "poem"
 const model2 = new ChatOpenAI({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   tags: ['poem']
 });
 
@@ -491,9 +491,9 @@ for await (const [msg, metadata] of await graph.stream(
   from langgraph.graph import START, StateGraph
 
   # The joke_model is tagged with "joke"
-  joke_model = init_chat_model(model="gpt-4.1-mini", tags=["joke"])
+  joke_model = init_chat_model(model="gpt-5.4-mini", tags=["joke"])
   # The poem_model is tagged with "poem"
-  poem_model = init_chat_model(model="gpt-4.1-mini", tags=["poem"])
+  poem_model = init_chat_model(model="gpt-5.4-mini", tags=["poem"])
 
 
   class State(TypedDict):
@@ -550,12 +550,12 @@ for await (const [msg, metadata] of await graph.stream(
 
   // The jokeModel is tagged with "joke"
   const jokeModel = new ChatOpenAI({
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-mini",
     tags: ["joke"]
   });
   // The poemModel is tagged with "poem"
   const poemModel = new ChatOpenAI({
-    model: "gpt-4.1-mini",
+    model: "gpt-5.4-mini",
     tags: ["poem"]
   });
 
@@ -673,7 +673,7 @@ for await (const [msg, metadata] of await graph.stream(
   from langgraph.graph import START, StateGraph
   from langchain_openai import ChatOpenAI
 
-  model = ChatOpenAI(model="gpt-4.1-mini")
+  model = ChatOpenAI(model="gpt-5.4-mini")
 
 
   class State(TypedDict):
@@ -730,7 +730,7 @@ for await (const [msg, metadata] of await graph.stream(
   import { StateGraph, StateSchema, GraphNode, START } from "@langchain/langgraph";
   import * as z from "zod";
 
-  const model = new ChatOpenAI({ model: "gpt-4.1-mini" });
+  const model = new ChatOpenAI({ model: "gpt-5.4-mini" });
 
   const State = new StateSchema({
     topic: z.string(),
@@ -1618,7 +1618,7 @@ for await (const chunk of await graph.stream(
   from openai import AsyncOpenAI
 
   openai_client = AsyncOpenAI()
-  model_name = "gpt-4.1-mini"
+  model_name = "gpt-5.4-mini"
 
 
   async def stream_tokens(model_name: str, messages: list[dict]):
@@ -1735,7 +1735,7 @@ for await (const chunk of await graph.stream(
   import OpenAI from "openai";
 
   const openaiClient = new OpenAI();
-  const modelName = "gpt-4.1-mini";
+  const modelName = "gpt-5.4-mini";
 
   async function* streamTokens(modelName: string, messages: any[]) {
     const response = await openaiClient.chat.completions.create({
@@ -2000,7 +2000,7 @@ This limits LangGraph ability to automatically propagate context, and affects La
   from langgraph.graph import START, StateGraph
   from langchain.chat_models import init_chat_model
 
-  model = init_chat_model(model="gpt-4.1-mini")
+  model = init_chat_model(model="gpt-5.4-mini")
 
   class State(TypedDict):
       topic: str

--- a/src/oss/langgraph/studio.mdx
+++ b/src/oss/langgraph/studio.mdx
@@ -55,7 +55,7 @@ def send_email(to: str, subject: str, body: str):
     return f"Email sent to {to}"
 
 agent = create_agent(
-    "gpt-4.1",
+    "gpt-5.4",
     tools=[send_email],
     system_prompt="You are an email assistant. Always use the send_email tool.",
 )
@@ -79,7 +79,7 @@ function sendEmail(to: string, subject: string, body: string): string {
 }
 
 const agent = createAgent({
-    model: "gpt-4.1",
+    model: "gpt-5.4",
     tools: [sendEmail],
     systemPrompt: "You are an email assistant. Always use the sendEmail tool.",
 });

--- a/src/oss/langgraph/use-graph-api.mdx
+++ b/src/oss/langgraph/use-graph-api.mdx
@@ -1209,7 +1209,7 @@ console.log(await graph.invoke({}, { context: { myRuntimeValue: "b" } }));  // [
 
   MODELS = {
       "anthropic": init_chat_model("claude-haiku-4-5-20251001"),
-      "openai": init_chat_model("gpt-4.1-mini"),
+      "openai": init_chat_model("gpt-5.4-mini"),
   }
 
   def call_model(state: MessagesState, runtime: Runtime[ContextSchema]):
@@ -1237,7 +1237,7 @@ console.log(await graph.invoke({}, { context: { myRuntimeValue: "b" } }));  // [
 
   ```
   claude-haiku-4-5-20251001
-  gpt-4.1-mini-2025-04-14
+  gpt-5.4-mini
   ```
   :::
 
@@ -1260,7 +1260,7 @@ console.log(await graph.invoke({}, { context: { myRuntimeValue: "b" } }));  // [
 
   const MODELS = {
     anthropic: new ChatAnthropic({ model: "claude-haiku-4-5-20251001" }),
-    openai: new ChatOpenAI({ model: "gpt-4.1-mini" }),
+    openai: new ChatOpenAI({ model: "gpt-5.4-mini" }),
   };
 
   const callModel: GraphNode<typeof State> = async (state, config) => {
@@ -1292,7 +1292,7 @@ console.log(await graph.invoke({}, { context: { myRuntimeValue: "b" } }));  // [
 
   ```
   claude-haiku-4-5-20251001
-  gpt-4.1-mini-2025-04-14
+  gpt-5.4-mini
   ```
   :::
 </Accordion>
@@ -1316,7 +1316,7 @@ console.log(await graph.invoke({}, { context: { myRuntimeValue: "b" } }));  // [
 
   MODELS = {
       "anthropic": init_chat_model("claude-haiku-4-5-20251001"),
-      "openai": init_chat_model("gpt-4.1-mini"),
+      "openai": init_chat_model("gpt-5.4-mini"),
   }
 
   def call_model(state: MessagesState, runtime: Runtime[ContextSchema]):
@@ -1372,7 +1372,7 @@ console.log(await graph.invoke({}, { context: { myRuntimeValue: "b" } }));  // [
 
   const MODELS = {
     anthropic: new ChatAnthropic({ model: "claude-haiku-4-5-20251001" }),
-    openai: new ChatOpenAI({ model: "gpt-4.1-mini" }),
+    openai: new ChatOpenAI({ model: "gpt-5.4-mini" }),
   };
 
   const callModel: GraphNode<typeof State> = async (state, config) => {

--- a/src/oss/langgraph/use-subgraphs.mdx
+++ b/src/oss/langgraph/use-subgraphs.mdx
@@ -653,13 +653,13 @@ def veggie_info(veggie_name: str) -> str:
 
 # Subagents - no checkpointer setting (inherits parent)
 fruit_agent = create_agent(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     tools=[fruit_info],
     prompt="You are a fruit expert. Use the fruit_info tool. Respond in one sentence.",
 )
 
 veggie_agent = create_agent(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     tools=[veggie_info],
     prompt="You are a veggie expert. Use the veggie_info tool. Respond in one sentence.",
 )
@@ -683,7 +683,7 @@ def ask_veggie_expert(question: str) -> str:
 
 # Outer agent with checkpointer
 agent = create_agent(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     tools=[ask_fruit_expert, ask_veggie_expert],
     prompt=(
         "You have two experts: ask_fruit_expert and ask_veggie_expert. "
@@ -786,13 +786,13 @@ const veggieInfo = tool(
 
 // Subagents - no checkpointer setting (inherits parent)
 const fruitAgent = createAgent({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   tools: [fruitInfo],
   prompt: "You are a fruit expert. Use the fruit_info tool. Respond in one sentence.",
 });
 
 const veggieAgent = createAgent({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   tools: [veggieInfo],
   prompt: "You are a veggie expert. Use the veggie_info tool. Respond in one sentence.",
 });
@@ -828,7 +828,7 @@ const askVeggieExpert = tool(
 
 // Outer agent with checkpointer
 const agent = createAgent({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   tools: [askFruitExpert, askVeggieExpert],
   prompt:
     "You have two experts: ask_fruit_expert and ask_veggie_expert. " +
@@ -939,7 +939,7 @@ def fruit_info(fruit_name: str) -> str:
 
 # Subagent with checkpointer=True for persistent state
 fruit_agent = create_agent(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     tools=[fruit_info],
     prompt="You are a fruit expert. Use the fruit_info tool. Respond in one sentence.",
     checkpointer=True,  # [!code highlight]
@@ -958,7 +958,7 @@ def ask_fruit_expert(question: str) -> str:
 # Use ToolCallLimitMiddleware to prevent parallel calls to per-thread subagents,
 # which would cause checkpoint conflicts.
 agent = create_agent(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     tools=[ask_fruit_expert],
     prompt="You have a fruit expert. ALWAYS delegate fruit questions to ask_fruit_expert.",
     middleware=[  # [!code highlight]
@@ -1036,11 +1036,11 @@ agent = create_agent(
       )
 
   fruit_agent = create_sub_agent(
-      "gpt-4.1-mini", name="fruit_agent",
+      "gpt-5.4-mini", name="fruit_agent",
       tools=[fruit_info], prompt="...", checkpointer=True,
   )
   veggie_agent = create_sub_agent(
-      "gpt-4.1-mini", name="veggie_agent",
+      "gpt-5.4-mini", name="veggie_agent",
       tools=[veggie_info], prompt="...", checkpointer=True,
   )
 
@@ -1086,7 +1086,7 @@ const fruitInfo = tool(
 
 // Subagent with checkpointer=true for persistent state
 const fruitAgent = createAgent({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   tools: [fruitInfo],
   prompt: "You are a fruit expert. Use the fruit_info tool. Respond in one sentence.",
   checkpointer: true,  // [!code highlight]
@@ -1111,7 +1111,7 @@ const askFruitExpert = tool(
 // Use toolCallLimitMiddleware to prevent parallel calls to per-thread subagents,
 // which would cause checkpoint conflicts.
 const agent = createAgent({
-  model: "gpt-4.1-mini",
+  model: "gpt-5.4-mini",
   tools: [askFruitExpert],
   prompt: "You have a fruit expert. ALWAYS delegate fruit questions to ask_fruit_expert.",
   middleware: [  // [!code highlight]
@@ -1192,10 +1192,10 @@ const agent = createAgent({
       .compile();
   }
 
-  const fruitAgent = createSubAgent("gpt-4.1-mini", {
+  const fruitAgent = createSubAgent("gpt-5.4-mini", {
     name: "fruit_agent", tools: [fruitInfo], prompt: "...", checkpointer: true,
   });
-  const veggieAgent = createSubAgent("gpt-4.1-mini", {
+  const veggieAgent = createSubAgent("gpt-5.4-mini", {
     name: "veggie_agent", tools: [veggieInfo], prompt: "...", checkpointer: true,
   });
   const config = { configurable: { thread_id: "1" } };

--- a/src/oss/python/integrations/callbacks/llmonitor.mdx
+++ b/src/oss/python/integrations/callbacks/llmonitor.mdx
@@ -101,7 +101,7 @@ os.environ["SERPAPI_API_KEY"] = ""
 handler = LLMonitorCallbackHandler()
 llm = ChatOpenAI(temperature=0, callbacks=[handler])
 tools = load_tools(["serpapi", "llm-math"], llm=llm)
-agent = create_agent("gpt-4.1-mini", tools)
+agent = create_agent("gpt-5.4-mini", tools)
 
 input_message = {
     "role": "user",

--- a/src/oss/python/integrations/chat/abso.mdx
+++ b/src/oss/python/integrations/chat/abso.mdx
@@ -48,7 +48,7 @@ Now we can instantiate our model object and generate chat completions:
 ```python
 from langchain_abso import ChatAbso
 
-llm = ChatAbso(fast_model="gpt-4.1", slow_model="o3-mini")
+llm = ChatAbso(fast_model="gpt-5.4", slow_model="o3-mini")
 ```
 
 ## Invocation

--- a/src/oss/python/integrations/chat/azure_chat_openai.mdx
+++ b/src/oss/python/integrations/chat/azure_chat_openai.mdx
@@ -144,7 +144,7 @@ To recover token counts when streaming with @[`ChatOpenAI`] or `AzureChatOpenAI`
 ```python
 from langchain_openai import AzureChatOpenAI
 
-llm = AzureChatOpenAI(model="gpt-4.1-mini", stream_usage=True)  # [!code highlight]
+llm = AzureChatOpenAI(model="gpt-5.4-mini", stream_usage=True)  # [!code highlight]
 ```
 
 ## Specifying model version

--- a/src/oss/python/integrations/chat/litellm.mdx
+++ b/src/oss/python/integrations/chat/litellm.mdx
@@ -68,7 +68,7 @@ You can instantiate a `ChatLiteLLM` model by providing a `model` name [supported
 ```python
 from langchain_litellm import ChatLiteLLM
 
-llm = ChatLiteLLM(model="gpt-4.1-nano", temperature=0.1)
+llm = ChatLiteLLM(model="gpt-5.4-nano", temperature=0.1)
 ```
 
 ### ChatLiteLLMRouter
@@ -81,18 +81,18 @@ from litellm import Router
 
 model_list = [
     {
-        "model_name": "gpt-4.1",
+        "model_name": "gpt-5.4",
         "litellm_params": {
-            "model": "azure/gpt-4.1",
+            "model": "azure/gpt-5.4",
             "api_key": "<your-api-key>",
             "api_version": "2024-10-21",
             "api_base": "https://<your-endpoint>.openai.azure.com/",
         },
     },
     {
-        "model_name": "gpt-4.1",
+        "model_name": "gpt-5.4",
         "litellm_params": {
-            "model": "azure/gpt-4.1",
+            "model": "azure/gpt-5.4",
             "api_key": "<your-api-key>",
             "api_version": "2024-10-21",
             "api_base": "https://<your-endpoint>.openai.azure.com/",
@@ -100,7 +100,7 @@ model_list = [
     },
 ]
 litellm_router = Router(model_list=model_list)
-llm = ChatLiteLLMRouter(router=litellm_router, model_name="gpt-4.1", temperature=0.1)
+llm = ChatLiteLLMRouter(router=litellm_router, model_name="gpt-5.4", temperature=0.1)
 ```
 
 ## Invocation

--- a/src/oss/python/integrations/chat/openai.mdx
+++ b/src/oss/python/integrations/chat/openai.mdx
@@ -134,7 +134,7 @@ To recover token counts when streaming with @[`ChatOpenAI`] or `AzureChatOpenAI`
 ```python
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4.1-mini", stream_usage=True)  # [!code highlight]
+llm = ChatOpenAI(model="gpt-5.4-mini", stream_usage=True)  # [!code highlight]
 ```
 
 ---
@@ -455,7 +455,7 @@ Use the [`with_structured_output`](/oss/langchain/models#structured-output) meth
 from langchain_openai import ChatOpenAI
 from pydantic import BaseModel, Field
 
-llm = ChatOpenAI(model="gpt-4.1")
+llm = ChatOpenAI(model="gpt-5.4")
 
 class Movie(BaseModel):
     """A movie with details."""
@@ -493,7 +493,7 @@ def weather_tool(location: str) -> str:
     return "Sunny and 75 degrees F."
 
 agent = create_agent(
-    model="openai:gpt-4.1",
+    model="openai:gpt-5.4",
     tools=[weather_tool],
     response_format=ProviderStrategy(Weather),  # [!code highlight]
 )
@@ -532,7 +532,7 @@ class OutputSchema(BaseModel):
     justification: str
 
 
-llm = ChatOpenAI(model="gpt-4.1")
+llm = ChatOpenAI(model="gpt-5.4")
 
 structured_llm = llm.bind_tools(
     [get_weather],
@@ -577,7 +577,7 @@ llm.invoke("...", tools=[{"type": "web_search_preview"}])
 ```python
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4.1-mini")
+llm = ChatOpenAI(model="gpt-5.4-mini")
 
 tool = {"type": "web_search_preview"}
 llm_with_tools = llm.bind_tools([tool])
@@ -644,7 +644,7 @@ llm.invoke("...", tools=[{"type": "image_generation"}])
 ```python
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4.1-mini")
+llm = ChatOpenAI(model="gpt-5.4-mini")
 
 tool = {"type": "image_generation", "quality": "low"}
 
@@ -678,7 +678,7 @@ To trigger a file search, pass a [file search tool](https://platform.openai.com/
 from langchain_openai import ChatOpenAI
 
 llm = ChatOpenAI(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     include=["file_search_call.results"],  # optionally include search results
 )
 
@@ -1190,7 +1190,7 @@ OpenAI implements a [code interpreter](https://platform.openai.com/docs/guides/t
 from langchain_openai import ChatOpenAI
 
 llm = ChatOpenAI(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     include=["code_interpreter_call.outputs"],  # optionally include outputs
 )
 
@@ -1235,7 +1235,7 @@ OpenAI implements a [remote MCP](https://platform.openai.com/docs/guides/tools-r
 ```python Example use
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4.1-mini")
+llm = ChatOpenAI(model="gpt-5.4-mini")
 
 llm_with_tools = llm.bind_tools(
     [
@@ -1318,7 +1318,7 @@ You can manage the state manually or using [LangGraph](/oss/langgraph/quickstart
 ```python
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4.1-mini", use_responses_api=True)
+llm = ChatOpenAI(model="gpt-5.4-mini", use_responses_api=True)
 
 first_query = "Hi, I'm Bob."
 messages = [{"role": "user", "content": first_query}]
@@ -1375,7 +1375,7 @@ ChatOpenAI can also automatically specify `previous_response_id` using the last 
 from langchain_openai import ChatOpenAI
 
 llm = ChatOpenAI(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     use_previous_response_id=True,  # [!code highlight]
 )
 ```
@@ -1632,7 +1632,7 @@ public class User
 }
 """
 
-llm = ChatOpenAI(model="gpt-4.1")
+llm = ChatOpenAI(model="gpt-5.4")
 query = (
     "Replace the Username property with an Email property. "
     "Respond only with code, and with no markdown formatting."
@@ -1743,7 +1743,7 @@ You can use the `prompt_cache_key` parameter to influence OpenAI's caching and o
 ```python
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4.1")
+llm = ChatOpenAI(model="gpt-5.4")
 
 # Use a cache key for repeated prompts
 messages = [
@@ -1793,7 +1793,7 @@ You can also set a default cache key at the model level using `model_kwargs`:
 
 ```python
 llm = ChatOpenAI(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     model_kwargs={"prompt_cache_key": "default-cache-v1"}
 )
 

--- a/src/oss/python/integrations/chat/openrouter.mdx
+++ b/src/oss/python/integrations/chat/openrouter.mdx
@@ -189,7 +189,7 @@ Use `with_structured_output` to generate a structured model response. Specify `m
 from langchain_openrouter import ChatOpenRouter
 from pydantic import BaseModel, Field
 
-model = ChatOpenRouter(model="openai/gpt-4.1")
+model = ChatOpenRouter(model="openai/gpt-5.4")
 
 class Movie(BaseModel):
     """A movie with details."""
@@ -227,7 +227,7 @@ def weather_tool(location: str) -> str:
     return "Sunny and 75 degrees F."
 
 agent = create_agent(
-    model="openrouter:openai/gpt-4.1",
+    model="openrouter:openai/gpt-5.4",
     tools=[weather_tool],
     response_format=ProviderStrategy(Weather),  # [!code highlight]
 )

--- a/src/oss/python/integrations/chat/premai.mdx
+++ b/src/oss/python/integrations/chat/premai.mdx
@@ -44,9 +44,9 @@ if os.environ.get("PREMAI_API_KEY") is None:
 
 ```python
 # By default it will use the model which was deployed through the platform
-# in my case it is "gpt-4.1"
+# in my case it is "gpt-5.4"
 
-chat = ChatPremAI(project_id=1234, model_name="gpt-4.1")
+chat = ChatPremAI(project_id=1234, model_name="gpt-5.4")
 ```
 
 ### Chat completions

--- a/src/oss/python/integrations/document_loaders/image_captions.mdx
+++ b/src/oss/python/integrations/document_loaders/image_captions.mdx
@@ -73,7 +73,7 @@ from langchain_classic.chains.combine_documents import create_stuff_documents_ch
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_openai import ChatOpenAI
 
-model = ChatOpenAI(model="gpt-4.1", temperature=0)
+model = ChatOpenAI(model="gpt-5.4", temperature=0)
 
 system_prompt = (
     "You are an assistant for question-answering tasks. "

--- a/src/oss/python/integrations/document_loaders/pdfminer.mdx
+++ b/src/oss/python/integrations/document_loaders/pdfminer.mdx
@@ -644,7 +644,7 @@ loader = PDFMinerLoader(
     "./example_data/layout-parser-paper.pdf",
     mode="page",
     images_inner_format="markdown-img",
-    images_parser=LLMImageBlobParser(model=ChatOpenAI(model="gpt-4.1", max_tokens=1024)),
+    images_parser=LLMImageBlobParser(model=ChatOpenAI(model="gpt-5.4", max_tokens=1024)),
 )
 docs = loader.load()
 print(docs[5].page_content)

--- a/src/oss/python/integrations/document_loaders/pymupdf4llm.mdx
+++ b/src/oss/python/integrations/document_loaders/pymupdf4llm.mdx
@@ -335,7 +335,7 @@ loader = PyMuPDF4LLMLoader(
     mode="page",
     extract_images=True,
     images_parser=LLMImageBlobParser(
-        model=ChatOpenAI(model="gpt-4.1-mini", max_tokens=1024)
+        model=ChatOpenAI(model="gpt-5.4-mini", max_tokens=1024)
     ),
 )
 docs = loader.load()

--- a/src/oss/python/integrations/document_loaders/pypdfium2.mdx
+++ b/src/oss/python/integrations/document_loaders/pypdfium2.mdx
@@ -530,7 +530,7 @@ loader = PyPDFium2Loader(
     "./example_data/layout-parser-paper.pdf",
     mode="page",
     images_inner_format="markdown-img",
-    images_parser=LLMImageBlobParser(model=ChatOpenAI(model="gpt-4.1", max_tokens=1024)),
+    images_parser=LLMImageBlobParser(model=ChatOpenAI(model="gpt-5.4", max_tokens=1024)),
 )
 docs = loader.load()
 print(docs[5].page_content)

--- a/src/oss/python/integrations/document_loaders/zeroxpdfloader.mdx
+++ b/src/oss/python/integrations/document_loaders/zeroxpdfloader.mdx
@@ -61,7 +61,7 @@ os.environ["OPENAI_API_KEY"] = (
 )
 
 # Initialize ZeroxPDFLoader with the desired model
-loader = ZeroxPDFLoader(file_path=file_path, model="azure/gpt-4.1-mini")
+loader = ZeroxPDFLoader(file_path=file_path, model="azure/gpt-5.4-mini")
 ```
 
 ## Load
@@ -163,13 +163,13 @@ This loader class initializes with a file path and model type, and supports cust
 - `file_path` (Union[str, Path]): Path to the PDF file.
 - `model` (str): Vision-capable model to use for processing in format `<provider>/<model>`.
 Some examples of valid values are:
-  - `model = "gpt-4.1-mini" ## openai model`
-  - `model = "azure/gpt-4.1-mini"`
-  - `model = "gemini/gpt-4.1-mini"`
+  - `model = "gpt-5.4-mini" ## openai model`
+  - `model = "azure/gpt-5.4-mini"`
+  - `model = "gemini/gpt-5.4-mini"`
   - `model="claude-3-opus-20240229"`
   - `model = "vertex_ai/gemini-2.5-flash"`
   - See more details in [Zerox documentation](https://github.com/getomni-ai/zerox)
-  - Defaults to `"gpt-4.1-mini".`
+  - Defaults to `"gpt-5.4-mini".`
 - `**zerox_kwargs` (dict): Additional Zerox-specific parameters such as API key, endpoint, etc.
   - See [Zerox documentation](https://github.com/getomni-ai/zerox)
 

--- a/src/oss/python/integrations/document_transformers/jina_rerank.mdx
+++ b/src/oss/python/integrations/document_transformers/jina_rerank.mdx
@@ -115,7 +115,7 @@ Answer any use questions based solely on the context below:
 ```python
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4.1-mini", temperature=0)
+llm = ChatOpenAI(model="gpt-5.4-mini", temperature=0)
 combine_docs_chain = create_stuff_documents_chain(llm, retrieval_qa_chat_prompt)
 chain = create_retrieval_chain(compression_retriever, combine_docs_chain)
 ```

--- a/src/oss/python/integrations/document_transformers/rankllm-reranker.mdx
+++ b/src/oss/python/integrations/document_transformers/rankllm-reranker.mdx
@@ -571,7 +571,7 @@ Retrieval + Reranking with RankGPT
 from langchain_classic.retrievers.contextual_compression import ContextualCompressionRetriever
 from langchain_community.document_compressors.rankllm_rerank import RankLLMRerank
 
-compressor = RankLLMRerank(top_n=3, model="gpt", gpt_model="gpt-4.1-mini")
+compressor = RankLLMRerank(top_n=3, model="gpt", gpt_model="gpt-5.4-mini")
 compression_retriever = ContextualCompressionRetriever(
     base_compressor=compressor, base_retriever=retriever
 )

--- a/src/oss/python/integrations/graphs/kuzu_db.mdx
+++ b/src/oss/python/integrations/graphs/kuzu_db.mdx
@@ -77,7 +77,7 @@ from langchain_openai import ChatOpenAI
 
 # Define the LLMGraphTransformer
 llm_transformer = LLMGraphTransformer(
-    llm=ChatOpenAI(model="gpt-4.1-mini", temperature=0, api_key=OPENAI_API_KEY),
+    llm=ChatOpenAI(model="gpt-5.4-mini", temperature=0, api_key=OPENAI_API_KEY),
     allowed_nodes=allowed_nodes,
     allowed_relationships=allowed_relationships,
 )
@@ -114,7 +114,7 @@ from langchain_kuzu.chains.graph_qa.kuzu import KuzuQAChain
 
 # Create the KuzuQAChain with verbosity enabled to see the generated Cypher queries
 chain = KuzuQAChain.from_llm(
-    llm=ChatOpenAI(model="gpt-4.1-mini", temperature=0.3, api_key=OPENAI_API_KEY),
+    llm=ChatOpenAI(model="gpt-5.4-mini", temperature=0.3, api_key=OPENAI_API_KEY),
     graph=graph,
     verbose=True,
     allow_dangerous_requests=True,
@@ -186,7 +186,7 @@ You can specify `cypher_llm` and `qa_llm` separately to use different LLMs for C
 
 ```python
 chain = KuzuQAChain.from_llm(
-    cypher_llm=ChatOpenAI(temperature=0, model="gpt-4.1-mini"),
+    cypher_llm=ChatOpenAI(temperature=0, model="gpt-5.4-mini"),
     qa_llm=ChatOpenAI(temperature=0, model="gpt-4"),
     graph=graph,
     verbose=True,

--- a/src/oss/python/integrations/graphs/timbr.mdx
+++ b/src/oss/python/integrations/graphs/timbr.mdx
@@ -80,7 +80,7 @@ export TIMBR_ONTOLOGY="timbr_knowledge_graph"
 # LLM configuration
 export LLM_TYPE="openai-chat"
 export LLM_API_KEY="your-openai-api-key"
-export LLM_MODEL="gpt-4.1"
+export LLM_MODEL="gpt-5.4"
 export LLM_TEMPERATURE="0.1"
 export LLM_ADDITIONAL_PARAMS='{"max_tokens": 1000}'
 ```
@@ -97,11 +97,11 @@ from langchain_openai import ChatOpenAI
 ```python
 # You can use the standard LangChain ChatOpenAI/ChatAnthropic models
 # or any other LLM model based on langchain_core.language_models.chat.BaseChatModel
-llm = ChatOpenAI(model="gpt-4.1", temperature=0, openai_api_key="open-ai-api-key")
+llm = ChatOpenAI(model="gpt-5.4", temperature=0, openai_api_key="open-ai-api-key")
 
 # Optional alternative: Use Timbr's LlmWrapper, which provides generic connections to different LLM providers
 from langchain_timbr import LlmWrapper, LlmTypes
-llm = LlmWrapper(llm_type=LlmTypes.OpenAI, api_key="open-ai-api-key", model="gpt-4.1")
+llm = LlmWrapper(llm_type=LlmTypes.OpenAI, api_key="open-ai-api-key", model="gpt-5.4")
 ```
 
 ### ExecuteTimbrQueryChain example

--- a/src/oss/python/integrations/middleware/azure_ai.mdx
+++ b/src/oss/python/integrations/middleware/azure_ai.mdx
@@ -96,7 +96,7 @@ from langchain.agents import create_agent
 from langchain_azure_ai.agents.middleware import AzureContentModerationMiddleware
 
 agent = create_agent(
-    model="azure_ai:gpt-4.1",
+    model="azure_ai:gpt-5.4",
     middleware=[
         AzureContentModerationMiddleware(
             project_endpoint="https://<resource>.services.ai.azure.com/api/projects/<project>",

--- a/src/oss/python/integrations/middleware/openai.mdx
+++ b/src/oss/python/integrations/middleware/openai.mdx
@@ -30,7 +30,7 @@ from langchain_openai.middleware import OpenAIModerationMiddleware
 from langchain.agents import create_agent
 
 agent = create_agent(
-    model=ChatOpenAI(model="gpt-4.1"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[search_tool, database_tool],
     middleware=[
         OpenAIModerationMiddleware(
@@ -111,7 +111,7 @@ from langchain.agents import create_agent
 
 # Basic moderation
 agent = create_agent(
-    model=ChatOpenAI(model="gpt-4.1"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[search_tool, customer_data_tool],
     middleware=[
         OpenAIModerationMiddleware(
@@ -124,7 +124,7 @@ agent = create_agent(
 
 # Strict moderation with custom message
 agent_strict = create_agent(
-    model=ChatOpenAI(model="gpt-4.1"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[search_tool, customer_data_tool],
     middleware=[
         OpenAIModerationMiddleware(
@@ -143,7 +143,7 @@ agent_strict = create_agent(
 
 # Moderation with replacement behavior
 agent_replace = create_agent(
-    model=ChatOpenAI(model="gpt-4.1"),
+    model=ChatOpenAI(model="gpt-5.4"),
     tools=[search_tool],
     middleware=[
         OpenAIModerationMiddleware(

--- a/src/oss/python/integrations/providers/azure_ai.mdx
+++ b/src/oss/python/integrations/providers/azure_ai.mdx
@@ -37,7 +37,7 @@ from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 from azure.identity import DefaultAzureCredential
 
 llm = AzureAIOpenAIApiChatModel(
-    model="gpt-4.1",
+    model="gpt-5.4",
     credential=DefaultAzureCredential(),
 )
 

--- a/src/oss/python/integrations/providers/cratedb.mdx
+++ b/src/oss/python/integrations/providers/cratedb.mdx
@@ -148,7 +148,7 @@ set_llm_cache(CrateDBCache(engine))
 
 # Invoke LLM conversation.
 llm = ChatOpenAI(
-    model_name="gpt-4.1",
+    model_name="gpt-5.4",
     temperature=0.7,
 )
 print()
@@ -185,7 +185,7 @@ set_llm_cache(
 )
 
 # Invoke LLM conversation.
-llm = ChatOpenAI(model_name="gpt-4.1")
+llm = ChatOpenAI(model_name="gpt-5.4")
 print()
 print("Asking with semantic cache:")
 answer = llm.invoke("What is the answer to everything?")

--- a/src/oss/python/integrations/providers/langfuse.mdx
+++ b/src/oss/python/integrations/providers/langfuse.mdx
@@ -37,7 +37,7 @@ langfuse = get_client()
 langfuse_handler = CallbackHandler()
 
 # Create your LangChain components
-llm = ChatOpenAI(model_name="gpt-4.1")
+llm = ChatOpenAI(model_name="gpt-5.4")
 prompt = ChatPromptTemplate.from_template("Tell me a joke about {topic}")
 chain = prompt | llm
 
@@ -133,7 +133,7 @@ class State(TypedDict):
 
 graph_builder = StateGraph(State)
 
-llm = ChatOpenAI(model = "gpt-4.1", temperature = 0.2)
+llm = ChatOpenAI(model = "gpt-5.4", temperature = 0.2)
 
 # The chatbot node function takes the current State as input and returns an updated messages list. This is the basic pattern for all LangGraph node functions.
 def chatbot(state: State):

--- a/src/oss/python/integrations/providers/microsoft.mdx
+++ b/src/oss/python/integrations/providers/microsoft.mdx
@@ -70,7 +70,7 @@ from langchain_azure_ai.chat_models import AzureAIOpenAIApiChatModel
 from azure.identity import DefaultAzureCredential
 
 llm = AzureAIOpenAIApiChatModel(
-    model="gpt-4.1",
+    model="gpt-5.4",
     credential=DefaultAzureCredential(),
 )
 ```

--- a/src/oss/python/integrations/providers/mlflow_tracking.mdx
+++ b/src/oss/python/integrations/providers/mlflow_tracking.mdx
@@ -62,7 +62,7 @@ from langchain_openai import ChatOpenAI
 mlflow.langchain.autolog()
 
 # Create a simple chain
-llm = ChatOpenAI(model_name="gpt-4.1")
+llm = ChatOpenAI(model_name="gpt-5.4")
 
 prompt = ChatPromptTemplate.from_messages(
     [
@@ -111,7 +111,7 @@ def count_words(text: str) -> str:
 
 
 # Create a LangGraph agent
-llm = ChatOpenAI(model="gpt-4.1")
+llm = ChatOpenAI(model="gpt-5.4")
 tools = [count_words]
 graph = create_agent(llm, tools)
 

--- a/src/oss/python/integrations/providers/oci.mdx
+++ b/src/oss/python/integrations/providers/oci.mdx
@@ -127,7 +127,7 @@ OpenAI Responses API compatibility for OCI commercial OpenAI models.
 from langchain_oci import ChatOCIOpenAI
 
 llm = ChatOCIOpenAI(
-    model="openai.gpt-4.1",
+    model="openai.gpt-5.4",
     service_endpoint="https://inference.generativeai.us-chicago-1.oci.oraclecloud.com",
     compartment_id="ocid1.compartment.oc1..your-compartment-id",
 )
@@ -256,7 +256,7 @@ result = agent.invoke({
 | **Google** | Gemini 2.0/2.5 Flash, Flash Lite, Pro | PDF, video, audio processing |
 | **xAI** | Grok 3, 4 (Fast, Mini) | Vision, reasoning modes |
 | **Cohere** | Command R+, Command A | RAG optimization, V2 vision |
-| **OpenAI** | GPT-4.1, GPT-5, o1, o3 | Reasoning (via ChatOCIOpenAI) |
+| **OpenAI** | GPT-5.4, GPT-5, o1, o3 | Reasoning (via ChatOCIOpenAI) |
 
 > **Note:** Model availability varies by region. See the [OCI Generative AI documentation](https://docs.oracle.com/en-us/iaas/Content/generative-ai/pretrained-models.htm) for the current model catalog.
 

--- a/src/oss/python/integrations/providers/premai.mdx
+++ b/src/oss/python/integrations/providers/premai.mdx
@@ -45,7 +45,7 @@ import getpass
 if "PREMAI_API_KEY" not in os.environ:
     os.environ["PREMAI_API_KEY"] = getpass.getpass("PremAI API Key:")
 
-chat = ChatPremAI(project_id=1234, model_name="gpt-4.1")
+chat = ChatPremAI(project_id=1234, model_name="gpt-5.4")
 ```
 
 ### Chat completions

--- a/src/oss/python/integrations/providers/tensorlake.mdx
+++ b/src/oss/python/integrations/providers/tensorlake.mdx
@@ -67,7 +67,7 @@ import os
 async def main(question):
     # Create the agent with the Tensorlake tool
     agent = create_agent(
-            model="gpt-4.1-mini",
+            model="gpt-5.4-mini",
             tools=[document_markdown_tool],
             prompt=(
                 """

--- a/src/oss/python/integrations/providers/truefoundry.mdx
+++ b/src/oss/python/integrations/providers/truefoundry.mdx
@@ -50,7 +50,7 @@ from langchain_openai import ChatOpenAI
 llm = ChatOpenAI(
     api_key=TRUEFOUNDRY_API_KEY,
     base_url=TRUEFOUNDRY_GATEWAY_BASE_URL,
-    model="openai-main/gpt-4.1"  # Similarly you can call any model from any model provider
+    model="openai-main/gpt-5.4"  # Similarly you can call any model from any model provider
 )
 
 llm.invoke("What is the meaning of life, universe and everything?")
@@ -72,7 +72,7 @@ def call_model(state: MessagesState):
         api_key=TRUEFOUNDRY_API_KEY,
         base_url=TRUEFOUNDRY_GATEWAY_BASE_URL,
         # Copy the exact model name from gateway
-        model="openai-main/gpt-4.1"
+        model="openai-main/gpt-5.4"
     )
     response = model.invoke(state["messages"])
     return {"messages": [response]}

--- a/src/oss/python/integrations/retrievers/azure_ai_search.mdx
+++ b/src/oss/python/integrations/retrievers/azure_ai_search.mdx
@@ -174,7 +174,7 @@ Context: {context}
 Question: {question}"""
 )
 
-llm = ChatOpenAI(model="gpt-4.1-mini")
+llm = ChatOpenAI(model="gpt-5.4-mini")
 
 
 def format_docs(docs):

--- a/src/oss/python/integrations/retrievers/tavily.mdx
+++ b/src/oss/python/integrations/retrievers/tavily.mdx
@@ -79,7 +79,7 @@ Context: {context}
 Question: {question}"""
 )
 
-llm = ChatOpenAI(model="gpt-4.1-mini")
+llm = ChatOpenAI(model="gpt-5.4-mini")
 
 
 def format_docs(docs):

--- a/src/oss/python/integrations/retrievers/valyu.mdx
+++ b/src/oss/python/integrations/retrievers/valyu.mdx
@@ -98,7 +98,7 @@ Context: {context}
 Question: {question}"""
 )
 
-llm = ChatOpenAI(model="gpt-4.1-mini")
+llm = ChatOpenAI(model="gpt-5.4-mini")
 
 
 def format_docs(docs):

--- a/src/oss/python/integrations/retrievers/zotero.mdx
+++ b/src/oss/python/integrations/retrievers/zotero.mdx
@@ -128,7 +128,7 @@ retriever_tool = StructuredTool.from_function(
 )
 
 
-llm = ChatOpenAI(model="gpt-4.1-mini-2025-04-14")
+llm = ChatOpenAI(model="gpt-5.4-mini")
 
 llm_with_tools = llm.bind_tools([retrieve])
 

--- a/src/oss/python/integrations/tools/ads4gpts.mdx
+++ b/src/oss/python/integrations/tools/ads4gpts.mdx
@@ -179,7 +179,7 @@ import os
 
 from langchain_openai import ChatOpenAI
 
-openai_model = ChatOpenAI(model="gpt-4.1", openai_api_key=os.environ["OPENAI_API_KEY"])
+openai_model = ChatOpenAI(model="gpt-5.4", openai_api_key=os.environ["OPENAI_API_KEY"])
 model = openai_model.bind_tools(tools)
 model_response = model.invoke(
     "Get me an ad for clothing. I am a young man looking to go out with friends."

--- a/src/oss/python/integrations/tools/agentql.mdx
+++ b/src/oss/python/integrations/tools/agentql.mdx
@@ -288,7 +288,7 @@ os.environ["OPENAI_API_KEY"] = "YOUR_OPENAI_API_KEY"
 ```python
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model(model="gpt-4.1", model_provider="openai")
+model = init_chat_model(model="gpt-5.4", model_provider="openai")
 ```
 
 ### Execute tool chain

--- a/src/oss/python/integrations/tools/anchor_browser.mdx
+++ b/src/oss/python/integrations/tools/anchor_browser.mdx
@@ -140,7 +140,7 @@ pip install -qU langchain langchain-openai
 ```python
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model(model="gpt-4.1", model_provider="openai")
+model = init_chat_model(model="gpt-5.4", model_provider="openai")
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/azure_dynamic_sessions.mdx
+++ b/src/oss/python/integrations/tools/azure_dynamic_sessions.mdx
@@ -162,7 +162,7 @@ from langchain.agents import AgentExecutor, create_tool_calling_agent
 from langchain_azure_dynamic_sessions import SessionsPythonREPLTool
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4.1", temperature=0)
+llm = ChatOpenAI(model="gpt-5.4", temperature=0)
 prompt = hub.pull("hwchase17/openai-functions-agent")
 agent = create_tool_calling_agent(llm, [tool], prompt)
 

--- a/src/oss/python/integrations/tools/bash.mdx
+++ b/src/oss/python/integrations/tools/bash.mdx
@@ -44,7 +44,7 @@ from langchain.agents import create_agent
 
 
 tools = [shell_tool]
-agent = create_agent("gpt-4.1-mini", tools)
+agent = create_agent("gpt-5.4-mini", tools)
 
 input_message = {
     "role": "user",

--- a/src/oss/python/integrations/tools/cdp_agentkit.mdx
+++ b/src/oss/python/integrations/tools/cdp_agentkit.mdx
@@ -104,7 +104,7 @@ We will need a LLM or chat model:
 ```python
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4.1-mini")
+llm = ChatOpenAI(model="gpt-5.4-mini")
 ```
 
 Initialize the agent with the tools:

--- a/src/oss/python/integrations/tools/compass.mdx
+++ b/src/oss/python/integrations/tools/compass.mdx
@@ -111,7 +111,7 @@ from langchain_openai import ChatOpenAI
 
 load_dotenv()
 
-llm = ChatOpenAI(model="gpt-4.1")
+llm = ChatOpenAI(model="gpt-5.4")
 ```
 
 Initialize the agent with the tools:

--- a/src/oss/python/integrations/tools/dappier.mdx
+++ b/src/oss/python/integrations/tools/dappier.mdx
@@ -117,7 +117,7 @@ We can use our tool in a chain by first binding it to a [tool-calling model](/os
 # !pip install -qU langchain langchain-openai
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model(model="gpt-4.1", model_provider="openai", temperature=0)
+model = init_chat_model(model="gpt-5.4", model_provider="openai", temperature=0)
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/exa_search.mdx
+++ b/src/oss/python/integrations/tools/exa_search.mdx
@@ -118,7 +118,7 @@ from langchain.agents import create_agent
 
 
 # Initialize the language model
-model = init_chat_model(model="gpt-4.1", model_provider="openai", temperature=0)
+model = init_chat_model(model="gpt-5.4", model_provider="openai", temperature=0)
 
 # Initialize Exa Tools
 exa_search = ExaSearchResults(

--- a/src/oss/python/integrations/tools/financial_datasets.mdx
+++ b/src/oss/python/integrations/tools/financial_datasets.mdx
@@ -100,7 +100,7 @@ Instantiate the LLM.
 from langchain.tools import tool
 from langchain_openai import ChatOpenAI
 
-model = ChatOpenAI(model="gpt-4.1")
+model = ChatOpenAI(model="gpt-5.4")
 ```
 
 Define a user query.

--- a/src/oss/python/integrations/tools/github.mdx
+++ b/src/oss/python/integrations/tools/github.mdx
@@ -164,7 +164,7 @@ We will need a LLM or chat model:
 
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4.1-mini", temperature=0)
+llm = ChatOpenAI(model="gpt-5.4-mini", temperature=0)
 ```
 
 Initialize the agent with a subset of tools:

--- a/src/oss/python/integrations/tools/goat.mdx
+++ b/src/oss/python/integrations/tools/goat.mdx
@@ -135,7 +135,7 @@ keypair = Keypair.from_base58_string(os.getenv("SOLANA_WALLET_SEED") or "")
 wallet = solana(client, keypair)
 
 # Initialize LLM
-llm = ChatOpenAI(model="gpt-4.1-mini")
+llm = ChatOpenAI(model="gpt-5.4-mini")
 
 def main():
     # Initialize tools with Solana wallet

--- a/src/oss/python/integrations/tools/google_books.mdx
+++ b/src/oss/python/integrations/tools/google_books.mdx
@@ -101,7 +101,7 @@ os.environ["OPENAI_API_KEY"] = getpass.getpass()
 os.environ["GOOGLE_BOOKS_API_KEY"] = "<your Google Books API key>"
 
 tool = GoogleBooksQueryRun(api_wrapper=GoogleBooksAPIWrapper())
-llm = ChatOpenAI(model="gpt-4.1-mini")
+llm = ChatOpenAI(model="gpt-5.4-mini")
 prompt = PromptTemplate.from_template(
     "Return the keyword, and only the keyword, that the user is looking for from this text: {text}"
 )
@@ -135,7 +135,7 @@ os.environ["OPENAI_API_KEY"] = getpass.getpass()
 os.environ["GOOGLE_BOOKS_API_KEY"] = "<your Google Books API key>"
 
 tool = GoogleBooksQueryRun(api_wrapper=GoogleBooksAPIWrapper())
-llm = ChatOpenAI(model="gpt-4.1-mini")
+llm = ChatOpenAI(model="gpt-5.4-mini")
 
 instructions = """You are a book suggesting assistant."""
 base_prompt = hub.pull("langchain-ai/openai-functions-template")

--- a/src/oss/python/integrations/tools/google_calendar.mdx
+++ b/src/oss/python/integrations/tools/google_calendar.mdx
@@ -141,7 +141,7 @@ We will need a LLM or chat model:
 
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4.1-mini", temperature=0)
+llm = ChatOpenAI(model="gpt-5.4-mini", temperature=0)
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/google_drive.mdx
+++ b/src/oss/python/integrations/tools/google_drive.mdx
@@ -119,7 +119,7 @@ from langchain.agents import create_agent
 os.environ["OPENAI_API_KEY"] = "your-openai-api-key"
 
 
-model = init_chat_model("gpt-4.1-mini", model_provider="openai", temperature=0)
+model = init_chat_model("gpt-5.4-mini", model_provider="openai", temperature=0)
 agent = create_agent(model, tools=[tool])
 
 events = agent.stream(

--- a/src/oss/python/integrations/tools/google_finance.mdx
+++ b/src/oss/python/integrations/tools/google_finance.mdx
@@ -54,7 +54,7 @@ os.environ["SERP_API_KEY"] = ""
 ```python
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model("gpt-4.1-mini", model_provider="openai")
+model = init_chat_model("gpt-5.4-mini", model_provider="openai")
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/google_gmail.mdx
+++ b/src/oss/python/integrations/tools/google_gmail.mdx
@@ -93,7 +93,7 @@ We will need a LLM or chat model:
 
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(model="gpt-4.1-mini", temperature=0)
+llm = ChatOpenAI(model="gpt-5.4-mini", temperature=0)
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/google_jobs.mdx
+++ b/src/oss/python/integrations/tools/google_jobs.mdx
@@ -70,7 +70,7 @@ tools = load_tools(["google-jobs"])
 from langchain.agents import create_agent
 
 
-agent = create_agent("gpt-4.1-mini", tools)
+agent = create_agent("gpt-5.4-mini", tools)
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/google_serper.mdx
+++ b/src/oss/python/integrations/tools/google_serper.mdx
@@ -49,7 +49,7 @@ from langchain.agents import create_agent
 
 os.environ["OPENAI_API_KEY"] = "[your openai key]"
 
-model = init_chat_model("gpt-4.1-mini", model_provider="openai", temperature=0)
+model = init_chat_model("gpt-5.4-mini", model_provider="openai", temperature=0)
 search = GoogleSerperAPIWrapper()
 
 

--- a/src/oss/python/integrations/tools/graphql.mdx
+++ b/src/oss/python/integrations/tools/graphql.mdx
@@ -42,7 +42,7 @@ tools = load_tools(
 from langchain.agents import create_agent
 
 
-agent = create_agent("gpt-4.1-mini", tools)
+agent = create_agent("gpt-5.4-mini", tools)
 ```
 
 Now, we can use the Agent to run queries against the Star Wars GraphQL API. Let's ask the Agent to list all the Star Wars films and their release dates.

--- a/src/oss/python/integrations/tools/jina_search.mdx
+++ b/src/oss/python/integrations/tools/jina_search.mdx
@@ -101,7 +101,7 @@ We can use our tool in a chain by first binding it to a [tool-calling model](/os
 # !pip install -qU langchain langchain-openai
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model(model="gpt-4.1", model_provider="openai")
+model = init_chat_model(model="gpt-5.4", model_provider="openai")
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/linkup_search.mdx
+++ b/src/oss/python/integrations/tools/linkup_search.mdx
@@ -104,7 +104,7 @@ We can use our tool in a chain by first binding it to a [tool-calling model](/os
 # !pip install -qU langchain langchain-openai
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model(model="gpt-4.1", model_provider="openai")
+model = init_chat_model(model="gpt-5.4", model_provider="openai")
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/memgraph.mdx
+++ b/src/oss/python/integrations/tools/memgraph.mdx
@@ -37,7 +37,7 @@ from langchain_memgraph.graphs.memgraph import MemgraphLangChain
 
 db = MemgraphLangChain(url=url, username=username, password=password)
 
-model = init_chat_model("gpt-4.1-mini", model_provider="openai")
+model = init_chat_model("gpt-5.4-mini", model_provider="openai")
 
 toolkit = MemgraphToolkit(
     db=db,  # Memgraph instance

--- a/src/oss/python/integrations/tools/naver_search.mdx
+++ b/src/oss/python/integrations/tools/naver_search.mdx
@@ -106,7 +106,7 @@ The Naver Search tool can be integrated into LangChain agents for more complex t
 ```python
 from langchain_openai import ChatOpenAI
 
-model = ChatOpenAI(model="gpt-4.1-mini")
+model = ChatOpenAI(model="gpt-5.4-mini")
 
 system_prompt = """
 You are a helpful assistant that can search the web for information.

--- a/src/oss/python/integrations/tools/opengradient_toolkit.mdx
+++ b/src/oss/python/integrations/tools/opengradient_toolkit.mdx
@@ -159,7 +159,7 @@ from langchain.agents import create_agent
 
 
 # Initialize LLM
-model = ChatOpenAI(model="gpt-4.1")
+model = ChatOpenAI(model="gpt-5.4")
 
 # Create tools from the toolkit
 tools = toolkit.get_tools()

--- a/src/oss/python/integrations/tools/openweathermap.mdx
+++ b/src/oss/python/integrations/tools/openweathermap.mdx
@@ -62,7 +62,7 @@ os.environ["OPENAI_API_KEY"] = ""
 os.environ["OPENWEATHERMAP_API_KEY"] = ""
 
 tools = [weather.run]
-agent = create_agent("gpt-4.1-mini", tools)
+agent = create_agent("gpt-5.4-mini", tools)
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/oxylabs.mdx
+++ b/src/oss/python/integrations/tools/oxylabs.mdx
@@ -105,7 +105,7 @@ import os
 from langchain.chat_models import init_chat_model
 
 os.environ["OPENAI_API_KEY"] = getpass.getpass("Enter API key for OpenAI: ")
-model = init_chat_model("gpt-4.1-mini", model_provider="openai")
+model = init_chat_model("gpt-5.4-mini", model_provider="openai")
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/parallel_search.mdx
+++ b/src/oss/python/integrations/tools/parallel_search.mdx
@@ -247,7 +247,7 @@ import ChatModelTabs from '/snippets/chat-model-tabs.mdx';
 # !pip install -qU langchain langchain-openai
 from langchain.chat_models import init_chat_model
 
-llm = init_chat_model(model="gpt-4.1", model_provider="openai")
+llm = init_chat_model(model="gpt-5.4", model_provider="openai")
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/polygon.mdx
+++ b/src/oss/python/integrations/tools/polygon.mdx
@@ -74,7 +74,7 @@ from langchain_classic import hub
 from langchain.agents import AgentExecutor, create_openai_functions_agent
 from langchain_openai import ChatOpenAI
 
-llm = ChatOpenAI(temperature=0, model="gpt-4.1")
+llm = ChatOpenAI(temperature=0, model="gpt-5.4")
 
 instructions = """You are an assistant."""
 base_prompt = hub.pull("langchain-ai/openai-functions-template")

--- a/src/oss/python/integrations/tools/prolog_tool.mdx
+++ b/src/oss/python/integrations/tools/prolog_tool.mdx
@@ -68,7 +68,7 @@ from langchain_openai import ChatOpenAI
 To use the tool, bind it to the LLM model:
 
 ```python
-model = ChatOpenAI(model="gpt-4.1-mini")
+model = ChatOpenAI(model="gpt-5.4-mini")
 model_with_tools = model.bind_tools([prolog_tool])
 ```
 

--- a/src/oss/python/integrations/tools/requests.mdx
+++ b/src/oss/python/integrations/tools/requests.mdx
@@ -150,7 +150,7 @@ from langchain_openai import ChatOpenAI
 from langchain.agents import create_agent
 
 
-model = ChatOpenAI(model="gpt-4.1-mini")
+model = ChatOpenAI(model="gpt-5.4-mini")
 
 system_message = """
 You have access to an API to help answer user queries.

--- a/src/oss/python/integrations/tools/scrapegraph.mdx
+++ b/src/oss/python/integrations/tools/scrapegraph.mdx
@@ -211,7 +211,7 @@ Let's use our tools with an LLM to analyze a website:
 # pip install -qU langchain langchain-openai
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model(model="gpt-4.1", model_provider="openai")
+model = init_chat_model(model="gpt-5.4", model_provider="openai")
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/scraperapi.mdx
+++ b/src/oss/python/integrations/tools/scraperapi.mdx
@@ -167,7 +167,7 @@ os.environ["SCRAPERAPI_API_KEY"] = "your-api-key"
 os.environ["OPENAI_API_KEY"] = "your-api-key"
 
 tools = [ScraperAPITool(output_format="markdown")]
-model = ChatOpenAI(model="gpt-4.1", temperature=0)
+model = ChatOpenAI(model="gpt-5.4", temperature=0)
 
 agent = create_agent(
     model=model,

--- a/src/oss/python/integrations/tools/searchapi.mdx
+++ b/src/oss/python/integrations/tools/searchapi.mdx
@@ -55,7 +55,7 @@ tools = [intermediate_answer]
 from langchain.agents import create_agent
 
 
-agent = create_agent("gpt-4.1-mini", tools)
+agent = create_agent("gpt-5.4-mini", tools)
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/slack.mdx
+++ b/src/oss/python/integrations/tools/slack.mdx
@@ -81,7 +81,7 @@ from langchain_openai import ChatOpenAI
 from langchain.agents import create_agent
 
 
-model = ChatOpenAI(model="gpt-4.1-mini")
+model = ChatOpenAI(model="gpt-5.4-mini")
 
 agent_executor = create_agent(model, tools)
 ```

--- a/src/oss/python/integrations/tools/steam.mdx
+++ b/src/oss/python/integrations/tools/steam.mdx
@@ -54,7 +54,7 @@ tools = [steam.run]
 ```python
 from langchain.agents import create_agent
 
-agent = create_agent("gpt-4.1-mini", tools)
+agent = create_agent("gpt-5.4-mini", tools)
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/tableau.mdx
+++ b/src/oss/python/integrations/tools/tableau.mdx
@@ -90,7 +90,7 @@ datasource_luid = (
 model_provider = "openai"  # the name of the model provider you are using for your Agent
 # Add variables to control LLM models for the Agent and Tools
 os.environ["OPENAI_API_KEY"]  # set an your model API key as an environment variable
-tooling_llm_model = "gpt-4.1-mini"
+tooling_llm_model = "gpt-5.4-mini"
 ```
 
 ## Instantiation
@@ -131,7 +131,7 @@ First, we'll initlialize the LLM of our choice. Then, we define an agent using a
 ```python
 from IPython.display import Markdown, display
 
-model = ChatOpenAI(model="gpt-4.1", temperature=0)
+model = ChatOpenAI(model="gpt-5.4", temperature=0)
 
 tableauAgent = create_agent(model, tools)
 

--- a/src/oss/python/integrations/tools/tavily_extract.mdx
+++ b/src/oss/python/integrations/tools/tavily_extract.mdx
@@ -120,7 +120,7 @@ if not os.environ.get("OPENAI_API_KEY"):
 # !pip install -qU langchain langchain-openai
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model(model="gpt-4.1", model_provider="openai", temperature=0)
+model = init_chat_model(model="gpt-5.4", model_provider="openai", temperature=0)
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/tavily_search.mdx
+++ b/src/oss/python/integrations/tools/tavily_search.mdx
@@ -134,7 +134,7 @@ if not os.environ.get("OPENAI_API_KEY"):
 # !pip install -qU langchain langchain-openai
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model(model="gpt-4.1", model_provider="openai", temperature=0)
+model = init_chat_model(model="gpt-5.4", model_provider="openai", temperature=0)
 ```
 
 We will need to install langgraph:

--- a/src/oss/python/integrations/tools/tilores.mdx
+++ b/src/oss/python/integrations/tools/tilores.mdx
@@ -153,7 +153,7 @@ We can use our tool in a chain by first binding it to a [tool-calling model](/os
 # !pip install -qU langchain langchain-openai
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model(model="gpt-4.1", model_provider="openai")
+model = init_chat_model(model="gpt-5.4", model_provider="openai")
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/valyu_search.mdx
+++ b/src/oss/python/integrations/tools/valyu_search.mdx
@@ -89,7 +89,7 @@ if not os.environ.get("OPENAI_API_KEY"):
 # !pip install -qU langchain langchain-openai
 from langchain.chat_models import init_chat_model
 
-model = init_chat_model(model="gpt-4.1", model_provider="openai", temperature=0)
+model = init_chat_model(model="gpt-5.4", model_provider="openai", temperature=0)
 ```
 
 ```python

--- a/src/oss/python/integrations/tools/vectara.mdx
+++ b/src/oss/python/integrations/tools/vectara.mdx
@@ -256,7 +256,7 @@ from langchain.agents import create_agent
 
 # Set up the tools and LLM
 tools = [vectara_rag_tool]
-model = ChatOpenAI(model="gpt-4.1-mini", temperature=0)
+model = ChatOpenAI(model="gpt-5.4-mini", temperature=0)
 
 # Construct the ReAct agent
 agent_executor = create_agent(model, tools)

--- a/src/oss/python/integrations/tools/yahoo_finance_news.mdx
+++ b/src/oss/python/integrations/tools/yahoo_finance_news.mdx
@@ -27,7 +27,7 @@ from langchain.agents import create_agent
 
 
 tools = [YahooFinanceNewsTool()]
-agent = create_agent("gpt-4.1-mini", tools)
+agent = create_agent("gpt-5.4-mini", tools)
 ```
 
 ```text

--- a/src/oss/python/migrate/langchain-v1.mdx
+++ b/src/oss/python/migrate/langchain-v1.mdx
@@ -196,7 +196,7 @@ def dynamic_prompt(request: ModelRequest) -> str:  # [!code highlight]
     return prompt  # [!code highlight]
 
 agent = create_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=tools,
     middleware=[dynamic_prompt],  # [!code highlight]
     context_schema=Context
@@ -231,7 +231,7 @@ def dynamic_prompt(state: AgentState) -> str:
     return base_prompt
 
 agent = create_react_agent(
-    model="gpt-4.1",
+    model="gpt-5.4",
     tools=tools,
     prompt=dynamic_prompt,
     context_schema=Context
@@ -549,7 +549,7 @@ model_with_tools = ChatOpenAI().bind_tools([some_tool])
 agent = create_agent(model_with_tools, tools=[])
 
 # Use instead
-agent = create_agent("gpt-4.1-mini", tools=[some_tool])
+agent = create_agent("gpt-5.4-mini", tools=[some_tool])
 ```
 
 <Note>
@@ -668,7 +668,7 @@ class OutputSchema(BaseModel):
 
 # Using ToolStrategy
 agent = create_agent(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     tools=tools,
     # explicitly using tool strategy
     response_format=ToolStrategy(OutputSchema)  # [!code highlight]
@@ -684,7 +684,7 @@ class OutputSchema(BaseModel):
     sentiment: str
 
 agent = create_react_agent(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     tools=tools,
     # using tool strategy by default with no option for provider strategy
     response_format=OutputSchema  # [!code highlight]
@@ -693,7 +693,7 @@ agent = create_react_agent(
 # OR
 
 agent = create_react_agent(
-    model="gpt-4.1-mini",
+    model="gpt-5.4-mini",
     tools=tools,
     # using a custom prompt to instruct the model to generate the output schema
     response_format=("please generate ...", OutputSchema)  # [!code highlight]
@@ -966,7 +966,7 @@ When interacting with the Responses API, `langchain-openai` now defaults to stor
 
 ```python
 # Enforce previous behavior with output_version flag
-model = ChatOpenAI(model="gpt-4.1-mini", output_version="v0")
+model = ChatOpenAI(model="gpt-5.4-mini", output_version="v0")
 ```
 
 ### Default `max_tokens` in `langchain-anthropic`

--- a/src/oss/python/releases/langchain-v1.mdx
+++ b/src/oss/python/releases/langchain-v1.mdx
@@ -234,7 +234,7 @@ def weather_tool(city: str) -> str:
     return f"it's sunny and 70 degrees in {city}"
 
 agent = create_agent(
-    "gpt-4.1-mini",
+    "gpt-5.4-mini",
     tools=[weather_tool],
     response_format=ToolStrategy(Weather)
 )

--- a/src/snippets/code-samples/middleware-dynamic-prompt-js.mdx
+++ b/src/snippets/code-samples/middleware-dynamic-prompt-js.mdx
@@ -12,7 +12,7 @@ const addContextMiddleware = createMiddleware({
 });
 
 const agent = createAgent({
-  model: "gpt-4.1",
+  model: "gpt-5.4",
   systemPrompt: "You are a helpful assistant.",
   middleware: [addContextMiddleware],
 });


### PR DESCRIPTION
Bump OpenAI model references from the `gpt-4.1` family to `gpt-5.4` across all illustrative code samples and prose. 

## Changes

- Swap `gpt-4.1` → `gpt-5.4` across Python kwarg (`model="..."`), JS object-literal (`model: "..."`), and positional call sites for `ChatOpenAI`, `init_chat_model`, `create_agent`, `AzureAIOpenAIApiChatModel`, and `ChatAbso`
- Bump `-mini` and `-nano` variants in parallel; collapse the dated snapshot `gpt-4.1-mini-2025-04-14` to `gpt-5.4-mini` in the `get_usage_metadata_callback` response examples in `src/oss/langchain/models.mdx`
- Update illustrative alias labels (`-creative`, `-factual`, `-mini-baseline`) used as `ls_model_name` metadata values or `experiment_prefix` strings, keeping them consistent with their surrounding model IDs
- Update 2 prose mentions: evaluator model recommendation in `src/langsmith/online-evaluations-multi-turn.mdx` and the OpenAI row of the OCI supported-models table in `src/oss/python/integrations/providers/oci.mdx`
