### PR TITLE
docs(deepagents): OpenAI Responses API and data retention on Models page

### DIFF
--- a/src/oss/deepagents/models.mdx
+++ b/src/oss/deepagents/models.mdx
@@ -97,6 +97,45 @@ To configure model-specific parameters, use @[`init_chat_model`] or instantiate 
   Available parameters vary by provider. See the [chat model integrations](/oss/integrations/chat) page for provider-specific configuration options.
 </Note>
 
+## OpenAI and the Responses API
+
+When you pass an `openai:...` **string** as the model, Deep Agents configure the OpenAI integration to use the [Responses API](/oss/integrations/chat/openai#responses-api) by default. That path supports OpenAI conversation state and related features; see the [OpenAI provider](/oss/integrations/providers/openai) and [chat model](/oss/integrations/chat/openai) docs for current API options.
+
+<Note>
+  Harness defaults apply to **model strings** only. To set OpenAI-specific kwargs such as `use_responses_api`, `store`, or `include`, build the model with @[`init_chat_model`] (Python) or `initChatModel` / a provider `ChatOpenAI` instance (TypeScript), then pass that **instance** as `model`.
+</Note>
+
+:::python
+To use [Chat Completions](https://platform.openai.com/docs/guides/responses-vs-chat-completions) instead of the Responses API, pass a pre-initialized model with `use_responses_api=False`:
+
+```python
+from langchain.chat_models import init_chat_model
+from deepagents import create_deep_agent
+
+model = init_chat_model("openai:gpt-5.4", use_responses_api=False)
+agent = create_deep_agent(model=model)
+```
+
+To keep the Responses API but **disable data retention** (`store=False`) while still receiving encrypted reasoning output, use the same pattern as in the @[`create_deep_agent`] docstring (OpenAI note): set `include` so reasoning is returned as encrypted content (parameter names and semantics follow `langchain-openai` and OpenAI's API):
+
+```python
+from langchain.chat_models import init_chat_model
+from deepagents import create_deep_agent
+
+model = init_chat_model(
+    "openai:gpt-5.4",
+    use_responses_api=True,
+    store=False,
+    include=["reasoning.encrypted_content"],
+)
+agent = create_deep_agent(model=model)
+```
+:::
+
+:::js
+Use the [OpenAI chat integration](/oss/integrations/chat/openai#responses-api) to choose the Responses API versus Chat Completions (`useResponsesApi`, model kwargs, and any storage or output options your version exposes). Pass the resulting model instance to `createDeepAgent({ model })` so those settings are preserved.
+:::
+
 ## Select a model at runtime
 
 If your application lets users choose a model (for example using a dropdown in the UI), use [middleware](/oss/langchain/middleware) to swap the model at runtime without rebuilding the agent.


### PR DESCRIPTION
Add "OpenAI and the Responses API" to models.mdx: default Responses path for openai: strings, Chat Completions via use_responses_api=False, and store=False + include=["reasoning.encrypted_content"] with a pre-built model instance. Aligns with create_deep_agent docstring; JS points to OpenAI chat integration.

## Overview

Documents Deep Agents behavior for OpenAI models on the [Models](/oss/deepagents/models) page: Responses API as the default for `openai:...` strings, how to switch to Chat Completions with a pre-initialized model, and how to opt out of data retention on Responses while keeping encrypted reasoning output (`store=False`, `include=["reasoning.encrypted_content"]`). Clarifies that OpenAI-specific kwargs require passing a configured model instance, not only a provider string. TypeScript readers are directed to the OpenAI chat integration for equivalent options.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: closes #3732
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed