### PR TITLE
docs: add PGVectorStore vs PGVector comparison section

### DIFF
--- a/src/oss/javascript/integrations/vectorstores/pgvector.mdx
+++ b/src/oss/javascript/integrations/vectorstores/pgvector.mdx
@@ -11,6 +11,35 @@ To enable vector search in generic PostgreSQL databases, LangChain.js supports u
 
 This guide provides a quick overview for getting started with PGVector [vector stores](/oss/integrations/vectorstores). For detailed documentation of all `PGVectorStore` features and configurations head to the [API reference](https://reference.langchain.com/javascript/langchain-community/vectorstores/pgvector/PGVectorStore).
 
+## PGVectorStore vs PGVector: Which one to use?
+
+LangChain has two Postgres vector store integrations. Here's how to choose the right one:
+
+| Feature | PGVector (Legacy) | PGVectorStore (Modern) |
+|---|---|---|
+| Package | `langchain-community` | `langchain-postgres` (Python) / `@langchain/community` (JS) |
+| Maintenance | Community-maintained | Official Partner Package |
+| Connection | Simple connection string | `PGEngine` (better connection pooling) |
+| Search Types | Standard Vector Search | Hybrid Search (Vector + BM25) |
+| Async Support | Limited | Full Native Async |
+| Schema | Fixed table structure | Customizable columns and schemas |
+
+**Use `PGVectorStore` (Modern — recommended) when:**
+- Starting any new project
+- You need Hybrid Search (vector + keyword combined)
+- You want better performance via connection pooling
+- You are building async applications (e.g., FastAPI, async Node.js)
+
+**Use `PGVector` (Legacy) only when:**
+- Maintaining an existing codebase that already uses it
+- Following an older tutorial that has not been updated yet
+
+<Note>
+For all new projects, we recommend using `PGVectorStore` from `langchain-postgres` (Python) or `@langchain/community` (JavaScript).
+</Note>
+
+---
+
 ## Overview
 
 ### Integration details

--- a/src/oss/javascript/integrations/vectorstores/pgvector.mdx
+++ b/src/oss/javascript/integrations/vectorstores/pgvector.mdx
@@ -24,7 +24,7 @@ LangChain has two Postgres vector store integrations. Here's how to choose the r
 | Async Support | Limited | Full Native Async |
 | Schema | Fixed table structure | Customizable columns and schemas |
 
-**Use `PGVectorStore` (Modern — recommended) when:**
+**Use `PGVectorStore` (Modern—recommended) when:**
 - Starting any new project
 - You need Hybrid Search (vector + keyword combined)
 - You want better performance via connection pooling


### PR DESCRIPTION
## Overview
Added a comparison section to the PGVector integration page explaining the difference 
between `PGVector` (Legacy) and `PGVectorStore` (Modern) - a common point of confusion 
for developers seeing two separate pages for the same database.

## Type of change
**Type:** Update existing documentation

## Related issues/PRs
- closes #3687

## Checklist
- [x] I have read the contributing guidelines
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes
The comparison table covers: package name, maintenance status, connection method, 
search types, async support, and schema flexibility. A recommendation note has been 
added advising new projects to use `PGVectorStore` from `langchain-postgres`.