### PR TITLE
docs: correct description of `GITHUB_APP_ID`

### DIFF
--- a/src/oss/python/integrations/tools/github.mdx
+++ b/src/oss/python/integrations/tools/github.mdx
@@ -50,7 +50,7 @@ Once the app has been registered, you must give your app permission to access ea
 
 Before initializing your agent, the following environment variables need to be set:
 
-* **GITHUB_APP_ID**- A six digit number found in your app's general settings
+* **GITHUB_APP_ID**- A unique integer identifier assigned by GitHub to your App, available in the app's general settings.
 * **GITHUB_APP_PRIVATE_KEY**- The location of your app's private key .pem file, or the full text of that file as a string.
 * **GITHUB_REPOSITORY**- The name of the GitHub repository you want your bot to act upon. Must follow the format \{username\}/\{repo-name\}. *Make sure the app has been added to this repository first!*
 * Optional: **GITHUB_BRANCH**- The branch where the bot will make its commits. Defaults to `repo.default_branch`.


### PR DESCRIPTION
## Summary
Updates the description of `GITHUB_APP_ID` to reflect that it is a unique numeric identifier assigned by GitHub, rather than a fixed-length value.