### PR TITLE
update deployment docs to put deepagents in

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -638,6 +638,7 @@
               "pages": [
                 "langsmith/deployment",
                 "langsmith/deployment-quickstart",
+                "langsmith/deployment-quickstart-da",
                 "langsmith/local-dev-testing",
                 {
                   "group": "Agent server",

--- a/src/docs.json
+++ b/src/docs.json
@@ -637,8 +637,8 @@
               "tab": "Agent deployment",
               "pages": [
                 "langsmith/deployment",
-                "langsmith/deployment-quickstart",
                 "langsmith/deployment-quickstart-da",
+                "langsmith/deployment-quickstart",
                 "langsmith/local-dev-testing",
                 {
                   "group": "Agent server",

--- a/src/langsmith/deployment-quickstart-da.mdx
+++ b/src/langsmith/deployment-quickstart-da.mdx
@@ -2,5 +2,5 @@
 title: Deploy your deep agent app to cloud
 sidebarTitle: Quickstart (Deep Agents)
 icon: "rocket"
-url: "/oss/deepagents/going-to-production"
+url: "/oss/deepagents/deploy"
 ---

--- a/src/langsmith/deployment-quickstart-da.mdx
+++ b/src/langsmith/deployment-quickstart-da.mdx
@@ -1,0 +1,6 @@
+---
+title: Deploy your deep agent app to cloud
+sidebarTitle: Quickstart (Deep Agents)
+icon: "rocket"
+url: "/oss/deepagents/going-to-production"
+---

--- a/src/langsmith/deployment-quickstart.mdx
+++ b/src/langsmith/deployment-quickstart.mdx
@@ -1,6 +1,6 @@
 ---
 title: Deploy your app to cloud
-sidebarTitle: Quickstart
+sidebarTitle: Quickstart (LangGraph)
 description: Deploy your first application to LangSmith Cloud using the LangGraph CLI.
 icon: "rocket"
 ---

--- a/src/langsmith/deployment.mdx
+++ b/src/langsmith/deployment.mdx
@@ -99,48 +99,6 @@ You can run the same [Agent Server](/langsmith/agent-server) runtime in several 
 Same runtime, same APIs. What changes is who manages the infrastructure.
 For a feature-level comparison and infrastructure setup, see [Platform setup](/langsmith/platform-setup).
 
-## Deployment capabilities
-
-<CardGroup cols={2}>
-
-<Card
-  title="Agent Server"
-  cta="Start exploring"
-  href="/langsmith/assistants"
-  icon="cpu"
->
-Agent Server's durable execution engine powers the core primitives: **assistants** to manage configurations, **threads** to persist state, and **runs** to execute workloads.
-</Card>
-
-<Card
-  title="Core capabilities"
-  cta="Start building"
-  href="/langsmith/streaming"
-  icon="bolt"
->
-Stream output to users, pause for human review, handle concurrent input, and connect agents via MCP and A2A—all available in Agent Server.
-</Card>
-
-<Card
-  title="Advanced configuration"
-  cta="Configure your server"
-  href="/langsmith/auth"
-  icon="lock"
->
-Authentication, encryption, custom routes, and short- and long-term memory stores.
-</Card>
-
-<Card
-  title="Tutorials"
-  cta="Browse tutorials"
-  href="/langsmith/agent-server-feedback"
-  icon="book"
->
-Guided examples to build production-ready agents for your use case.
-</Card>
-
-</CardGroup>
-
 ## Prepare agents for deployment
 
 **Start here if you're building or operating agent applications.** This section is about deploying **your LangSmith application**. If you need to set up LangSmith infrastructure, the [Platform setup section](/langsmith/platform-setup) covers infrastructure options.
@@ -161,15 +119,49 @@ For Deep Agents, see [Going to production with Deep Agents](/oss/deepagents/goin
   </Card>
 </CardGroup>
 
-### Studio
+## Deployment capabilities
 
-[Studio](/langsmith/studio) connects to any Agent Server (local or deployed) and gives you an interactive environment for developing and debugging agents. Visualize execution graphs, inspect state at any checkpoint, step through runs, modify state mid-execution, and branch to explore alternative paths.
+Once an agent is deployed, you work with [Agent Server](/langsmith/assistants)’s execution model: **assistants** for configuration, **threads** for state, and **runs** for workloads.
 
-### Agent composition
+<CardGroup cols={2}>
 
-Agents don't run in isolation. [RemoteGraph](/langsmith/use-remote-graph) lets any agent call other deployed agents using the same interface you use locally: a research agent delegates to a search agent on a different deployment, a routing agent dispatches to specialized sub-agents. The agents don't need to know whether they're calling something local or remote.
+<Card
+  title="Core capabilities"
+  cta="Start building"
+  href="/langsmith/streaming"
+  icon="bolt"
+>
+Stream to users, pause for human review, handle concurrent input, and connect via MCP and A2A.
+</Card>
 
-Native support for [MCP](/langsmith/server-mcp) and [A2A](/langsmith/server-a2a) means your deployed agents can expose and consume tool interfaces and agent-to-agent protocols alongside the broader ecosystem.
+<Card
+  title="Studio"
+  cta="Develop with Studio"
+  href="/langsmith/studio"
+  icon="window"
+>
+Use an interactive environment for developing and debugging agents.
+</Card>
+
+<Card
+  title="Advanced configuration"
+  cta="Configure your server"
+  href="/langsmith/auth"
+  icon="lock"
+>
+Authentication, encryption, custom routes, and short- and long-term memory stores.
+</Card>
+
+<Card
+  title="Agent composition"
+  cta="Connect agents"
+  href="/langsmith/use-remote-graph"
+  icon="book"
+>
+RemoteGraph lets any agent call other deployed agents with MCP and A2A.
+</Card>
+
+</CardGroup>
 
 ### Reference & operations
 

--- a/src/langsmith/deployment.mdx
+++ b/src/langsmith/deployment.mdx
@@ -15,6 +15,15 @@ LangSmith Deployment is framework-agnostic which means you can deploy agents bui
 <CardGroup cols={2}>
 
 <Card
+  title="Deep Agents"
+  cta="Open quickstart"
+  href="/oss/deepagents/deploy"
+  icon="robot"
+>
+Use the Deep Agents CLI to deploy a deep agent to LangSmith Cloud.
+</Card>
+
+<Card
   title="LangGraph"
   cta="Open quickstart"
   href="/langsmith/deployment-quickstart"
@@ -30,15 +39,6 @@ Use the LangGraph CLI and app templates to deploy a LangGraph application to Lan
   icon="link"
 >
 Connect LangChain agents to LangSmith using the same Agent Server and deployment flow as LangGraph.
-</Card>
-
-<Card
-  title="Deep Agents"
-  cta="Open quickstart"
-  href="/langsmith/deployment-quickstart-da"
-  icon="robot"
->
-Bundle a Deep Agents project and deploy to LangSmith Cloud.
 </Card>
 
 <Card

--- a/src/langsmith/deployment.mdx
+++ b/src/langsmith/deployment.mdx
@@ -6,15 +6,100 @@ description: Deploy and manage agents with durable execution, real-time streamin
 icon: "layout-grid"
 ---
 
-LangSmith Deployment is a workflow orchestration runtime purpose-built for agent workloads. It provides the managed infrastructure agents need to run reliably in production at scale, supporting the full lifecycle from local development to deployment. LangSmith Deployment is framework-agnostic: you can deploy agents built with LangGraph or [other frameworks](/langsmith/deploy-other-frameworks).
+LangSmith Deployment is a workflow orchestration runtime purpose-built for agent workloads. It provides the managed infrastructure agents need to run reliably in production at scale, supporting the full lifecycle from local development to deployment.
 
-<Note>
-LangSmith Deployment requires a [Plus plan or above](https://www.langchain.com/pricing). [Get a demo](https://www.langchain.com/contact-sales) to learn more about BYOC deployment and premium support options.
-</Note>
+## Deployable products
 
-<Callout icon="rocket" color="#4F46E5" iconType="regular">
-**Get started building in minutes with the [Cloud agent deployment quickstart](/langsmith/deployment-quickstart).**
-</Callout>
+LangSmith Deployment is framework-agnostic which means you can deploy agents built with:
+
+<CardGroup cols={2}>
+
+<Card
+  title="LangGraph"
+  cta="Open quickstart"
+  href="/langsmith/deployment-quickstart"
+  icon="chart-dots-3"
+>
+Use the LangGraph CLI and app templates to deploy a LangGraph application to LangSmith.
+</Card>
+
+<Card
+  title="LangChain"
+  cta="Open quickstart"
+  href="/oss/langchain/deploy"
+  icon="link"
+>
+Connect LangChain agents to LangSmith using the same Agent Server and deployment flow as LangGraph.
+</Card>
+
+<Card
+  title="Deep Agents"
+  cta="Open quickstart"
+  href="/langsmith/deployment-quickstart-da"
+  icon="robot"
+>
+Bundle a Deep Agents project and deploy to LangSmith Cloud.
+</Card>
+
+<Card
+  title="Other frameworks"
+  cta="View guide"
+  href="/langsmith/deploy-other-frameworks"
+  icon="packages"
+>
+Use the LangGraph Functional API to deploy Strands, CrewAI, and other agent frameworks.
+</Card>
+
+</CardGroup>
+
+## Deployment environments
+
+You can run the same [Agent Server](/langsmith/agent-server) runtime in several hosting models. A **standalone server** is the lightest option: you run containers yourself without the LangSmith [control plane](/langsmith/control-plane). For managed deployments through the UI and APIs, use **Cloud** or, on Enterprise, **Self-hosted** (full platform in your infrastructure) or **Hybrid** (control plane in LangChain’s cloud, data plane in yours).
+
+<CardGroup cols={2}>
+
+<Card
+  title="Standalone server"
+  cta="View guide"
+  href="/langsmith/deploy-standalone-server"
+  icon="server"
+>
+  Deploy Agent Server with Docker, Compose, or Kubernetes. Bring your own PostgreSQL, Redis, and LangSmith license; no control plane. Optional [LangSmith tracing](/langsmith/observability) to Cloud or a self-hosted instance.
+</Card>
+
+<Card
+  title="Cloud"
+  cta="View guide"
+  href="/langsmith/deploy-to-cloud"
+  icon="cloud"
+>
+  Fully managed by LangChain. Create deployments from GitHub in the LangSmith UI or with [`langgraph deploy`](/langsmith/cli#deploy). Requires a [Plus plan or above](https://www.langchain.com/pricing).
+</Card>
+
+<Card
+  title="Self-hosted"
+  cta="View guide"
+  href="/langsmith/self-hosted"
+  icon="buildings"
+>
+  Run the full LangSmith platform, including the control plane and data plane, in your cloud (for example on Kubernetes). Requires [Enterprise plan](https://www.langchain.com/pricing). Integrates observability, evaluation, and agent deployment in one private stack.
+</Card>
+
+<Card
+  title="Hybrid"
+  cta="View guide"
+  href="/langsmith/deploy-with-control-plane"
+  icon="arrows-left-right"
+>
+  [Control plane](/langsmith/control-plane) in LangChain’s cloud; [Agent Servers](/langsmith/agent-server) and the data plane in your cloud. Requires [Enterprise plan](https://www.langchain.com/pricing).
+</Card>
+
+</CardGroup>
+
+Same runtime, same APIs. What changes is who manages the infrastructure.
+For a feature-level comparison and infrastructure setup, see [Platform setup](/langsmith/platform-setup).
+
+## Deployment capabilities
 
 <CardGroup cols={2}>
 
@@ -37,15 +122,6 @@ Stream output to users, pause for human review, handle concurrent input, and con
 </Card>
 
 <Card
-  title="Tutorials"
-  cta="Browse tutorials"
-  href="/langsmith/agent-server-feedback"
-  icon="book"
->
-Guided examples to build production-ready agents for your use case.
-</Card>
-
-<Card
   title="Advanced configuration"
   cta="Configure your server"
   href="/langsmith/auth"
@@ -54,13 +130,21 @@ Guided examples to build production-ready agents for your use case.
 Authentication, encryption, custom routes, and short- and long-term memory stores.
 </Card>
 
+<Card
+  title="Tutorials"
+  cta="Browse tutorials"
+  href="/langsmith/agent-server-feedback"
+  icon="book"
+>
+Guided examples to build production-ready agents for your use case.
+</Card>
+
 </CardGroup>
 
-## Agent deployment workflow
+## Prepare agents for deployment
 
-<Note>
-**Start here if you're building or operating agent applications.** This section is about deploying **your application**. If you need to set up LangSmith infrastructure, the [Platform setup section](/langsmith/platform-setup) covers infrastructure options.
-</Note>
+**Start here if you're building or operating agent applications.** This section is about deploying **your LangSmith application**. If you need to set up LangSmith infrastructure, the [Platform setup section](/langsmith/platform-setup) covers infrastructure options.
+For Deep Agents, see [Going to production with Deep Agents](/oss/deepagents/going-to-production) instead.
 
 <CardGroup cols={2}>
   <Card title="1. Test locally" href="/langsmith/local-dev-testing" icon="terminal">
@@ -77,12 +161,6 @@ Authentication, encryption, custom routes, and short- and long-term memory store
   </Card>
 </CardGroup>
 
-## Capabilities
-
-
-
-
-
 ### Studio
 
 [Studio](/langsmith/studio) connects to any Agent Server (local or deployed) and gives you an interactive environment for developing and debugging agents. Visualize execution graphs, inspect state at any checkpoint, step through runs, modify state mid-execution, and branch to explore alternative paths.
@@ -92,14 +170,6 @@ Authentication, encryption, custom routes, and short- and long-term memory store
 Agents don't run in isolation. [RemoteGraph](/langsmith/use-remote-graph) lets any agent call other deployed agents using the same interface you use locally: a research agent delegates to a search agent on a different deployment, a routing agent dispatches to specialized sub-agents. The agents don't need to know whether they're calling something local or remote.
 
 Native support for [MCP](/langsmith/server-mcp) and [A2A](/langsmith/server-a2a) means your deployed agents can expose and consume tool interfaces and agent-to-agent protocols alongside the broader ecosystem.
-
-### Deployment options
-
-- **[Cloud](/langsmith/deploy-to-cloud)**: Fully managed. Push from a git repo or use [`langgraph deploy`](/langsmith/cli#deploy).
-- **[Hybrid](/langsmith/deploy-with-control-plane)**: Runs in your cloud, managed by the LangSmith [control plane](/langsmith/control-plane).
-- **[Self-hosted](/langsmith/self-hosted)**: Fully self-managed in your own infrastructure.
-
-Same runtime, same APIs. What changes is who manages the infrastructure. For a comparison, refer to [Platform setup](/langsmith/platform-setup).
 
 ### Reference & operations
 
@@ -113,7 +183,3 @@ Same runtime, same APIs. What changes is who manages the infrastructure. For a c
 - [CI/CD pipelines](/langsmith/cicd-pipeline-example)
 - [TTL configuration](/langsmith/configure-ttl) for state and thread management
 - [Semantic search](/langsmith/semantic-search)
-
-#### Reference
-
-- [Agent Server](/langsmith/agent-server): Runtime architecture reference

--- a/src/langsmith/deployment.mdx
+++ b/src/langsmith/deployment.mdx
@@ -24,21 +24,12 @@ Use the Deep Agents CLI to deploy a deep agent to LangSmith Cloud.
 </Card>
 
 <Card
-  title="LangGraph"
+  title="LangGraph (and LangChain)"
   cta="Open quickstart"
   href="/langsmith/deployment-quickstart"
   icon="chart-dots-3"
 >
 Use the LangGraph CLI and app templates to deploy a LangGraph application to LangSmith.
-</Card>
-
-<Card
-  title="LangChain"
-  cta="Open quickstart"
-  href="/oss/langchain/deploy"
-  icon="link"
->
-Connect LangChain agents to LangSmith using the same Agent Server and deployment flow as LangGraph.
 </Card>
 
 <Card
@@ -54,7 +45,7 @@ Use the LangGraph Functional API to deploy Strands, CrewAI, and other agent fram
 
 ## Deployment environments
 
-You can run the same [Agent Server](/langsmith/agent-server) runtime in several hosting models. A **standalone server** is the lightest option: you run containers yourself without the LangSmith [control plane](/langsmith/control-plane). For managed deployments through the UI and APIs, use **Cloud** or, on Enterprise, **Self-hosted** (full platform in your infrastructure) or **Hybrid** (control plane in LangChain’s cloud, data plane in yours).
+You can run the same [Agent Server](/langsmith/agent-server) runtime in several hosting models. A **standalone server** is the lightest option: you run containers yourself without the LangSmith [control plane](/langsmith/control-plane). For managed deployments through the UI and APIs, use **Cloud** or **Self-hosted** (full platform in your infrastructure).
 
 <CardGroup cols={2}>
 
@@ -85,39 +76,10 @@ You can run the same [Agent Server](/langsmith/agent-server) runtime in several 
   Run the full LangSmith platform, including the control plane and data plane, in your cloud (for example on Kubernetes). Requires [Enterprise plan](https://www.langchain.com/pricing). Integrates observability, evaluation, and agent deployment in one private stack.
 </Card>
 
-<Card
-  title="Hybrid"
-  cta="View guide"
-  href="/langsmith/deploy-with-control-plane"
-  icon="arrows-left-right"
->
-  [Control plane](/langsmith/control-plane) in LangChain’s cloud; [Agent Servers](/langsmith/agent-server) and the data plane in your cloud. Requires [Enterprise plan](https://www.langchain.com/pricing).
-</Card>
-
 </CardGroup>
 
 Same runtime, same APIs. What changes is who manages the infrastructure.
 For a feature-level comparison and infrastructure setup, see [Platform setup](/langsmith/platform-setup).
-
-## Prepare agents for deployment
-
-**Start here if you're building or operating agent applications.** This section is about deploying **your LangSmith application**. If you need to set up LangSmith infrastructure, the [Platform setup section](/langsmith/platform-setup) covers infrastructure options.
-For Deep Agents, see [Going to production with Deep Agents](/oss/deepagents/going-to-production) instead.
-
-<CardGroup cols={2}>
-  <Card title="1. Test locally" href="/langsmith/local-dev-testing" icon="terminal">
-    Run your app on a local development server.
-  </Card>
-  <Card title="2. Configure" href="/langsmith/application-structure" icon="file-code">
-    Set up dependencies, project structure, and environment config.
-  </Card>
-  <Card title="3. Choose hosting & deploy your agent" href="/langsmith/platform-setup" icon="rocket">
-    Select Cloud, Hybrid, or Self-hosted, then deploy via git push, Docker image, or standalone server.
-  </Card>
-  <Card title="4. Monitor" href="/langsmith/observability" icon="chart-bar">
-    Track traces, alerts, and dashboards.
-  </Card>
-</CardGroup>
 
 ## Deployment capabilities
 
@@ -164,6 +126,13 @@ RemoteGraph lets any agent call other deployed agents with MCP and A2A.
 </CardGroup>
 
 ### Reference & operations
+
+#### Tutorials
+
+- [Collect user feedback for Agent Server runs](/langsmith/agent-server-feedback): Attach end-user feedback to runs and traces
+- [Deploy other frameworks (e.g., Strands, CrewAI)](/langsmith/deploy-other-frameworks): Wrap existing agents with Functional API and deploy
+- [Implement generative user interfaces with LangGraph](/langsmith/generative-ui-react): Stream UI elements to a React client
+- [Implement a CI/CD pipeline](/langsmith/cicd-pipeline-example): Automate tests, evaluations, and deployments with GitHub Actions
 
 #### Securing and customizing your server
 

--- a/src/langsmith/deployment.mdx
+++ b/src/langsmith/deployment.mdx
@@ -50,21 +50,21 @@ You can run the same [Agent Server](/langsmith/agent-server) runtime in several 
 <CardGroup cols={2}>
 
 <Card
-  title="Standalone server"
-  cta="View guide"
-  href="/langsmith/deploy-standalone-server"
-  icon="server"
->
-  Deploy Agent Server with Docker, Compose, or Kubernetes. Bring your own PostgreSQL, Redis, and LangSmith license; no control plane. Optional [LangSmith tracing](/langsmith/observability) to Cloud or a self-hosted instance.
-</Card>
-
-<Card
   title="Cloud"
   cta="View guide"
   href="/langsmith/deploy-to-cloud"
   icon="cloud"
 >
   Fully managed by LangChain. Create deployments from GitHub in the LangSmith UI or with [`langgraph deploy`](/langsmith/cli#deploy). Requires a [Plus plan or above](https://www.langchain.com/pricing).
+</Card>
+
+<Card
+  title="Standalone server"
+  cta="View guide"
+  href="/langsmith/deploy-standalone-server"
+  icon="server"
+>
+  Deploy Agent Server with Docker, Compose, or Kubernetes. Bring your own PostgreSQL, Redis, and LangSmith license; no control plane. Optional [LangSmith tracing](/langsmith/observability) to Cloud or a self-hosted instance.
 </Card>
 
 <Card


### PR DESCRIPTION
Without diving in too deep, I have updated the top level deployment page. I felt it was a bit overwhelming, so I restructured it. It points to the deployable products which should make it clear deepagents is supported immediately. I'm also putting a link to the DA docs in the sidebar. 

Let's keep this PR scoped to the overview page and that link in the sidebar. 
