### PR TITLE
docs(oss): add light version of streaming docs

### DIFF
--- a/src/oss/deepagents/event-streaming.mdx
+++ b/src/oss/deepagents/event-streaming.mdx
@@ -3,14 +3,14 @@ title: Event streaming
 description: Stream subagents, messages, tool calls, and final output from Deep Agents.
 ---
 
-Deep Agents build on LangGraph's Event Streaming model and add a first-class `subagents` projection. Use it when you want application-facing streams for the coordinator agent, delegated subagents, nested messages, tool calls, and final state.
+Deep Agents build on LangGraph's [event streaming](/oss/langgraph/streaming/event-streaming) model and add a first-class `subagents` projection. Use it when you want application-facing streams for the coordinator agent, delegated subagents, nested messages, tool calls, and final state.
 
-<Info>
-Want to try Event Streaming in a working project? Start with the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook) for runnable examples and links to deeper docs.
-</Info>
+<Tip>
+Check out the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook) for runnable examples and links to detailed reference documentation.
+</Tip>
 
 <Note>
-Interested in lower-level Pregel stream modes and the existing Deep Agents streaming guide? See the [Streaming page](/oss/deepagents/streaming).
+For information about lower-level Pregel stream modes, refer to the [Deep Agents streaming](/oss/deepagents/streaming) docs.
 </Note>
 
 ## Stream subagents

--- a/src/oss/deepagents/event-streaming.mdx
+++ b/src/oss/deepagents/event-streaming.mdx
@@ -1,0 +1,238 @@
+---
+title: Event Streaming
+description: Stream subagents, messages, tool calls, and final output from Deep Agents.
+---
+
+Deep Agents build on LangGraph's Event Streaming model and add a first-class `subagents` projection. Use it when you want application-facing streams for the coordinator agent, delegated subagents, nested messages, tool calls, and final state.
+
+<Info>
+Want to try Event Streaming in a working project? Start with the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook) for runnable examples and links to deeper docs.
+</Info>
+
+<Note>
+Interested in lower-level Pregel stream modes and the existing Deep Agents streaming guide? See the [Streaming page](/oss/deepagents/streaming).
+</Note>
+
+## Stream subagents
+
+Deep Agents add a subagent projection on top of LangGraph streaming. Use `run.subagents` when you want one stream handle per delegated `task` call. The projection discovers subagent tasks first, then opens message, tool-call, and value streams when you access them on a subagent handle.
+
+:::python
+```python
+run = agent.stream_events(
+    {"messages": [{"role": "user", "content": "Write me a haiku about the sea"}]},
+    version="v3",
+)
+
+for subagent in run.subagents:
+    print(subagent.name, subagent.path, subagent.status)
+
+    for message in subagent.messages:
+        print(str(message.text))
+```
+:::
+
+:::js
+```typescript
+const run = await agent.streamEvents(
+  { messages: [{ role: "user", content: "Write me a haiku about the sea" }] },
+  { version: "v3" }
+);
+
+for await (const subagent of run.subagents) {
+  console.log(subagent.name);
+  console.log(await subagent.taskInput);
+
+  for await (const message of subagent.messages) {
+    console.log(await message.text);
+  }
+}
+```
+:::
+
+## Subagent stream fields
+
+Each subagent stream exposes the same kinds of projections as the parent run, such as messages, tool calls, nested subagents, and final output. For the general parent-run streaming model, see [LangChain Event Streaming](/oss/langchain/event-streaming).
+
+:::python
+Python uses snake_case projection names such as `tool_calls`. Each subagent stream can expose `.messages`, `.tool_calls`, `.values`, `.subagents`, and `.output`.
+:::
+
+:::js
+TypeScript uses camelCase projection names such as `toolCalls` and `taskInput`.
+:::
+
+| Field | Description |
+| ----- | ----------- |
+| `name` | Subagent name. |
+| `messages` | Messages emitted by the subagent. |
+| `subagents` | Nested subagent invocations. |
+| `output` | Final subagent state, or completion signal for the delegated task. |
+:::python
+| `task_input` | Prompt or input passed to the task tool. |
+| `path` | Namespace path for the subagent run. |
+| `status` | Lifecycle status such as `started`, `running`, `completed`, `failed`, or `interrupted`. |
+| `tool_calls` | Tool calls scoped to the subagent. |
+:::
+:::js
+| `taskInput` | Promise for the prompt passed to the task tool. |
+| `callId` | Tool-call ID for the delegated task. |
+| `namespace` | Namespace path for the subagent run. |
+| `toolCalls` | Tool calls scoped to the subagent. |
+:::
+
+## Track subagent lifecycle
+
+Use `run.subagents` when you only need to show which subagents started and finished. You do not need to subscribe to message or value streams unless you access those projections on an individual subagent.
+
+:::python
+```python
+run = agent.stream_events(input, version="v3")
+
+running = 0
+completed = 0
+failed = 0
+
+for subagent in run.subagents:
+    running += 1
+    print(f"{subagent.name}: started")
+
+    try:
+        _ = subagent.output
+        running -= 1
+        completed += 1
+        print(f"{subagent.name}: completed")
+    except Exception:
+        running -= 1
+        failed += 1
+        print(f"{subagent.name}: failed")
+```
+:::
+
+:::js
+```typescript
+const run = await agent.streamEvents(input, { version: "v3" });
+
+let running = 0;
+let completed = 0;
+let failed = 0;
+const watchers: Promise<void>[] = [];
+
+for await (const subagent of run.subagents) {
+  running += 1;
+  console.log(`${subagent.name}: started (${subagent.callId})`);
+
+  watchers.push(
+    subagent.output.then(
+      () => {
+        running -= 1;
+        completed += 1;
+        console.log(`${subagent.name}: completed`);
+      },
+      () => {
+        running -= 1;
+        failed += 1;
+        console.log(`${subagent.name}: failed`);
+      }
+    )
+  );
+}
+
+await Promise.all(watchers);
+console.log({ running, completed, failed });
+```
+:::
+
+## Stream messages and tools
+
+Deep Agents can emit messages and tool calls from the coordinator agent and from delegated subagents. Use `run.messages` or `run.tool_calls` for coordinator streams, then access the same projections on each subagent.
+
+:::python
+```python
+run = agent.stream_events(input, version="v3")
+
+for message in run.messages:
+    print("[coordinator]", str(message.text))
+
+for subagent in run.subagents:
+    for message in subagent.messages:
+        print(f"[{subagent.name}]", str(message.text))
+
+    for call in subagent.tool_calls:
+        print(f"[{subagent.name} tool]", call.tool_name, call.input)
+        for delta in call.output_deltas:
+            print(delta, end="", flush=True)
+```
+:::
+
+:::js
+```typescript
+const run = await agent.streamEvents(input, { version: "v3" });
+
+for await (const message of run.messages) {
+  console.log("[coordinator]", await message.text);
+}
+
+for await (const subagent of run.subagents) {
+  for await (const message of subagent.messages) {
+    console.log(`[${subagent.name}]`, await message.text);
+  }
+
+  for await (const call of subagent.toolCalls) {
+    console.log(`[${subagent.name} tool]`, call.name, call.input);
+    console.log(await call.status);
+  }
+}
+```
+:::
+
+## Consume concurrently
+
+Coordinator and subagent output often interleave. Consume projections concurrently when you need live UI updates.
+
+:::python
+Use `run.interleave(...)` when you want one sync loop over multiple projections:
+
+```python
+run = agent.stream_events(input, version="v3")
+
+for name, item in run.interleave("messages", "subagents"):
+    if name == "messages":
+        print("[coordinator]", str(item.text))
+    else:
+        for message in item.messages:
+            print(f"[{item.name}]", str(message.text))
+```
+:::
+
+:::js
+Use concurrent consumers in JavaScript:
+
+```typescript
+const run = await agent.streamEvents(input, { version: "v3" });
+
+await Promise.all([
+  (async () => {
+    for await (const message of run.messages) {
+      console.log("[coordinator]", await message.text);
+    }
+  })(),
+  (async () => {
+    for await (const subagent of run.subagents) {
+      void (async () => {
+        for await (const message of subagent.messages) {
+          console.log(`[${subagent.name}]`, await message.text);
+        }
+      })();
+    }
+  })(),
+]);
+```
+:::
+
+## Related
+
+- [Streaming cookbook](https://github.com/langchain-ai/streaming-cookbook) shows runnable Event Streaming examples.
+- [LangChain Event Streaming](/oss/langchain/event-streaming) covers general agent message and tool-call streaming concepts.
+- [Subagent frontend streaming](/oss/deepagents/frontend/subagent-streaming) shows UI patterns that separate coordinator messages from subagent cards.
+- [LangGraph Event Streaming](/oss/langgraph/streaming/event-streaming) covers the underlying graph streaming model.

--- a/src/oss/deepagents/event-streaming.mdx
+++ b/src/oss/deepagents/event-streaming.mdx
@@ -1,5 +1,5 @@
 ---
-title: Event Streaming
+title: Event streaming
 description: Stream subagents, messages, tool calls, and final output from Deep Agents.
 ---
 

--- a/src/oss/deepagents/streaming.mdx
+++ b/src/oss/deepagents/streaming.mdx
@@ -3,6 +3,10 @@ title: Streaming
 description: Stream real-time updates from deep agent runs and subagent execution
 ---
 
+<Info>
+Try the new Event Streaming preview for typed Deep Agents projections over coordinator messages, delegated subagents, tool calls, and final output. Start with [Deep Agents Event Streaming](/oss/deepagents/event-streaming), or explore runnable examples in the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook).
+</Info>
+
 Deep Agents build on LangGraph's streaming infrastructure with first-class support for subagent streams. When a deep agent delegates work to subagents, you can stream updates from each subagent independently—tracking progress, LLM tokens, and tool calls in real time.
 
 What's possible with deep agent streaming:

--- a/src/oss/deepagents/streaming.mdx
+++ b/src/oss/deepagents/streaming.mdx
@@ -4,7 +4,7 @@ description: Stream real-time updates from deep agent runs and subagent executio
 ---
 
 <Info>
-Try the new Event Streaming preview for typed Deep Agents projections over coordinator messages, delegated subagents, tool calls, and final output. Start with [Deep Agents Event Streaming](/oss/deepagents/event-streaming), or explore runnable examples in the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook).
+**In preview:** Try event streaming typed Deep Agents projections over coordinator messages, delegated subagents, tool calls, and final output. Start with [Deep Agents Event Streaming](/oss/deepagents/event-streaming), or explore runnable examples in the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook).
 </Info>
 
 Deep Agents build on LangGraph's streaming infrastructure with first-class support for subagent streams. When a deep agent delegates work to subagents, you can stream updates from each subagent independently—tracking progress, LLM tokens, and tool calls in real time.

--- a/src/oss/langchain/event-streaming.mdx
+++ b/src/oss/langchain/event-streaming.mdx
@@ -7,9 +7,9 @@ LangChain agents are built on LangGraph, so they support the same Event Streamin
 
 For most application and frontend use cases, use Event Streaming through `stream_events(..., version="v3")`. Event Streaming returns a run object with typed projections, so you can choose the view you need instead of parsing stream-mode tuples.
 
-<Info>
-Want to try Event Streaming in a working project? Start with the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook) for runnable examples and links to deeper docs.
-</Info>
+<Tip>
+Check out the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook) for runnable examples and links to detailed reference documentation.
+</Tip>
 
 <Note>
 Interested in streaming Pregel modes such as `updates`, `messages`, or `custom` directly? See the [Streaming page](/oss/langchain/streaming).

