### PR TITLE
docs: surface Deep Agents CLI on Perplexity providers page

### DIFF
--- a/src/oss/python/integrations/providers/perplexity.mdx
+++ b/src/oss/python/integrations/providers/perplexity.mdx
@@ -23,7 +23,7 @@ uv add langchain-perplexity
 ```
 </CodeGroup>
 
-Get your API key from the [Perplexity API key dashboard](https://www.perplexity.ai/account/api/keys) and set it as the `PPLX_API_KEY` (or `PERPLEXITY_API_KEY`) environment variable. See the [Perplexity getting started guide](https://docs.perplexity.ai/docs/getting-started) for more details.
+Get your API key from the [Perplexity API key dashboard](https://www.perplexity.ai/account/api/keys) and set it as the `PERPLEXITY_API_KEY` (or `PPLX_API_KEY`) environment variable. See the [Perplexity getting started guide](https://docs.perplexity.ai/docs/getting-started) for more details.
 
 ## Chat models
 
@@ -66,6 +66,20 @@ See a [usage example](/oss/integrations/embeddings/perplexity).
 ```python
 from langchain_perplexity import PerplexityEmbeddings
 ```
+
+## Deep Agents CLI
+
+Use Perplexity as a first-class provider in the [Deep Agents CLI](/oss/deepagents/cli/providers).
+
+Install the CLI with the Perplexity extra:
+
+<CodeGroup>
+```bash uv
+uv tool install 'deepagents-cli[perplexity]'
+```
+</CodeGroup>
+
+Then set `PERPLEXITY_API_KEY` and reference Perplexity models with the `perplexity:` prefix (e.g. `perplexity:sonar-pro`) in the interactive `/model` switcher or your config.
 
 ## Components reference
 


### PR DESCRIPTION
## Summary

Two small edits to `src/oss/python/integrations/providers/perplexity.mdx`:

### 1. Env-var ordering — list canonical name first

Flip the order in the "Installation and setup" paragraph so the canonical `PERPLEXITY_API_KEY` is mentioned first, with the legacy `PPLX_API_KEY` shown in parentheses.

**Before:**

> Get your API key from the [Perplexity API key dashboard](https://www.perplexity.ai/account/api/keys) and set it as the `PPLX_API_KEY` (or `PERPLEXITY_API_KEY`) environment variable.

**After:**

> Get your API key from the [Perplexity API key dashboard](https://www.perplexity.ai/account/api/keys) and set it as the `PERPLEXITY_API_KEY` (or `PPLX_API_KEY`) environment variable.

### 2. Add a Deep Agents CLI section

New H2 inserted after "Embedding models" and before "Components reference", mirroring the same shape (intro line + install snippet in a `<CodeGroup>` + usage note) that the existing Chat models / Retriever / Tools / Embedding models sections use:

````markdown
## Deep Agents CLI

Use Perplexity as a first-class provider in the [Deep Agents CLI](/oss/deepagents/cli/providers).

Install the CLI with the Perplexity extra:

<CodeGroup>
```bash uv
uv tool install 'deepagents-cli[perplexity]'
```
</CodeGroup>

Then set `PERPLEXITY_API_KEY` and reference Perplexity models with the `perplexity:` prefix (e.g. `perplexity:sonar-pro`) in the interactive `/model` switcher or your config.
````

This is the same convention the providers page already uses for the chat / retriever / tools / embeddings sections — just one more entry below them.

## Related

- Upstream code PR: https://github.com/langchain-ai/deepagents/pull/3061
- Companion docs PR (Deep Agents CLI providers reference): https://github.com/langchain-ai/docs/pull/3821

## Scope

Single-file edit — `src/oss/python/integrations/providers/perplexity.mdx` only. No sidebar / `docs.json` changes. The JS Perplexity page is intentionally untouched (Deep Agents CLI is Python-only).
