### PR TITLE
docs(deepagents): align Perplexity env var with PERPLEXITY_API_KEY

### DIFF
--- a/src/oss/deepagents/cli/providers.mdx
+++ b/src/oss/deepagents/cli/providers.mdx
@@ -70,7 +70,7 @@ Using a provider not listed here? See [Arbitrary providers](/oss/deepagents/cli/
 | IBM (watsonx.ai) | [`langchain-ibm`](/oss/integrations/chat/ibm_watsonx) | `WATSONX_APIKEY` | ❌ |
 | Nvidia | [`langchain-nvidia-ai-endpoints`](/oss/integrations/chat/nvidia_ai_endpoints) | `NVIDIA_API_KEY` | ✅ |
 | xAI | [`langchain-xai`](/oss/integrations/chat/xai) | `XAI_API_KEY` | ✅ |
-| Perplexity | [`langchain-perplexity`](/oss/integrations/chat/perplexity) | `PPLX_API_KEY` | ✅ |
+| Perplexity | [`langchain-perplexity`](/oss/integrations/chat/perplexity) | `PERPLEXITY_API_KEY` (or `PPLX_API_KEY`) | ✅ |
 | OpenRouter | [`langchain-openrouter`](/oss/integrations/chat/openrouter) | `OPENROUTER_API_KEY` | ✅ |
 | LiteLLM | [`langchain-litellm`](/oss/integrations/chat/litellm) | Per-provider (see [docs](https://docs.litellm.ai/)) | ❌ |
 


### PR DESCRIPTION
## Summary

Updates the Deep Agents CLI providers table to surface `PERPLEXITY_API_KEY` as the canonical Perplexity environment variable, with `PPLX_API_KEY` listed as a fallback for backwards compatibility.

This aligns the published docs page (https://docs.langchain.com/oss/python/deepagents/cli/providers) with the upstream code change in [langchain-ai/deepagents#3061](https://github.com/langchain-ai/deepagents/pull/3061), which switches the canonical entry in `PROVIDER_API_KEY_ENV` from `PPLX_API_KEY` to `PERPLEXITY_API_KEY` while preserving `PPLX_API_KEY` as a fallback. Without this docs change, the providers table will be inconsistent with the shipped CLI behavior the moment #3061 merges.

`PERPLEXITY_API_KEY` is the canonical name per the official [Perplexity API docs](https://docs.perplexity.ai); `PPLX_API_KEY` remains supported so existing users are not broken.

This is a follow-up to two recently merged Perplexity docs PRs in this repo: #3798 (Perplexity Search retriever/tool) and #3806 (PerplexityEmbeddings).

## Testing

- Single-line edit to `src/oss/deepagents/cli/providers.mdx`; rendered table cell now reads `` `PERPLEXITY_API_KEY` (or `PPLX_API_KEY`) ``.
- No other rows or files touched.