--- a/src/oss/langchain/event-streaming.mdx
+++ b/src/oss/langchain/event-streaming.mdx
@@ -1,0 +1,230 @@
+---
+title: Event Streaming
+description: Stream real-time updates from LangChain agent runs with typed projections.
+---
+
+LangChain agents are built on LangGraph, so they support the same Event Streaming model with agent-focused projections for messages, tool calls, state, and custom updates.
+
+For most application and frontend use cases, use Event Streaming through `stream_events(..., version="v3")`. Event Streaming returns a run object with typed projections, so you can choose the view you need instead of parsing stream-mode tuples.
+
+<Info>
+Want to try Event Streaming in a working project? Start with the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook) for runnable examples and links to deeper docs.
+</Info>
+
+<Note>
+Interested in streaming Pregel modes such as `updates`, `messages`, or `custom` directly? See the [Streaming page](/oss/langchain/streaming).
+</Note>
+
+:::python
+```python
+from langchain.agents import create_agent
+
+
+def get_weather(city: str) -> str:
+    """Get weather for a city."""
+    return f"It's always sunny in {city}!"
+
+
+agent = create_agent(
+    model="gpt-5-nano",
+    tools=[get_weather],
+)
+
+run = agent.stream_events(
+    {"messages": [{"role": "user", "content": "What is the weather in SF?"}]},
+    version="v3",
+)
+
+for message in run.messages:
+    for delta in message.text:
+        print(delta, end="", flush=True)
+
+final_state = run.output
+```
+:::
+
+:::js
+```typescript
+import { createAgent, tool } from "langchain";
+import * as z from "zod";
+
+const getWeather = tool(
+  async ({ city }) => `It's always sunny in ${city}!`,
+  {
+    name: "get_weather",
+    description: "Get weather for a city.",
+    schema: z.object({ city: z.string() }),
+  }
+);
+
+const agent = createAgent({
+  model: "gpt-5-nano",
+  tools: [getWeather],
+});
+
+const run = await agent.streamEvents(
+  { messages: [{ role: "user", content: "What is the weather in SF?" }] },
+  { version: "v3" }
+);
+
+for await (const message of run.messages) {
+  for await (const delta of message.text) {
+    process.stdout.write(delta);
+  }
+}
+
+const finalState = await run.output;
+```
+:::
+
+## What you can stream
+
+| Projection | Use |
+| ---------- | --- |
+| `for event in run` | Raw protocol events when you need exact arrival order. |
+| `run.messages` | Model message streams, one per LLM call. |
+| `message.text` | Text deltas and final text for a message. |
+| `message.reasoning` | Reasoning deltas for models that expose reasoning content. |
+| `message.tool_calls` | Tool-call argument chunks and finalized tool calls. |
+| `message.output` | Final message object after the model call completes. |
+| `message.usage` | Token usage metadata when the provider returns it. |
+| `run.values` | Agent state snapshots. |
+| `run.output` | Final agent state. |
+| `run.extensions` | Custom transformer projections. |
+:::python
+| `run.tool_calls` | Tool execution lifecycle, inputs, output deltas, final output, and errors. |
+:::
+:::js
+| `run.toolCalls` | Tool execution lifecycle, inputs, output deltas, final output, and errors. |
+:::
+
+:::python
+`run.messages` yields `ChatModelStream` objects. Each message stream exposes `.text`, `.reasoning`, `.tool_calls`, and `.output`. Sync projections are iterable for live deltas and drainable for final values.
+:::
+
+:::js
+`run.messages` yields message streams. Each message stream exposes `.text`, `.reasoning`, `.toolCalls`, `.output`, and `.usage`. Async projections can be iterated for live deltas or awaited for final values.
+:::
+
+## Stream agent messages
+
+Use `run.messages` when you want model output from each LLM call.
+
+:::python
+```python
+run = agent.stream_events(input, version="v3")
+
+for message in run.messages:
+    print(f"[{message.node}] ", end="")
+    for delta in message.text:
+        print(delta, end="", flush=True)
+
+    full_message = message.output
+    usage = full_message.usage_metadata
+    if usage:
+        print(usage)
+```
+:::
+
+:::js
+```typescript
+const run = await agent.streamEvents(input, { version: "v3" });
+
+for await (const message of run.messages) {
+  process.stdout.write(`[${message.node}] `);
+  for await (const delta of message.text) {
+    process.stdout.write(delta);
+  }
+
+  const fullMessage = await message.output;
+  console.log(fullMessage.content);
+
+  const usage = await message.usage;
+  if (usage) {
+    console.log(usage);
+  }
+}
+```
+:::
+
+## Stream tool calls
+
+There are two useful tool-call projections:
+
+- `message.tool_calls` streams tool-call argument chunks while the model is producing the tool call.
+- `run.tool_calls` streams the lifecycle of tool execution after the tool call starts.
+
+:::python
+```python
+run = agent.stream_events(input, version="v3")
+
+for message in run.messages:
+    for chunk in message.tool_calls:
+        print(f"tool call chunk: {chunk}")
+
+    finalized = message.tool_calls.get()
+    if finalized:
+        print(f"finalized tool calls: {finalized}")
+
+for call in run.tool_calls:
+    print(f"{call.tool_name}({call.input})")
+    for delta in call.output_deltas:
+        print(delta, end="", flush=True)
+    print(call.output, call.error)
+```
+:::
+
+:::js
+```typescript
+const run = await agent.streamEvents(input, { version: "v3" });
+
+await Promise.all([
+  (async () => {
+    for await (const message of run.messages) {
+      for await (const chunk of message.toolCalls) {
+        console.log("tool call chunk", chunk);
+      }
+    }
+  })(),
+  (async () => {
+    for await (const call of run.toolCalls) {
+      console.log(call.name, call.input);
+      console.log(await call.output, await call.error);
+    }
+  })(),
+]);
+```
+:::
+
+## Stream state and final output
+
+Use `run.values` for state snapshots and `run.output` for the final agent state.
+
+:::python
+```python
+run = agent.stream_events(input, version="v3")
+
+for snapshot in run.values:
+    print(snapshot)
+
+final_state = run.output
+```
+:::
+
+:::js
+```typescript
+const run = await agent.streamEvents(input, { version: "v3" });
+
+for await (const snapshot of run.values) {
+  console.log(snapshot);
+}
+
+const finalState = await run.output;
+```
+:::
+
+## Related
+
+- [Streaming cookbook](https://github.com/langchain-ai/streaming-cookbook) shows runnable Event Streaming examples.
+- [LangChain Streaming](/oss/langchain/streaming) covers lower-level Pregel stream modes.
+- [LangGraph Event Streaming](/oss/langgraph/streaming/event-streaming) explains the underlying graph streaming model.

--- a/src/oss/langchain/streaming.mdx
+++ b/src/oss/langchain/streaming.mdx
@@ -6,6 +6,10 @@ description: Stream real-time updates from agent runs
 import StreamingReasoningTokensPy from '/snippets/code-samples/streaming-reasoning-tokens-py.mdx';
 import StreamingReasoningTokensJs from '/snippets/code-samples/streaming-reasoning-tokens-js.mdx';
 
+<Info>
+Try the new Event Streaming preview for typed agent projections over messages, tool calls, state, and final output. Start with [LangChain Event Streaming](/oss/langchain/event-streaming), or explore runnable examples in the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook).
+</Info>
+
 LangChain implements a streaming system to surface real-time updates.
 
 Streaming is crucial for enhancing the responsiveness of applications built on LLMs. By displaying output progressively, even before a complete response is ready, streaming significantly improves user experience (UX), particularly when dealing with the latency of LLMs.

--- a/src/oss/langchain/streaming.mdx
+++ b/src/oss/langchain/streaming.mdx
@@ -7,7 +7,7 @@ import StreamingReasoningTokensPy from '/snippets/code-samples/streaming-reasoni
 import StreamingReasoningTokensJs from '/snippets/code-samples/streaming-reasoning-tokens-js.mdx';
 
 <Info>
-Try the new Event Streaming preview for typed agent projections over messages, tool calls, state, and final output. Start with [LangChain Event Streaming](/oss/langchain/event-streaming), or explore runnable examples in the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook).
+**In preview:** Try event streaming typed agent projections over messages, tool calls, state, and final output. Start with [LangChain Event Streaming](/oss/langchain/event-streaming), or explore runnable examples in the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook).
 </Info>
 
 LangChain implements a streaming system to surface real-time updates.

--- a/src/oss/langgraph/streaming.mdx
+++ b/src/oss/langgraph/streaming.mdx
@@ -6,7 +6,7 @@ import NostreamTagPy from '/snippets/code-samples/nostream-tag-py.mdx';
 import NostreamTagJs from '/snippets/code-samples/nostream-tag-js.mdx';
 
 <Info>
-Try the new Event Streaming preview for typed projections over messages, state, subgraphs, output, and custom extensions. Start with the [Event Streaming summary](/oss/langgraph/streaming/event-streaming), or explore runnable examples in the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook).
+**In preview:** Try event streaming typed projections over messages, state, subgraphs, output, and custom extensions. Start with the [Event Streaming summary](/oss/langgraph/streaming/event-streaming), or explore runnable examples in the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook).
 </Info>
 
 LangGraph implements a streaming system to surface real-time updates. Streaming is crucial for enhancing the responsiveness of applications built on LLMs. By displaying output progressively, even before a complete response is ready, streaming significantly improves user experience (UX), particularly when dealing with the latency of LLMs.

--- a/src/oss/langgraph/streaming.mdx
+++ b/src/oss/langgraph/streaming.mdx
@@ -5,6 +5,10 @@ title: Streaming
 import NostreamTagPy from '/snippets/code-samples/nostream-tag-py.mdx';
 import NostreamTagJs from '/snippets/code-samples/nostream-tag-js.mdx';
 
+<Info>
+Try the new Event Streaming preview for typed projections over messages, state, subgraphs, output, and custom extensions. Start with the [Event Streaming summary](/oss/langgraph/streaming/event-streaming), or explore runnable examples in the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook).
+</Info>
+
 LangGraph implements a streaming system to surface real-time updates. Streaming is crucial for enhancing the responsiveness of applications built on LLMs. By displaying output progressively, even before a complete response is ready, streaming significantly improves user experience (UX), particularly when dealing with the latency of LLMs.
 
 ## Get started

--- a/src/oss/langgraph/streaming/event-streaming.mdx
+++ b/src/oss/langgraph/streaming/event-streaming.mdx
@@ -5,9 +5,9 @@ description: Stream LangGraph runs with typed projections, protocol events, and 
 
 Event Streaming is the recommended in-process streaming model for most LangGraph application code. It returns a run stream object that can be consumed in multiple ways at the same time.
 
-<Info>
-Want to try Event Streaming in a working project? Start with the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook) for runnable examples and links to deeper docs.
-</Info>
+<Tip>
+Check out the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook) for runnable examples and links to detailed reference documentation.
+</Tip>
 
 :::python
 ```python

