### PR TITLE
Consolidate LangSmith CTA links with clean UTM tracking

### DIFF
--- a/pipeline/preprocessors/markdown_preprocessor.py
+++ b/pipeline/preprocessors/markdown_preprocessor.py
@@ -11,6 +11,7 @@ import re
 from pathlib import Path
 
 from pipeline.preprocessors.handle_auto_links import replace_autolinks
+from pipeline.preprocessors.utm_links import add_utm_to_cta_links
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +102,9 @@ def preprocess_markdown(
 
     # Apply cross-reference preprocessing
     content = replace_autolinks(content, str(file_path), default_scope=default_scope)
+
+    # Add UTM tracking to LangSmith CTA links
+    content = add_utm_to_cta_links(content, file_path)
 
     # Apply conditional rendering for code blocks
     return _apply_conditional_rendering(content, target_language)

--- a/pipeline/preprocessors/utm_links.py
+++ b/pipeline/preprocessors/utm_links.py
@@ -1,0 +1,71 @@
+"""Add UTM tracking to LangSmith CTA links at build time.
+
+Tags conversion-oriented links (signup, Fleet onboarding) with UTM parameters.
+Functional links (settings, hub, projects, traces) are left untouched.
+"""
+
+import re
+from pathlib import Path
+from urllib.parse import urlencode, urlparse, urlunparse
+
+# Paths treated as CTAs. Everything else on smith.langchain.com is functional.
+_CTA_PATHS = {"", "/", "/agents", "/agents/"}
+
+_UTM_BASE = {
+    "utm_source": "docs",
+    "utm_medium": "cta",
+    "utm_campaign": "langsmith-signup",
+}
+
+# Markdown links to smith.langchain.com: [text](url) or [text](url "title")
+_MD_LINK_RE = re.compile(
+    r"\[(?P<text>[^\]]*)\]"
+    r"\((?P<url>https://smith\.langchain\.com[^)\s]*)(?:\s+\"[^\"]*\")?\)"
+)
+
+_CODE_FENCE_RE = re.compile(r"^\s*(`{3,}|~{3,})")
+
+
+def _file_path_to_utm_content(file_path: Path) -> str:
+    """Derive utm_content from file path (e.g. src/langsmith/home.mdx -> langsmith-home)."""
+    parts = file_path.with_suffix("").parts
+    try:
+        parts = parts[parts.index("src") + 1 :]
+    except ValueError:
+        pass
+    return "-".join(parts) or "home"
+
+
+def _is_cta_url(url: str) -> bool:
+    """Return True if the URL is a signup/onboarding CTA."""
+    return urlparse(url).path in _CTA_PATHS
+
+
+def _add_utm(url: str, utm_content: str) -> str:
+    """Append UTM query parameters, preserving existing params."""
+    parsed = urlparse(url)
+    sep = "&" if parsed.query else ""
+    new_query = parsed.query + sep + urlencode({**_UTM_BASE, "utm_content": utm_content})
+    return urlunparse(parsed._replace(query=new_query))
+
+
+def add_utm_to_cta_links(content: str, file_path: Path) -> str:
+    """Add UTM parameters to LangSmith CTA links, skipping code blocks."""
+    utm_content = _file_path_to_utm_content(file_path)
+
+    def _replace(match: re.Match[str]) -> str:
+        url = match.group("url")
+        if not _is_cta_url(url):
+            return match.group(0)
+        return match.group(0).replace(url, _add_utm(url, utm_content), 1)
+
+    lines = content.splitlines(keepends=True)
+    result: list[str] = []
+    in_code_block = False
+
+    for line in lines:
+        if _CODE_FENCE_RE.match(line.strip()):
+            in_code_block = not in_code_block
+        result.append(line if in_code_block else _MD_LINK_RE.sub(_replace, line))
+
+    return "".join(result)

--- a/src/index.mdx
+++ b/src/index.mdx
@@ -129,7 +129,7 @@ mode: "custom"
 
         <CardGroup cols={4}>
             <Card title="Build your first agent with LangChain" icon="settings" href="/oss/python/langchain/quickstart" cta="Get started" />
-            <Card title="Sign up for LangSmith" icon="tools" href="https://smith.langchain.com/" cta="Try LangSmith" />
+            <Card title="Sign up for LangSmith" icon="tools" href="https://smith.langchain.com?utm_source=docs&utm_medium=cta&utm_campaign=langsmith-signup&utm_content=home-card" cta="Try LangSmith" />
             <Card title="Build an advanced agent with LangGraph" icon="robot" href="/oss/python/langgraph/quickstart" cta="Get started"/>
             <Card title="Enroll in LangChain Academy" icon="school" href="https://academy.langchain.com/" cta="Get started"/>
         </CardGroup>

--- a/src/langsmith/annotation-queues.mdx
+++ b/src/langsmith/annotation-queues.mdx
@@ -20,7 +20,7 @@ For a demonstration of using annotation queues, watch the [Getting started with 
 
 ## Single-run annotation queues
 
-Single-run queues present one run at a time and let reviewers submit any rubric feedback you configure. They can be created directly from the **Annotation queues** section in the [LangSmith UI](https://smith.langchain.com/).
+Single-run queues present one run at a time and let reviewers submit any rubric feedback you configure. They can be created directly from the **Annotation queues** section in the [LangSmith UI](https://smith.langchain.com).
 
 ### Create a single-run queue
 

--- a/src/langsmith/cicd-pipeline-example.mdx
+++ b/src/langsmith/cicd-pipeline-example.mdx
@@ -136,7 +136,7 @@ The workflow includes:
 Before setting up the CI/CD pipeline, ensure you have:
 
 - <Icon icon="robot" /> An AI agent application (in this case built using [LangGraph](/oss/langgraph/overview))
-- <Icon icon="user" /> A [LangSmith account](https://smith.langchain.com/)
+- <Icon icon="user" /> A [LangSmith account](https://smith.langchain.com)
 - <Icon icon="key" /> A [LangSmith API key](/langsmith/create-account-api-key) needed to deploy agents and retrieve experiment results
 - <Icon icon="settings" /> Project-specific environment variables configured in your repository secrets (e.g., LLM model API keys, vector store credentials, database connections)
 

--- a/src/langsmith/deployment-quickstart.mdx
+++ b/src/langsmith/deployment-quickstart.mdx
@@ -19,7 +19,7 @@ The `langgraph deploy` command is in **beta**.
 
 Before you begin, ensure you have:
 
-- A [LangSmith account](https://smith.langchain.com/) on the [Plus plan or above](https://www.langchain.com/pricing) and an [API key](/langsmith/create-account-api-key).
+- A [LangSmith account](https://smith.langchain.com) on the [Plus plan or above](https://www.langchain.com/pricing) and an [API key](/langsmith/create-account-api-key).
 - [Docker](https://docs.docker.com/get-docker/) installed and running. Verify with `docker ps`.
 - On Apple Silicon (M1/M2/M3): [Docker Buildx](https://docs.docker.com/build/install-buildx/) for cross-compiling to `linux/amd64`.
 - The [LangGraph CLI](/langsmith/cli):
@@ -77,7 +77,7 @@ You can also use `langgraph deploy list` to see all deployments, `langgraph depl
 
 Once the deployment is ready:
 
-1. Go to [LangSmith](https://smith.langchain.com/) and select **Deployments** in the left sidebar.
+1. Go to [LangSmith](https://smith.langchain.com) and select **Deployments** in the left sidebar.
 1. Select your deployment to view its details.
 1. Click **Studio** in the top right corner to open [Studio](/langsmith/studio).
 

--- a/src/langsmith/integrations.mdx
+++ b/src/langsmith/integrations.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Overview
 mode: wide
 ---
 
-[LangSmith](https://smith.langchain.com/) provides integrations for a growing set of popular [LLM providers](#llm-providers) and [agent frameworks](#agent-frameworks) as well as [Deep Agents](/oss/deepagents/overview), [LangChain](/oss/langchain/overview), and [LangGraph](/oss/langgraph/overview). For setup and usage, refer to the guides listed on this page.
+[LangSmith](https://smith.langchain.com) provides integrations for a growing set of popular [LLM providers](#llm-providers) and [agent frameworks](#agent-frameworks) as well as [Deep Agents](/oss/deepagents/overview), [LangChain](/oss/langchain/overview), and [LangGraph](/oss/langgraph/overview). For setup and usage, refer to the guides listed on this page.
 
 ## LLM providers
 

--- a/src/langsmith/trace-with-n8n.mdx
+++ b/src/langsmith/trace-with-n8n.mdx
@@ -12,7 +12,7 @@ LangSmith tracing is available for **self-hosted n8n instances** only.
 
 ## Prerequisites
 
-- A [LangSmith account](https://smith.langchain.com/) and [API key](/langsmith/create-account-api-key)
+- A [LangSmith account](https://smith.langchain.com) and [API key](/langsmith/create-account-api-key)
 - A self-hosted n8n instance
 
 ## Set up tracing
@@ -34,7 +34,7 @@ LangSmith tracing is available for **self-hosted n8n instances** only.
 
 After running an AI workflow:
 
-1. Open [LangSmith](https://smith.langchain.com/).
+1. Open [LangSmith](https://smith.langchain.com).
 1. Select your project. If you just created your account, the `"default"` project appears after the first trace is sent.
 1. Locate the trace corresponding to your workflow execution.
 

--- a/src/langsmith/trace-with-temporal.mdx
+++ b/src/langsmith/trace-with-temporal.mdx
@@ -10,7 +10,7 @@ LangSmith supports OpenTelemetry (OTEL) trace ingestion, which integrates seamle
 
 ## Prerequisites
 
-- A [LangSmith account](https://smith.langchain.com/) and API key
+- A [LangSmith account](https://smith.langchain.com) and API key
 - Temporal server running (local or cloud)
 - OpenTelemetry SDK for your language
 

--- a/src/oss/deepagents/cli/overview.mdx
+++ b/src/oss/deepagents/cli/overview.mdx
@@ -765,7 +765,7 @@ For a deeper look at sandbox architecture, integration patterns, and security be
 
 ## Tracing with LangSmith
 
-Enable [LangSmith](https://smith.langchain.com/) tracing to see agent operations, tool calls, and decisions in a LangSmith project.
+Enable [LangSmith](https://smith.langchain.com) tracing to see agent operations, tool calls, and decisions in a LangSmith project.
 
 Add your tracing keys to `~/.deepagents/.env` so tracing is enabled in every session without per-shell exports:
 

--- a/src/oss/deepagents/content-builder.mdx
+++ b/src/oss/deepagents/content-builder.mdx
@@ -41,7 +41,7 @@ API keys:
 - Anthropic (Claude) or other provider API key
 - Google (Gemini) for image generation with `gemini-2.5-flash-image`
 - [Tavily](https://www.tavily.com/) for web search (free tier)
-- [LangSmith](https://smith.langchain.com/) for tracing (optional)
+- [LangSmith](https://smith.langchain.com) for tracing (optional)
 
 :::python
 Python 3.11 or later.

--- a/src/oss/deepagents/deep-research.mdx
+++ b/src/oss/deepagents/deep-research.mdx
@@ -40,7 +40,7 @@ API keys for:
 
 - Anthropic (Claude) or Google (Gemini)
 - [Tavily](https://www.tavily.com/) for web search (optional - free tier sufficient)
-- [LangSmith](https://smith.langchain.com/) for tracing (optional)
+- [LangSmith](https://smith.langchain.com) for tracing (optional)
 
 ## Setup
 

--- a/src/oss/javascript/integrations/tools/duckduckgo_search.mdx
+++ b/src/oss/javascript/integrations/tools/duckduckgo_search.mdx
@@ -33,7 +33,7 @@ pnpm add @langchain/community @langchain/core duck-duck-scrape
 
 ### Credentials
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```typescript
 process.env.LANGSMITH_TRACING="true"

--- a/src/oss/javascript/integrations/tools/google_scholar.mdx
+++ b/src/oss/javascript/integrations/tools/google_scholar.mdx
@@ -35,7 +35,7 @@ Ensure you have the appropriate API key to access Google Scholar. Set it in your
 SERPAPI_API_KEY="your-serp-api-key"
 ```
 
-It's also helpful to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```typescript
 process.env.LANGSMITH_TRACING="true"

--- a/src/oss/javascript/integrations/tools/nia.mdx
+++ b/src/oss/javascript/integrations/tools/nia.mdx
@@ -37,7 +37,7 @@ Sign up at [trynia.ai](https://trynia.ai) to get an API key.
 process.env.NIA_API_KEY = "nk_...";
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```typescript
 process.env.LANGSMITH_TRACING = "true";

--- a/src/oss/javascript/integrations/tools/serpapi.mdx
+++ b/src/oss/javascript/integrations/tools/serpapi.mdx
@@ -39,7 +39,7 @@ pnpm add @langchain/community @langchain/core
 process.env.SERPAPI_API_KEY = "YOUR_API_KEY"
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```typescript
 process.env.LANGSMITH_TRACING="true"

--- a/src/oss/javascript/integrations/tools/tavily_crawl.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_crawl.mdx
@@ -39,7 +39,7 @@ pnpm add @langchain/tavily @langchain/core
 process.env.TAVILY_API_KEY = "YOUR_API_KEY"
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```typescript
 process.env.LANGSMITH_TRACING="true"

--- a/src/oss/javascript/integrations/tools/tavily_extract.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_extract.mdx
@@ -39,7 +39,7 @@ pnpm add @langchain/tavily @langchain/core
 process.env.TAVILY_API_KEY = "YOUR_API_KEY"
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```typescript
 process.env.LANGSMITH_TRACING="true"

--- a/src/oss/javascript/integrations/tools/tavily_map.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_map.mdx
@@ -39,7 +39,7 @@ pnpm add @langchain/tavily @langchain/core
 process.env.TAVILY_API_KEY = "YOUR_API_KEY"
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```typescript
 process.env.LANGSMITH_TRACING="true"

--- a/src/oss/javascript/integrations/tools/tavily_search.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_search.mdx
@@ -39,7 +39,7 @@ pnpm add @langchain/tavily @langchain/core
 process.env.TAVILY_API_KEY = "YOUR_API_KEY"
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```typescript
 process.env.LANGSMITH_TRACING="true"

--- a/src/oss/javascript/integrations/tools/tavily_search_community.mdx
+++ b/src/oss/javascript/integrations/tools/tavily_search_community.mdx
@@ -46,7 +46,7 @@ pnpm add @langchain/community @langchain/core
 process.env.TAVILY_API_KEY = "YOUR_API_KEY"
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```typescript
 process.env.LANGSMITH_TRACING="true"

--- a/src/oss/langchain/deploy.mdx
+++ b/src/oss/langchain/deploy.mdx
@@ -13,7 +13,7 @@ When you're ready to deploy your LangChain agent to production, LangSmith provid
 Before you begin, ensure you have the following:
 
 - A [GitHub account](https://github.com/)
-- A [LangSmith account](https://smith.langchain.com/) (free to sign up)
+- A [LangSmith account](https://smith.langchain.com) (free to sign up)
 
 ## Deploy your agent
 

--- a/src/oss/langchain/test/evals.mdx
+++ b/src/oss/langchain/test/evals.mdx
@@ -519,7 +519,7 @@ async def test_async_evaluation():
 
 ## Run evals in LangSmith
 
-For tracking experiments over time, log evaluator results to [LangSmith](https://smith.langchain.com/). First, set the required environment variables:
+For tracking experiments over time, log evaluator results to [LangSmith](https://smith.langchain.com). First, set the required environment variables:
 
 ```bash
 export LANGSMITH_API_KEY="your_langsmith_api_key"

--- a/src/oss/langgraph/deploy.mdx
+++ b/src/oss/langgraph/deploy.mdx
@@ -15,7 +15,7 @@ LangSmith offers multiple deployment options beyond Cloud, including deploying w
 Before you begin, ensure you have the following:
 
 - A [GitHub account](https://github.com/)
-- A [LangSmith account](https://smith.langchain.com/) (free to sign up)
+- A [LangSmith account](https://smith.langchain.com) (free to sign up)
 
 ## Deploy your agent
 
@@ -28,7 +28,7 @@ Your application's code must reside in a GitHub repository to be deployed on Lan
 
 <Steps>
 <Step title="Navigate to LangSmith Deployment">
-    Log in to [LangSmith](https://smith.langchain.com/). In the left sidebar, select **Deployments**.
+    Log in to [LangSmith](https://smith.langchain.com). In the left sidebar, select **Deployments**.
 </Step>
 <Step title="Create new deployment">
     Click the **+ New Deployment** button. A pane will open where you can fill in the required fields.

--- a/src/oss/langgraph/observability.mdx
+++ b/src/oss/langgraph/observability.mdx
@@ -2,7 +2,7 @@
 title: LangSmith Observability
 ---
 
-Traces are a series of steps that your application takes to go from input to output. Each of these individual steps is represented by a run. You can use [LangSmith](https://smith.langchain.com/) to visualize these execution steps. To use it, [enable tracing for your application](/langsmith/trace-with-langgraph). This enables you to do the following:
+Traces are a series of steps that your application takes to go from input to output. Each of these individual steps is represented by a run. You can use [LangSmith](https://smith.langchain.com) to visualize these execution steps. To use it, [enable tracing for your application](/langsmith/trace-with-langgraph). This enables you to do the following:
 
 * [Debug a locally running application](/langsmith/observability-studio#debug-langsmith-traces).
 * [Evaluate the application performance](/oss/langchain/test/evals).

--- a/src/oss/python/integrations/chat/cohere.mdx
+++ b/src/oss/python/integrations/chat/cohere.mdx
@@ -24,7 +24,7 @@ import os
 os.environ["COHERE_API_KEY"] = getpass.getpass()
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability
 
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"

--- a/src/oss/python/integrations/document_loaders/parsers/writer_pdf_parser.mdx
+++ b/src/oss/python/integrations/document_loaders/parsers/writer_pdf_parser.mdx
@@ -41,7 +41,7 @@ if not os.getenv("WRITER_API_KEY"):
     os.environ["WRITER_API_KEY"] = getpass.getpass("Enter your WRITER API key: ")
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability. If you wish to do so, you can set the `LANGSMITH_TRACING` and `LANGSMITH_API_KEY` environment variables:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability. If you wish to do so, you can set the `LANGSMITH_TRACING` and `LANGSMITH_API_KEY` environment variables:
 
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"

--- a/src/oss/python/integrations/llms/cohere.mdx
+++ b/src/oss/python/integrations/llms/cohere.mdx
@@ -43,7 +43,7 @@ if "COHERE_API_KEY" not in os.environ:
 pip install -U langchain-community langchain-cohere
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability
 
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"

--- a/src/oss/python/integrations/retrievers/asknews.mdx
+++ b/src/oss/python/integrations/retrievers/asknews.mdx
@@ -24,7 +24,7 @@ os.environ["ASKNEWS_CLIENT_ID"] = getpass.getpass()
 os.environ["ASKNEWS_CLIENT_SECRET"] = getpass.getpass()
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability
 
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"

--- a/src/oss/python/integrations/retrievers/you-retriever.mdx
+++ b/src/oss/python/integrations/retrievers/you-retriever.mdx
@@ -30,7 +30,7 @@ os.environ["OPENAI_API_KEY"] = ""
 # dotenv.load_dotenv()
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability
 
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"

--- a/src/oss/python/integrations/tools/discord.mdx
+++ b/src/oss/python/integrations/tools/discord.mdx
@@ -43,7 +43,7 @@ import os
 #     os.environ["DISCORD_BOT_TOKEN"] = getpass.getpass("DISCORD Bot Token:\n")
 ```
 
-You can optionally set up [LangSmith](https://smith.langchain.com/) for tracing or observability:
+You can optionally set up [LangSmith](https://smith.langchain.com) for tracing or observability:
 
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"

--- a/src/oss/python/integrations/tools/fmp-data.mdx
+++ b/src/oss/python/integrations/tools/fmp-data.mdx
@@ -28,7 +28,7 @@ os.environ["FMP_API_KEY"] = "your-fmp-api-key"  # pragma: allowlist secret
 os.environ["OPENAI_API_KEY"] = "your-openai-api-key"  # pragma: allowlist secret
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"

--- a/src/oss/python/integrations/tools/jina_search.mdx
+++ b/src/oss/python/integrations/tools/jina_search.mdx
@@ -37,7 +37,7 @@ if not os.environ.get("JINA_API_KEY"):
     os.environ["JINA_API_KEY"] = getpass.getpass("Jina API key:\n")
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"

--- a/src/oss/python/integrations/tools/linkup_search.mdx
+++ b/src/oss/python/integrations/tools/linkup_search.mdx
@@ -37,7 +37,7 @@ import os
 #     os.environ["LINKUP_API_KEY"] = getpass.getpass("LINKUP API key:\n")
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"

--- a/src/oss/python/integrations/tools/permit.mdx
+++ b/src/oss/python/integrations/tools/permit.mdx
@@ -35,7 +35,7 @@ PERMIT_PDP_URL=your_pdp_url # or your deployed url
 TEST_JWT_TOKEN= # for quick test purposes
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ## Instantiation
 

--- a/src/oss/python/integrations/tools/polygon.mdx
+++ b/src/oss/python/integrations/tools/polygon.mdx
@@ -27,7 +27,7 @@ if "POLYGON_API_KEY" not in os.environ:
     os.environ["POLYGON_API_KEY"] = getpass.getpass()
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability
 
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"

--- a/src/oss/python/integrations/tools/scrapegraph.mdx
+++ b/src/oss/python/integrations/tools/scrapegraph.mdx
@@ -51,7 +51,7 @@ if not os.environ.get("SGAI_API_KEY"):
     os.environ["SGAI_API_KEY"] = getpass.getpass("ScrapeGraph AI API key:\n")
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"

--- a/src/oss/python/integrations/tools/stripe.mdx
+++ b/src/oss/python/integrations/tools/stripe.mdx
@@ -37,7 +37,7 @@ if not os.environ.get("STRIPE_SECRET_KEY"):
     os.environ["STRIPE_SECRET_KEY"] = getpass.getpass("STRIPE API key:\n")
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"

--- a/src/oss/python/integrations/tools/taiga.mdx
+++ b/src/oss/python/integrations/tools/taiga.mdx
@@ -42,7 +42,7 @@ export TAIGA_PASSWORD="pw"
 export OPENAI_API_KEY="OPENAI_API_KEY"
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability:
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability:
 
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"

--- a/src/oss/python/integrations/tools/you.mdx
+++ b/src/oss/python/integrations/tools/you.mdx
@@ -30,7 +30,7 @@ os.environ["OPENAI_API_KEY"] = ""
 # dotenv.load_dotenv()
 ```
 
-It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com/) for best-in-class observability
+It's also helpful (but not needed) to set up [LangSmith](https://smith.langchain.com) for best-in-class observability
 
 ```python
 os.environ["LANGSMITH_TRACING"] = "true"

--- a/src/snippets/oss/deploy-js.mdx
+++ b/src/snippets/oss/deploy-js.mdx
@@ -3,7 +3,7 @@
 
 <Steps>
 <Step title="Navigate to LangSmith Deployment">
-    Log in to [LangSmith](https://smith.langchain.com/). In the left sidebar, select **Deployments**.
+    Log in to [LangSmith](https://smith.langchain.com). In the left sidebar, select **Deployments**.
 </Step>
 <Step title="Create new deployment">
     Click the **+ New Deployment** button. A pane will open where you can fill in the required fields.

--- a/src/snippets/oss/deploy-py.mdx
+++ b/src/snippets/oss/deploy-py.mdx
@@ -3,7 +3,7 @@
 
 <Steps>
 <Step title="Navigate to LangSmith Deployment">
-    Log in to [LangSmith](https://smith.langchain.com/). In the left sidebar, select **Deployments**.
+    Log in to [LangSmith](https://smith.langchain.com). In the left sidebar, select **Deployments**.
 </Step>
 <Step title="Create new deployment">
     Click the **+ New Deployment** button. A pane will open where you can fill in the required fields.

--- a/tests/unit_tests/test_utm_links.py
+++ b/tests/unit_tests/test_utm_links.py
@@ -1,0 +1,100 @@
+"""Tests for the UTM link preprocessor."""
+
+from pathlib import Path
+
+import pytest
+
+from pipeline.preprocessors.utm_links import (
+    _file_path_to_utm_content,
+    _is_cta_url,
+    add_utm_to_cta_links,
+)
+
+
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://smith.langchain.com", True),
+        ("https://smith.langchain.com/", True),
+        ("https://smith.langchain.com/agents", True),
+        ("https://smith.langchain.com/agents?skipOnboarding=true", True),
+        ("https://smith.langchain.com/settings", False),
+        ("https://smith.langchain.com/hub", False),
+        ("https://smith.langchain.com/projects", False),
+        ("https://smith.langchain.com/public/abc123/r", False),
+        ("https://smith.langchain.com/studio", False),
+    ],
+)
+def test_is_cta_url(url: str, expected: bool) -> None:
+    assert _is_cta_url(url) is expected
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("src/langsmith/home.mdx", "langsmith-home"),
+        ("src/index.mdx", "index"),
+        ("src/oss/langgraph/overview.mdx", "oss-langgraph-overview"),
+        ("src/snippets/oss/studio-py.mdx", "snippets-oss-studio-py"),
+        ("src/langsmith/fleet/index.mdx", "langsmith-fleet-index"),
+    ],
+)
+def test_file_path_to_utm_content(path: str, expected: str) -> None:
+    assert _file_path_to_utm_content(Path(path)) == expected
+
+
+class TestAddUtmToCTALinks:
+    fp = Path("src/langsmith/home.mdx")
+
+    def test_bare_cta_gets_utm(self) -> None:
+        result = add_utm_to_cta_links("[LS](https://smith.langchain.com)\n", self.fp)
+        assert "utm_source=docs" in result
+        assert "utm_content=langsmith-home" in result
+
+    def test_trailing_slash_gets_utm(self) -> None:
+        result = add_utm_to_cta_links("[LS](https://smith.langchain.com/)\n", self.fp)
+        assert "utm_source=docs" in result
+
+    def test_agents_gets_utm(self) -> None:
+        result = add_utm_to_cta_links("[Fleet](https://smith.langchain.com/agents)\n", self.fp)
+        assert "utm_source=docs" in result
+
+    def test_existing_query_preserved(self) -> None:
+        result = add_utm_to_cta_links(
+            "[LS](https://smith.langchain.com/agents?skipOnboarding=true)\n", self.fp
+        )
+        assert "skipOnboarding=true" in result
+        assert "utm_source=docs" in result
+
+    def test_functional_link_untouched(self) -> None:
+        md = "[Settings](https://smith.langchain.com/settings)\n"
+        assert add_utm_to_cta_links(md, self.fp) == md
+
+    def test_deep_link_untouched(self) -> None:
+        md = "[Trace](https://smith.langchain.com/public/abc/r)\n"
+        assert add_utm_to_cta_links(md, self.fp) == md
+
+    def test_code_block_skipped(self) -> None:
+        md = "```\n[LS](https://smith.langchain.com)\n```\n"
+        assert "utm_source" not in add_utm_to_cta_links(md, self.fp)
+
+    def test_tilde_fence_skipped(self) -> None:
+        md = "~~~\n[LS](https://smith.langchain.com)\n~~~\n"
+        assert "utm_source" not in add_utm_to_cta_links(md, self.fp)
+
+    def test_non_smith_link_untouched(self) -> None:
+        md = "[Google](https://google.com)\n"
+        assert add_utm_to_cta_links(md, self.fp) == md
+
+    def test_api_domain_untouched(self) -> None:
+        md = "[API](https://api.smith.langchain.com/redoc)\n"
+        assert add_utm_to_cta_links(md, self.fp) == md
+
+    def test_mixed_links_only_cta_tagged(self) -> None:
+        md = "[A](https://smith.langchain.com) and [B](https://smith.langchain.com/settings)\n"
+        result = add_utm_to_cta_links(md, self.fp)
+        assert result.count("utm_source") == 1
+
+    def test_no_links_unchanged(self) -> None:
+        md = "# Heading\n\nSome text.\n"
+        assert add_utm_to_cta_links(md, self.fp) == md


### PR DESCRIPTION
Added a build pipeline preprocessor (pipeline/preprocessors/utm_links.py) that auto-tags LangSmith signup links with UTM       
  parameters at build time, so CTA attribution collapses to a single trackable URL in GA/Looker. Normalized 39 files with        
  inconsistent trailing slashes and manually tagged the home page card CTA (the only JSX href the preprocessor can't reach).

Fixes DOC-1088