### PR TITLE
docs: restore detailed self-hosted v0.14.0 changelog entry

### DIFF
--- a/src/langsmith/self-hosted-changelog.mdx
+++ b/src/langsmith/self-hosted-changelog.mdx
@@ -110,12 +110,44 @@ rss: true
 **Download the Helm chart:** [`langsmith-0.14.1.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.1/langsmith-0.14.1.tgz)
 </Update>
 
-<Update label="2026-04-20" tags={["self-hosted"]}>
+<Update label="2026-04-19" tags={["self-hosted"]}>
 ## langsmith-0.14.0
 
-- Internal improvements and maintenance updates
+LangSmith Self-Hosted v0.14 brings **Polly** (our AI assistant for traces and runs) to self-hosted, takes **ABAC and audit logs** GA (on by default), and enables the **LLM Auth Proxy** by default with URL allowlisting and richer JWT claims. Admins get **unified model configurations** shared across Agent Builder, Polly, Insights, Playground, and Evaluators, and fine-grained **Prompt Owners** for locking down who can promote or delete individual prompts. Evaluators gain **multi-modal support** and workspaces can now set **cost alerts** on tracing projects. Playground model support expands (Anthropic via Vertex AI, custom Azure models, Bedrock inference profiles, Gemini 3.1 Pro, GPT-5.3 / 5.4, Baseten + GLM-5), and new agent tools and triggers land for Google Sheets & Docs, Outlook, Teams, and Salesforce SOQL. On the infrastructure side, v0.14 adds **GCS Workload Identity** support for blob storage, **Valkey** as a drop-in Redis replacement, and a pre-upgrade migration hook for safer rollouts.
 
-**Download the Helm chart:** [`langsmith-0.14.0.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.0/langsmith-0.14.0.tgz)
+Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access to everything. To book time with LangChain support for your upgrade, contact `support@langchain.dev`.
+
+### Breaking changes
+
+- Fixed an issue where `host-backend` wasn't picking up `commonEnv`. This may result in duplicate environment variables that need to be removed.
+
+### Infrastructure changes
+
+- Migrations now run as a `Pre-upgrade` hook prior to image versions rolling out. This will prevent issues when migrations fail.
+- **GCS Workload Identity support** — authenticate to GCS blob storage using cloud-native workload identity instead of long-lived credentials.
+- **Valkey support** — Valkey can now be used as a drop-in replacement for Redis.
+
+### New features
+
+- **Polly on self-hosted** — our AI assistant for understanding traces, runs, and evaluator feedback is now available in self-hosted.
+- **ABAC and audit logs GA** — Attribute-Based Access Control and audit logs are enabled by default for self-hosted deployments.
+- **LLM Auth Proxy on by default** — URL allowlist prevents credential forwarding to unintended hosts, and JWTs now carry `organization_name` and `workspace_name` claims.
+- **Unified model configurations** — Agent Builder, Polly, Insights, Playground, and Evaluators now share a single set of model configs, with workspace-admin controls over model access across all AI features.
+- **Prompt Owners** — designate a specific group of users with fine-grained permission to promote or delete individual prompts, without granting broader org access.
+- **Multi-modal evaluators** — pass attachments and base64 content (images, audio, PDFs) directly into evaluators.
+- **Cost alerts on tracing projects** — set alerts on tracing project-level costs alongside existing LangSmith alerts.
+- **Expanded playground model support** — Anthropic via Vertex AI, custom Azure models, Bedrock inference profiles and configurable base URLs, Gemini 3.1 Pro, GPT-5.3 / 5.4 (now default), and Baseten + GLM-5.
+- **New agent tools and triggers** — Google Sheets and Docs, Outlook mail and calendar, Microsoft Teams, Salesforce SOQL, Gmail OAuth v2 with refresh tokens, and an Outlook Trigger.
+- **Insights enhancements** — scheduled Insights reports, categories trending over time, full feedback comments in analysis, and a lower minimum job interval (6h → 1h).
+- **Annotation and review upgrades** — required reviewers per queue, pairwise queues that honor `reviewer_access_mode`, an "Assigned to me" filter, per-annotator CSV export, and bulk table actions.
+- **Prompt Hub and tool registry** — commit tag search, model select in template creation, a workspace-scoped tool registry API, and a private registry UI.
+- **Evaluator workflow improvements** — prebuilt LLM evaluators use strict structured outputs by default, evaluators support tagging and reuse, retries no longer lose scores, and a new API runs playground experiments programmatically.
+- **Custom iframe output renderer** — drag-to-resize HTML chart outputs in experiments and trace views.
+- **Thread and inbox UX** — auto-generated thread titles, redesigned run details in threads, session-level feedback stats, keyboard shortcuts, and filtering out internal helper threads.
+
+### Admin changes
+
+- **Granular usage reporting** — granular billable usage APIs that allow you to retrieve detailed trace usage data broken down by workspace, project, user, or API key.
 </Update>
 
 <Update label="2026-04-17" tags={["self-hosted"]}>
@@ -786,62 +818,6 @@ rss: true
 - Introduced migration support for mTLS in ClickHouse for enhanced security compliance.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.1.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.1/langsmith-0.15.0-rc.1.tgz)
