### PR TITLE
Document LangSmith login SaaS limitation

### DIFF
--- a/src/langsmith/langsmith-cli.mdx
+++ b/src/langsmith/langsmith-cli.mdx
@@ -46,6 +46,10 @@ Use the `--dry-run` flag to preview the update without installing.
 
 The recommended local setup is to authenticate with OAuth:
 
+<Note>
+`langsmith login` currently supports LangSmith Cloud (SaaS) only. For self-hosted or other non-SaaS LangSmith endpoints, authenticate with an API key or create an API-key profile.
+</Note>
+
 ```bash
 langsmith login
 ```

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -137,6 +137,10 @@ langsmith --format pretty profile list
 
 Run `langsmith login` to authenticate with OAuth instead of manually creating an API-key profile. The command starts a browser-based device authorization flow, stores OAuth tokens in the selected profile, and sets that profile as current.
 
+<Note>
+`langsmith login` currently supports LangSmith Cloud (SaaS) only. For self-hosted or other non-SaaS LangSmith endpoints, create an API-key profile instead.
+</Note>
+
 ```shell
 langsmith login
 ```


### PR DESCRIPTION
## Summary
- Note that `langsmith login` currently supports LangSmith Cloud (SaaS) only
- Point self-hosted and other non-SaaS endpoint users to API-key authentication/profile setup

## Test Plan
- `git diff --check`