### PR TITLE
docs: fix broken create_agent reference link in LangGraph v1 migratio…

### DIFF
--- a/src/oss/python/migrate/langgraph-v1.mdx
+++ b/src/oss/python/migrate/langgraph-v1.mdx
@@ -26,7 +26,7 @@ The following table lists all items deprecated in LangGraph v1:
 
 | Deprecated item | Alternative |
 |----------------|-------------|
-| `create_react_agent` | @[`langchain.agents.create_agent`][create_agent] |
+| `create_react_agent` | @[`create_agent`] |
 | `AgentState` | @[`langchain.agents.AgentState`][AgentState] |
 | `AgentStatePydantic` | `langchain.agents.AgentState` (no more pydantic state) |
 | `AgentStateWithStructuredResponse` | `langchain.agents.AgentState` |


### PR DESCRIPTION
docs: fix broken create_agent reference link in LangGraph v1 migration guide

The deprecation table used @[langchain.agents.create_agent][create_agent] as the display text, which points users to a 'Symbol Not Found' page at /python/langchain/agents/create_agent. Replaced with the @[create_agent] shorthand to match the rest of the file and resolve correctly via link_map.py to /python/langchain/agents/factory/create_agent. Fixes #3630

## Overview

The LangGraph v1 migration guide has a broken reference in the deprecation table. The entry for `create_react_agent` links to `create_agent` using the full display text `langchain.agents.create_agent`, but this path doesn't exist on the reference site — it returns a "Symbol Not Found" error. The actual symbol lives under `langchain.agents.factory.create_agent`.

Swapped it to use the `@[create_agent]` shorthand (same pattern already used on lines 21, 37, 38, and 42 of the same file), which resolves correctly through `link_map.py`.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs

- GitHub issue: closes #3630

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes

Verified both URLs manually:
- `/python/langchain/agents/create_agent` → "Symbol Not Found" page
- `/python/langchain/agents/factory/create_agent` → correct API reference page

Single-line change; no other files affected.
