### PR TITLE
docs(deepagents): document explicit model and link from customization

### DIFF
--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -61,6 +61,10 @@ For the full parameter list, see the [`createDeepAgent`](https://reference.langc
 
 Pass a `model` string in `provider:model` format, or an initialized model instance. See [supported models](/oss/deepagents/models#supported-models) for all providers and [suggested models](/oss/deepagents/models#suggested-models) for tested recommendations.
 
+<Note>
+Always pass `model` explicitly. In Python, omitting `model` or using `model=None` is deprecated. See [Pass an explicit model](/oss/deepagents/models#pass-an-explicit-model) on the models page.
+</Note>
+
 <Tip>
     Use the `provider:model` format (for example `openai:gpt-5.4`) to quickly switch between models.
 </Tip>

--- a/src/oss/deepagents/models.mdx
+++ b/src/oss/deepagents/models.mdx
@@ -30,6 +30,20 @@ Open-weight models are available through providers like [Baseten](/oss/integrati
 Open-weight models are available through providers like [OpenRouter](/oss/integrations/chat/openrouter), [Fireworks](/oss/integrations/chat/fireworks) or [Ollama](/oss/integrations/chat/ollama).
 :::
 
+## Pass an explicit model
+
+:::python
+<Warning>
+Omitting the `model` argument or passing `model=None` to @[`create_deep_agent`] is deprecated. The library emits a `DeprecationWarning` and will eventually require an explicit model. In current releases, the fallback is a @[`ChatAnthropic`] instance configured with `claude-sonnet-4-6`.
+</Warning>
+
+Always pass `model` as a `provider:model` string (see [Supported models](#supported-models)) or as a pre-configured chat model instance.
+:::
+
+:::js
+Always pass `model` when you call @[`createDeepAgent`]. Use a `provider:model` string or a pre-configured chat model instance (see [Supported models](#supported-models)).
+:::
+
 ## Configure model parameters
 
 :::python


### PR DESCRIPTION
## Overview

Document that Python callers should always pass an explicit `model` to `create_deep_agent`: omitting `model` or passing `model=None` is deprecated (raises `DeprecationWarning`), a future release will drop `None` from the type, and the current fallback is `ChatAnthropic` with `claude-sonnet-4-6`. Add a short JavaScript reminder to always pass `model` to `createDeepAgent`. Add a Note under Customize Deep Agents → Model that links to the models page for the full wording.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: closes #3726
- Feature PR:

- Linear issue:
- Slack thread:

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed