### PR TITLE
docs: add self-hosted FIPS images guide

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -815,7 +815,8 @@
                             "langsmith/self-host-organization-charts",
                             "langsmith/langsmith-managed-clickhouse",
                             "langsmith/self-host-ingress",
-                            "langsmith/self-host-mirroring-images"
+                            "langsmith/self-host-mirroring-images",
+                            "langsmith/self-host-fips"
                           ]
                         }
                       ]

--- a/src/langsmith/self-host-fips.mdx
+++ b/src/langsmith/self-host-fips.mdx
@@ -1,7 +1,7 @@
 ---
 title: FIPS-compliant images
 sidebarTitle: FIPS-compliant images
-description: Run a self-hosted LangSmith on FIPS 140 compliant container images built on Chainguard FIPS.
+description: Run self-hosted LangSmith installation on FIPS 140 compliant container images
 ---
 
 <Note>

--- a/src/langsmith/self-host-fips.mdx
+++ b/src/langsmith/self-host-fips.mdx
@@ -12,7 +12,7 @@ As of v15, every LangChain-authored LangSmith image has a `-fips` counterpart th
 
 ## How the images are built
 
-The `-fips` variants are built on top of [Chainguard FIPS container images](https://edu.chainguard.dev/chainguard/fips/fips-images/), which ship NIST-validated cryptographic modules (OpenSSL FIPS provider, Bouncy Castle FIPS, or BoringCrypto depending on the base). See [Chainguard's FIPS commitment](https://edu.chainguard.dev/chainguard/fips/fips-images/) for the list of modules and their CMVP certificates.
+The `-fips` variants are built on top of [Chainguard FIPS container images](https://edu.chainguard.dev/chainguard/fips/fips-images/), which ship NIST-validated cryptographic modules (OpenSSL FIPS provider, Bouncy Castle FIPS, or BoringCrypto depending on the base). For the list of modules and their CMVP certificates, refer to [Chainguard's FIPS commitment](https://edu.chainguard.dev/chainguard/fips/fips-images/).
 
 Every LangChain-authored image has a `-fips` counterpart published at the same tag as the non-FIPS version:
 

--- a/src/langsmith/self-host-fips.mdx
+++ b/src/langsmith/self-host-fips.mdx
@@ -30,7 +30,7 @@ PostgreSQL, Redis, and ClickHouse are not published as FIPS variants by LangChai
 
 ## Use FIPS images
 
-Update `values.yaml` in your LangSmith Helm installation to point each LangChain image repository at its `-fips` counterpart, keeping your existing tag. Replace `0.15.0` with the LangSmith version you want to deploy:
+Update `values.yaml` in your LangSmith Helm installation to point each LangChain image repository at its `-fips` counterpart, keeping your existing tag. Replace `0.15.0` with the [LangSmith version](/langsmith/self-hosted-changelog) you want to deploy:
 
 ```yaml
 images:

--- a/src/langsmith/self-host-fips.mdx
+++ b/src/langsmith/self-host-fips.mdx
@@ -1,0 +1,108 @@
+---
+title: FIPS-compliant images
+sidebarTitle: FIPS-compliant images
+description: Run a self-hosted LangSmith on FIPS 140 compliant container images built on Chainguard FIPS.
+---
+
+<Note>
+  FIPS and airgapped LangSmith deployments require a conversation with your LangChain account executive before rollout. Reach out to scope licensing, supported configurations, and upgrade paths before you change your installation.
+</Note>
+
+As of v15, every LangChain-authored LangSmith image has a `-fips` counterpart that runs in FIPS 140 mode. Use these images when your self-hosted deployment needs FIPS compliance, for example in federal agencies, defense contractors, and regulated industries.
+
+## How the images are built
+
+The `-fips` variants are built on top of [Chainguard FIPS container images](https://edu.chainguard.dev/chainguard/fips/fips-images/), which ship NIST-validated cryptographic modules (OpenSSL FIPS provider, Bouncy Castle FIPS, or BoringCrypto depending on the base). See [Chainguard's FIPS commitment](https://edu.chainguard.dev/chainguard/fips/fips-images/) for the list of modules and their CMVP certificates.
+
+Every LangChain-authored image has a `-fips` counterpart published at the same tag as the non-FIPS version:
+
+| Non-FIPS image | FIPS image |
+| --- | --- |
+| `langchain/langsmith-ace-backend` | `langchain/langsmith-ace-backend-fips` |
+| `langchain/langsmith-backend` | `langchain/langsmith-backend-fips` |
+| `langchain/langsmith-frontend` | `langchain/langsmith-frontend-fips` |
+| `langchain/langsmith-go-backend` | `langchain/langsmith-go-backend-fips` |
+| `langchain/langsmith-playground` | `langchain/langsmith-playground-fips` |
+| `langchain/hosted-langserve-backend` | `langchain/hosted-langserve-backend-fips` |
+| `langchain/langgraph-operator` | `langchain/langgraph-operator-fips` |
+
+PostgreSQL, Redis, and ClickHouse are not published as FIPS variants by LangChain. If your deployment requires FIPS for these components, bring your own FIPS-mode service and connect via [external Postgres](/langsmith/self-host-external-postgres), [external Redis](/langsmith/self-host-external-redis), or [external ClickHouse](/langsmith/self-host-external-clickhouse).
+
+## Use FIPS images
+
+Update `values.yaml` in your LangSmith Helm installation to point each LangChain image repository at its `-fips` counterpart, keeping your existing tag. Replace `0.15.0` with the LangSmith version you want to deploy:
+
+```yaml
+images:
+  aceBackendImage:
+    repository: "langchain/langsmith-ace-backend-fips"
+    pullPolicy: IfNotPresent
+    tag: "0.15.0"
+  backendImage:
+    repository: "langchain/langsmith-backend-fips"
+    pullPolicy: IfNotPresent
+    tag: "0.15.0"
+  frontendImage:
+    repository: "langchain/langsmith-frontend-fips"
+    pullPolicy: IfNotPresent
+    tag: "0.15.0"
+  hostBackendImage:
+    repository: "langchain/hosted-langserve-backend-fips"
+    pullPolicy: IfNotPresent
+    tag: "0.15.0"
+  operatorImage:
+    repository: "langchain/langgraph-operator-fips"
+    pullPolicy: IfNotPresent
+    tag: "0.15.0"
+  platformBackendImage:
+    repository: "langchain/langsmith-go-backend-fips"
+    pullPolicy: IfNotPresent
+    tag: "0.15.0"
+  playgroundImage:
+    repository: "langchain/langsmith-playground-fips"
+    pullPolicy: IfNotPresent
+    tag: "0.15.0"
+```
+
+Apply the change and upgrade following [Upgrading LangSmith](/langsmith/self-host-upgrades).
+
+## Verify FIPS mode
+
+Chainguard ships the `openssl-fips-test` tool inside every FIPS image. Running it against a pod prints the FIPS self-tests, the active FIPS provider version, and a link to the applicable CMVP certificate.
+
+Check a running pod:
+
+```bash
+kubectl exec <pod-name> -- openssl-fips-test
+```
+
+Expected output (abridged):
+
+```text
+Checking OpenSSL lifecycle assurance.
+	✓ Self-test KAT_Integrity HMAC ... passed.
+	✓ Self-test Module_Integrity HMAC ... passed.
+	...
+	✓ 29 out of 29 self-tests passed.
+	✓ Check FIPS cryptographic module is available... passed.
+	✓ Check FIPS approved only mode (EVP_default_properties_is_fips_enabled)... passed.
+Public OpenSSL API (libssl.so & libcrypto.so):
+	name:      OpenSSL 3.6.0 1 Oct 2025
+	version:   3.6.0
+FIPS cryptographic module provider details (fips.so):
+	name:      OpenSSL FIPS Provider
+	version:   3.1.2
+Locate applicable CMVP certificate(s) at: CMVP #4985
+```
+
+You can also verify an image outside Kubernetes:
+
+```bash
+docker run --rm --entrypoint openssl-fips-test langchain/langsmith-go-backend-fips:0.15.0
+```
+
+For more detail on interpreting the output, see [Chainguard's FIPS verification guide](https://edu.chainguard.dev/chainguard/fips/verify-fips/).
+
+## Mirror for airgapped deployments
+
+The `-fips` naming convention applies identically when mirroring images to a private registry. Follow the [image mirroring guide](/langsmith/self-host-mirroring-images) and substitute each repository with its `-fips` counterpart. Airgapped rollouts, with or without FIPS, require scoping with your LangChain account executive before you begin.

--- a/src/langsmith/self-host-fips.mdx
+++ b/src/langsmith/self-host-fips.mdx
@@ -64,7 +64,7 @@ images:
     tag: "0.15.0"
 ```
 
-Apply the change and upgrade following [Upgrading LangSmith](/langsmith/self-host-upgrades).
+Apply the change and upgrade following the [Upgrading LangSmith](/langsmith/self-host-upgrades) guide.
 
 ## Verify FIPS mode
 


### PR DESCRIPTION
## Summary
- Adds `src/langsmith/self-host-fips.mdx`, documenting the `-fips` image variants shipped for every LangChain-authored LangSmith image as of v15.
- Covers how the images are built (Chainguard FIPS base), the `values.yaml` overrides, and how to verify FIPS mode with `openssl-fips-test`.
- Links out to Chainguard's FIPS image overview and verification guide, and cross-links to the existing image-mirroring and external Postgres/Redis/ClickHouse pages.
- Calls out that Postgres/Redis/ClickHouse aren't published as `-fips` variants by LangChain and that FIPS and airgapped rollouts require a conversation with the account executive.
- Adds the new page to `src/docs.json` under Self-hosted → Setup guides → Manage an installation, immediately after the image-mirroring page.

## Test plan
- [x] `make lint_prose FILES="src/langsmith/self-host-fips.mdx"` — 0 errors, 0 warnings, 0 suggestions.
- [ ] Eyeball the rendered page locally via `mint dev` to confirm the image-mapping table and the `openssl-fips-test` output block render cleanly.
- [ ] Confirm the nav entry appears in the expected Self-hosted → Setup guides → Manage an installation group.
- [ ] Verify the two Chainguard links and the three internal cross-links resolve.

---
Authored with assistance from Claude Code (Opus 4.7).