### PR TITLE
fix: update links for prompt caching examples

### DIFF
--- a/src/oss/python/integrations/chat/anthropic.mdx
+++ b/src/oss/python/integrations/chat/anthropic.mdx
@@ -1136,7 +1136,7 @@ model = ChatAnthropic(model="claude-sonnet-4-5")
 
 # Pull LangChain readme
 get_response = requests.get(
-    "https://raw.githubusercontent.com/langchain-ai/langchain/master/README.md"
+    "https://raw.githubusercontent.com/langchain-ai/langchain/b476fdb54aa6e6f5f0b24a68c2f4a94e43b369f9/README.md"
 )
 readme = get_response.text
 
@@ -1194,7 +1194,7 @@ model = ChatAnthropic(model="claude-sonnet-4-5")
 
 # Pull LangChain readme
 get_response = requests.get(
-    "https://raw.githubusercontent.com/langchain-ai/langchain/master/README.md"
+    "https://raw.githubusercontent.com/langchain-ai/langchain/b476fdb54aa6e6f5f0b24a68c2f4a94e43b369f9/README.md"
 )
 readme = get_response.text
 

--- a/src/oss/python/integrations/chat/bedrock.mdx
+++ b/src/oss/python/integrations/chat/bedrock.mdx
@@ -245,7 +245,7 @@ llm = ChatBedrockConverse(model="us.anthropic.claude-sonnet-4-6")
 
 # Pull LangChain readme
 get_response = requests.get(
-    "https://raw.githubusercontent.com/langchain-ai/langchain/master/README.md"
+    "https://raw.githubusercontent.com/langchain-ai/langchain/b476fdb54aa6e6f5f0b24a68c2f4a94e43b369f9/README.md"
 )
 readme = get_response.text
 


### PR DESCRIPTION
The LangChain README is now too short to trigger prompt caching. So we use an earlier version that was long enough.