--- a/src/oss/langgraph/streaming/event-streaming.mdx
+++ b/src/oss/langgraph/streaming/event-streaming.mdx
@@ -1,0 +1,281 @@
+---
+title: Event Streaming
+description: Stream LangGraph runs with typed projections, protocol events, and custom extensions.
+---
+
+Event Streaming is the recommended in-process streaming model for most LangGraph application code. It returns a run stream object that can be consumed in multiple ways at the same time.
+
+<Info>
+Want to try Event Streaming in a working project? Start with the [streaming cookbook](https://github.com/langchain-ai/streaming-cookbook) for runnable examples and links to deeper docs.
+</Info>
+
+:::python
+```python
+run = graph.stream_events(
+    {"messages": [{"role": "user", "content": "What is 42 * 17?"}]},
+    version="v3",
+)
+
+for message in run.messages:
+    for token in message.text:
+        print(token, end="", flush=True)
+
+final_state = run.output
+```
+:::
+
+:::js
+```typescript
+const run = await graph.streamEvents(
+  { messages: [{ role: "user", content: "What is 42 * 17?" }] },
+  { version: "v3" }
+);
+
+for await (const message of run.messages) {
+  for await (const token of message.text) {
+    process.stdout.write(token);
+  }
+}
+
+const finalState = await run.output;
+```
+:::
+
+<Note>
+The `version="v3"` flag is temporarily required to opt in to this stream behavior. The new behavior will become the default stream version in the next major LangGraph release.
+</Note>
+
+## What Event Streaming provides
+
+The run stream exposes typed projections over one underlying event flow:
+
+| Projection | Use |
+| ---------- | --- |
+| `run` | Iterate every protocol event. |
+| `run.messages` | Stream chat model messages and token deltas. |
+| `run.values` | Iterate state snapshots and await the final value. |
+| `run.output` | Await the final output. |
+| `run.subgraphs` | Discover and observe nested graph executions. |
+| `run.interrupts` | Inspect human-in-the-loop interrupt payloads. |
+| `run.interrupted` | Check whether the run paused for human input. |
+| `run.extensions` | Consume custom stream transformer projections. |
+
+Multiple consumers can read these projections concurrently. Reading `run.messages` does not consume events needed by `run.values`, `run.subgraphs`, or `run.output`.
+
+## Stream protocol events
+
+Use the run object itself when you want the raw protocol event stream:
+
+:::python
+```python
+run = graph.stream_events(input, version="v3")
+
+for event in run:
+    namespace = event["params"]["namespace"]
+    print(namespace, event["method"], event["params"]["data"])
+```
+:::
+
+:::js
+```typescript
+const run = await graph.streamEvents(input, { version: "v3" });
+
+for await (const event of run) {
+  const namespace = event.params.namespace;
+  console.log(namespace, event.method, event.params.data);
+}
+```
+:::
+
+Each protocol event has a channel-like `method`, a monotonic `seq` number, and `params` containing `namespace`, `timestamp`, optional `node`, and channel-specific `data`.
+
+```json
+{
+  "type": "event",
+  "seq": 42,
+  "method": "messages",
+  "params": {
+    "namespace": [],
+    "timestamp": 1770000000000,
+    "node": "agent",
+    "data": {
+      "event": "content-block-delta",
+      "content_block": {
+        "type": "text",
+        "text": "hello"
+      }
+    }
+  }
+}
+```
+
+Core channels include:
+
+| Channel | Purpose |
+| ------- | ------- |
+| `values` | Full graph state snapshots. |
+| `updates` | Per-node state deltas. |
+| `messages` | Content-block-centric chat model output. |
+| `tools` | Tool call start, streamed output, finish, and error events. |
+| `lifecycle` | Run, subgraph, and subagent status changes. |
+| `checkpoints` | Lightweight checkpoint envelopes for branching and time travel. |
+| `input` | Human-in-the-loop input requests and responses. |
+| `tasks` | Pregel task creation and result events. |
+| `custom` | User-defined payloads from graph code. |
+| `custom:<name>` | Application-defined stream transformer output. |
+
+The `messages` channel models output as content blocks. This makes token streaming, reasoning blocks, tool-call blocks, and multimodal content explicit without requiring provider-specific formats in application code.
+
+## Add custom transformers
+
+Stream transformers are the projection layer in Event Streaming. They observe protocol events, keep their own state, and expose derived views of a run such as progress events, artifacts, token totals, tool activity, or third-party protocol messages.
+
+```mermaid
+flowchart TD
+    A[Pregel modes] --> B[Events]
+    B --> C[Built-in projections]
+    C --> D[User transformers]
+    D --> E[Run projections]
+```
+
+A transformer creates a projection in `init()`, observes each event in `process()`, and finalizes or fails the projection when the run completes.
+
+:::python
+```python
+from langgraph.stream import ProtocolEvent, StreamTransformer
+
+
+class MyTransformer(StreamTransformer):
+    def init(self) -> dict:
+        ...
+
+    def process(self, event: ProtocolEvent) -> bool:
+        ...
+
+    def finalize(self) -> None:
+        ...
+
+    def fail(self, err: BaseException) -> None:
+        ...
+```
+:::
+
+:::js
+```typescript
+interface StreamTransformer<TProjection = unknown> {
+  init(): TProjection;
+  process(event: ProtocolEvent): boolean;
+  finalize?(): void | PromiseLike<void>;
+  fail?(err: unknown): void;
+}
+```
+:::
+
+Pass transformers when you start the event stream:
+
+:::python
+```python
+run = graph.stream_events(
+    input,
+    version="v3",
+    transformers=[ToolActivityTransformer],
+)
+
+for activity in run.extensions["tool_activity"]:
+    print(activity)
+```
+:::
+
+:::js
+```typescript
+const run = await graph.streamEvents(input, {
+  version: "v3",
+  transformers: [toolActivityTransformer],
+});
+
+for await (const activity of run.extensions.toolActivity) {
+  console.log(activity);
+}
+```
+:::
+
+## Use StreamChannel
+
+`StreamChannel` is the projection primitive for custom streaming data. It gives in-process consumers an iterable stream, and it can also forward pushed values to remote SDK clients when the channel has a protocol name.
+
+| Need | Use |
+| ---- | --- |
+| Data should stay in process only | `StreamChannel()` or `new StreamChannel<T>()` |
+| Data should be available in process and over the wire | `StreamChannel(name)` or `new StreamChannel<T>(name)` |
+
+Named channel payloads must be serializable because they are also emitted as `custom:<name>` protocol events. Keep promises, async iterables, class instances, and other in-process handles local.
+
+:::python
+```python
+from typing import TypedDict
+
+from langgraph.stream import ProtocolEvent, StreamChannel, StreamTransformer
+
+
+class ToolActivity(TypedDict):
+    name: str
+    status: str
+
+
+class ToolActivityTransformer(StreamTransformer):
+    required_stream_modes = ("tools",)
+
+    def __init__(self, scope: tuple[str, ...] = ()) -> None:
+        super().__init__(scope)
+        self.activity = StreamChannel[ToolActivity]("tool_activity")
+
+    def init(self) -> dict:
+        return {"tool_activity": self.activity}
+
+    def process(self, event: ProtocolEvent) -> bool:
+        if event["method"] != "tools":
+            return True
+
+        data = event["params"]["data"]
+        if isinstance(data, dict) and data.get("tool_name") and data.get("event"):
+            status = "error" if data["event"] == "tool-error" else "started"
+            self.activity.push({"name": data["tool_name"], "status": status})
+        return True
+```
+:::
+
+:::js
+```typescript
+import { StreamChannel } from "@langchain/langgraph";
+
+const toolActivityTransformer = () => {
+  const activity = new StreamChannel<{
+    name: string;
+    status: "started" | "finished" | "error";
+  }>("toolActivity");
+
+  return {
+    init: () => ({ toolActivity: activity }),
+    process(event) {
+      if (event.method === "tools") {
+        const data = event.params.data as { tool_name?: string; event?: string };
+        if (data.tool_name && data.event) {
+          activity.push({
+            name: data.tool_name,
+            status: data.event === "tool-error" ? "error" : "started",
+          });
+        }
+      }
+      return true;
+    },
+  };
+};
+```
+:::
+
+## Related
+
+- [Streaming cookbook](https://github.com/langchain-ai/streaming-cookbook) shows runnable Event Streaming examples.
+- [LangGraph Streaming](/oss/langgraph/streaming) covers lower-level stream modes.
+- [LangChain Event Streaming](/oss/langchain/event-streaming) covers the agent streaming surface built on LangGraph.
+- [Deep Agents Event Streaming](/oss/deepagents/event-streaming) covers delegated subagent streams.


### PR DESCRIPTION
For the soft launch of the new streaming primitives this patch adds single pages giving some insight into what is coming as well as links to the [streaming-cookbook](https://github.com/langchain-ai/streaming-cookbook). For the "big" release we then will replace current streaming docs with what is proposed in https://github.com/langchain-ai/docs/pull/3763