### PR TITLE
da-cli: `--startup-cmd` flag

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -19,6 +19,10 @@
 # and any of its subdirectories.
 /src/oss/python/integrations/ @mdrxy
 
+# Any file in `/src/oss/deepagents/cli/`
+# (must come after the general /src/oss/ rule — last match wins).
+/src/oss/deepagents/cli/ @mdrxy @npentrel
+
 # Any file in the `/src/langsmith`
 # and any of its subdirectories.
 /src/langsmith/ @katmayb @fjmorris

--- a/src/oss/deepagents/cli/overview.mdx
+++ b/src/oss/deepagents/cli/overview.mdx
@@ -285,6 +285,27 @@ Shell execution is disabled by default in non-interactive mode. Use `-S`/`--shel
     `-S all` (or `--shell-allow-list all`) lets the agent execute arbitrary shell commands with no human confirmation.
 </Warning>
 
+## Run a command at startup
+
+Use `--startup-cmd` to run a shell command once before the session accepts its first prompt. The output is shown to you at the top of the session — handy for checking `git status`, listing files, or verifying environment setup before typing the first prompt.
+
+```bash
+# Interactive: show git status before the first prompt
+deepagents --startup-cmd "git status"
+
+# Combine with an initial prompt — the command runs first, then the prompt is submitted
+deepagents --startup-cmd "ls -la" -m "Summarize what's in this directory"
+
+# Non-interactive: see env state before the task runs
+deepagents --startup-cmd "git diff --stat" -n "Review these changes"
+```
+
+The command runs before any `-m` prompt or `--skill` invocation is dispatched and respects your shell environment. Non-zero exits and timeouts emit a warning but do not abort the session. In non-interactive mode, the command has a 60-second timeout.
+
+<Note>
+    The output is **not** injected into the agent's message history — the LLM does not see it. To hand command output to the agent, pipe it in via stdin instead (e.g., `git diff | deepagents -n "Review these changes"`).
+</Note>
+
 ## Switch models
 
 You can switch models during a session without restarting the CLI using the `/model` command, or at launch with the `--model` flag:
@@ -840,6 +861,7 @@ deepagents -y
         | `-r`, `--resume [ID]`  | Resume a session: `-r` for most recent, `-r <ID>` for a specific thread |
         | `-m`, `--message TEXT` | Initial prompt to auto-submit when the session starts (interactive mode) |
         | `--skill NAME`         | Invoke a skill at startup |
+        | `--startup-cmd CMD`    | Shell command to run at startup, before the first prompt. Output is rendered in the transcript for your reference but is **not** added to the agent's message history. Non-zero exits and timeouts warn but do not abort; non-interactive mode applies a 60s timeout. See [Run a command at startup](#run-a-command-at-startup) |
         | `-n`, `--non-interactive TEXT` | Run a single task non-interactively and exit. Shell is disabled unless `--shell-allow-list` is set |
         | `--max-turns N`        | Cap agentic turns in non-interactive mode. Exits with code 124 when exceeded. Requires `-n` or piped stdin. See [Cap turn count with `--max-turns`](#non-interactive-mode-and-piping) |
         | `-q`, `--quiet`        | Clean output for piping—only the agent's response goes to stdout. Requires `-n` or piped stdin |

--- a/src/oss/deepagents/cli/overview.mdx
+++ b/src/oss/deepagents/cli/overview.mdx
@@ -287,7 +287,7 @@ Shell execution is disabled by default in non-interactive mode. Use `-S`/`--shel
 
 ## Run a command at startup
 
-Use `--startup-cmd` to run a shell command once before the session accepts its first prompt. The output is shown to you at the top of the session — handy for checking `git status`, listing files, or verifying environment setup before typing the first prompt.
+Use `--startup-cmd` to run a shell command once before the session accepts its first prompt. The output is shown to you at the top of the session, which is handy for checking `git status`, listing files, or verifying environment setup before typing the first prompt.
 
 ```bash
 # Interactive: show git status before the first prompt


### PR DESCRIPTION
Document the new `--startup-cmd` CLI flag from [deepagents#2841](https://github.com/langchain-ai/deepagents/pull/2841), which runs a shell command once at session start.