### PR TITLE
docs(deepagents): document OpenAI Responses API default on models page

### DIFF
--- a/src/oss/deepagents/models.mdx
+++ b/src/oss/deepagents/models.mdx
@@ -97,6 +97,40 @@ To configure model-specific parameters, use @[`init_chat_model`] or instantiate 
   Available parameters vary by provider. See the [chat model integrations](/oss/integrations/chat) page for provider-specific configuration options.
 </Note>
 
+## OpenAI and the Responses API
+
+:::python
+When you pass an `openai:` model string to @[`create_deep_agent`], Deep Agents resolves it with harness defaults merged into @[`init_chat_model`], including **`use_responses_api=True`**. That routes OpenAI chat models through the **Responses API** by default, not Chat Completions.
+
+To use **Chat Completions** instead, initialize the model with `use_responses_api=False` and pass the **instance** to `create_deep_agent` (string specs keep the Deep Agents default):
+
+```python
+from langchain.chat_models import init_chat_model
+from deepagents import create_deep_agent
+
+model = init_chat_model("openai:gpt-5.4", use_responses_api=False)
+agent = create_deep_agent(model=model)
+```
+
+If you keep the Responses API and need to tune **data retention**, configure the model explicitly before passing it in, for example `init_chat_model("openai:...", use_responses_api=True, store=False, include=["reasoning.encrypted_content"])`. See the [OpenAI](/oss/integrations/providers/openai) provider documentation and LangChain chat model references for current parameter names and behavior.
+:::
+
+:::js
+When you pass an `openai:` model string to @[`createDeepAgent`], the package resolves it through `initChatModel` with provider defaults that enable the OpenAI **Responses API** (for example `useResponsesApi: true` on the underlying chat model) unless you override them.
+
+To use **Chat Completions** instead, pass a model instance configured with the Responses API disabled, then pass that object to `createDeepAgent`:
+
+```typescript
+import { initChatModel } from "langchain/chat_models/universal";
+import { createDeepAgent } from "deepagents";
+
+const model = await initChatModel("openai:gpt-5.4", { useResponsesApi: false });
+const agent = await createDeepAgent({ model });
+```
+
+For retention and Responses-specific options, see the [Responses API](/oss/integrations/chat/openai#responses-api) section of the OpenAI chat integration docs and configure `initChatModel` or `ChatOpenAI` accordingly before passing `model` to `createDeepAgent`.
+:::
+
 ## Select a model at runtime
 
 If your application lets users choose a model (for example using a dropdown in the UI), use [middleware](/oss/langchain/middleware) to swap the model at runtime without rebuilding the agent.


### PR DESCRIPTION
Add an OpenAI and the Responses API section explaining that `openai:` string models resolve with `use_responses_api=True` by default, how to opt into Chat Completions via `init_chat_model` / `initChatModel` and a model instance, and pointers to retention and integration docs for Python and JavaScript.

## Overview

Adds a new **OpenAI and the Responses API** section to `src/oss/deepagents/models.mdx` so readers learn that Deep Agents merges harness defaults (including the Responses API) when resolving `openai:` model strings, how to force Chat Completions by passing a pre-configured model instance, and where to read retention and integration details for Python and JavaScript.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: closes #3730
- Feature PR:

- Linear issue:
- Slack thread:

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed