### PR TITLE
docs(deepagents): document graph cache on Customization page

### DIFF
--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -44,6 +44,7 @@ import CreateDeepAgentConfigOptionsJs from '/snippets/create-deep-agent-config-o
 - [Human-in-the-loop](#human-in-the-loop)
 - [Skills](#skills)
 - [Memory](#memory)
+- [Graph cache](#graph-cache)
 
 :::python
 <CreateDeepAgentConfigOptionsPy />
@@ -56,6 +57,20 @@ For the full parameter list, see the @[`create_deep_agent`] API reference.
 
 For the full parameter list, see the [`createDeepAgent`](https://reference.langchain.com/javascript/deepagents/types/CreateDeepAgentParams) API reference.
 :::
+
+## Graph cache
+
+The optional **`cache`** argument configures a LangGraph **`BaseCache`** backend for **graph compile / node-level caching** when nodes use a **`cache_policy`** (TTL, cache keys, and so on). See [Node caching](/oss/langgraph/graph-api#node-caching) for the full model.
+
+`create_deep_agent` and `createDeepAgent` forward **`cache`** into the same LangChain agent entrypoint as @[`create_agent`] / `createAgent`, alongside **`checkpointer`** and **`store`**. For typical Deep Agents usage—without custom LangGraph nodes that declare cache policies—you can omit **`cache`** (leave it **`None`** / undefined).
+
+Do **not** confuse **`cache`** with:
+
+- **`checkpointer`** — thread checkpoints, resume, and human-in-the-loop.
+- **`store`** — durable application storage (for example with `StoreBackend` and [memory](/oss/deepagents/memory) files).
+- **Provider prompt caching** — for example @[`AnthropicPromptCachingMiddleware`], which caches prompt blocks with the model provider, not LangGraph node outputs.
+
+Caching the wrong inputs can return **stale** or **non-replayable** results for non-deterministic steps, so treat **`cache_policy`** and TTL as a performance optimization only when inputs are stable and safe to reuse.
 
 ## Model
 

--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -44,7 +44,9 @@ import CreateDeepAgentConfigOptionsJs from '/snippets/create-deep-agent-config-o
 - [Human-in-the-loop](#human-in-the-loop)
 - [Skills](#skills)
 - [Memory](#memory)
+:::python
 - [Graph cache](#graph-cache)
+:::
 
 :::python
 <CreateDeepAgentConfigOptionsPy />
@@ -58,6 +60,7 @@ For the full parameter list, see the @[`create_deep_agent`] API reference.
 For the full parameter list, see the [`createDeepAgent`](https://reference.langchain.com/javascript/deepagents/types/CreateDeepAgentParams) API reference.
 :::
 
+:::python
 ## Graph cache
 
 The optional **`cache`** argument configures a LangGraph **`BaseCache`** backend for **graph compile / node-level caching** when nodes use a **`cache_policy`** (TTL, cache keys, and so on). See [Node caching](/oss/langgraph/graph-api#node-caching) for the full model.
@@ -71,6 +74,7 @@ Do **not** confuse **`cache`** with:
 - **Provider prompt caching** — for example @[`AnthropicPromptCachingMiddleware`], which caches prompt blocks with the model provider, not LangGraph node outputs.
 
 Caching the wrong inputs can return **stale** or **non-replayable** results for non-deterministic steps, so treat **`cache_policy`** and TTL as a performance optimization only when inputs are stable and safe to reuse.
+:::
 
 ## Model
 

--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -60,15 +60,6 @@ For the full parameter list, see the @[`create_deep_agent`] API reference.
 For the full parameter list, see the [`createDeepAgent`](https://reference.langchain.com/javascript/deepagents/types/CreateDeepAgentParams) API reference.
 :::
 
-:::python
-## Graph cache
-
-The optional **`cache`** argument configures a LangGraph **`BaseCache`** backend for **graph compile / node-level caching** when nodes use a **`cache_policy`** (TTL, cache keys, and so on). See [Node caching](/oss/langgraph/graph-api#node-caching) for the full model.
-
-`create_deep_agent` forward **`cache`** into the same LangChain agent entrypoint as @[`create_agent`] / `createAgent`, alongside **`checkpointer`** and **`store`**. For typical Deep Agents usage without custom LangGraph nodes that declare cache policies you can omit **`cache`**.
-
-:::
-
 ## Model
 
 Pass a `model` string in `provider:model` format, or an initialized model instance. See [supported models](/oss/deepagents/models#supported-models) for all providers and [suggested models](/oss/deepagents/models#suggested-models) for tested recommendations.
@@ -853,6 +844,15 @@ You can pass one or more file paths to the `memory` parameter when creating your
     ```
   </Tab>
 </Tabs>
+
+:::
+
+:::python
+## Graph cache
+
+The optional **`cache`** argument configures a LangGraph **`BaseCache`** backend for **graph compile / node-level caching** when nodes use a **`cache_policy`** (TTL, cache keys, and so on). See [Node caching](/oss/langgraph/graph-api#node-caching) for the full model.
+
+`create_deep_agent` forward **`cache`** into the same LangChain agent entrypoint as @[`create_agent`] / `createAgent`, alongside **`checkpointer`** and **`store`**. For typical Deep Agents usage without custom LangGraph nodes that declare cache policies you can omit **`cache`**.
 
 :::
 

--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -65,7 +65,7 @@ For the full parameter list, see the [`createDeepAgent`](https://reference.langc
 
 The optional **`cache`** argument configures a LangGraph **`BaseCache`** backend for **graph compile / node-level caching** when nodes use a **`cache_policy`** (TTL, cache keys, and so on). See [Node caching](/oss/langgraph/graph-api#node-caching) for the full model.
 
-`create_deep_agent` and `createDeepAgent` forward **`cache`** into the same LangChain agent entrypoint as @[`create_agent`] / `createAgent`, alongside **`checkpointer`** and **`store`**. For typical Deep Agents usage—without custom LangGraph nodes that declare cache policies—you can omit **`cache`** (leave it **`None`** / undefined).
+`create_deep_agent` forward **`cache`** into the same LangChain agent entrypoint as @[`create_agent`] / `createAgent`, alongside **`checkpointer`** and **`store`**. For typical Deep Agents usage without custom LangGraph nodes that declare cache policies you can omit **`cache`**.
 
 Do **not** confuse **`cache`** with:
 

--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -67,13 +67,6 @@ The optional **`cache`** argument configures a LangGraph **`BaseCache`** backend
 
 `create_deep_agent` forward **`cache`** into the same LangChain agent entrypoint as @[`create_agent`] / `createAgent`, alongside **`checkpointer`** and **`store`**. For typical Deep Agents usage without custom LangGraph nodes that declare cache policies you can omit **`cache`**.
 
-Do **not** confuse **`cache`** with:
-
-- **`checkpointer`** — thread checkpoints, resume, and human-in-the-loop.
-- **`store`** — durable application storage (for example with `StoreBackend` and [memory](/oss/deepagents/memory) files).
-- **Provider prompt caching** — for example @[`AnthropicPromptCachingMiddleware`], which caches prompt blocks with the model provider, not LangGraph node outputs.
-
-Caching the wrong inputs can return **stale** or **non-replayable** results for non-deterministic steps, so treat **`cache_policy`** and TTL as a performance optimization only when inputs are stable and safe to reuse.
 :::
 
 ## Model


### PR DESCRIPTION
Add a Customization "Graph cache" section and TOC link: LangGraph BaseCache with node cache_policy, passthrough with create_agent, when to omit cache, and contrast with checkpointer, store, and Anthropic prompt caching.

## Overview

Adds a **Graph cache** section and in-page TOC entry on [Customize Deep Agents](/oss/deepagents/customization). Explains the optional **`cache`** argument as LangGraph **`BaseCache`** for node-level **`cache_policy`**, links to [Node caching](/oss/langgraph/graph-api#node-caching), notes passthrough with **`checkpointer`** / **`store`** via LangChain’s agent entrypoint, when **`None`** is appropriate, and how this differs from **`checkpointer`**, **`store`**, and @[`AnthropicPromptCachingMiddleware`].

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: closes #3736
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly (no new runnable code blocks in this change)
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed (not required — same page, in-page TOC only)