### PR TITLE
Correct mariadb API reference link

### DIFF
--- a/src/oss/python/integrations/vectorstores/mariadb.mdx
+++ b/src/oss/python/integrations/vectorstores/mariadb.mdx
@@ -146,4 +146,4 @@ results = vectorstore.similarity_search(
 
 ## API reference
 
-See the [langchain-mariadb repository](https://github.com/mariadb-corporation/langchain-mariadb) for more detail.
+See the [langchain-mariadb API documentation](https://mariadb.com/docs/connectors/other/langchain-mariadb/api-reference) for more detail.


### PR DESCRIPTION

## Overview
mariadb API reference link was referring to source code, in place of API reference


## Type of change

**Type:** Update existing documentation / Fix link

## Checklist
- [X] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [X ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed
