### PR TITLE
docs: update LangSmith CLI login minimum version

### DIFF
--- a/src/langsmith/langsmith-cli.mdx
+++ b/src/langsmith/langsmith-cli.mdx
@@ -46,6 +46,10 @@ Use the `--dry-run` flag to preview the update without installing.
 
 The recommended local setup is to authenticate with OAuth:
 
+<Note>
+`langsmith login` currently supports LangSmith Cloud (SaaS) only. For self-hosted or other non-SaaS LangSmith endpoints, authenticate with an API key or create an API-key profile.
+</Note>
+
 ```bash
 langsmith login
 ```

--- a/src/langsmith/langsmith-cli.mdx
+++ b/src/langsmith/langsmith-cli.mdx
@@ -42,7 +42,7 @@ Use the `--dry-run` flag to preview the update without installing.
 
 ## Authenticate
 
-`langsmith login` and `langsmith profile` commands require LangSmith CLI `v0.2.26` or later.
+`langsmith login` requires LangSmith CLI `v0.2.29` or later. `langsmith profile` commands require LangSmith CLI `v0.2.26` or later.
 
 The recommended local setup is to authenticate with OAuth:
 

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -137,6 +137,10 @@ langsmith --format pretty profile list
 
 Run `langsmith login` to authenticate with OAuth instead of manually creating an API-key profile. The command starts a browser-based device authorization flow, stores OAuth tokens in the selected profile, and sets that profile as current.
 
+<Note>
+`langsmith login` currently supports LangSmith Cloud (SaaS) only. For self-hosted or other non-SaaS LangSmith endpoints, create an API-key profile instead.
+</Note>
+
 ```shell
 langsmith login
 ```

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -18,7 +18,8 @@ Profile support is available in the following releases:
 
 | Tool or SDK | Minimum version |
 | --- | --- |
-| LangSmith CLI profile commands and `langsmith login` | `v0.2.26` |
+| LangSmith CLI profile commands | `v0.2.26` |
+| `langsmith login` | `v0.2.29` |
 | Go SDK | `v0.7.0` |
 | Python SDK | `v0.8.1` |
 | TypeScript SDK | `v0.6.1` |


### PR DESCRIPTION
## Summary
- clarify that `langsmith login` requires LangSmith CLI v0.2.29 or later
- keep `langsmith profile` command minimum version at v0.2.26
- keep the SaaS-only login note from the branch

## Verification
- git diff --check