### PR TITLE
docs(langsmith): document sandbox auth proxy callbacks

### DIFF
--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -185,15 +185,15 @@ await client.createSandbox(snapshotId, {
 
 ## Dynamic credentials with callbacks
 
-Static rules pull credentials from your workspace secrets at sandbox creation time. For credentials that need to be resolved per-request — short-lived OAuth tokens, per-user-scoped tokens, tokens minted by your own auth service — use a **callback** instead. The proxy POSTs to a URL you provide, your endpoint returns the headers to inject, and the proxy caches the result.
+Static rules pull credentials from your workspace secrets at sandbox creation time. For credentials that need to be resolved per-request—short-lived OAuth tokens, per-user-scoped tokens, tokens minted by your own auth service—use a **callback** instead. The proxy POSTs to a URL you provide, your endpoint returns the headers to inject, and the proxy caches the result.
 
 Callbacks are configured alongside rules under `proxy_config`:
 
 | Field | Description |
 |-------|-------------|
-| `match_hosts` | Hosts to intercept (same syntax as rules; supports globs like `*.github.com`) |
+| `match_hosts` | Hosts to intercept (same syntax as rules; supports globs like `*.github.com`). |
 | `url` | Your callback endpoint. Must be an `http://` or `https://` URL reachable from the proxy. |
-| `request_headers` | Headers attached to the proxy → callback request, e.g. an HMAC or shared secret your endpoint uses to verify the request. Only `plaintext` and `opaque` types are permitted (no `workspace_secret`). |
+| `request_headers` | Headers attached to the proxy → callback request, e.g., an HMAC or shared secret your endpoint uses to verify the request. Only `plaintext` and `opaque` types are permitted (no `workspace_secret`). |
 | `ttl_seconds` | How long resolved headers are cached before re-invoking the callback. Must be between 60 and 3600. |
 
 **Static rules win.** If any rule in `rules` matches the host, the callback is skipped for that host. Within rules, first-match-wins; the same applies between callbacks if multiple match.
@@ -225,7 +225,7 @@ The proxy injects every header in the response into the sandbox's outbound reque
 
 ### Example
 
-Use a callback when, for example, your OAuth tokens are minted on demand by your own service:
+Use a callback when your OAuth tokens are minted on demand by your own service:
 
 ```bash
 curl -X POST "$LANGSMITH_ENDPOINT/api/v2/sandboxes/boxes" \

--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -182,3 +182,133 @@ await client.createSandbox(snapshotId, {
 ```
 
 </CodeGroup>
+
+## Dynamic credentials with callbacks
+
+Static rules pull credentials from your workspace secrets at sandbox creation time. For credentials that need to be resolved per-request — short-lived OAuth tokens, per-user-scoped tokens, tokens minted by your own auth service — use a **callback** instead. The proxy POSTs to a URL you provide, your endpoint returns the headers to inject, and the proxy caches the result.
+
+Callbacks are configured alongside rules under `proxy_config`:
+
+| Field | Description |
+|-------|-------------|
+| `match_hosts` | Hosts to intercept (same syntax as rules; supports globs like `*.github.com`) |
+| `url` | Your callback endpoint. Must be an `http://` or `https://` URL reachable from the proxy. |
+| `request_headers` | Headers attached to the proxy → callback request, e.g. an HMAC or shared secret your endpoint uses to verify the request. Only `plaintext` and `opaque` types are permitted (no `workspace_secret`). |
+| `ttl_seconds` | How long resolved headers are cached before re-invoking the callback. Must be between 60 and 3600. |
+
+**Static rules win.** If any rule in `rules` matches the host, the callback is skipped for that host. Within rules, first-match-wins; the same applies between callbacks if multiple match.
+
+### Callback contract
+
+The proxy makes the following request whenever it needs to resolve credentials for a matched host on a cache miss:
+
+```
+POST <callback.url>
+Content-Type: application/json
+<request_headers from your config, attached verbatim>
+
+{"host": "api.example.com", "port": 443}
+```
+
+Your endpoint must respond `2xx` with a JSON body:
+
+```json
+{
+  "headers": {
+    "Authorization": "Bearer <token>",
+    "X-Org-Id": "..."
+  }
+}
+```
+
+The proxy injects every header in the response into the sandbox's outbound request and caches the response for `ttl_seconds`. Any non-2xx response, transport error, or malformed JSON fails closed: the sandbox's request is rejected with `502 callback resolution failed` (no headers injected, response not cached).
+
+### Example
+
+Use a callback when, for example, your OAuth tokens are minted on demand by your own service:
+
+```bash
+curl -X POST "$LANGSMITH_ENDPOINT/api/v2/sandboxes/boxes" \
+  -H "x-api-key: $LANGSMITH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "snapshot_id": "<snapshot-uuid>",
+    "name": "callback-sandbox",
+    "wait_for_ready": true,
+    "proxy_config": {
+      "callbacks": [
+        {
+          "match_hosts": ["api.github.com", "*.githubusercontent.com"],
+          "url": "https://auth.your-app.example.com/sandbox-credentials",
+          "request_headers": [
+            {
+              "name": "X-Integrator-Secret",
+              "type": "opaque",
+              "value": "<shared-secret-your-endpoint-verifies>"
+            }
+          ],
+          "ttl_seconds": 300
+        }
+      ]
+    }
+  }'
+```
+
+### Configure via SDK
+
+<CodeGroup>
+
+```python Python
+from langsmith.sandbox import SandboxClient
+
+client = SandboxClient()
+
+client.create_sandbox(
+    snapshot_id=SNAPSHOT_ID,
+    name="callback-sandbox",
+    proxy_config={
+        "callbacks": [
+            {
+                "match_hosts": ["api.github.com", "*.githubusercontent.com"],
+                "url": "https://auth.your-app.example.com/sandbox-credentials",
+                "request_headers": [
+                    {
+                        "name": "X-Integrator-Secret",
+                        "type": "opaque",
+                        "value": "<shared-secret-your-endpoint-verifies>",
+                    }
+                ],
+                "ttl_seconds": 300,
+            }
+        ]
+    },
+)
+```
+
+```ts TypeScript
+import { SandboxClient } from "langsmith/experimental/sandbox";
+
+const client = new SandboxClient();
+
+await client.createSandbox(snapshotId, {
+  name: "callback-sandbox",
+  proxyConfig: {
+    callbacks: [
+      {
+        matchHosts: ["api.github.com", "*.githubusercontent.com"],
+        url: "https://auth.your-app.example.com/sandbox-credentials",
+        requestHeaders: [
+          {
+            name: "X-Integrator-Secret",
+            type: "opaque",
+            value: "<shared-secret-your-endpoint-verifies>",
+          },
+        ],
+        ttlSeconds: 300,
+      },
+    ],
+  },
+});
+```
+
+</CodeGroup>


### PR DESCRIPTION
## Overview

Adds a new section to the Sandbox auth proxy doc covering callbacks — the dynamic credential lookup feature that landed in [langchainplus#23296](https://github.com/langchain-ai/langchainplus/pull/23296).

Static rules pull workspace secrets at sandbox creation time. Callbacks let an integrator host their own endpoint that the proxy POSTs to per-host on cache miss; the response body's `headers` are injected into the sandbox's outbound request. Useful for short-lived OAuth tokens, per-user-scoped credentials, or anything you don't want to bake into a static rule.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Feature PR: langchain-ai/langchainplus#23296

## What the new section covers

- Configuration fields (`match_hosts`, `url`, `request_headers`, `ttl_seconds`)
- Precedence: static rules win over callbacks; first-match-wins within each
- Proxy → callback HTTP contract: POST `{host, port}` → response `{headers}`
- Fail-closed semantics on non-2xx / transport / parse errors (502 to the sandbox)
- curl + Python + TypeScript SDK examples

## Checklist

- [x] Tested locally with `docs dev` (rendered Markdown only — no new components)
- [x] Code examples mirror the smith-go validator + smith-launcher contract
- [x] Internal links use root-relative paths (no internal links added in this section)
- [x] No `src/docs.json` change needed (existing page, no new route)

🤖 Generated with [Claude Code](https://claude.com/claude-code)