### PR TITLE
clarify `subgraphs=True` needed when wrapping `create_agent`

### DIFF
--- a/src/oss/langchain/streaming.mdx
+++ b/src/oss/langchain/streaming.mdx
@@ -256,6 +256,10 @@ for await (const [token, metadata] of await agent.stream(
 ```
 :::
 
+<Warning>
+    **Wrapping an agent as a node in a parent `StateGraph`?** @[`create_agent`] returns a compiled graph, so using it as a node makes it a subgraph. `stream_mode="messages"` on the parent graph will not emit tokens from subgraphs unless you pass `subgraphs=True` (`subgraphs: true` in JS). See [Subgraph outputs](/oss/langgraph/streaming#subgraph-outputs) and [Streaming from sub-agents](#streaming-from-sub-agents).
+</Warning>
+
 ## Custom updates
 
 :::python

--- a/src/oss/langchain/streaming.mdx
+++ b/src/oss/langchain/streaming.mdx
@@ -256,9 +256,17 @@ for await (const [token, metadata] of await agent.stream(
 ```
 :::
 
-<Warning>
-    **Wrapping an agent as a node in a parent `StateGraph`?** @[`create_agent`] returns a compiled graph, so using it as a node makes it a subgraph. `stream_mode="messages"` on the parent graph will not emit tokens from subgraphs unless you pass `subgraphs=True` (`subgraphs: true` in JS). See [Subgraph outputs](/oss/langgraph/streaming#subgraph-outputs) and [Streaming from sub-agents](#streaming-from-sub-agents).
-</Warning>
+:::python
+<Note>
+    **Wrapping an agent as a node in a parent `StateGraph`?** @[`create_agent`] returns a compiled graph, so using it as a node makes it a subgraph. `stream_mode="messages"` on the parent graph will not emit token chunks from the inner agent's LLM calls unless you pass `subgraphs=True`. See [Subgraph outputs](/oss/langgraph/streaming#subgraph-outputs).
+</Note>
+:::
+
+:::js
+<Note>
+    **Wrapping an agent as a node in a parent `StateGraph`?** @[`createAgent`] returns a `ReactAgent` wrapper; pass `agent.graph` when adding it as a node. Use `subgraphs: true` so message chunks include the subgraph namespace. See [Subgraph outputs](/oss/langgraph/streaming#subgraph-outputs).
+</Note>
+:::
 
 ## Custom updates
 

--- a/src/oss/langgraph/streaming.mdx
+++ b/src/oss/langgraph/streaming.mdx
@@ -1282,7 +1282,7 @@ for await (const chunk of await graph.stream(
 
 :::python
 <Note>
-    This applies to every `stream_mode`, including `"messages"`. Agent builders like @[`create_agent`] return a **compiled graph**, so adding one as a node turns it into a subgraph. Without `subgraphs=True`, `stream_mode="messages"` on the parent graph will not emit token chunks from the inner agent's LLM calls — invoking `agent.astream(...)` directly will, which is why this often shows up only after wrapping.
+    This applies to every `stream_mode`, including `"messages"`. Agent builders like @[`create_agent`] return a **compiled graph**, so adding one as a node turns it into a subgraph. Without `subgraphs=True`, `stream_mode="messages"` on the parent graph will not emit token chunks from the inner agent's LLM calls—invoking `agent.astream(...)` directly will, which is why this often shows up only after wrapping.
 
     ```python
     from langchain.agents import create_agent
@@ -1308,7 +1308,7 @@ for await (const chunk of await graph.stream(
 
 :::js
 <Note>
-    This applies to every `streamMode`, including `"messages"`. Agent builders like @[`createAgent`] return a **compiled graph**, so adding one as a node turns it into a subgraph. Without `subgraphs: true`, `streamMode: "messages"` on the parent graph will not emit token chunks from the inner agent's LLM calls — invoking `agent.stream(...)` directly will, which is why this often shows up only after wrapping.
+    This applies to every `streamMode`, including `"messages"`. Agent builders like @[`createAgent`] return a **compiled graph**, so adding one as a node turns it into a subgraph. Without `subgraphs: true`, `streamMode: "messages"` on the parent graph will not emit token chunks from the inner agent's LLM calls—invoking `agent.stream(...)` directly will, which is why this often shows up only after wrapping.
 
     ```typescript
     import { createAgent } from "langchain";

--- a/src/oss/langgraph/streaming.mdx
+++ b/src/oss/langgraph/streaming.mdx
@@ -1282,7 +1282,7 @@ for await (const chunk of await graph.stream(
 
 :::python
 <Note>
-    This applies to every `stream_mode`, including `"messages"`. Agent builders like @[`create_agent`] return a **compiled graph**, so adding one as a node turns it into a subgraph. Without `subgraphs=True`, `stream_mode="messages"` on the parent graph will not emit token chunks from the inner agent's LLM calls. Invoking `agent.astream(...)` directly will, which is why this often shows up only after wrapping.
+    This applies to every `stream_mode`, including `"messages"`. Agent builders like @[`create_agent`] return a **compiled graph**, so adding one as a node turns it into a subgraph. Without `subgraphs=True`, `stream_mode="messages"` on the parent graph will not emit token chunks from the inner agent's LLM calls. Invoking `agent.stream(...)` directly will, which is why this often shows up only after wrapping.
 
     ```python
     from langchain.agents import create_agent

--- a/src/oss/langgraph/streaming.mdx
+++ b/src/oss/langgraph/streaming.mdx
@@ -1282,7 +1282,7 @@ for await (const chunk of await graph.stream(
 
 :::python
 <Note>
-    This applies to every `stream_mode`, including `"messages"`. Agent builders like @[`create_agent`] return a **compiled graph**, so adding one as a node turns it into a subgraph. Without `subgraphs=True`, `stream_mode="messages"` on the parent graph will not emit token chunks from the inner agent's LLM calls—invoking `agent.astream(...)` directly will, which is why this often shows up only after wrapping.
+    This applies to every `stream_mode`, including `"messages"`. Agent builders like @[`create_agent`] return a **compiled graph**, so adding one as a node turns it into a subgraph. Without `subgraphs=True`, `stream_mode="messages"` on the parent graph will not emit token chunks from the inner agent's LLM calls. Invoking `agent.astream(...)` directly will, which is why this often shows up only after wrapping.
 
     ```python
     from langchain.agents import create_agent
@@ -1296,38 +1296,44 @@ for await (const chunk of await graph.stream(
         .compile()
     )
 
-    async for ns, chunk in graph.astream(
-        {"messages": [HumanMessage("...")]},
+    for chunk in graph.stream(
+        {"messages": [{"role": "user", "content": "..."}]},
         stream_mode="messages",
         subgraphs=True,  # [!code highlight]
+        version="v2",
     ):
-        ...
+        print(chunk["type"])  # "messages"
+        print(chunk["ns"])    # () for root, ("agent:<task_id>",) for subgraph
+        print(chunk["data"])  # (token, metadata)
     ```
 </Note>
 :::
 
 :::js
 <Note>
-    This applies to every `streamMode`, including `"messages"`. Agent builders like @[`createAgent`] return a **compiled graph**, so adding one as a node turns it into a subgraph. Without `subgraphs: true`, `streamMode: "messages"` on the parent graph will not emit token chunks from the inner agent's LLM calls—invoking `agent.stream(...)` directly will, which is why this often shows up only after wrapping.
+    This applies to every `streamMode`, including `"messages"`. @[`createAgent`] returns a `ReactAgent` wrapper; pass `agent.graph` when adding it as a node so the parent treats it as a subgraph. With `subgraphs: true`, message chunks are `[namespace, [token, metadata]]`, so you can tell which subgraph emitted them.
 
     ```typescript
     import { createAgent } from "langchain";
     import { END, START, StateGraph } from "@langchain/langgraph";
 
+    const agent = createAgent({ model, tools, stateSchema: State });
+
     const graph = new StateGraph(State)
-        .addNode("agent", createAgent({ model, tools, stateSchema: State }))
+        .addNode("agent", agent.graph)
         .addEdge(START, "agent")
         .addEdge("agent", END)
         .compile();
 
-    for await (const [ns, chunk] of await graph.stream(
-        { messages: [new HumanMessage("...")] },
+    for await (const [ns, data] of await graph.stream(
+        { messages: [{ role: "user", content: "..." }] },
         {
             streamMode: "messages",
             subgraphs: true, // [!code highlight]
         }
     )) {
-        // ...
+        const [token, metadata] = data;
+        console.log(ns, token, metadata);
     }
     ```
 </Note>

--- a/src/oss/langgraph/streaming.mdx
+++ b/src/oss/langgraph/streaming.mdx
@@ -1280,6 +1280,59 @@ for await (const chunk of await graph.stream(
 ```
 :::
 
+:::python
+<Note>
+    This applies to every `stream_mode`, including `"messages"`. Agent builders like @[`create_agent`] return a **compiled graph**, so adding one as a node turns it into a subgraph. Without `subgraphs=True`, `stream_mode="messages"` on the parent graph will not emit token chunks from the inner agent's LLM calls — invoking `agent.astream(...)` directly will, which is why this often shows up only after wrapping.
+
+    ```python
+    from langchain.agents import create_agent
+    from langgraph.graph import END, START, StateGraph
+
+    graph = (
+        StateGraph(State)
+        .add_node("agent", create_agent(model, tools, state_schema=State))
+        .add_edge(START, "agent")
+        .add_edge("agent", END)
+        .compile()
+    )
+
+    async for ns, chunk in graph.astream(
+        {"messages": [HumanMessage("...")]},
+        stream_mode="messages",
+        subgraphs=True,  # [!code highlight]
+    ):
+        ...
+    ```
+</Note>
+:::
+
+:::js
+<Note>
+    This applies to every `streamMode`, including `"messages"`. Agent builders like @[`createAgent`] return a **compiled graph**, so adding one as a node turns it into a subgraph. Without `subgraphs: true`, `streamMode: "messages"` on the parent graph will not emit token chunks from the inner agent's LLM calls — invoking `agent.stream(...)` directly will, which is why this often shows up only after wrapping.
+
+    ```typescript
+    import { createAgent } from "langchain";
+    import { END, START, StateGraph } from "@langchain/langgraph";
+
+    const graph = new StateGraph(State)
+        .addNode("agent", createAgent({ model, tools, stateSchema: State }))
+        .addEdge(START, "agent")
+        .addEdge("agent", END)
+        .compile();
+
+    for await (const [ns, chunk] of await graph.stream(
+        { messages: [new HumanMessage("...")] },
+        {
+            streamMode: "messages",
+            subgraphs: true, // [!code highlight]
+        }
+    )) {
+        // ...
+    }
+    ```
+</Note>
+:::
+
 <Accordion title="Extended example: streaming from subgraphs">
   :::python
   ```python


### PR DESCRIPTION
Document a subtle streaming gotcha: when `create_agent` (a compiled graph) is added as a node in a parent `StateGraph`, it becomes a subgraph, and `stream_mode="messages"` won't emit inner LLM tokens without `subgraphs=True`. This commonly surfaces when code that streams tokens fine via `agent.astream(...)` suddenly goes silent after wrapping.