### PR TITLE
docs(deepagents): document SystemMessage for main system_prompt

### DIFF
--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -187,6 +187,10 @@ Deep Agents ship with a built-in base system prompt that teaches the agent how t
 <CustomizationSystemPromptJs />
 :::
 
+<Note>
+Besides a string, the main agent also accepts a @[`SystemMessage`] with structured [content blocks](/oss/langchain/messages#standard-content-blocks); Deep Agents preserve those blocks and append the built-in base prompt ([subagent](/oss/deepagents/subagents) dictionary specs remain strings).
+</Note>
+
 When middleware adds special tools, like the filesystem tools, it appends its own guidance to the system prompt at runtime.
 
 :::python


### PR DESCRIPTION
Add a Customization section for main-agent system_prompt as SystemMessage: preserve content_blocks/contentBlocks, append base prompt, and note that subagent specs stay string-only. Python and TypeScript examples.

## Overview

Updates [Customize Deep Agents](/oss/deepagents/customization) under **System prompt**: documents that the main agent accepts a @[`SystemMessage`] with structured blocks (`content_blocks` / `contentBlocks`), that Deep Agents keep those blocks in order and append the built-in base prompt as a final text block, and that [subagent](/oss/deepagents/subagents) dictionary `system_prompt` / `systemPrompt` fields remain strings. Adds matching Python and TypeScript examples and links to [standard content blocks](/oss/langchain/messages#standard-content-blocks).

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: closes #3734
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed (no change required — same page, no new routes)