### PR TITLE
docs(deepagents): add streaming mode coverage to human-in-the-loop page

### DIFF
--- a/src/oss/deepagents/human-in-the-loop.mdx
+++ b/src/oss/deepagents/human-in-the-loop.mdx
@@ -191,6 +191,145 @@ console.log(result.messages[result.messages.length - 1].content);
 ```
 :::
 
+## Handle interrupts with streaming
+
+For real-time UIs, use `.stream()` instead of `.invoke()` to display tokens and tool call progress while handling HITL interrupts. Interrupts appear as `__interrupt__` entries in the `updates` stream. After the stream completes, collect human decisions and resume by streaming again with `Command(resume=...)`.
+
+<Note>
+When streaming, the resume payload is keyed by **interrupt ID** (from each interrupt object), not just a flat `{"decisions": [...]}` like with `.invoke()`. This allows multiple independent interrupts to be resolved in a single resume.
+</Note>
+
+:::python
+```python
+from langchain_core.utils.uuid import uuid7
+from langgraph.types import Command
+
+config = {"configurable": {"thread_id": str(uuid7())}}
+stream_input = {"messages": [{"role": "user", "content": "Delete the file temp.txt"}]}
+
+while True:
+    pending_interrupts = {}
+
+    for chunk in agent.stream(  # [!code highlight]
+        stream_input,
+        stream_mode=["messages", "updates"],  # [!code highlight]
+        subgraphs=True,
+        config=config,
+        version="v2",
+    ):
+        if chunk["type"] == "messages":
+            token, metadata = chunk["data"]
+            # Display tokens in real time
+            if token.content and not chunk["ns"]:
+                print(token.content, end="", flush=True)
+
+        elif chunk["type"] == "updates" and isinstance(chunk["data"], dict):
+            if "__interrupt__" in chunk["data"]:  # [!code highlight]
+                for interrupt_obj in chunk["data"]["__interrupt__"]:  # [!code highlight]
+                    pending_interrupts[interrupt_obj.id] = interrupt_obj.value  # [!code highlight]
+
+    # If no interrupts occurred, the agent finished
+    if not pending_interrupts:
+        break
+
+    # Collect human decisions for each interrupt
+    resume_payload = {}
+    for interrupt_id, interrupt_value in pending_interrupts.items():
+        action_requests = interrupt_value["action_requests"]
+        review_configs = interrupt_value["review_configs"]
+        config_map = {cfg["action_name"]: cfg for cfg in review_configs}
+
+        for action in action_requests:
+            review = config_map[action["name"]]
+            print(f"\nTool: {action['name']}")
+            print(f"Arguments: {action['args']}")
+            print(f"Allowed: {review['allowed_decisions']}")
+
+        # Collect one decision per action_request, in order
+        decisions = [{"type": "approve"} for _ in action_requests]
+        resume_payload[interrupt_id] = {"decisions": decisions}  # [!code highlight]
+
+    # Resume the stream with collected decisions
+    stream_input = Command(resume=resume_payload)  # [!code highlight]
+
+print()
+```
+:::
+
+:::js
+```typescript
+import { v7 as uuid7 } from "uuid";
+import { Command } from "@langchain/langgraph";
+
+const config = { configurable: { thread_id: uuid7() } };
+let streamInput: Record<string, any> | Command = {
+  messages: [{ role: "user", content: "Delete the file temp.txt" }],
+};
+
+while (true) {
+  const pendingInterrupts = new Map<string, any>();
+
+  for await (const chunk of await agent.stream(  // [!code highlight]
+    streamInput,
+    {
+      streamMode: ["messages", "updates"],  // [!code highlight]
+      subgraphs: true,
+      ...config,
+    }
+  )) {
+    const [namespace, mode, data] = chunk;
+
+    if (mode === "messages") {
+      const [token] = data;
+      // Display tokens in real time
+      if (token.text && namespace.length === 0) {
+        process.stdout.write(token.text);
+      }
+    }
+
+    if (mode === "updates" && data?.__interrupt__) {  // [!code highlight]
+      for (const interruptObj of data.__interrupt__) {  // [!code highlight]
+        pendingInterrupts.set(interruptObj.id, interruptObj.value);  // [!code highlight]
+      }
+    }
+  }
+
+  // If no interrupts occurred, the agent finished
+  if (pendingInterrupts.size === 0) break;
+
+  // Collect human decisions for each interrupt
+  const resumePayload: Record<string, any> = {};
+  for (const [interruptId, interruptValue] of pendingInterrupts) {
+    const actionRequests = interruptValue.actionRequests;
+    const reviewConfigs = interruptValue.reviewConfigs;
+    const configMap = Object.fromEntries(
+      reviewConfigs.map((cfg: any) => [cfg.actionName, cfg])
+    );
+
+    for (const action of actionRequests) {
+      const review = configMap[action.name];
+      console.log(`\nTool: ${action.name}`);
+      console.log(`Arguments: ${JSON.stringify(action.args)}`);
+      console.log(`Allowed: ${review.allowedDecisions}`);
+    }
+
+    // Collect one decision per actionRequest, in order
+    const decisions = actionRequests.map(() => ({ type: "approve" }));
+    resumePayload[interruptId] = { decisions };  // [!code highlight]
+  }
+
+  // Resume the stream with collected decisions
+  streamInput = new Command({ resume: resumePayload });  // [!code highlight]
+}
+
+process.stdout.write("\n");
+```
+:::
+
+<Tip>
+Combine `"messages"` and `"updates"` stream modes to show real-time LLM tokens to the user while still catching HITL interrupts. The `"messages"` mode streams tokens; the `"updates"` mode delivers interrupt payloads.
+</Tip>
+
 ## Multiple tool calls
 
 When the agent calls multiple tools that require approval, all interrupts are batched together in a single interrupt. You must provide decisions for each one in order.

--- a/src/oss/deepagents/human-in-the-loop.mdx
+++ b/src/oss/deepagents/human-in-the-loop.mdx
@@ -515,6 +515,8 @@ const agent = createDeepAgent({
 
 When a subagent triggers an interrupt, the handling is the same—check for `interrupts` on the result and resume with `Command`.
 
+When streaming, subagent interrupts also surface as `__interrupt__` entries in the `updates` stream. Enable `subgraphs=True` so subagent events (including interrupts) propagate to the top-level stream. See [Handle interrupts with streaming](#handle-interrupts-with-streaming) for the full pattern.
+
 ### Interrupts within tool calls
 
 Subagent tools can call `interrupt()` directly to pause execution and await approval:

--- a/src/oss/deepagents/streaming.mdx
+++ b/src/oss/deepagents/streaming.mdx
@@ -888,6 +888,43 @@ for (const [id, sub] of activeSubagents) {
 ```
 :::
 
+### Handle human-in-the-loop interrupts
+
+When [`interrupt_on`](/oss/deepagents/human-in-the-loop) is configured, the `updates` stream may contain `__interrupt__` entries that pause execution for human approval. Detect them by checking for the `__interrupt__` key in update chunks:
+
+:::python
+```python
+for chunk in agent.stream(
+    {"messages": [{"role": "user", "content": "Delete temp.txt"}]},
+    stream_mode=["messages", "updates"],
+    subgraphs=True,
+    config=config,
+    version="v2",
+):
+    if chunk["type"] == "updates" and isinstance(chunk["data"], dict):
+        if "__interrupt__" in chunk["data"]:  # [!code highlight]
+            for interrupt_obj in chunk["data"]["__interrupt__"]:
+                print(f"Approval needed: {interrupt_obj.value}")
+```
+:::
+
+:::js
+```typescript
+for await (const [namespace, mode, data] of await agent.stream(
+  { messages: [{ role: "user", content: "Delete temp.txt" }] },
+  { streamMode: ["messages", "updates"], subgraphs: true, ...config }
+)) {
+  if (mode === "updates" && data?.__interrupt__) {  // [!code highlight]
+    for (const interruptObj of data.__interrupt__) {
+      console.log("Approval needed:", interruptObj.value);
+    }
+  }
+}
+```
+:::
+
+See [Human-in-the-loop: Handle interrupts with streaming](/oss/deepagents/human-in-the-loop#handle-interrupts-with-streaming) for the complete stream-resume loop pattern.
+
 :::python
 ## v2 streaming format
 
@@ -931,6 +968,7 @@ See the [LangGraph streaming docs](/oss/langgraph/streaming#stream-output-format
 
 ## Related
 
+- [Human-in-the-loop](/oss/deepagents/human-in-the-loop)—Configure approval workflows for sensitive tool operations
 - [Subagents](/oss/deepagents/subagents)—Configure and use subagents with Deep Agents
 - [Frontend streaming](/oss/deepagents/streaming/frontend)—Build React UIs with `useStream` for Deep Agents
 - [LangChain streaming overview](/oss/langchain/streaming/overview)—General streaming concepts with LangChain agents


### PR DESCRIPTION
## Overview

Add streaming mode coverage to the Deep Agents human-in-the-loop documentation. The existing HITL page only covered the `.invoke()` path. This PR adds streaming examples, a subagent streaming note, and cross-references between the HITL and streaming pages.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: closes #3723
- Feature PR:
- Linear issue:
- Slack thread:

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed


**Changes across 3 commits:**

1. **`human-in-the-loop.mdx`** — New "Handle interrupts with streaming" section with full Python + TypeScript examples showing the stream → detect `__interrupt__` → collect decisions → `Command(resume=...)` → re-stream loop pattern
2. **`human-in-the-loop.mdx`** — Added a note in the "Subagent interrupts" section that subagent interrupts also surface in the `updates` stream when `subgraphs=True` is enabled, with cross-link
3. **`streaming.mdx`** — New "Handle human-in-the-loop interrupts" subsection in common patterns with short detection snippets, plus HITL link added to Related section

No new pages were added, so `src/docs.json` does not need updating. Code examples are based on patterns from the Deep Agents CLI source (`textual_adapter.py`, `non_interactive.py`).