### PR TITLE
Add LangSmith profile configuration docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,6 +110,7 @@ celerybeat.pid
 
 # Environments
 .env
+.env.*
 .envrc
 .venv
 .venvs
@@ -118,6 +119,12 @@ venv/
 ENV/
 env.bak/
 venv.bak/
+
+# Secret material
+*.pem
+*.key
+*.crt
+credentials.json
 
 # Spyder project settings
 .spyderproject

--- a/src/docs.json
+++ b/src/docs.json
@@ -176,6 +176,7 @@
               "pages": [
                 "langsmith/home",
                 "langsmith/create-account-api-key",
+                "langsmith/profile-configuration",
                 "langsmith/get-started-integrations",
                 "langsmith/pricing-plans",
                 "langsmith/enterprise",

--- a/src/langsmith/create-account-api-key.mdx
+++ b/src/langsmith/create-account-api-key.mdx
@@ -78,6 +78,8 @@ You may also need the following additional environment variables.
 
 `LANGSMITH_WORKSPACE_ID=<Workspace ID>`
 
+To reuse endpoint, API key, and workspace settings across local shells or remote runtimes, see [Profile configuration](/langsmith/profile-configuration).
+
 ## Use API keys outside of the SDK
 
 See [instructions for managing your organization via API](/langsmith/manage-organization-by-api).

--- a/src/langsmith/langsmith-cli.mdx
+++ b/src/langsmith/langsmith-cli.mdx
@@ -42,6 +42,8 @@ Use the `--dry-run` flag to preview the update without installing.
 
 ## Authenticate
 
+`langsmith login` and `langsmith profile` commands require LangSmith CLI `v0.2.26` or later.
+
 The recommended local setup is to authenticate with OAuth:
 
 ```bash

--- a/src/langsmith/langsmith-cli.mdx
+++ b/src/langsmith/langsmith-cli.mdx
@@ -42,6 +42,38 @@ Use the `--dry-run` flag to preview the update without installing.
 
 ## Authenticate
 
+The recommended local setup is to authenticate with OAuth:
+
+```bash
+langsmith login
+```
+
+This opens a browser-based authorization flow and stores OAuth tokens in `~/.langsmith/config.json` under the selected [profile](/langsmith/profile-configuration). Select a profile with `--profile` or `LANGSMITH_PROFILE`:
+
+```bash
+langsmith login --profile dev
+langsmith --profile dev project list
+```
+
+In headless environments, pass `--no-browser` and open the printed URL manually:
+
+```bash
+langsmith login --no-browser --workspace-id <workspace-id>
+```
+
+To manage saved profiles:
+
+```bash
+langsmith profile list
+langsmith profile create dev --workspace-id <workspace-id> --set-current
+langsmith profile use dev
+langsmith profile set-workspace <workspace-id>
+```
+
+For the full profile configuration reference, see [Profile configuration](/langsmith/profile-configuration).
+
+You can also authenticate with an API key directly.
+
 Set your [API key](/langsmith/create-account-api-key) as an environment variable:
 
 ```bash

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -12,6 +12,18 @@ Use profiles when you switch between LangSmith deployments or workspaces often, 
 Profile files can contain API keys and OAuth refresh tokens. Do not commit them to source control, bake them into container images, or print them in logs. Store and mount them with the same care as other credentials.
 </Warning>
 
+## Minimum versions
+
+Profile support is available in the following releases:
+
+| Tool or SDK | Minimum version |
+| --- | --- |
+| LangSmith CLI profile commands and `langsmith login` | `v0.2.26` |
+| Go SDK | `v0.7.0` |
+| Python SDK | Minimum version to be added with the Python SDK release. |
+| TypeScript SDK | Minimum version to be added with the TypeScript SDK release. |
+| Java SDK | Minimum version to be added with the Java SDK release. |
+
 ## Profile file location
 
 By default, SDKs look for a profile file at:

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -4,7 +4,7 @@ description: Configure LangSmith SDK credentials and endpoints with a local prof
 icon: "id"
 ---
 
-LangSmith SDK profiles let you keep API keys, endpoints, and workspace IDs in a reusable JSON file instead of setting the same environment variables in every shell session.
+LangSmith SDK profiles let you keep [API keys](/langsmith/create-account-api-key), endpoints, and workspace IDs in a reusable JSON file instead of setting the same environment variables in every shell session.
 
 Use profiles when you switch between LangSmith deployments or workspaces often, or when you want a remote runtime to load the same SDK configuration from a mounted file.
 

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -22,7 +22,7 @@ Profile support is available in the following releases:
 | Go SDK | `v0.7.0` |
 | Python SDK | Minimum version to be added with the Python SDK release. |
 | TypeScript SDK | Minimum version to be added with the TypeScript SDK release. |
-| Java SDK | Minimum version to be added with the Java SDK release. |
+| Java SDK | `v0.1.0-beta.3` |
 
 ## Profile file location
 

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -6,7 +6,7 @@ icon: "id"
 
 LangSmith SDK profiles let you keep [API keys](/langsmith/create-account-api-key), endpoints, and workspace IDs in a reusable JSON file instead of setting the same environment variables in every shell session.
 
-Use profiles when you switch between LangSmith deployments or workspaces often, or when you want a remote runtime to load the same SDK configuration from a mounted file.
+Use profiles when you switch between LangSmith [deployments](/langsmith/deployment) or [workspaces](/langsmith/administration-overview#workspaces) often, or when you want a remote runtime to load the same SDK configuration from a mounted file.
 
 <Warning>
 Profile files can contain API keys and OAuth refresh tokens. Do not commit them to source control, bake them into container images, or print them in logs. Store and mount them with the same care as other credentials.

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -6,7 +6,7 @@ icon: "id"
 
 LangSmith SDK profiles let you keep [API keys](/langsmith/create-account-api-key), endpoints, and workspace IDs in a reusable JSON file instead of setting the same environment variables in every shell session.
 
-Use profiles when you switch between LangSmith [instances](/langsmith/deployment) or [workspaces](/langsmith/administration-overview#workspaces) often, or when you want a remote runtime to load the same SDK configuration from a mounted file.
+Use profiles when you switch between [LangSmith Cloud regions](/langsmith/cloud#regional-storage), self-hosted instances, or [workspaces](/langsmith/administration-overview#workspaces) often, or when you want a remote runtime to load the same SDK configuration from a mounted file.
 
 <Warning>
 Profile files can contain API keys and OAuth refresh tokens. Do not commit them to source control, bake them into container images, or print them in logs. Store and mount them with the same care as other credentials.

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -20,8 +20,8 @@ Profile support is available in the following releases:
 | --- | --- |
 | LangSmith CLI profile commands and `langsmith login` | `v0.2.26` |
 | Go SDK | `v0.7.0` |
-| Python SDK | Minimum version to be added with the Python SDK release. |
-| TypeScript SDK | Minimum version to be added with the TypeScript SDK release. |
+| Python SDK | `v0.8.1` |
+| TypeScript SDK | `v0.6.1` |
 | Java SDK | `v0.1.0-beta.3` |
 
 ## Profile file location

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -89,7 +89,7 @@ For example:
 export LANGSMITH_PROFILE=eu
 ```
 
-The LangSmith CLI also accepts a global `--profile` flag, which takes precedence over `LANGSMITH_PROFILE` for that command:
+The [LangSmith CLI](/langsmith/langsmith-cli) also accepts a global `--profile` flag, which takes precedence over `LANGSMITH_PROFILE` for that command:
 
 ```shell
 langsmith --profile eu project list

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -1,0 +1,296 @@
+---
+title: Profile configuration
+description: Configure LangSmith SDK credentials and endpoints with a local profile file.
+icon: "id"
+---
+
+LangSmith SDK profiles let you keep API keys, endpoints, and workspace IDs in a reusable JSON file instead of setting the same environment variables in every shell session.
+
+Use profiles when you switch between LangSmith deployments or workspaces often, or when you want a remote runtime to load the same SDK configuration from a mounted file.
+
+<Warning>
+Profile files can contain API keys and OAuth refresh tokens. Do not commit them to source control, bake them into container images, or print them in logs. Store and mount them with the same care as other credentials.
+</Warning>
+
+## Profile file location
+
+By default, SDKs look for a profile file at:
+
+```text
+~/.langsmith/config.json
+```
+
+To use a different path, set `LANGSMITH_CONFIG_FILE`:
+
+```shell
+export LANGSMITH_CONFIG_FILE=/path/to/langsmith-config.json
+```
+
+The TypeScript SDK only loads profiles in Node.js-like runtimes. Browser and web worker runtimes do not have filesystem access, so pass configuration explicitly in those environments.
+
+## Create a profile file
+
+Create `~/.langsmith/config.json` with a `profiles` object. Each profile can define:
+
+| Field | Description |
+| --- | --- |
+| `api_url` | LangSmith API endpoint. Use the same value you would use for `LANGSMITH_ENDPOINT`. |
+| `api_key` | LangSmith API key. See [Create an account and API key](/langsmith/create-account-api-key). |
+| `workspace_id` | Workspace ID. Required when the API key can access multiple workspaces. |
+| `oauth` | OAuth token metadata created by LangSmith tooling. |
+
+```json
+{
+  "current_profile": "dev",
+  "profiles": {
+    "dev": {
+      "api_url": "https://api.smith.langchain.com",
+      "api_key": "<LANGSMITH_API_KEY>",
+      "workspace_id": "<WORKSPACE_ID>"
+    },
+    "eu": {
+      "api_url": "https://eu.api.smith.langchain.com",
+      "api_key": "<EU_LANGSMITH_API_KEY>",
+      "workspace_id": "<EU_WORKSPACE_ID>"
+    }
+  }
+}
+```
+
+Restrict the file so only your user can read it:
+
+```shell
+chmod 600 ~/.langsmith/config.json
+```
+
+## Select a profile
+
+SDKs select profiles in this order:
+
+1. `LANGSMITH_PROFILE`, if set.
+1. `current_profile` in the profile file, if set.
+1. A profile named `default`, if present.
+
+For example:
+
+```shell
+export LANGSMITH_PROFILE=eu
+```
+
+The LangSmith CLI also accepts a global `--profile` flag, which takes precedence over `LANGSMITH_PROFILE` for that command:
+
+```shell
+langsmith --profile eu project list
+```
+
+## Manage profiles with the CLI
+
+Use the [LangSmith CLI](/langsmith/langsmith-cli) to create, inspect, switch, and delete profiles without editing the JSON file by hand.
+
+To create an API-key profile from an existing API key:
+
+```shell
+export LANGSMITH_API_KEY=<LANGSMITH_API_KEY>
+langsmith profile create dev \
+  --workspace-id <WORKSPACE_ID> \
+  --set-current
+```
+
+You can also pass the key and endpoint as flags. Prefer environment variables on shared machines, because shell history may record command flags.
+
+```shell
+langsmith profile create eu \
+  --api-key <EU_LANGSMITH_API_KEY> \
+  --api-url https://eu.api.smith.langchain.com \
+  --workspace-id <EU_WORKSPACE_ID>
+```
+
+Common profile commands:
+
+| Command | Description |
+| --- | --- |
+| `langsmith profile list` | List saved profiles. Alias: `langsmith profile ls`. |
+| `langsmith profile show <name>` | Show a saved profile. Secret values are redacted in output. |
+| `langsmith profile use <name>` | Set `current_profile` in the profile file. |
+| `langsmith profile set-workspace <workspace-id>` | Set the default workspace for the selected profile. |
+| `langsmith profile delete <name>` | Delete a saved profile. |
+
+Use `--format pretty` for human-readable tables:
+
+```shell
+langsmith --format pretty profile list
+```
+
+## Authenticate with `langsmith login`
+
+Run `langsmith login` to authenticate with OAuth instead of manually creating an API-key profile. The command starts a browser-based device authorization flow, stores OAuth tokens in the selected profile, and sets that profile as current.
+
+```shell
+langsmith login
+```
+
+Choose the profile with `--profile` or `LANGSMITH_PROFILE`:
+
+```shell
+langsmith login --profile dev
+```
+
+For a headless environment, suppress automatic browser opening and pass a workspace ID:
+
+```shell
+langsmith login \
+  --profile prod \
+  --no-browser \
+  --workspace-id <WORKSPACE_ID>
+```
+
+`langsmith login` chooses the profile name in this order:
+
+1. `--profile`, if passed.
+1. `LANGSMITH_PROFILE`, if set.
+1. `current_profile` in the profile file, if set.
+1. `default`.
+
+It chooses the API URL in this order:
+
+1. `--api-url`, if passed.
+1. `LANGSMITH_ENDPOINT`, if set.
+1. The selected profile's `api_url`, if present.
+1. The default LangSmith Cloud endpoint.
+
+After login, the CLI and SDKs can use the saved profile. The CLI refreshes OAuth tokens when needed and writes refreshed token fields back to the profile file. SDKs also use the OAuth access token from the profile when environment or constructor API-key auth is not set.
+
+## Override profile values
+
+Explicit client constructor arguments and environment variables take precedence over profile values.
+
+| Setting | Precedence |
+| --- | --- |
+| Endpoint | Constructor `api_url` or `apiUrl`, then `LANGSMITH_ENDPOINT`, then profile `api_url`, then the default LangSmith Cloud endpoint. |
+| Authentication | Constructor API key, then `LANGSMITH_API_KEY`, then profile OAuth access token, then profile `api_key`. |
+| Workspace | Constructor `workspace_id` or `workspaceId`, then `LANGSMITH_WORKSPACE_ID`, then profile `workspace_id`. |
+
+The older `LANGCHAIN_API_KEY`, `LANGCHAIN_ENDPOINT`, and `LANGCHAIN_WORKSPACE_ID` aliases still work, but prefer the `LANGSMITH_*` names for new configuration.
+
+If a profile contains both `oauth.access_token` and `api_key`, SDKs use the OAuth access token first. If an OAuth refresh token is present and the access token is expired or close to expiring, SDKs can refresh the token and write the updated token fields back to the profile file.
+
+<Note>
+If you mount a profile file as read-only, OAuth token refresh cannot persist updated tokens. Read-only mounts are appropriate for API-key profiles. Use a writable mount only when you intentionally rely on OAuth token refresh.
+</Note>
+
+## Use profiles in code
+
+When the profile file is present, create the client normally:
+
+<CodeGroup>
+
+```python Python
+from langsmith import Client
+
+client = Client()
+```
+
+```typescript TypeScript
+import { Client } from "langsmith";
+
+const client = new Client();
+```
+
+</CodeGroup>
+
+To override a profile in code, pass the value explicitly:
+
+<CodeGroup>
+
+```python Python
+from langsmith import Client
+
+client = Client(api_key="<LANGSMITH_API_KEY>")
+```
+
+```typescript TypeScript
+import { Client } from "langsmith";
+
+const client = new Client({ apiKey: "<LANGSMITH_API_KEY>" });
+```
+
+</CodeGroup>
+
+## Mount profiles in remote runtimes
+
+For remote runtimes, mount the profile file as a secret file and set `LANGSMITH_CONFIG_FILE` to the mounted path. Do not copy the file into the image or repository.
+
+### Docker
+
+Mount your local profile directory into the container:
+
+```shell
+docker run --rm \
+  -e LANGSMITH_CONFIG_FILE=/home/app/.langsmith/config.json \
+  -e LANGSMITH_PROFILE=prod \
+  -v "$HOME/.langsmith:/home/app/.langsmith:ro" \
+  my-image
+```
+
+Use a read-write mount only when the profile uses OAuth refresh tokens:
+
+```shell
+docker run --rm \
+  -e LANGSMITH_CONFIG_FILE=/home/app/.langsmith/config.json \
+  -e LANGSMITH_PROFILE=prod \
+  -v "$HOME/.langsmith:/home/app/.langsmith" \
+  my-image
+```
+
+### Kubernetes
+
+Create a Kubernetes secret from the profile file:
+
+```shell
+kubectl create secret generic langsmith-profile \
+  --from-file=config.json="$HOME/.langsmith/config.json"
+```
+
+Mount the secret and point the SDK to it:
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: app
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: my-image
+          env:
+            - name: LANGSMITH_CONFIG_FILE
+              value: /var/run/langsmith/config.json
+            - name: LANGSMITH_PROFILE
+              value: prod
+          volumeMounts:
+            - name: langsmith-profile
+              mountPath: /var/run/langsmith
+              readOnly: true
+      volumes:
+        - name: langsmith-profile
+          secret:
+            secretName: langsmith-profile
+```
+
+Kubernetes secret volumes are read-only. Use API-key profiles for this pattern, or use a writable secret-sync mechanism if your OAuth profile must refresh and persist tokens.
+
+### Remote development and CI
+
+In remote development environments or CI jobs, store the profile JSON in the platform's secret store, write it to a temporary file at runtime, and set `LANGSMITH_CONFIG_FILE` to that file path.
+
+```shell
+mkdir -p "$RUNNER_TEMP/langsmith"
+printf '%s' "$LANGSMITH_PROFILE_JSON" > "$RUNNER_TEMP/langsmith/config.json"
+chmod 600 "$RUNNER_TEMP/langsmith/config.json"
+export LANGSMITH_CONFIG_FILE="$RUNNER_TEMP/langsmith/config.json"
+export LANGSMITH_PROFILE=prod
+```
+
+For hosted LangSmith Cloud deployments, configure these values as deployment environment variables or workspace secrets unless the platform explicitly supports mounting secret files.

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -26,7 +26,7 @@ Profile support is available in the following releases:
 
 ## Profile file location
 
-By default, SDKs look for a profile file at:
+By default, [SDKs](/langsmith/reference) look for a profile file at:
 
 ```text
 ~/.langsmith/config.json

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -6,7 +6,7 @@ icon: "id"
 
 LangSmith SDK profiles let you keep [API keys](/langsmith/create-account-api-key), endpoints, and workspace IDs in a reusable JSON file instead of setting the same environment variables in every shell session.
 
-Use profiles when you switch between LangSmith [deployments](/langsmith/deployment) or [workspaces](/langsmith/administration-overview#workspaces) often, or when you want a remote runtime to load the same SDK configuration from a mounted file.
+Use profiles when you switch between LangSmith [instances](/langsmith/deployment) or [workspaces](/langsmith/administration-overview#workspaces) often, or when you want a remote runtime to load the same SDK configuration from a mounted file.
 
 <Warning>
 Profile files can contain API keys and OAuth refresh tokens. Do not commit them to source control, bake them into container images, or print them in logs. Store and mount them with the same care as other credentials.


### PR DESCRIPTION
Adds LangSmith profile configuration docs.

- Documents the profile file format, profile selection precedence, and SDK behavior
- Covers CLI profile management commands and `langsmith login`
- Adds guidance for mounting profiles in Docker, Kubernetes, and remote CI environments
- Adds `.gitignore` credential-file patterns

Verification:
- `make lint_prose FILES="src/langsmith/profile-configuration.mdx src/langsmith/create-account-api-key.mdx src/langsmith/langsmith-cli.mdx"`
- `make broken-links`
- `git diff --check`