-</Update>
-
-<Update label="2026-04-20" tags={["self-hosted"]}>
-## langsmith-0.14.2
-
-- Internal improvements and maintenance updates
-
-**Download the Helm chart:** [`langsmith-0.14.2.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.2/langsmith-0.14.2.tgz)
-</Update>
-
-<Update label="2026-04-20" tags={["self-hosted"]}>
-## langsmith-0.14.1
-
-- Internal improvements and maintenance updates
-
-**Download the Helm chart:** [`langsmith-0.14.1.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.1/langsmith-0.14.1.tgz)
-</Update>
-
-<Update label="2026-04-19" tags={["self-hosted"]}>
-## langsmith-0.14.0
-
-LangSmith Self-Hosted v0.14 brings **Polly** (our AI assistant for traces and runs) to self-hosted, takes **ABAC and audit logs** GA (on by default), and enables the **LLM Auth Proxy** by default with URL allowlisting and richer JWT claims. Admins get **unified model configurations** shared across Agent Builder, Polly, Insights, Playground, and Evaluators, and fine-grained **Prompt Owners** for locking down who can promote or delete individual prompts. Evaluators gain **multi-modal support** and workspaces can now set **cost alerts** on tracing projects. Playground model support expands (Anthropic via Vertex AI, custom Azure models, Bedrock inference profiles, Gemini 3.1 Pro, GPT-5.3 / 5.4, Baseten + GLM-5), and new agent tools and triggers land for Google Sheets & Docs, Outlook, Teams, and Salesforce SOQL. On the infrastructure side, v0.14 adds **GCS Workload Identity** support for blob storage, **Valkey** as a drop-in Redis replacement, and a pre-upgrade migration hook for safer rollouts.
-
-Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access to everything. To book time with LangChain support for your upgrade, contact `support@langchain.dev`.
-
-### Breaking changes
-
-- Fixed an issue where `host-backend` wasn't picking up `commonEnv`. This may result in duplicate environment variables that need to be removed.
-
-### Infrastructure changes
-
-- Migrations now run as a `Pre-upgrade` hook prior to image versions rolling out. This will prevent issues when migrations fail.
-- **GCS Workload Identity support** — authenticate to GCS blob storage using cloud-native workload identity instead of long-lived credentials.
-- **Valkey support** — Valkey can now be used as a drop-in replacement for Redis.
-
-### New features
-
-- **Polly on self-hosted** — our AI assistant for understanding traces, runs, and evaluator feedback is now available in self-hosted.
-- **ABAC and audit logs GA** — Attribute-Based Access Control and audit logs are enabled by default for self-hosted deployments.
-- **LLM Auth Proxy on by default** — URL allowlist prevents credential forwarding to unintended hosts, and JWTs now carry `organization_name` and `workspace_name` claims.
-- **Unified model configurations** — Agent Builder, Polly, Insights, Playground, and Evaluators now share a single set of model configs, with workspace-admin controls over model access across all AI features.
-- **Prompt Owners** — designate a specific group of users with fine-grained permission to promote or delete individual prompts, without granting broader org access.
-- **Multi-modal evaluators** — pass attachments and base64 content (images, audio, PDFs) directly into evaluators.
-- **Cost alerts on tracing projects** — set alerts on tracing project-level costs alongside existing LangSmith alerts.
-- **Expanded playground model support** — Anthropic via Vertex AI, custom Azure models, Bedrock inference profiles and configurable base URLs, Gemini 3.1 Pro, GPT-5.3 / 5.4 (now default), and Baseten + GLM-5.
-- **New agent tools and triggers** — Google Sheets and Docs, Outlook mail and calendar, Microsoft Teams, Salesforce SOQL, Gmail OAuth v2 with refresh tokens, and an Outlook Trigger.
-- **Insights enhancements** — scheduled Insights reports, categories trending over time, full feedback comments in analysis, and a lower minimum job interval (6h → 1h).
-- **Annotation and review upgrades** — required reviewers per queue, pairwise queues that honor `reviewer_access_mode`, an "Assigned to me" filter, per-annotator CSV export, and bulk table actions.
-- **Prompt Hub and tool registry** — commit tag search, model select in template creation, a workspace-scoped tool registry API, and a private registry UI.
-- **Evaluator workflow improvements** — prebuilt LLM evaluators use strict structured outputs by default, evaluators support tagging and reuse, retries no longer lose scores, and a new API runs playground experiments programmatically.
-- **Custom iframe output renderer** — drag-to-resize HTML chart outputs in experiments and trace views.
-- **Thread and inbox UX** — auto-generated thread titles, redesigned run details in threads, session-level feedback stats, keyboard shortcuts, and filtering out internal helper threads.
-
-### Admin changes
-
-- **Granular usage reporting** — granular billable usage APIs that allow you to retrieve detailed trace usage data broken down by workspace, project, user, or API key.
 </Update>
 
 <Update label="2026-04-15" tags={["self-hosted"]}>


### PR DESCRIPTION
## Summary

- The changelog bot in #3716 prepended a minimal `langsmith-0.14.0` entry ("Internal improvements and maintenance updates") at the top of `src/langsmith/self-hosted-changelog.mdx`, overwriting the detailed v0.14.0 release notes that were added in #3638.
- The bot also left a duplicate set of `0.14.0`/`0.14.1`/`0.14.2` entries lower in the file (the original PR #3638 entry plus minimal copies).
- This PR restores the detailed v0.14.0 entry from #3638 at the top (date corrected to `2026-04-19` to match the original) and removes the duplicate set.

## Test plan

- [x] `make lint_prose FILES="src/langsmith/self-hosted-changelog.mdx"` passes
- [ ] Spot-check rendered changelog page in Mintlify preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)