### PR TITLE
docs: add Synmerco integration

### DIFF
--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -2760,6 +2760,14 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
+        title="Synmerco"
+        href="/oss/integrations/providers/synmerco"
+        icon="link"
+    >
+        Trust infrastructure for autonomous agent transactions.
+    </Card>
+
+    <Card
         title="Tableau"
         href="/oss/integrations/providers/tableau"
         icon="link"

--- a/src/oss/python/integrations/providers/synmerco.mdx
+++ b/src/oss/python/integrations/providers/synmerco.mdx
@@ -1,0 +1,49 @@
+---
+title: "Synmerco integrations"
+description: "Integrate with Synmerco trust and escrow tools using LangChain Python."
+---
+
+[Synmerco](https://synmerco.com) provides trust infrastructure for autonomous AI agent transactions: escrow, reputation scoring, dispute resolution, and a marketplace of verified agents. The `synmerco-langchain` package exposes 46 LangChain tools covering reads (search, lookup, fee estimation) and writes (escrow lifecycle, disputes, wallets).
+
+## Installation and setup
+
+Install the integration package:
+
+<CodeGroup>
+```bash pip
+pip install synmerco-langchain
+```
+
+```bash uv
+uv add synmerco-langchain
+```
+</CodeGroup>
+
+## API Key
+
+Read-only tools (search, lookup, compare, fees) require no authentication. Write operations (escrow, disputes, reputation) require a Synmerco API key. Get one at [synmerco.com](https://synmerco.com) and add it to your environment:
+
+```
+export SYNMERCO_API_KEY="your-api-key-here"
+```
+
+## Tools and toolkits
+
+Load all 46 tools at once:
+
+```python
+from synmerco_langchain import get_synmerco_tools
+
+tools = get_synmerco_tools()
+```
+
+Or import a single tool by name:
+
+```python
+from synmerco_langchain import get_synmerco_tools
+
+lookup = next(t for t in get_synmerco_tools() if t.name == "lookup_trust_score")
+result = lookup.invoke({"did": "did:key:zSynmercoAmbassador"})
+```
+
+See the [tools documentation and usage example](/oss/integrations/tools/synmerco) for a full quick-start.

--- a/src/oss/python/integrations/tools/synmerco.mdx
+++ b/src/oss/python/integrations/tools/synmerco.mdx
@@ -1,0 +1,80 @@
+---
+title: "Synmerco tools integration"
+description: "Integrate with Synmerco trust and escrow tools using LangChain Python."
+---
+
+[Synmerco](https://synmerco.com) is the trust standard for autonomous AI agent transactions. The `synmerco-langchain` package provides 46 tools covering escrow, reputation, dispute resolution, marketplace search, and platform info.
+
+## Installation
+
+<CodeGroup>
+```bash pip
+pip install synmerco-langchain
+```
+
+```bash uv
+uv add synmerco-langchain
+```
+</CodeGroup>
+
+## Load all tools
+
+```python
+from synmerco_langchain import get_synmerco_tools
+
+tools = get_synmerco_tools()
+print(f"Loaded {len(tools)} tools")
+```
+
+## Use a single tool
+
+Read-only tools work without authentication. Look up an agent's trust score:
+
+```python
+from synmerco_langchain import get_synmerco_tools
+
+lookup = next(t for t in get_synmerco_tools() if t.name == "lookup_trust_score")
+result = lookup.invoke({"did": "did:key:zSynmercoAmbassador"})
+print(result)
+```
+
+Estimate fees on a transaction before creating an escrow:
+
+```python
+from synmerco_langchain import get_synmerco_tools
+
+fees = next(t for t in get_synmerco_tools() if t.name == "estimate_fees")
+result = fees.invoke({"amount": 10000})  # cents
+print(result)
+```
+
+## Use with an agent
+
+Pass the tools to any LangChain agent so it can transact on the Synmerco network autonomously:
+
+```python
+from langchain.chat_models import init_chat_model
+from langchain.agents import create_agent
+from synmerco_langchain import get_synmerco_tools
+
+model = init_chat_model("anthropic:claude-sonnet-4-5-20250929")
+agent = create_agent(model=model, tools=get_synmerco_tools())
+
+response = agent.invoke({
+    "messages": [
+        ("user", "Estimate fees for a $50 transaction, then look up the trust score of did:key:zSynmercoAmbassador.")
+    ]
+})
+
+print(response["messages"][-1].content)
+```
+
+## Authentication
+
+Set `SYNMERCO_API_KEY` to enable write operations like creating escrows or submitting disputes:
+
+```
+export SYNMERCO_API_KEY="your-api-key-here"
+```
+
+Get a key at [synmerco.com](https://synmerco.com).


### PR DESCRIPTION
## Overview

Adds a provider page and tools quick-start for `synmerco-langchain` (third-party PyPI package), which exposes 46 LangChain tools for AI agent escrow, reputation, disputes, marketplace search, and platform info.

## Type of change

**Type:** New documentation page

## Related issues/PRs

No related issues. Read-only tools (search, lookup, fee estimation) require no auth. Write operations use `SYNMERCO_API_KEY`.

Package: https://pypi.org/project/synmerco-langchain/
Source: https://github.com/synmerco/integration
Homepage: https://synmerco.com

## Checklist

- [x] Added new MDX files (no Jupyter notebooks per repo guidelines)
- [x] Added entry to `all_providers.mdx` registry, alphabetically sorted
- [x] Followed frontmatter convention (`title` + `description` only)
- [x] Used existing `agentql.mdx` as the structural template