### PR TITLE
Docs/fix langchain setup guide nebius

### DIFF
--- a/src/oss/python/integrations/chat/nebius.mdx
+++ b/src/oss/python/integrations/chat/nebius.mdx
@@ -3,9 +3,9 @@ title: "Nebius integration"
 description: "Integrate with the Nebius chat model using LangChain Python."
 ---
 
-This page will help you get started with Nebius AI Studio [chat models](/oss/langchain/models).
+This page will help you get started with Nebius Token Factory [chat models](/oss/langchain/models).
 
-[Nebius AI Studio](https://studio.nebius.ai/) provides API access to a wide range of state-of-the-art Large Language Models and embedding models for various use cases.
+[Nebius Token Factory](https://tokenfactory.nebius.com/) provides API access to a wide range of state-of-the-art Large Language Models and embedding models for various use cases.
 
 ## Overview
 
@@ -35,7 +35,7 @@ pip install -U langchain-nebius
 
 ### Credentials
 
-Nebius requires an API key that can be passed as an initialization parameter `api_key` or set as the environment variable `NEBIUS_API_KEY`. You can obtain an API key by creating an account on [Nebius AI Studio](https://studio.nebius.ai/).
+Nebius requires an API key that can be passed as an initialization parameter `api_key` or set as the environment variable `NEBIUS_API_KEY`. You can obtain an API key by creating an account on [Nebius Token Factory](https://tokenfactory.nebius.com/).
 
 ```python
 import getpass
@@ -329,7 +329,7 @@ The capital of Germany is **Berlin**. It is also the largest city in the country
 
 ### Available models
 
-The full list of supported models can be found in the [Nebius AI Studio Documentation](https://studio.nebius.com/).
+The full list of supported models can be found in the [Nebius Token Factory Models Page](https://tokenfactory.nebius.com/).
 
 ## Chaining
 
@@ -405,4 +405,4 @@ And none shall be alone, though far away.
 
 ## API reference
 
-For more details about the Nebius AI Studio API, visit the [Nebius AI Studio Documentation](https://studio.nebius.com/api-reference).
+For more details about the Nebius Token Factory API, visit the [Nebius Token Factory Documentation](https://docs.tokenfactory.nebius.com/quickstart).

--- a/src/oss/python/integrations/embeddings/nebius.mdx
+++ b/src/oss/python/integrations/embeddings/nebius.mdx
@@ -3,19 +3,19 @@ title: "Nebius integration"
 description: "Integrate with the Nebius embedding model using LangChain Python."
 ---
 
-[Nebius AI Studio](https://studio.nebius.ai/) provides API access to high-quality embedding models through a unified interface. The Nebius embedding models convert text into numerical vectors that capture semantic meaning, making them useful for various applications like semantic search, clustering, and recommendations.
+[Nebius Token Factory](https://tokenfactory.nebius.com/) provides API access to high-quality embedding models through a unified interface. The Nebius embedding models convert text into numerical vectors that capture semantic meaning, making them useful for various applications like semantic search, clustering, and recommendations.
 
 ## Overview
 
-The `NebiusEmbeddings` class provides access to Nebius AI Studio's embedding models through LangChain. These embeddings can be used for semantic search, document similarity, and other NLP tasks requiring vector representations of text.
+The `NebiusEmbeddings` class provides access to Nebius Token Factory's embedding models through LangChain. These embeddings can be used for semantic search, document similarity, and other NLP tasks requiring vector representations of text.
 
 ### Integration details
 
-- **Provider**: Nebius AI Studio
-- **Model Types**: Text embedding models
-- **Primary Use Case**: Generate vector representations of text for semantic similarity and retrieval
-- **Available Models**: Various embedding models including BAAI/bge-en-icl and others
-- **Dimensions**: Varies by model (typically 1024-4096 dimensions)
+- **Provider**: Nebius Token Factory
+- **Model type**: Text embedding models
+- **Primary use case**: Generate vector representations of text for semantic similarity and retrieval
+- **Currently highlighted model**: `Qwen/Qwen3-Embedding-8B`
+- **Embedding dimensions**: 4,096 (for `Qwen/Qwen3-Embedding-8B`)
 
 ## Setup
 
@@ -29,7 +29,7 @@ pip install -U langchain-nebius
 
 ### Credentials
 
-Nebius requires an API key that can be passed as an initialization parameter `api_key` or set as the environment variable `NEBIUS_API_KEY`. You can obtain an API key by creating an account on [Nebius AI Studio](https://studio.nebius.ai/).
+Nebius requires an API key that can be passed as an initialization parameter `api_key` or set as the environment variable `NEBIUS_API_KEY`. You can obtain an API key by creating an account on [Nebius Token Factory](https://tokenfactory.nebius.com/).
 
 ```python
 import getpass
@@ -50,13 +50,13 @@ from langchain_nebius import NebiusEmbeddings
 # Initialize the embeddings model
 embeddings = NebiusEmbeddings(
     # api_key="YOUR_API_KEY",  # You can pass the API key directly
-    model="BAAI/bge-en-icl"  # The default embedding model
+    model="Qwen/Qwen3-Embedding-8B"  # The default embedding model
 )
 ```
 
 ### Available models
 
-The list of supported models is available at [studio.nebius.com/?modality=embedding](https://studio.nebius.com/?modality=embedding)
+The list of supported models is available at [https://tokenfactory.nebius.com/models?modality=embedding](https://tokenfactory.nebius.com/models?modality=embedding)
 
 ## Indexing and retrieval
 
@@ -245,4 +245,4 @@ Document 4: ['0.7985', '0.8315', '0.5918', '1.0000']
 
 ## API reference
 
-For more details about the Nebius AI Studio API, visit the [Nebius AI Studio Documentation](https://studio.nebius.ai/docs/api-reference).
+For more details about the Nebius Token Factory API, visit the [Nebius Token Factory Documentation](https://docs.tokenfactory.nebius.com/quickstart).

--- a/src/oss/python/integrations/embeddings/nebius.mdx
+++ b/src/oss/python/integrations/embeddings/nebius.mdx
@@ -12,10 +12,10 @@ The `NebiusEmbeddings` class provides access to Nebius Token Factory's embedding
 ### Integration details
 
 - **Provider**: Nebius Token Factory
-- **Model type**: Text embedding models
-- **Primary use case**: Generate vector representations of text for semantic similarity and retrieval
-- **Currently highlighted model**: `Qwen/Qwen3-Embedding-8B`
-- **Embedding dimensions**: 4,096 (for `Qwen/Qwen3-Embedding-8B`)
+- **Model Type**: Text embedding models
+- **Primary Use Case**: Generate vector representations of text for semantic similarity and retrieval
+- **Currently Highlighted model**: `Qwen/Qwen3-Embedding-8B`
+- **Embedding Dimensions**: 4,096 (for `Qwen/Qwen3-Embedding-8B`)
 
 ## Setup
 
@@ -56,7 +56,7 @@ embeddings = NebiusEmbeddings(
 
 ### Available models
 
-The list of supported models is available at [https://tokenfactory.nebius.com/models?modality=embedding](https://tokenfactory.nebius.com/models?modality=embedding)
+The list of supported models is available at [Nebius Token Factory Models Page](https://tokenfactory.nebius.com/models?modality=embedding)
 
 ## Indexing and retrieval
 

--- a/src/oss/python/integrations/embeddings/nebius.mdx
+++ b/src/oss/python/integrations/embeddings/nebius.mdx
@@ -14,7 +14,7 @@ The `NebiusEmbeddings` class provides access to Nebius Token Factory's embedding
 - **Provider**: Nebius Token Factory
 - **Model Type**: Text embedding models
 - **Primary Use Case**: Generate vector representations of text for semantic similarity and retrieval
-- **Currently Highlighted model**: `Qwen/Qwen3-Embedding-8B`
+- **Currently Highlighted Model**: `Qwen/Qwen3-Embedding-8B`
 - **Embedding Dimensions**: 4,096 (for `Qwen/Qwen3-Embedding-8B`)
 
 ## Setup

--- a/src/oss/python/integrations/providers/nebius.mdx
+++ b/src/oss/python/integrations/providers/nebius.mdx
@@ -3,9 +3,9 @@ title: "Nebius integrations"
 description: "Integrate with Nebius using LangChain Python."
 ---
 
-All functionality related to Nebius AI Studio
+All functionality related to Nebius Token Factory
 
->[Nebius AI Studio](https://studio.nebius.ai/) provides API access to a wide range of state-of-the-art large language models and embedding models for various use cases.
+>[Nebius Token Factory](https://tokenfactory.nebius.com/) provides API access to a wide range of state-of-the-art large language models and embedding models for various use cases.
 
 ## Installation and setup
 
@@ -21,7 +21,7 @@ uv add langchain-nebius
 ```
 </CodeGroup>
 
-To use Nebius AI Studio, you'll need an API key which you can obtain from [Nebius AI Studio](https://studio.nebius.ai/). The API key can be passed as an initialization parameter `api_key` or set as the environment variable `NEBIUS_API_KEY`.
+To use Nebius Token Factory, you'll need an API key which you can obtain from [Nebius Token Factory](https://tokenfactory.nebius.com/). The API key can be passed as an initialization parameter `api_key` or set as the environment variable `NEBIUS_API_KEY`.
 
 ```python
 import os
@@ -30,14 +30,14 @@ os.environ["NEBIUS_API_KEY"] = "YOUR-NEBIUS-API-KEY"
 
 ### Available models
 
-The full list of supported models can be found in the [Nebius AI Studio Documentation](https://studio.nebius.com/).
+The full list of supported models can be found in the [Nebius Token Factory Models Page](https://tokenfactory.nebius.com/models).
 
 
 ## Chat models
 
 ### ChatNebius
 
-The `ChatNebius` class allows you to interact with Nebius AI Studio's chat models.
+The `ChatNebius` class allows you to interact with Nebius Token Factory's chat models.
 
 See a [usage example](/oss/integrations/chat/nebius).
 
@@ -46,7 +46,7 @@ from langchain_nebius import ChatNebius
 
 # Initialize the chat model
 chat = ChatNebius(
-    model="Qwen/Qwen3-30B-A3B-fast",  # Choose from available models
+    model="moonshotai/Kimi-K2.5",  # Choose from available models
     temperature=0.6,
     top_p=0.95
 )
@@ -56,7 +56,7 @@ chat = ChatNebius(
 
 ### NebiusEmbeddings
 
-The `NebiusEmbeddings` class allows you to generate vector embeddings using Nebius AI Studio's embedding models.
+The `NebiusEmbeddings` class allows you to generate vector embeddings using Nebius Token Factory's embedding models.
 
 See a [usage example](/oss/integrations/embeddings/nebius).
 
@@ -65,7 +65,7 @@ from langchain_nebius import NebiusEmbeddings
 
 # Initialize embeddings
 embeddings = NebiusEmbeddings(
-    model="BAAI/bge-en-icl"  # Default embedding model
+    model="Qwen/Qwen3-Embedding-8B"  # Default embedding model
 )
 ```
 
@@ -73,7 +73,7 @@ embeddings = NebiusEmbeddings(
 
 ### NebiusRetriever
 
-The `NebiusRetriever` enables efficient similarity search using embeddings from Nebius AI Studio. It leverages high-quality embedding models to enable semantic search over documents.
+The `NebiusRetriever` enables efficient similarity search using embeddings from Nebius Token Factory. It leverages high-quality embedding models to enable semantic search over documents.
 
 See a [usage example](/oss/integrations/retrievers/nebius).
 

--- a/src/oss/python/integrations/retrievers/nebius.mdx
+++ b/src/oss/python/integrations/retrievers/nebius.mdx
@@ -3,7 +3,7 @@ title: "Nebius integration"
 description: "Integrate with the Nebius retriever using LangChain Python."
 ---
 
-The `NebiusRetriever` enables efficient similarity search using embeddings from [Nebius AI Studio](https://studio.nebius.ai/). It leverages high-quality embedding models to enable semantic search over documents.
+The `NebiusRetriever` enables efficient similarity search using embeddings from [Nebius Token Factory](https://tokenfactory.nebius.com/). It leverages high-quality embedding models to enable semantic search over documents.
 
 This retriever is optimized for scenarios where you need to perform similarity search over a collection of documents, but don't need to persist the vectors to a vector database. It performs vector similarity search in-memory using matrix operations, making it efficient for medium-sized document collections.
 
@@ -19,7 +19,7 @@ pip install -U langchain-nebius
 
 ### Credentials
 
-Nebius requires an API key that can be passed as an initialization parameter `api_key` or set as the environment variable `NEBIUS_API_KEY`. You can obtain an API key by creating an account on [Nebius AI Studio](https://studio.nebius.ai/).
+Nebius requires an API key that can be passed as an initialization parameter `api_key` or set as the environment variable `NEBIUS_API_KEY`. You can obtain an API key by creating an account on [Nebius Token Factory](https://tokenfactory.nebius.com/).
 
 ```python
 import getpass
@@ -307,4 +307,4 @@ This approach is efficient for medium-sized document collections, as it avoids t
 
 ## API reference
 
-For more details about the Nebius AI Studio API, visit the [Nebius AI Studio Documentation](https://studio.nebius.com/api-reference).
+For more details about the Nebius Token Factory API, visit the [Nebius Token Factory Documentation](https://docs.tokenfactory.nebius.com/quickstart).


### PR DESCRIPTION
## Overview
Replaces Nebius AI Studio references with Nebius Token Factory across Nebius Python integration docs, including updated links and model examples.

## Type of change
**Type:** Update existing documentation

## Additional notes
Updated:
- `src/oss/python/integrations/chat/nebius.mdx`
- `src/oss/python/integrations/embeddings/nebius.mdx`
- `src/oss/python/integrations/providers/nebius.mdx`
- `src/oss/python/integrations/retrievers/nebius.mdx`