### PR TITLE
Fix typos in HITL doc and minor formatting issue

### DIFF
--- a/src/oss/langchain/human-in-the-loop.mdx
+++ b/src/oss/langchain/human-in-the-loop.mdx
@@ -43,14 +43,13 @@ from langgraph.checkpoint.memory import InMemorySaver # [!code highlight]
 
 agent = create_agent(
     model="gpt-5.4",
-    tools=[write_file_tool, execute_sql_tool, read_data_tool],
+    tools=[write_file, execute_sql, read_data],
     middleware=[
         HumanInTheLoopMiddleware( # [!code highlight]
             interrupt_on={
                 "write_file": True,  # All decisions (approve, edit, reject) allowed
                 "execute_sql": {"allowed_decisions": ["approve", "reject"]},  # No editing allowed
-                # Safe operation, no approval needed
-                "read_data": False,
+                "read_data": False, # Safe operation, no approval needed
             },
             # Prefix for interrupt messages - combined with tool name and args to form the full message
             # e.g., "Tool execution pending approval: execute_sql with query='DELETE FROM...'"


### PR DESCRIPTION
## Overview
According to LangChain Reference and Tools docs, the name of a tool comes from function name if no overriding, and tool names in interrupt_on should exactly match the names of tools. Therefore i plan to fix it in this way. To make it somehow consistent, I relocated a comment and i think it should be fine.

## Type of change

**Type:** Update existing documentation / Fix typo/bug/link/formatting


## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed


## Additional notes
<!-- Any other information that would be helpful for reviewers -->
