### PR TITLE
Document prebuilt evaluators available in the LangSmith UI

### DIFF
--- a/src/langsmith/evaluators.mdx
+++ b/src/langsmith/evaluators.mdx
@@ -2,6 +2,7 @@
 title: Manage evaluators
 sidebarTitle: Manage evaluators
 description: View and manage evaluators at the workspace level in LangSmith.
+keywords: ["prebuilt evals langsmith", "prebuilt evals", "prebuilt evaluators langsmith", "prebuilt evaluators", "eval packs", "evaluator packs"]
 ---
 
 [Evaluators](/langsmith/evaluation-concepts#evaluators) in LangSmith are workspace-level resources. You can attach a single evaluator to multiple tracing projects and datasets, so you can apply consistent evaluation logic across your work without recreating it each time.


### PR DESCRIPTION
Modified evaluators.mdx, added keywords in frontmatter.

Fixes DOC-1028
