### PR TITLE
feat: Add backward compatiblity for langgraph

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -1221,6 +1221,7 @@
                       "pages": [
                         "oss/python/langgraph/application-structure",
                         "oss/python/langgraph/test",
+                        "oss/python/langgraph/backward-compatibility",
                         "oss/python/langgraph/studio",
                         "oss/python/langgraph/ui",
                         "oss/python/langgraph/deploy",
@@ -1662,6 +1663,7 @@
                       "pages": [
                         "oss/javascript/langgraph/application-structure",
                         "oss/javascript/langgraph/test",
+                        "oss/javascript/langgraph/backward-compatibility",
                         "oss/javascript/langgraph/studio",
                         "oss/javascript/langgraph/ui",
                         "oss/javascript/langgraph/deploy",

--- a/src/oss/langgraph/backward-compatibility.mdx
+++ b/src/oss/langgraph/backward-compatibility.mdx
@@ -9,17 +9,17 @@ Unlike workflow engines that pin a run to the version of code it started with, L
 
 There are three categories of compatibility issues to watch for, in roughly the order you will encounter them:
 
-1. [Technical compatibility](#technical-compatibility): the most common; the new code must still load and execute against existing State.
-2. [Business compatibility](#business-compatibility): less common; existing runs should keep following the old business logic even though the code has changed.
-3. [Non-determinism](#non-determinism): only applies to the [Functional API](/oss/langgraph/functional-api).
+1. [Technical compatibility](#technical-compatibility): The most common; the new code must still load and execute against existing State.
+2. [Business compatibility](#business-compatibility): Less common; existing runs should keep following the old business logic even though the code has changed.
+3. [Non-determinism](#non-determinism): Only applies to the [Functional API](/oss/langgraph/functional-api).
 
 <Tip>
-For a short summary of which graph topology and State changes the runtime supports out of the box, see [Graph migrations](/oss/langgraph/graph-api#graph-migrations). The rest of this page covers the patterns you can apply when a change falls outside that supported set.
+For a short summary of which graph topology and state changes the runtime supports by default, see [Graph migrations](/oss/langgraph/graph-api#graph-migrations). The rest of this page covers the patterns you can apply when a change falls outside that supported set.
 </Tip>
 
 ## Technical compatibility
 
-Technical compatibility is the equivalent of an API breaking change in a microservice. The "API" here is the contract between your graph code and the data already persisted by the [checkpointer](/oss/langgraph/persistence#checkpointer-libraries) for existing threads. When a thread resumes, LangGraph deserializes the saved State, dispatches it to a node by name, and expects the node to return values that fit the State schema.
+Technical compatibility is the equivalent of an API breaking change in a microservice. The "API" here is the contract between your graph code and the data already persisted by the [checkpointer](/oss/langgraph/persistence#checkpointer-libraries) for existing threads. When a thread resumes, LangGraph deserializes the saved state, dispatches it to a node by name, and expects the node to return values that fit the state schema.
 
 Common technical breakages:
 
@@ -33,7 +33,7 @@ Edge topology itself is *not* persisted in the checkpoint. Adding, removing, or 
 
 :::python
 
-- Add new State fields as `NotRequired` (or `Optional[...] = None`) so old checkpoints still validate:
+- Add new state fields as `NotRequired` (or `Optional[...] = None`) so old checkpoints still validate:
 
   ```python
   from typing import NotRequired
@@ -44,16 +44,16 @@ Edge topology itself is *not* persisted in the checkpoint. Adding, removing, or 
       summary: NotRequired[str]  # [!code ++]
   ```
 
-- Treat removals as deprecations. Keep the field defined on the State for at least one drain cycle, even if no node reads it, so existing checkpoints continue to load.
-- Rename via *add-then-remove*. Add the new field or node alongside the old one, dual-write or route to both for a deprecation window, then remove the old one once you have confirmed no in-flight thread depends on it.
-- Keep node functions tolerant of unknown keys. `TypedDict` ignores extra keys at runtime, so leftover State from an older code version will not raise unless a node explicitly reads a missing key.
+- Treat removals as deprecations. Keep the field defined on the state for at least one drain cycle, even if no node reads it, so existing checkpoints continue to load.
+- Rename through *add-then-remove*. Add the new field or node alongside the old one, dual-write or route to both for a deprecation window, then remove the old one once you have confirmed no in-flight thread depends on it.
+- Keep node functions tolerant of unknown keys. `TypedDict` ignores extra keys at runtime, so leftover state from an older code version will not raise unless a node explicitly reads a missing key.
 - Use [time travel](/oss/langgraph/use-time-travel) and @[`graph.get_state`][get_state] to spot-check existing threads against the new code in a staging deployment before rolling out.
 
 :::
 
 :::js
 
-- Mark new State fields as optional (`z.string().optional()` or `.nullish()`) so old checkpoints still validate.
+- Mark new state fields as optional (`z.string().optional()` or `.nullish()`) so old checkpoints still validate.
 - Treat removals as deprecations: keep the field on the schema for at least one drain cycle so existing checkpoints continue to load.
 - Rename via add-then-remove: add the new field or node alongside the old one, dual-write or route to both for a deprecation window, then remove the old one once no in-flight thread depends on it.
 - Use [time travel](/oss/langgraph/use-time-travel) and @[`graph.getState`][get_state] to spot-check existing threads against the new code in a staging deployment before rolling out.
@@ -66,7 +66,7 @@ Before you remove a node, rename a State key, or otherwise make a change that ol
 
 **If you deploy to [LangSmith](/langsmith/deployment).** Use the Agent Server's thread search to filter by status. The `status` field accepts `idle`, `busy`, `interrupted`, and `error`, so you can bulk-query for `interrupted` or `busy` threads, optionally narrowed with metadata filters. See [Filter by thread status](/langsmith/use-threads#filter-by-thread-status) and [List threads](/langsmith/use-threads#list-threads).
 
-**Anywhere LangGraph runs.** Use [LangSmith tracing](/oss/langgraph/observability) to monitor which nodes are being entered and exited in production. This is the most reliable signal that a node or State field is no longer reachable in any active code path.
+**Anywhere LangGraph runs.** Use [LangSmith tracing](/oss/langgraph/observability) to monitor which nodes are being entered and exited in production. This is the most reliable signal that a node or state field is no longer reachable in any active code path.
 
 **When you already have a `thread_id`.** Inspect that single thread directly:
 
@@ -95,7 +95,7 @@ For example, suppose your graph runs `intake → triage → respond`, and you de
 - Threads that have already passed `triage` should continue straight to `respond` (the old flow).
 - New threads should run the full new flow.
 
-The recommended pattern is to record the relevant *behavioral version* on the State at thread start, then branch on it with a [conditional edge](/oss/langgraph/graph-api#conditional-edges):
+The recommended pattern is to record the relevant *behavioral version* on the state at thread start, then branch on it with a [conditional edge](/oss/langgraph/graph-api#conditional-edges):
 
 :::python
 
@@ -145,7 +145,7 @@ graph = builder.compile()
 
 :::
 
-Old threads that resume after `triage` read `flow_version` from their saved State (or fall through to the v1 default) and skip `policy_check`. New threads start at `intake`, are stamped with `flow_version=2`, and run the new path. Once all v1 threads have completed, you can remove the version flag and the conditional edge.
+Old threads that resume after `triage` read `flow_version` from their saved state (or fall through to the v1 default) and skip `policy_check`. New threads start at `intake`, are stamped with `flow_version=2`, and run the new path. Once all v1 threads have completed, you can remove the version flag and the conditional edge.
 
 This pattern only works if you set the version *at thread start*, before any branch that needs to be versioned. Setting it later means existing threads will not have it set when they need it.
 

--- a/src/oss/langgraph/backward-compatibility.mdx
+++ b/src/oss/langgraph/backward-compatibility.mdx
@@ -1,0 +1,167 @@
+---
+title: Backward compatibility
+description: Update LangGraph graph code in production without breaking in-flight runs.
+---
+
+Software needs to change in production. New requirements, bug fixes, and refactors all eventually land in your graph code. Because LangGraph runs the latest deployed graph against state that has been [persisted](/oss/langgraph/persistence) for existing threads, every change you ship is effectively a backward-compatible API change with respect to your existing checkpoints.
+
+Unlike workflow engines that pin a run to the version of code it started with, LangGraph applies the latest graph immediately to *every* thread, both new threads and threads that resume from a checkpoint. This is convenient: bug fixes propagate to in-flight conversations and agents without ceremony. It also means you must reason about how each change interacts with runs that started under the previous version of the code.
+
+There are three categories of compatibility issues to watch for, in roughly the order you will encounter them:
+
+1. [Technical compatibility](#technical-compatibility): the most common; the new code must still load and execute against existing State.
+2. [Business compatibility](#business-compatibility): less common; existing runs should keep following the old business logic even though the code has changed.
+3. [Non-determinism](#non-determinism): only applies to the [Functional API](/oss/langgraph/functional-api).
+
+<Tip>
+For a short summary of which graph topology and State changes the runtime supports out of the box, see [Graph migrations](/oss/langgraph/graph-api#graph-migrations). The rest of this page covers the patterns you can apply when a change falls outside that supported set.
+</Tip>
+
+## Technical compatibility
+
+Technical compatibility is the equivalent of an API breaking change in a microservice. The "API" here is the contract between your graph code and the data already persisted by the [checkpointer](/oss/langgraph/persistence#checkpointer-libraries) for existing threads. When a thread resumes, LangGraph deserializes the saved State, dispatches it to a node by name, and expects the node to return values that fit the State schema.
+
+Common technical breakages:
+
+- **Renaming or removing a node** while threads are paused at or about to enter that node, for example at an @[`interrupt`] or via a checkpointed conditional edge that still routes to the old name. On resume, LangGraph cannot find the node by its saved name and the run fails. The [starting point for resuming a run](/oss/langgraph/durable-execution#starting-points-for-resuming-workflows) is the beginning of the node where execution stopped, so a missing node has nowhere to resume from.
+- **Renaming or removing a State key** that older checkpoints still contain or that downstream nodes still read.
+- **Tightening a State field**, such as making an `Optional` field required, narrowing a type, or adding a new required field with no default. Existing checkpoints will not satisfy the new schema.
+
+Edge topology itself is *not* persisted in the checkpoint. Adding, removing, or rerouting edges between nodes that still exist is safe for in-flight threads. Per the [Graph migrations](/oss/langgraph/graph-api#graph-migrations) summary, the only topology change that can break an interrupted thread is renaming or removing a node.
+
+### Recommended patterns
+
+:::python
+
+- Add new State fields as `NotRequired` (or `Optional[...] = None`) so old checkpoints still validate:
+
+  ```python
+  from typing import NotRequired
+  from typing_extensions import TypedDict
+
+  class State(TypedDict):
+      messages: list
+      summary: NotRequired[str]  # [!code ++]
+  ```
+
+- Treat removals as deprecations. Keep the field defined on the State for at least one drain cycle, even if no node reads it, so existing checkpoints continue to load.
+- Rename via *add-then-remove*. Add the new field or node alongside the old one, dual-write or route to both for a deprecation window, then remove the old one once you have confirmed no in-flight thread depends on it.
+- Keep node functions tolerant of unknown keys. `TypedDict` ignores extra keys at runtime, so leftover State from an older code version will not raise unless a node explicitly reads a missing key.
+- Use [time travel](/oss/langgraph/use-time-travel) and @[`graph.get_state`][get_state] to spot-check existing threads against the new code in a staging deployment before rolling out.
+
+:::
+
+:::js
+
+- Mark new State fields as optional (`z.string().optional()` or `.nullish()`) so old checkpoints still validate.
+- Treat removals as deprecations: keep the field on the schema for at least one drain cycle so existing checkpoints continue to load.
+- Rename via add-then-remove: add the new field or node alongside the old one, dual-write or route to both for a deprecation window, then remove the old one once no in-flight thread depends on it.
+- Use [time travel](/oss/langgraph/use-time-travel) and @[`graph.getState`][get_state] to spot-check existing threads against the new code in a staging deployment before rolling out.
+
+:::
+
+### Detecting in-flight threads
+
+Before you remove a node, rename a State key, or otherwise make a change that older threads cannot tolerate, you want to know whether any threads are currently parked on the version of the code you are about to drop. LangGraph itself does not maintain a search index over thread state, so the answer depends on where your graph runs.
+
+**If you deploy to [LangSmith](/langsmith/deployment).** Use the Agent Server's thread search to filter by status. The `status` field accepts `idle`, `busy`, `interrupted`, and `error`, so you can bulk-query for `interrupted` or `busy` threads, optionally narrowed with metadata filters. See [Filter by thread status](/langsmith/use-threads#filter-by-thread-status) and [List threads](/langsmith/use-threads#list-threads).
+
+**Anywhere LangGraph runs.** Use [LangSmith tracing](/oss/langgraph/observability) to monitor which nodes are being entered and exited in production. This is the most reliable signal that a node or State field is no longer reachable in any active code path.
+
+**When you already have a `thread_id`.** Inspect that single thread directly:
+
+:::python
+
+- @[`graph.get_state(config)`][get_state] returns the latest checkpoint, including which node the thread is paused at and any pending interrupts.
+- @[`graph.get_state_history(config)`][get_state_history] returns the full chronological list of checkpoints for the thread.
+
+:::
+
+:::js
+
+- @[`graph.getState(config)`][get_state] returns the latest checkpoint, including which node the thread is paused at and any pending interrupts.
+- @[`graph.getStateHistory(config)`][get_state_history] returns the full chronological list of checkpoints for the thread.
+
+:::
+
+When in doubt, keep the deprecated node or field in place until both the Agent Server thread list and tracing show no further activity on it.
+
+## Business compatibility
+
+Sometimes a change is technically valid (every existing checkpoint still loads and every node still resolves), but the *meaning* of the new graph differs from the old one. The new behavior is correct for new threads, and you do not want to retroactively apply it to threads that started under the old logic.
+
+For example, suppose your graph runs `intake → triage → respond`, and you decide to insert a new `policy_check` step between `triage` and `respond`:
+
+- Threads that have already passed `triage` should continue straight to `respond` (the old flow).
+- New threads should run the full new flow.
+
+The recommended pattern is to record the relevant *behavioral version* on the State at thread start, then branch on it with a [conditional edge](/oss/langgraph/graph-api#conditional-edges):
+
+:::python
+
+```python
+from typing import NotRequired
+from typing_extensions import TypedDict
+
+from langgraph.graph import END, START, StateGraph
+
+
+class State(TypedDict):
+    request: str
+    flow_version: NotRequired[int]
+    response: NotRequired[str]
+
+
+def intake(state: State) -> dict:
+    # Stamp new threads with the current flow version. Existing threads
+    # that resume past `intake` keep whatever value was already saved.
+    return {"flow_version": state.get("flow_version", 2)}
+
+
+def triage(state: State) -> dict: ...
+def policy_check(state: State) -> dict: ...
+def respond(state: State) -> dict: ...
+
+
+def after_triage(state: State) -> str:
+    if state.get("flow_version", 1) >= 2:
+        return "policy_check"
+    return "respond"
+
+
+builder = StateGraph(State)
+builder.add_node("intake", intake)
+builder.add_node("triage", triage)
+builder.add_node("policy_check", policy_check)
+builder.add_node("respond", respond)
+builder.add_edge(START, "intake")
+builder.add_edge("intake", "triage")
+builder.add_conditional_edges("triage", after_triage, ["policy_check", "respond"])
+builder.add_edge("policy_check", "respond")
+builder.add_edge("respond", END)
+
+graph = builder.compile()
+```
+
+:::
+
+Old threads that resume after `triage` read `flow_version` from their saved State (or fall through to the v1 default) and skip `policy_check`. New threads start at `intake`, are stamped with `flow_version=2`, and run the new path. Once all v1 threads have completed, you can remove the version flag and the conditional edge.
+
+This pattern only works if you set the version *at thread start*, before any branch that needs to be versioned. Setting it later means existing threads will not have it set when they need it.
+
+## Non-determinism
+
+This category only applies to the [Functional API](/oss/langgraph/functional-api). The [Graph API](/oss/langgraph/graph-api) re-enters at the node boundary on resume, so node code is not "replayed" from the start of the function the way Temporal-style workflows are.
+
+The Functional API, in contrast, replays the body of an `@entrypoint` from the beginning when a run resumes, using cached @[`@task`][task] results to skip work that has already been done. Two kinds of changes break this model:
+
+- **Adding, removing, or reordering `@task` calls or @[`interrupt`] calls** that come *before* the resume point. LangGraph matches cached results and resume values to calls by their position in the replay, so shifting that position can cause the wrong cached value to be replayed against a different call.
+- **Introducing non-deterministic operations outside of a `@task`**, such as `time.time()`, `random.random()`, or a network call inlined in the entrypoint body. On replay these produce different values than they did on the first run, which can change the control flow.
+
+For a deeper treatment with examples, see [Determinism](/oss/langgraph/functional-api#determinism) and [Common pitfalls](/oss/langgraph/functional-api#common-pitfalls) in the Functional API guide.
+
+If you need to make non-trivial code changes to an `@entrypoint` that has in-flight runs, the safest options are:
+
+- Let in-flight runs drain before deploying the change.
+- Wrap any new logic in a new `@task` so its results are checkpointed independently.
+- Register a new entrypoint under a new graph name in `langgraph.json` for the new behavior, and route new threads to it.


### PR DESCRIPTION
## Overview

Adds a new docs page **Backward compatibility** under the LangGraph **Production** tab (right after **Test**) that explains how to safely change graph code in production without breaking in-flight runs.

LangGraph applies the latest deployed graph immediately to every thread, including threads that resume from a checkpoint. That makes most code changes implicit backward-compatible API changes against your existing checkpoints, and there are no team-wide guidelines today that walk users through what is safe vs. what isn't. This page fills that gap.

The page is organized around three categories of compatibility issues, in roughly the order users will hit them:

1. **Technical compatibility** (most common) — the new code must still load and execute against existing State. Covers renaming/removing nodes, State key removal/rename, tightening State field types, and clarifies that edge topology is *not* persisted in the checkpoint.
2. **Business compatibility** — the new code is technically valid but the new behavior shouldn't apply to in-flight threads. Covers the "stamp a `flow_version` flag on the State at thread start, branch on it via a conditional edge" pattern.
3. **Non-determinism** — only relevant for the Functional API, since the Graph API does not replay node bodies. Cross-links to the existing Determinism / Common pitfalls sections rather than re-deriving them.

Also includes a **Detecting in-flight threads** subsection that tells users how to find threads parked on a node before deprecating it, leading with the Agent Server's ``threads.search(status="interrupted"|"busy")``, falling back to LangSmith tracing, and finally to per-thread ``get_state`` / ``get_state_history`` when you already have a ``thread_id``.

The structure and three-category framing are inspired by [iWF's versioning guide](https://github.com/indeedeng/iwf/wiki/%5BVersioning%5DHow-to-modify-workflow-code-without-breaking-changes), adapted for LangGraph (WorkflowState → Node, Input → State), Python-only examples, and reflecting that LangGraph has no Search Attribute equivalent — Agent Server thread search and LangSmith tracing are the analogues.

## Type of change

**Type:** New documentation page

## Related issues/PRs
- GitHub issue:
- Feature PR:
- Linear issue:
- Slack thread:

## Checklist
- [ ] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes

### Reviewer pointers

- **Title.** Went with `Backward compatibility` over alternatives (`Versioning`, `Update graphs in production`, `Evolving graph code`) since it matches the noun-style of neighboring Production-tab pages (`Test`, `Studio`, `Deploy`, `Observability`) and is the most direct description of the topic. Easy to rename if reviewers prefer otherwise.
- **Overlap with [`graph-api.mdx#graph-migrations`](https://docs.langchain.com/oss/langgraph/graph-api#graph-migrations).** That existing five-bullet section is a quick reference; this page is the longer narrative companion with patterns and examples. Cross-linked from a `<Tip>` near the top so readers who land on either entry point find the other.
- **Python-first by design.** The conceptual prose applies to both Python and TypeScript; only the State-versioning code example is Python-only (wrapped in `:::python`). JS readers still see the prose and SDK pointers (`graph.getState`, `graph.getStateHistory`). Happy to add a TS code example for the versioning pattern if reviewers want symmetry.
- **Code examples.** The State-versioning Python snippet is illustrative — the `triage` / `policy_check` / `respond` node bodies are stubbed with `...` since the point is the conditional edge wiring, not the work each node does. The smaller `NotRequired` snippet is a copy/paste-runnable schema fragment. Neither has been executed as a full graph.
- **Cross-links manually verified** (since `mint` isn't available in my env to run `make broken-links`): `#starting-points-for-resuming-workflows` (durable-execution), `#determinism` and `#common-pitfalls` (functional-api), `#filter-by-thread-status` and `#list-threads` (use-threads), `#conditional-edges` and `#graph-migrations` (graph-api), `#checkpointer-libraries` and `#get-state` (persistence).
- **Vale clean.** `make lint_prose FILES="src/oss/langgraph/backward-compatibility.mdx"` passes with 0 errors / 0 warnings.

### AI agent involvement

This PR was drafted with assistance from an AI coding agent (Cursor + Claude). All technical claims (in particular the "edges are not persisted in the checkpoint" clarification and the Agent Server `threads.search` recommendation) were cross-checked against the existing docs before being included.