### PR TITLE
fix: clarify langgraph checkpoint boundaries [closes DOC-1061]

### DIFF
--- a/src/oss/langgraph/persistence.mdx
+++ b/src/oss/langgraph/persistence.mdx
@@ -54,11 +54,13 @@ The checkpointer uses `thread_id` as the primary key for storing and retrieving 
 
 ### Checkpoints
 
-The state of a thread at a particular point in time is called a checkpoint. A checkpoint is a snapshot of the graph state saved at each [super-step](#super-steps) and is represented by a `StateSnapshot` object (see [StateSnapshot fields](#statesnapshot-fields) for the full field reference).
+The state of a thread at a particular point in time is called a checkpoint. A checkpoint is a full snapshot of the graph state saved at each [super-step](#super-steps) and is represented by a `StateSnapshot` object (see [StateSnapshot fields](#statesnapshot-fields) for the full field reference).
 
 #### Super-steps
 
-LangGraph created a checkpoint at each **super-step** boundary. A super-step is a single "tick" of the graph where all nodes scheduled for that step execute (potentially in parallel). For a sequential graph like `START -> A -> B -> END`, there are separate super-steps for the input, node A, and node B — producing a checkpoint after each one. Understanding super-step boundaries is important for [time travel](/oss/langgraph/use-time-travel), because you can only resume execution from a checkpoint (i.e., a super-step boundary).
+LangGraph creates a full checkpoint at each **super-step** boundary. A super-step is a single "tick" of the graph where all nodes scheduled for that step execute (potentially in parallel). For a sequential graph like `START -> A -> B -> END`, there are separate super-steps for the input, node A, and node B, producing a checkpoint after each one.
+
+LangGraph also persists writes from individual node executions within a super-step. These writes are stored as tasks and used for fault tolerance: if another node in the same super-step fails, successful node writes do not need to be recomputed when you resume. These task writes are not full `StateSnapshot` checkpoints, so time travel resumes from full checkpoints at super-step boundaries.
 
 Checkpoints are persisted and can be used to restore the state of a thread at a later time.
 

--- a/src/oss/langgraph/persistence.mdx
+++ b/src/oss/langgraph/persistence.mdx
@@ -54,11 +54,11 @@ The checkpointer uses `thread_id` as the primary key for storing and retrieving 
 
 ### Checkpoints
 
-The state of a thread at a particular point in time is called a checkpoint. A checkpoint is a full snapshot of the graph state saved at each [super-step](#super-steps) and is represented by a `StateSnapshot` object (see [StateSnapshot fields](#statesnapshot-fields) for the full field reference).
+The state of a thread at a particular point in time is called a checkpoint. A checkpoint is a snapshot of the graph state saved at each [super-step](#super-steps) and is represented by a `StateSnapshot` object (see [StateSnapshot fields](#statesnapshot-fields) for the full field reference).
 
 #### Super-steps
 
-LangGraph creates a full checkpoint at each **super-step** boundary. A super-step is a single "tick" of the graph where all nodes scheduled for that step execute (potentially in parallel). For a sequential graph like `START -> A -> B -> END`, there are separate super-steps for the input, node A, and node B, producing a checkpoint after each one.
+LangGraph created a checkpoint at each **super-step** boundary. A super-step is a single "tick" of the graph where all nodes scheduled for that step execute (potentially in parallel). For a sequential graph like `START -> A -> B -> END`, there are separate super-steps for the input, node A, and node B — producing a checkpoint after each one. Understanding super-step boundaries is important for [time travel](/oss/langgraph/use-time-travel), because you can only resume execution from a checkpoint (i.e., a super-step boundary).
 
 LangGraph also persists writes from individual node executions within a super-step. These writes are stored as tasks and used for fault tolerance: if another node in the same super-step fails, successful node writes do not need to be recomputed when you resume. These task writes are not full `StateSnapshot` checkpoints, so time travel resumes from full checkpoints at super-step boundaries.
 


### PR DESCRIPTION
## Description
Clarifies LangGraph persistence docs by adding a note that node-level task writes are persisted for fault tolerance while preserving the existing super-step and time-travel guidance. Prepared by Open SWE.

## Release Note
Clarified LangGraph persistence documentation for node-level task writes.

## Test Plan
- [ ] Review the Persistence page section on super-steps in the docs preview

_Opened collaboratively by Quanzheng Long and open-swe._