### PR TITLE
docs: sso group sync and supabase attribute mapping

### DIFF
--- a/src/langsmith/authentication-methods.mdx
+++ b/src/langsmith/authentication-methods.mdx
@@ -17,7 +17,7 @@ Users can alternatively use their credentials from GitHub or Google.
 
 ### SAML SSO
 
-Enterprise customers can configure [SAML SSO](/langsmith/user-management), [SCIM](/langsmith/user-management#set-up-scim-for-your-organization), or [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) for automated provisioning and role assignment. [Get a demo](https://www.langchain.com/contact-sales) to learn more.
+Enterprise customers can configure [SAML SSO](/langsmith/user-management) and [SCIM](/langsmith/user-management). [Get a demo](https://www.langchain.com/contact-sales) to learn more.
 
 ## Self-Hosted
 

--- a/src/langsmith/authentication-methods.mdx
+++ b/src/langsmith/authentication-methods.mdx
@@ -17,7 +17,7 @@ Users can alternatively use their credentials from GitHub or Google.
 
 ### SAML SSO
 
-Enterprise customers can configure [SAML SSO](/langsmith/user-management) and [SCIM](/langsmith/user-management). [Get a demo](https://www.langchain.com/contact-sales) to learn more.
+Enterprise customers can configure [SAML SSO](/langsmith/user-management), [SCIM](/langsmith/user-management#set-up-scim-for-your-organization), or [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) for automated provisioning and role assignment. [Get a demo](https://www.langchain.com/contact-sales) to learn more.
 
 ## Self-Hosted
 

--- a/src/langsmith/jit-invite-sso.mdx
+++ b/src/langsmith/jit-invite-sso.mdx
@@ -202,15 +202,15 @@ SCIM group membership overrides manually assigned roles or roles assigned via JI
 
 ## SSO Groups Sync
 
-[SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) is an alternative to SCIM that reads group memberships from the SSO token at login time and assigns org and workspace roles using the SCIM naming convention. It runs after JIT/invite resolution on each login and is authoritative only for memberships it created.
+[SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) is an alternative to SCIM that reads group memberships from the SSO token at login time and assigns org and workspace roles using the SCIM naming convention. The sync runs after JIT and invite resolution on each login, and owns only the memberships it created.
 
 **Precedence with JIT, invites, and SCIM:**
 
 - **SCIM-sourced** memberships are never modified by SSO Groups Sync.
 - **SSO Groups Sync–sourced** memberships are fully replaced on each login based on the token's group membership.
-- **Manual and JIT-provisioned** memberships are untouched by SSO Groups Sync.
+- **Manual and JIT-provisioned** memberships are not modified by SSO Groups Sync.
 
-We recommend choosing one of SCIM or SSO Groups Sync per organization, not both, to avoid confusing precedence behavior. See [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) for configuration and tradeoffs.
+We recommend choosing one of SCIM or SSO Groups Sync per organization, not both, to avoid confusing precedence behavior. For configuration and tradeoffs, refer to [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative).
 
 ## Related documentation
 

--- a/src/langsmith/jit-invite-sso.mdx
+++ b/src/langsmith/jit-invite-sso.mdx
@@ -200,6 +200,18 @@ If your organization uses [SCIM](/langsmith/user-management#set-up-scim-for-your
 SCIM group membership overrides manually assigned roles or roles assigned via JIT provisioning. If you're using SCIM, consider disabling JIT provisioning to avoid conflicts.
 </Note>
 
+## SSO Groups Sync
+
+[SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) is an alternative to SCIM that reads group memberships from the SSO token at login time and assigns org and workspace roles using the SCIM naming convention. It runs after JIT/invite resolution on each login and is authoritative only for memberships it created.
+
+**Precedence with JIT, invites, and SCIM:**
+
+- **SCIM-sourced** memberships are never modified by SSO Groups Sync.
+- **SSO Groups Sync–sourced** memberships are fully replaced on each login based on the token's group membership.
+- **Manual and JIT-provisioned** memberships are untouched by SSO Groups Sync.
+
+We recommend choosing one of SCIM or SSO Groups Sync per organization, not both, to avoid confusing precedence behavior. See [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) for configuration and tradeoffs.
+
 ## Related documentation
 
 - [Set up SSO with OAuth2.0 and OIDC](/langsmith/self-host-sso) (Self-hosted)

--- a/src/langsmith/rbac.mdx
+++ b/src/langsmith/rbac.mdx
@@ -21,7 +21,7 @@ In LangSmith, each user has:
 
 On Enterprise plans, organizations can create [custom workspace roles](#custom-roles) with granular permission combinations.
 
-To learn how to set up RBAC and assign roles to users, refer to the [User Management guide](/langsmith/user-management#set-up-access-control). Roles can also be assigned automatically from your identity provider via [SCIM groups](/langsmith/user-management#set-up-scim-for-your-organization) or [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative).
+To learn how to set up RBAC and assign roles to users, refer to the [User Management guide](/langsmith/user-management#set-up-access-control). Your identity provider can also assign roles automatically via [SCIM groups](/langsmith/user-management#set-up-scim-for-your-organization) or [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative).
 
 <Note>
 <PermissionReference/>

--- a/src/langsmith/rbac.mdx
+++ b/src/langsmith/rbac.mdx
@@ -21,7 +21,7 @@ In LangSmith, each user has:
 
 On Enterprise plans, organizations can create [custom workspace roles](#custom-roles) with granular permission combinations.
 
-To learn how to set up RBAC and assign roles to users, refer to the [User Management guide](/langsmith/user-management#set-up-access-control).
+To learn how to set up RBAC and assign roles to users, refer to the [User Management guide](/langsmith/user-management#set-up-access-control). Roles can also be assigned automatically from your identity provider via [SCIM groups](/langsmith/user-management#set-up-scim-for-your-organization) or [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative).
 
 <Note>
 <PermissionReference/>

--- a/src/langsmith/self-host-sso.mdx
+++ b/src/langsmith/self-host-sso.mdx
@@ -102,7 +102,7 @@ ISSUER_SUB_CLAIM_OVERRIDES='{"https://login.microsoftonline.com/": "oid", "https
 ### SSO Groups Sync
 
 <Note>
-SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.2rc2**) or later.
+SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.2rc1**) or later.
 </Note>
 
 [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) lets LangSmith assign org and workspace roles from a group membership claim on the OIDC token, as a simpler alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization). On self-hosted, you must configure the IdP to include groups in the OIDC ID token before LangSmith can read them.

--- a/src/langsmith/self-host-sso.mdx
+++ b/src/langsmith/self-host-sso.mdx
@@ -102,7 +102,7 @@ ISSUER_SUB_CLAIM_OVERRIDES='{"https://login.microsoftonline.com/": "oid", "https
 ### SSO Groups Sync
 
 <Note>
-**\[TBD: REPLACE BEFORE MERGE]** SSO Groups Sync on self-hosted requires LangSmith chart version **\[TBD]** (application version **\[TBD]**) or later.
+SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0** (application version **0.15.2**) or later.
 </Note>
 
 [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) lets LangSmith assign org and workspace roles from a group membership claim on the OIDC token at login time, as a lighter-weight alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization). On self-hosted, the IdP must be configured to include groups in the OIDC ID token before LangSmith can read them.

--- a/src/langsmith/self-host-sso.mdx
+++ b/src/langsmith/self-host-sso.mdx
@@ -105,11 +105,11 @@ ISSUER_SUB_CLAIM_OVERRIDES='{"https://login.microsoftonline.com/": "oid", "https
 SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.1rc3**) or later.
 </Note>
 
-[SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) lets LangSmith assign org and workspace roles from a group membership claim on the OIDC token at login time, as a lighter-weight alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization). On self-hosted, the IdP must be configured to include groups in the OIDC ID token before LangSmith can read them.
+[SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) lets LangSmith assign org and workspace roles from a group membership claim on the OIDC token, as a simpler alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization). On self-hosted, you must configure the IdP to include groups in the OIDC ID token before LangSmith can read them.
 
 **IdP-side configuration (varies by provider):**
 
-1. Configure your IdP application to emit a group membership claim in the OIDC ID token. The source attribute and the resulting claim name vary by IdP — common examples include `groups`, `roles`, or a custom claim name. LangSmith does not dictate the source attribute.
+1. Configure your IdP application to emit a group membership claim in the OIDC ID token. The source attribute and the resulting claim name vary by IdP. Common examples include `groups`, `roles`, or a custom claim name. LangSmith does not dictate the source attribute.
 2. Depending on your IdP, you may need to add an additional scope (commonly `groups`) to `oauthScopes` to receive the claim. Check your IdP's documentation for the required scope and any additional configuration needed to include group memberships in the token.
 3. Group names must follow the [SCIM naming convention](/langsmith/user-management#group-naming-convention) (e.g., `LS:Organization Admin`, `LS:Organization User:prod:Editor`). The separator is shared with SCIM via [`scim_group_name_separator`](/langsmith/user-management#configure-custom-separator).
 
@@ -147,7 +147,7 @@ The exact scope name (`groups`, `roles`, etc.) depends on your IdP. Check your I
 
 **LangSmith-side configuration:**
 
-Per-provider SSO Groups Sync settings are stored on the SSO provider record and toggled via the LangSmith UI or API — not via Helm values. Once your IdP emits the groups claim, configure SSO Groups Sync in **Settings** → **Members and roles** → **SSO Configuration** → **SSO Groups Sync**, or via the API as described in the [main SSO Groups Sync documentation](/langsmith/user-management#sso-groups-sync-alternative). The claim name configured in the **Groups claim field** must match the claim emitted by your IdP.
+Per-provider SSO Groups Sync settings are stored on the SSO provider record and toggled via the [LangSmith UI](https://smith.langchain.com) or [API](/langsmith/reference) (not via Helm values). Once your IdP emits the groups claim, configure SSO Groups Sync from the UI in **Settings** → **Members and roles** → **SSO Configuration** → **SSO Groups Sync**. Or, via the API as described in the [main SSO Groups Sync documentation](/langsmith/user-management#sso-groups-sync-alternative). The claim name configured in the **Groups claim field** must match the claim emitted by your IdP.
 
 ### Google workspace IdP setup
 

--- a/src/langsmith/self-host-sso.mdx
+++ b/src/langsmith/self-host-sso.mdx
@@ -99,6 +99,56 @@ If unset, the default value for this configuration uses the `oid` claim when Azu
 ISSUER_SUB_CLAIM_OVERRIDES='{"https://login.microsoftonline.com/": "oid", "https://sts.windows.net/": "oid", "https://login.microsoftonline.us/": "oid", "https://login.partner.microsoftonline.cn/": "oid"}'
 ```
 
+### SSO Groups Sync
+
+<Note>
+**\[TBD: REPLACE BEFORE MERGE]** SSO Groups Sync on self-hosted requires LangSmith chart version **\[TBD]** (application version **\[TBD]**) or later.
+</Note>
+
+[SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) lets LangSmith assign org and workspace roles from a group membership claim on the OIDC token at login time, as a lighter-weight alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization). On self-hosted, the IdP must be configured to include groups in the OIDC ID token before LangSmith can read them.
+
+**IdP-side configuration (varies by provider):**
+
+1. Configure your IdP application to emit a group membership claim in the OIDC ID token. The source attribute and the resulting claim name vary by IdP — common examples include `groups`, `roles`, or a custom claim name. LangSmith does not dictate the source attribute.
+2. Depending on your IdP, you may need to add an additional scope (commonly `groups`) to `oauthScopes` to receive the claim. Check your IdP's documentation for the required scope and any additional configuration needed to include group memberships in the token.
+3. Group names must follow the [SCIM naming convention](/langsmith/user-management#group-naming-convention) (e.g., `LS:Organization Admin`, `LS:Organization User:prod:Editor`). The separator is shared with SCIM via [`scim_group_name_separator`](/langsmith/user-management#configure-custom-separator).
+
+**Helm configuration:**
+
+If your IdP requires an additional OIDC scope to include groups in the token (commonly `groups`), add it to `oauthScopes`:
+
+<CodeGroup>
+
+```yaml Helm
+config:
+  authType: mixed
+  hostname: https://langsmith.example.com
+  oauth:
+    enabled: true
+    oauthClientId: <YOUR CLIENT ID>
+    oauthClientSecret: <YOUR CLIENT SECRET>
+    oauthIssuerUrl: <YOUR DISCOVERY URL>
+    oauthScopes: "email,profile,openid,groups"
+```
+
+```bash Docker
+# In your .env file
+AUTH_TYPE=mixed
+LANGSMITH_URL=https://langsmith.example.com
+OAUTH_CLIENT_ID=your-client-id
+OAUTH_CLIENT_SECRET=your-client-secret
+OAUTH_ISSUER_URL=https://your-issuer-url
+OAUTH_SCOPES=email,profile,openid,groups
+```
+
+</CodeGroup>
+
+The exact scope name (`groups`, `roles`, etc.) depends on your IdP. Check your IdP's OIDC documentation.
+
+**LangSmith-side configuration:**
+
+Per-provider SSO Groups Sync settings are stored on the SSO provider record and toggled via the LangSmith UI or API — not via Helm values. Once your IdP emits the groups claim, configure SSO Groups Sync in **Settings** → **Members and roles** → **SSO Configuration** → **SSO Groups Sync**, or via the API as described in the [main SSO Groups Sync documentation](/langsmith/user-management#sso-groups-sync-alternative). The claim name configured in the **Groups claim field** must match the claim emitted by your IdP.
+
 ### Google workspace IdP setup
 
 You can use Google Workspace as a single sign-on (SSO) provider using [OAuth2.0 and OIDC](https://developers.google.com/identity/openid-connect/openid-connect) without PKCE.

--- a/src/langsmith/self-host-sso.mdx
+++ b/src/langsmith/self-host-sso.mdx
@@ -102,7 +102,7 @@ ISSUER_SUB_CLAIM_OVERRIDES='{"https://login.microsoftonline.com/": "oid", "https
 ### SSO Groups Sync
 
 <Note>
-SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0** (application version **0.15.2**) or later.
+SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.1rc3**) or later.
 </Note>
 
 [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) lets LangSmith assign org and workspace roles from a group membership claim on the OIDC token at login time, as a lighter-weight alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization). On self-hosted, the IdP must be configured to include groups in the OIDC ID token before LangSmith can read them.

--- a/src/langsmith/self-host-sso.mdx
+++ b/src/langsmith/self-host-sso.mdx
@@ -102,7 +102,7 @@ ISSUER_SUB_CLAIM_OVERRIDES='{"https://login.microsoftonline.com/": "oid", "https
 ### SSO Groups Sync
 
 <Note>
-SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.2rc1**) or later.
+SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.2rc2**) or later.
 </Note>
 
 [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) lets LangSmith assign org and workspace roles from a group membership claim on the OIDC token, as a simpler alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization). On self-hosted, you must configure the IdP to include groups in the OIDC ID token before LangSmith can read them.

--- a/src/langsmith/self-host-sso.mdx
+++ b/src/langsmith/self-host-sso.mdx
@@ -102,7 +102,7 @@ ISSUER_SUB_CLAIM_OVERRIDES='{"https://login.microsoftonline.com/": "oid", "https
 ### SSO Groups Sync
 
 <Note>
-SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.1rc3**) or later.
+SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.2rc1**) or later.
 </Note>
 
 [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) lets LangSmith assign org and workspace roles from a group membership claim on the OIDC token, as a simpler alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization). On self-hosted, you must configure the IdP to include groups in the OIDC ID token before LangSmith can read them.

--- a/src/langsmith/self-host-user-management.mdx
+++ b/src/langsmith/self-host-user-management.mdx
@@ -54,6 +54,16 @@ To change your default organization, use **Set Default Organization** in the org
 </Note>
 
 
+### SSO Groups Sync
+
+<Note>
+**\[TBD: REPLACE BEFORE MERGE]** SSO Groups Sync on self-hosted requires LangSmith chart version **\[TBD]** (application version **\[TBD]**) or later.
+</Note>
+
+[SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) reads group memberships from the OIDC ID token at login time and assigns org and workspace roles using the [SCIM naming convention](/langsmith/user-management#group-naming-convention). It is a lighter-weight alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization) for self-hosted organizations whose IdP can include groups in the OIDC token but cannot easily run SCIM provisioning.
+
+For IdP-side configuration (claim, scope) refer to the [SSO Groups Sync section in the OIDC SSO setup guide](/langsmith/self-host-sso#sso-groups-sync). For settings reference and behavior, see the [main SSO Groups Sync documentation](/langsmith/user-management#sso-groups-sync-alternative).
+
 ### Disabling organization creating
 
 By default, any user can create an organization in LangSmith. For self-hosted customers, an admin may want to restrict this ability after setting up initial organizations. This feature flag allows an admin to disable the ability for users to create new organizations.

--- a/src/langsmith/self-host-user-management.mdx
+++ b/src/langsmith/self-host-user-management.mdx
@@ -57,7 +57,7 @@ To change your default organization, use **Set Default Organization** in the org
 ### SSO Groups Sync
 
 <Note>
-SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.2rc1**) or later.
+SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.2rc2**) or later.
 </Note>
 
 [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) reads group memberships from the OIDC ID token and assigns org and workspace roles using the [SCIM naming convention](/langsmith/user-management#group-naming-convention). It is a simpler alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization) for self-hosted organizations whose IdP can include groups in the OIDC token but cannot easily run SCIM provisioning.

--- a/src/langsmith/self-host-user-management.mdx
+++ b/src/langsmith/self-host-user-management.mdx
@@ -60,7 +60,7 @@ To change your default organization, use **Set Default Organization** in the org
 SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.1rc3**) or later.
 </Note>
 
-[SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) reads group memberships from the OIDC ID token at login time and assigns org and workspace roles using the [SCIM naming convention](/langsmith/user-management#group-naming-convention). It is a lighter-weight alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization) for self-hosted organizations whose IdP can include groups in the OIDC token but cannot easily run SCIM provisioning.
+[SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) reads group memberships from the OIDC ID token and assigns org and workspace roles using the [SCIM naming convention](/langsmith/user-management#group-naming-convention). It is a simpler alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization) for self-hosted organizations whose IdP can include groups in the OIDC token but cannot easily run SCIM provisioning.
 
 For IdP-side configuration (claim, scope) refer to the [SSO Groups Sync section in the OIDC SSO setup guide](/langsmith/self-host-sso#sso-groups-sync). For settings reference and behavior, see the [main SSO Groups Sync documentation](/langsmith/user-management#sso-groups-sync-alternative).
 

--- a/src/langsmith/self-host-user-management.mdx
+++ b/src/langsmith/self-host-user-management.mdx
@@ -57,7 +57,7 @@ To change your default organization, use **Set Default Organization** in the org
 ### SSO Groups Sync
 
 <Note>
-SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.2rc2**) or later.
+SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.2rc1**) or later.
 </Note>
 
 [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) reads group memberships from the OIDC ID token and assigns org and workspace roles using the [SCIM naming convention](/langsmith/user-management#group-naming-convention). It is a simpler alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization) for self-hosted organizations whose IdP can include groups in the OIDC token but cannot easily run SCIM provisioning.

--- a/src/langsmith/self-host-user-management.mdx
+++ b/src/langsmith/self-host-user-management.mdx
@@ -57,7 +57,7 @@ To change your default organization, use **Set Default Organization** in the org
 ### SSO Groups Sync
 
 <Note>
-**\[TBD: REPLACE BEFORE MERGE]** SSO Groups Sync on self-hosted requires LangSmith chart version **\[TBD]** (application version **\[TBD]**) or later.
+SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0** (application version **0.15.2**) or later.
 </Note>
 
 [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) reads group memberships from the OIDC ID token at login time and assigns org and workspace roles using the [SCIM naming convention](/langsmith/user-management#group-naming-convention). It is a lighter-weight alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization) for self-hosted organizations whose IdP can include groups in the OIDC token but cannot easily run SCIM provisioning.

--- a/src/langsmith/self-host-user-management.mdx
+++ b/src/langsmith/self-host-user-management.mdx
@@ -57,7 +57,7 @@ To change your default organization, use **Set Default Organization** in the org
 ### SSO Groups Sync
 
 <Note>
-SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.1rc3**) or later.
+SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.2rc1**) or later.
 </Note>
 
 [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) reads group memberships from the OIDC ID token and assigns org and workspace roles using the [SCIM naming convention](/langsmith/user-management#group-naming-convention). It is a simpler alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization) for self-hosted organizations whose IdP can include groups in the OIDC token but cannot easily run SCIM provisioning.

--- a/src/langsmith/self-host-user-management.mdx
+++ b/src/langsmith/self-host-user-management.mdx
@@ -57,7 +57,7 @@ To change your default organization, use **Set Default Organization** in the org
 ### SSO Groups Sync
 
 <Note>
-SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0** (application version **0.15.2**) or later.
+SSO Groups Sync on self-hosted requires LangSmith chart version **0.15.0-rc.3** (application version **0.15.1rc3**) or later.
 </Note>
 
 [SSO Groups Sync](/langsmith/user-management#sso-groups-sync-alternative) reads group memberships from the OIDC ID token at login time and assigns org and workspace roles using the [SCIM naming convention](/langsmith/user-management#group-naming-convention). It is a lighter-weight alternative to [SCIM](/langsmith/user-management#set-up-scim-for-your-organization) for self-hosted organizations whose IdP can include groups in the OIDC token but cannot easily run SCIM provisioning.

--- a/src/langsmith/user-management.mdx
+++ b/src/langsmith/user-management.mdx
@@ -369,6 +369,10 @@ Once service-provider–initiated SSO is configured, users can sign in using a u
 
 ## Set up SCIM for your organization
 
+<Note>
+Looking for a lighter-weight alternative to SCIM that doesn't require IdP admin involvement to push groups? See [SSO Groups Sync](#sso-groups-sync-alternative) below—it reads group memberships directly from the SSO token at login time and reuses the same naming convention.
+</Note>
+
 System for Cross-domain Identity Management (SCIM) is an open standard that allows for the automation of user provisioning. Using SCIM, you can automatically provision and de-provision users in your LangSmith [organization and workspaces](/langsmith/administration-overview), keeping user access synchronized with your organization's identity provider.
 
 <Note>
@@ -733,3 +737,83 @@ Follow Okta's [Enable Group Push](https://help.okta.com/en-us/content/topics/use
 #### Other identity providers
 
 Other identity providers have not been tested but may function depending on their SCIM implementation.
+
+### SSO Groups Sync (alternative)
+
+<Note>
+SSO Groups Sync is available for organizations on the [Enterprise plan](https://www.langchain.com/pricing-langsmith) with SAML SSO (cloud) or OIDC (self-hosted) configured. [Contact sales](https://www.langchain.com/contact-sales) to learn more.
+</Note>
+
+SSO Groups Sync is a lighter-weight alternative to [SCIM](#set-up-scim-for-your-organization) for organizations that can't or prefer not to configure SCIM group push. Instead of pushing groups from your IdP to LangSmith on a separate sync interval, LangSmith reads group memberships directly from a configurable claim in the SSO token at login time and applies org-level and workspace-level role assignments using the same [naming convention](#group-naming-convention) as SCIM.
+
+This is a well-established pattern used by GitLab (SAML Group Links), Grafana (Team Sync), HashiCorp Vault (`groups_claim`), and Atlassian (JIT group assignment).
+
+#### When to use SSO Groups Sync vs. SCIM
+
+SSO Groups Sync and SCIM can technically coexist (each only manages identities tagged with its own provisioning method), but we recommend choosing **one mechanism per organization** — not both — to avoid confusing precedence behavior.
+
+| | SSO Groups Sync | SCIM |
+| --- | --- | --- |
+| **Sync trigger** | At each SSO login | Proactive push from IdP (~1 hour cadence) |
+| **IdP admin involvement** | Minimal — just include groups in the SSO token | Required — configure SCIM provisioning app |
+| **Deprovisioning** | Lags until next login | Near-real-time via IdP push |
+| **Naming convention** | Reuses [SCIM convention](#group-naming-convention) | [SCIM convention](#group-naming-convention) |
+| **Custom separator** | Reuses org-level [`scim_group_name_separator`](#configure-custom-separator) | [`scim_group_name_separator`](#configure-custom-separator) |
+
+Choose **SSO Groups Sync** when IdP admin involvement is minimal and reactive (login-time) sync is acceptable. Choose **SCIM** when proactive provisioning/deprovisioning and near-real-time group membership updates are required.
+
+#### Configuration
+
+1. In your IdP: add the user's group memberships to the SSO token claim (default claim name: `groups`). Group names must follow the [SCIM naming convention](#group-naming-convention).
+2. In LangSmith: go to **Settings** → **Members and roles** → **SSO Configuration** → **SSO Groups Sync** and configure the following:
+
+   | Setting | Description |
+   | --- | --- |
+   | **Enable SSO Groups Sync** | Automatically assign workspace roles based on group memberships in the SSO token. |
+   | **Groups claim field** (default `groups`) | The claim name in the SSO token that contains group memberships. |
+   | **Sync workspace/role assignments** | Update workspace memberships and roles from group names on each SSO login. |
+   | **Require matching group to sign in** | Block login if the SSO token contains no groups matching the naming convention. |
+
+You can also configure these settings via the API by sending a `PATCH` to the SSO settings endpoint:
+
+```bash
+curl -X PATCH $LANGCHAIN_ENDPOINT/api/v1/orgs/current/sso-settings/$SSO_PROVIDER_ID \
+  -H "X-Api-Key: $LANGCHAIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "sso_groups_enabled": true,
+    "sso_groups_claim_field": "groups",
+    "sso_groups_role_sync_enabled": true,
+    "sso_groups_required": false
+  }'
+```
+
+<Warning>
+Disabling SSO Groups Sync does not remove existing access. Users provisioned by SSO groups will retain their current access until their next login.
+</Warning>
+
+#### Group naming examples
+
+Group names follow the [SCIM naming convention](#group-naming-convention). The `<workspace_role>` segment accepts both built-in roles and [custom workspace roles](/langsmith/rbac#custom-roles) by name.
+
+| Intent | Example group name |
+| --- | --- |
+| Org admin (grants workspace admin in all workspaces) | `LS:Organization Admins` |
+| Workspace admin in `Production` | `LS:Organization User:Production:Admin` |
+| Workspace editor in `Engineering` | `LS:Organization User:Engineering:Editor` |
+| Workspace viewer in `Marketing` | `LS:Organization User:Marketing:Viewer` |
+| Custom role `Annotators` in `Production` | `LS:Organization User:Production:Annotators` |
+
+#### Behavior
+
+- **Naming convention** — Group names are parsed using the same convention as SCIM (`<optional_prefix>Organization Admin`, `<optional_prefix><org_role><separator><workspace_name><separator><workspace_role>`). The separator is configured per-org via [`scim_group_name_separator`](#configure-custom-separator) and is shared with SCIM.
+- **Malformed group names** — Group names that don't match the convention are skipped silently (logged) and don't block login for valid groups.
+- **Login gate** — When **Require matching group to sign in** is enabled and the SSO token contains zero matching groups, login is blocked with `error=no_matching_groups`.
+- **Precedence** — SCIM-sourced identities are never modified by SSO Groups Sync. Manually assigned and JIT-provisioned memberships are also untouched. SSO Groups Sync is fully authoritative for its own assignments and replaces them on each login based on the token's group membership.
+- **Org admin propagation** — If a user receives an org admin role from their groups, they are granted workspace admin in all workspaces (same as SCIM behavior).
+
+#### Tradeoffs
+
+- **Deprovisioning lag** — Unlike SCIM (proactive push), SSO Groups Sync only updates on login. A user removed from an group in the IdP retains their existing workspace access until their next LangSmith login. The **Require matching group to sign in** gate mitigates this by blocking the user entirely on next login.
+- **No retroactive sync** — Changing role mappings or enabling the feature does not update existing users until they log in again.
+- **Naming convention required** — Customers must name their IdP groups following the SCIM convention. If your IdP groups follow a different naming policy, SCIM with `description`-based mapping (see [Group attributes](#group-attributes)) may be a better fit.

--- a/src/langsmith/user-management.mdx
+++ b/src/langsmith/user-management.mdx
@@ -147,16 +147,16 @@ For IdP-specific configuration steps, refer to one of the following:
 ### Supabase Attribute Mapping
 
 <Note>
-Supabase Attribute Mapping is a cloud-only feature. Self-hosted deployments configure SAML/OIDC attributes directly with the IdP—see [Set up SSO with OAuth2.0 and OIDC](/langsmith/self-host-sso).
+Supabase Attribute Mapping is a [cloud-only](/langsmith/cloud) feature. [Self-hosted](/langsmith/self-hosted) deployments configure SAML/OIDC attributes directly with the IdP—see [Set up SSO with OAuth2.0 and OIDC](/langsmith/self-host-sso).
 </Note>
 
 LangSmith cloud uses [Supabase](/langsmith/cloud) as the SAML SSO backend. Supabase passes a small set of standard SAML attributes (such as `email` and `sub`) onto the user's JWT automatically. Any additional, non-standard SAML attribute your IdP emits (for example, `groups` for [SSO Groups Sync](#sso-groups-sync-alternative)) must be explicitly forwarded through Supabase before LangSmith can read it.
 
 **Attribute flow (1:1):**
 
-1. **IdP** — emits a SAML attribute with the configured name (e.g., `groups`).
-2. **Supabase** — forwards the attribute onto the user's JWT only if the attribute name appears in the **Supabase Attribute Mapping** table on the SSO provider. Standard attributes are forwarded automatically; non-standard attributes are dropped unless explicitly listed.
-3. **LangSmith** — reads the JWT claim by name (e.g., the value of [SSO Groups Sync](#sso-groups-sync-alternative)'s **Groups claim field**).
+1. **IdP**: emits a SAML attribute with the configured name (e.g., `groups`).
+2. **Supabase**: forwards the attribute onto the user's JWT only if the attribute name appears in the **Supabase Attribute Mapping** table on the SSO provider. Standard attributes are forwarded automatically; non-standard attributes are dropped unless explicitly listed.
+3. **LangSmith**: reads the JWT claim by name (e.g., the value of [SSO Groups Sync](#sso-groups-sync-alternative)'s **Groups claim field**).
 
 The attribute name is preserved end-to-end: the IdP attribute name, the Supabase Attribute Mapping entry, and the downstream LangSmith setting all use the same string.
 
@@ -768,26 +768,26 @@ Other identity providers have not been tested but may function depending on thei
 ### SSO Groups Sync (alternative)
 
 <Note>
-SSO Groups Sync is available for organizations on the [Enterprise plan](https://www.langchain.com/pricing-langsmith) with SAML SSO (cloud) or OIDC (self-hosted) configured. [Contact sales](https://www.langchain.com/contact-sales) to learn more.
+SSO Groups Sync is available for organizations on the [Enterprise plan](/langsmith/pricing-plans) with SAML SSO (cloud) or OIDC (self-hosted) configured. [Contact sales](https://www.langchain.com/contact-sales) to learn more.
 </Note>
 
-SSO Groups Sync is a lighter-weight alternative to [SCIM](#set-up-scim-for-your-organization) for organizations that can't or prefer not to configure SCIM group push. Instead of pushing groups from your IdP to LangSmith on a separate sync interval, LangSmith reads group memberships directly from a configurable claim in the SSO token at login time and applies org-level and workspace-level role assignments using the same [naming convention](#group-naming-convention) as SCIM.
+SSO Groups Sync is a simpler alternative to [SCIM](#set-up-scim-for-your-organization) for organizations that can't or prefer not to configure SCIM group push. Instead of pushing groups from your IdP to LangSmith on a separate sync interval, LangSmith reads group memberships directly from a configurable claim in the SSO token at login time and applies org-level and workspace-level role assignments using the same [naming convention](#group-naming-convention) as SCIM.
 
 This is a well-established pattern used by GitLab (SAML Group Links), Grafana (Team Sync), HashiCorp Vault (`groups_claim`), and Atlassian (JIT group assignment).
 
 #### When to use SSO Groups Sync vs. SCIM
 
-SSO Groups Sync and SCIM can technically coexist (each only manages identities tagged with its own provisioning method), but we recommend choosing **one mechanism per organization** — not both — to avoid confusing precedence behavior.
+SSO Groups Sync and SCIM can technically coexist (each only manages identities tagged with its own provisioning method), but we recommend choosing **one mechanism per organization**, not both, to avoid confusing precedence behavior.
 
 | | SSO Groups Sync | SCIM |
 | --- | --- | --- |
 | **Sync trigger** | At each SSO login | Proactive push from IdP (~1 hour cadence) |
-| **IdP admin involvement** | Minimal — just include groups in the SSO token | Required — configure SCIM provisioning app |
-| **Deprovisioning** | Lags until next login | Near-real-time via IdP push |
+| **IdP admin involvement** | Minimal, just include groups in the SSO token | Required, configure SCIM provisioning app |
+| **Deprovisioning** | Lags until next login | Near real-time via IdP push |
 | **Naming convention** | Reuses [SCIM convention](#group-naming-convention) | [SCIM convention](#group-naming-convention) |
 | **Custom separator** | Reuses org-level [`scim_group_name_separator`](#configure-custom-separator) | [`scim_group_name_separator`](#configure-custom-separator) |
 
-Choose **SSO Groups Sync** when IdP admin involvement is minimal and reactive (login-time) sync is acceptable. Choose **SCIM** when proactive provisioning/deprovisioning and near-real-time group membership updates are required.
+Choose **SSO Groups Sync** when IdP admin involvement is minimal and reactive (login-time) sync is acceptable. Choose **SCIM** when proactive provisioning/deprovisioning and near real-time group membership updates are required.
 
 #### Configuration
 
@@ -822,7 +822,7 @@ Disabling SSO Groups Sync does not remove existing access. Users provisioned by 
 #### Configure your IdP to emit a groups SAML attribute (cloud)
 
 <Note>
-This section applies to **enterprise cloud** only. Self-hosted customers configure groups directly in their OIDC IdP — see [SSO Groups Sync on self-hosted](/langsmith/self-host-sso#sso-groups-sync).
+This section applies to **enterprise cloud** only. Self-hosted customers configure groups directly in their OIDC IdP, see [SSO Groups Sync on self-hosted](/langsmith/self-host-sso#sso-groups-sync).
 </Note>
 
 To make a user's group memberships visible to LangSmith at login, you need to do two things:
@@ -835,7 +835,7 @@ To make a user's group memberships visible to LangSmith at login, you need to do
 - The IdP attribute name (e.g., `groups`) must match both the **Supabase Attribute Mapping** entry and the **Groups claim field** value (default `groups`).
 - The attribute must be **multi-valued** (a list of strings), not a single delimited string. If your IdP only supports single-valued attributes, you'll need to emit one attribute statement per group.
 - Each value must be a group name following the [SCIM naming convention](#group-naming-convention).
-- Only groups whose names match the convention are processed. Other groups (org-wide directory groups, app assignment groups, etc.) are skipped — emit them in the SAML attribute regardless if it's easier; LangSmith ignores irrelevant entries.
+- Only groups whose names match the convention are processed. LangSmith ignores groups that don't match its naming convention, such as org-wide directory groups or app assignment groups. You don't need to filter these out on the IdP side—emit all groups and LangSmith will skip the irrelevant ones.
 
 **Per-IdP setup:**
 
@@ -886,14 +886,14 @@ Group names follow the [SCIM naming convention](#group-naming-convention). The `
 
 #### Behavior
 
-- **Naming convention** — Group names follow the same format as SCIM (e.g., `LS:Organization Admins` for org admins, `LS:Organization User:Production:Editor` for workspace-scoped). See [Group naming convention](#group-naming-convention) for the full format. The separator is configured per-org via [`scim_group_name_separator`](#configure-custom-separator) and is shared with SCIM.
-- **Malformed group names** — Group names that don't match the convention are skipped silently (logged) and don't block login for valid groups.
-- **Login gate** — When **Require matching group to sign in** is enabled and the SSO token contains zero matching groups, login is blocked.
-- **Precedence** — SCIM-sourced identities are never modified by SSO Groups Sync. Manually assigned and JIT-provisioned memberships are also untouched. SSO Groups Sync is fully authoritative for its own assignments and replaces them on each login based on the token's group membership.
-- **Org admin propagation** — If a user receives an org admin role from their groups, they are granted workspace admin in all workspaces (same as SCIM behavior).
+- **Naming convention**: Group names follow the same format as SCIM (e.g., `LS:Organization Admins` for org admins, `LS:Organization User:Production:Editor` for workspace-scoped). See [Group naming convention](#group-naming-convention) for the full format. The separator is configured per-org via [`scim_group_name_separator`](#configure-custom-separator) and is shared with SCIM.
+- **Malformed group names**: Group names that don't match the convention are skipped silently (logged) and don't block login for valid groups.
+- **Login gate**: When **Require matching group to sign in** is enabled and the SSO token contains zero matching groups, login is blocked.
+- **Precedence**: SSO Groups Sync does not modify SCIM-sourced, manually assigned, or JIT-provisioned memberships. It is fully authoritative for its own assignments and replaces them on each login based on the token's group membership.
+- **Org admin propagation**: If a user receives an org admin role from their groups, they are granted workspace admin in all workspaces (same as SCIM behavior).
 
 #### Things to note
 
-- **Deprovisioning lag** — Unlike SCIM (proactive push), SSO Groups Sync only updates on login. A user removed from a group in the IdP retains their existing workspace access until their next LangSmith login. The **Require matching group to sign in** gate mitigates this by blocking the user entirely on next login.
-- **No retroactive sync** — Changing role mappings or enabling the feature does not update existing users until they log in again.
-- **Naming convention required** — Customers must name their IdP groups following the SCIM convention. If your IdP groups follow a different naming policy, SCIM with `description`-based mapping (see [Group attributes](#group-attributes)) may be a better fit.
+- **Deprovisioning lag**: Unlike SCIM (proactive push), SSO Groups Sync only updates on login. A user removed from a group in the IdP retains their existing workspace access until their next LangSmith login. The **Require matching group to sign in** gate mitigates this by blocking the user entirely on next login.
+- **No retroactive sync**: Changing role mappings or enabling the feature does not update existing users until they log in again.
+- **Naming convention required**: Customers must name their IdP groups following the SCIM convention. If your IdP groups follow a different naming policy, SCIM with `description`-based mapping (see [Group attributes](#group-attributes)) may be a better fit.

--- a/src/langsmith/user-management.mdx
+++ b/src/langsmith/user-management.mdx
@@ -792,6 +792,56 @@ curl -X PATCH $LANGCHAIN_ENDPOINT/api/v1/orgs/current/sso-settings/$SSO_PROVIDER
 Disabling SSO Groups Sync does not remove existing access. Users provisioned by SSO groups will retain their current access until their next login.
 </Warning>
 
+#### Configure your IdP to emit a groups SAML attribute (cloud)
+
+<Note>
+This section applies to **enterprise cloud** only. Self-hosted customers configure groups directly in their OIDC IdP — see [SSO Groups Sync on self-hosted](/langsmith/self-host-sso#sso-groups-sync).
+</Note>
+
+LangSmith cloud uses [Supabase](/langsmith/cloud) as the SAML SSO backend. To make a user's group memberships visible to LangSmith at login, configure your IdP's SAML application to emit a multi-valued group attribute. Supabase passes SAML attributes through to the user's token, where LangSmith reads them based on the **Groups claim field** setting.
+
+**Requirements:**
+
+- The IdP attribute name (e.g., `groups`) must match the value configured in the **Groups claim field** setting (default `groups`).
+- The attribute must be **multi-valued** (a list of strings), not a single delimited string. If your IdP only supports single-valued attributes, you'll need to emit one attribute statement per group.
+- Each value must be a group name following the [SCIM naming convention](#group-naming-convention).
+- Only groups whose names match the convention are processed. Other groups (org-wide directory groups, app assignment groups, etc.) are skipped — emit them in the SAML attribute regardless if it's easier; LangSmith ignores irrelevant entries.
+
+**Per-IdP setup:**
+
+<Tabs>
+<Tab title="Okta">
+
+In the LangSmith SAML application:
+
+1. **Directory** → **Profile Editor** → select the LangSmith application's user profile.
+2. Add a custom attribute named `groups` with **Type** `string array`.
+3. **Sign On** → edit the SAML settings and add an attribute statement:
+   - **Name**: `groups`
+   - **Name format**: `Unspecified` (or `Basic`)
+   - **Filter**: `Matches regex` with `.*` to send all groups, or use a more restrictive regex (e.g., `^LS:.*`) to limit to LangSmith-prefixed groups.
+
+</Tab>
+<Tab title="Entra ID (Azure)">
+
+In the LangSmith Enterprise Application:
+
+1. **Single sign-on** → **Attributes & Claims** → **Add a group claim**.
+2. Choose which groups to emit (typically **Groups assigned to the application**).
+3. Set **Source attribute** to `Cloud-only group display names` so the group name (which must match the [naming convention](#group-naming-convention)) is sent rather than the object ID.
+4. Set the claim **Name** to `groups` (or your configured **Groups claim field** value), with no namespace.
+
+</Tab>
+<Tab title="Google Workspace">
+
+Google's SAML SSO does not natively emit Google Group memberships as a SAML attribute. To use SSO Groups Sync with Google Workspace, you must either:
+
+- Manage group membership through a directory sync tool that exposes groups as a SAML attribute, or
+- Use [SCIM](#set-up-scim-for-your-organization) instead, which supports group push from Google Workspace.
+
+</Tab>
+</Tabs>
+
 #### Group naming examples
 
 Group names follow the [SCIM naming convention](#group-naming-convention). The `<workspace_role>` segment accepts both built-in roles and [custom workspace roles](/langsmith/rbac#custom-roles) by name.
@@ -806,14 +856,14 @@ Group names follow the [SCIM naming convention](#group-naming-convention). The `
 
 #### Behavior
 
-- **Naming convention** — Group names are parsed using the same convention as SCIM (`<optional_prefix>Organization Admin`, `<optional_prefix><org_role><separator><workspace_name><separator><workspace_role>`). The separator is configured per-org via [`scim_group_name_separator`](#configure-custom-separator) and is shared with SCIM.
+- **Naming convention** — Group names follow the same format as SCIM (e.g., `LS:Organization Admins` for org admins, `LS:Organization User:Production:Editor` for workspace-scoped). See [Group naming convention](#group-naming-convention) for the full format. The separator is configured per-org via [`scim_group_name_separator`](#configure-custom-separator) and is shared with SCIM.
 - **Malformed group names** — Group names that don't match the convention are skipped silently (logged) and don't block login for valid groups.
-- **Login gate** — When **Require matching group to sign in** is enabled and the SSO token contains zero matching groups, login is blocked with `error=no_matching_groups`.
+- **Login gate** — When **Require matching group to sign in** is enabled and the SSO token contains zero matching groups, login is blocked.
 - **Precedence** — SCIM-sourced identities are never modified by SSO Groups Sync. Manually assigned and JIT-provisioned memberships are also untouched. SSO Groups Sync is fully authoritative for its own assignments and replaces them on each login based on the token's group membership.
 - **Org admin propagation** — If a user receives an org admin role from their groups, they are granted workspace admin in all workspaces (same as SCIM behavior).
 
-#### Tradeoffs
+#### Things to note
 
-- **Deprovisioning lag** — Unlike SCIM (proactive push), SSO Groups Sync only updates on login. A user removed from an group in the IdP retains their existing workspace access until their next LangSmith login. The **Require matching group to sign in** gate mitigates this by blocking the user entirely on next login.
+- **Deprovisioning lag** — Unlike SCIM (proactive push), SSO Groups Sync only updates on login. A user removed from a group in the IdP retains their existing workspace access until their next LangSmith login. The **Require matching group to sign in** gate mitigates this by blocking the user entirely on next login.
 - **No retroactive sync** — Changing role mappings or enabling the feature does not update existing users until they log in again.
 - **Naming convention required** — Customers must name their IdP groups following the SCIM convention. If your IdP groups follow a different naming policy, SCIM with `description`-based mapping (see [Group attributes](#group-attributes)) may be a better fit.

--- a/src/langsmith/user-management.mdx
+++ b/src/langsmith/user-management.mdx
@@ -144,6 +144,33 @@ For IdP-specific configuration steps, refer to one of the following:
       - `Default workspace role` and `Default workspaces` are editable. The updated settings will apply to new users only, not existing users.
       - (Coming soon) `SAML metadata URL` and `SAML metadata XML` are editable. This is usually only necessary when cryptographic keys are rotated/expired or the metadata URL has changed but the same IdP is still used.
 
+### Supabase Attribute Mapping
+
+<Note>
+Supabase Attribute Mapping is a cloud-only feature. Self-hosted deployments configure SAML/OIDC attributes directly with the IdP—see [Set up SSO with OAuth2.0 and OIDC](/langsmith/self-host-sso).
+</Note>
+
+LangSmith cloud uses [Supabase](/langsmith/cloud) as the SAML SSO backend. Supabase passes a small set of standard SAML attributes (such as `email` and `sub`) onto the user's JWT automatically. Any additional, non-standard SAML attribute your IdP emits (for example, `groups` for [SSO Groups Sync](#sso-groups-sync-alternative)) must be explicitly forwarded through Supabase before LangSmith can read it.
+
+**Attribute flow (1:1):**
+
+1. **IdP** — emits a SAML attribute with the configured name (e.g., `groups`).
+2. **Supabase** — forwards the attribute onto the user's JWT only if the attribute name appears in the **Supabase Attribute Mapping** table on the SSO provider. Standard attributes are forwarded automatically; non-standard attributes are dropped unless explicitly listed.
+3. **LangSmith** — reads the JWT claim by name (e.g., the value of [SSO Groups Sync](#sso-groups-sync-alternative)'s **Groups claim field**).
+
+The attribute name is preserved end-to-end: the IdP attribute name, the Supabase Attribute Mapping entry, and the downstream LangSmith setting all use the same string.
+
+#### Configuration
+
+In **Settings** → **Members and roles** → **SSO Configuration**, scroll to the **Supabase Attribute Mapping** section and add one row per non-standard attribute you want to forward:
+
+| Column | Description |
+| --- | --- |
+| **Attribute name** | The SAML attribute name as emitted by your IdP. Must match the JWT claim name LangSmith expects downstream (for SSO Groups Sync, this matches the **Groups claim field** value). |
+| **Array** | Check this if the attribute is multi-valued (a list of strings). Leave unchecked for scalar (single-value) attributes. Example: check this for `groups`; leave unchecked for `full_name`. |
+
+Click **Add row** for each additional attribute, then **Save**. An empty mapping table means no non-standard attributes flow through to the JWT.
+
 ### Entra ID (Azure)
 
 For additional information, see Microsoft's [documentation](https://learn.microsoft.com/en-us/entra/identity/enterprise-apps/add-application-portal-setup-sso).
@@ -798,11 +825,14 @@ Disabling SSO Groups Sync does not remove existing access. Users provisioned by 
 This section applies to **enterprise cloud** only. Self-hosted customers configure groups directly in their OIDC IdP — see [SSO Groups Sync on self-hosted](/langsmith/self-host-sso#sso-groups-sync).
 </Note>
 
-LangSmith cloud uses [Supabase](/langsmith/cloud) as the SAML SSO backend. To make a user's group memberships visible to LangSmith at login, configure your IdP's SAML application to emit a multi-valued group attribute. Supabase passes SAML attributes through to the user's token, where LangSmith reads them based on the **Groups claim field** setting.
+To make a user's group memberships visible to LangSmith at login, you need to do two things:
+
+1. Configure your IdP's SAML application to emit a multi-valued group attribute.
+2. Add a matching entry to [Supabase Attribute Mapping](#supabase-attribute-mapping) so the attribute flows through to the JWT (with **Array** checked).
 
 **Requirements:**
 
-- The IdP attribute name (e.g., `groups`) must match the value configured in the **Groups claim field** setting (default `groups`).
+- The IdP attribute name (e.g., `groups`) must match both the **Supabase Attribute Mapping** entry and the **Groups claim field** value (default `groups`).
 - The attribute must be **multi-valued** (a list of strings), not a single delimited string. If your IdP only supports single-valued attributes, you'll need to emit one attribute statement per group.
 - Each value must be a group name following the [SCIM naming convention](#group-naming-convention).
 - Only groups whose names match the convention are processed. Other groups (org-wide directory groups, app assignment groups, etc.) are skipped — emit them in the SAML attribute regardless if it's easier; LangSmith ignores irrelevant entries.


### PR DESCRIPTION
## Summary

Documents the SSO Groups Sync provisioning path — an alternative to SCIM that reads group memberships from the SSO token at login time and assigns roles using the existing SCIM naming convention.

- `user-management.mdx` — new `### SSO Groups Sync (alternative)` nested under SCIM, with comparison table, UI settings reference, API `PATCH` example, naming examples (built-in and custom roles), behavior, and tradeoffs.
- `self-host-sso.mdx` — new `### SSO Groups Sync` section with Helm/Docker scope examples, IdP-side guidance, and minimum chart/app version Note.
- `self-host-user-management.mdx` — feature entry with minimum chart/app version Note.
- `jit-invite-sso.mdx` — adds SSO Groups Sync precedence relative to JIT/invites/SCIM.
- `authentication-methods.mdx` — one-line update under SAML SSO.
- `rbac.mdx` — one-sentence note that roles can be assigned via SCIM groups or SSO Groups Sync.

Self-hosted minimum: Helm chart **0.15.0-rc.3** / app **0.15.2rc1**.

## Test plan

- [x] `make lint_prose` passes on changed files (verified locally)
- [x] `make broken-links` shows no new failures attributable to this branch (verified — pre-existing failures only)
- [x] All anchor links (`#sso-groups-sync-alternative`, `#group-naming-convention`, `#configure-custom-separator`) resolve in preview
- [x] Reviewer: confirm UI label copy matches the live LangSmith Settings → SSO Configuration page

## AI agent disclosure

Drafted with Claude Code (Opus 4.7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
