### PR TITLE
LangSmith CTAs

### DIFF
--- a/src/oss/deepagents/quickstart.mdx
+++ b/src/oss/deepagents/quickstart.mdx
@@ -440,6 +440,10 @@ console.log(result.messages[result.messages.length - 1].content);
 ```
 :::
 
+<Tip>
+Trace your agent's planning steps, tool calls, and subagent delegation with [LangSmith](https://smith.langchain.com). Follow the [observability quickstart](/langsmith/observability-quickstart) to get set up.
+</Tip>
+
 ## How does it work?
 
 Your deep agent automatically:

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -364,3 +364,7 @@ These are a few general guidelines for using tools and skills:
 - Use skills when there is a lot of context to reduce the number of tokens in the system prompt.
 - Use skills to bundle capabilities together into larger actions and provide additional context beyond single tool descriptions.
 - Use tools if the agent does not have access to the file system.
+
+<Tip>
+Trace how your agent discovers and executes skills with [LangSmith](https://smith.langchain.com). Follow the [observability quickstart](/langsmith/observability-quickstart) to get set up.
+</Tip>

--- a/src/oss/langchain/agents.mdx
+++ b/src/oss/langchain/agents.mdx
@@ -57,6 +57,10 @@ Learn more about the [Graph API](/oss/langgraph/graph-api).
 
 </Info>
 
+<Tip>
+Trace each step of this loop, debug tool calls, and evaluate agent outputs with [LangSmith](https://smith.langchain.com). Follow the [tracing quickstart](/langsmith/trace-with-langchain) to get set up.
+</Tip>
+
 ## Core components
 
 ### Model
@@ -1095,10 +1099,6 @@ await agent.invoke({
 For streaming steps and / or tokens from the agent, refer to the [streaming](/oss/langchain/streaming) guide.
 
 Otherwise, the agent follows the LangGraph [Graph API](/oss/langgraph/use-graph-api) and supports all associated methods, such as `stream` and `invoke`.
-
-<Tip>
-Use [LangSmith](/langsmith/home) to trace, debug, and evaluate your agents.
-</Tip>
 
 ## Advanced concepts
 

--- a/src/oss/langchain/install.mdx
+++ b/src/oss/langchain/install.mdx
@@ -102,3 +102,7 @@ See the [Integrations tab](/oss/integrations/providers/overview) for a full list
 </Tip>
 
 Now that you have LangChain installed, you can get started by following the [Quickstart guide](/oss/langchain/quickstart).
+
+<Tip>
+Set up [LangSmith](https://smith.langchain.com) tracing to debug your first LangChain app. Follow the [tracing quickstart](/langsmith/trace-with-langchain) to get started.
+</Tip>

--- a/src/oss/langchain/mcp.mdx
+++ b/src/oss/langchain/mcp.mdx
@@ -133,6 +133,10 @@ const weatherResponse = await agent.invoke({
 ```
 :::
 
+<Tip>
+Trace MCP tool calls alongside your agent's reasoning steps with [LangSmith](https://smith.langchain.com). Follow the [tracing quickstart](/langsmith/trace-with-langchain) to get set up.
+</Tip>
+
 ## Custom servers
 
 :::python

--- a/src/oss/langchain/multi-agent/index.mdx
+++ b/src/oss/langchain/multi-agent/index.mdx
@@ -5,6 +5,10 @@ sidebarTitle: Overview
 
 Multi-agent systems coordinate specialized components to tackle complex workflows. However, not every complex task requires this approach—a single agent with the right (sometimes dynamic) tools and prompt can often achieve similar results.
 
+<Tip>
+Trace the full coordination flow across agents with [LangSmith](https://smith.langchain.com). Follow the [tracing quickstart](/langsmith/trace-with-langchain) to get set up.
+</Tip>
+
 ## Why multi-agent?
 
 When developers say they need "multi-agent," they're usually looking for one or more of these capabilities:

--- a/src/oss/langchain/overview.mdx
+++ b/src/oss/langchain/overview.mdx
@@ -13,6 +13,8 @@ LangChain provides a prebuilt agent architecture and model integrations to help 
 Start with [Deep Agents](/oss/deepagents/overview/) for a "batteries-included" agent with features like automatic context compression, a virtual filesystem, and subagent-spawning. Deep Agents are built on LangChain [agents](/oss/langchain/agents/) which you can also use LangChain directly.
 
 Use [LangGraph](/oss/langgraph/overview), our low-level orchestration framework, for advanced needs combining deterministic and agentic workflows.
+
+Use [LangSmith](/langsmith/home) to trace, debug, and evaluate agents built with any of these frameworks. Follow the [tracing quickstart](/langsmith/trace-with-langchain) to get set up.
 </Tip>
 
 ## <Icon icon="wand" /> Create an agent

--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -587,7 +587,7 @@ When you run the code and prompt the agent to tell you about the weather in San 
 The agent understands that you are asking about the weather for the city San Francisco and therefore calls the weather tool with the provided city name.
 
 <Tip>
-    You can use [any supported model](/oss/integrations/providers/overview) by changing the model name in the code and setting up the appropriate API key.
+You can use [any supported model](/oss/integrations/providers/overview) by changing the model name and setting up the appropriate API key. Trace what's happening inside your agent with [LangSmith](https://smith.langchain.com)—follow the [tracing quickstart](/langsmith/trace-with-langchain) to get set up.
 </Tip>
 
 ## Build a real-world agent

--- a/src/oss/langchain/tools.mdx
+++ b/src/oss/langchain/tools.mdx
@@ -15,7 +15,7 @@ Tools extend what [agents](/oss/langchain/agents) can do—letting them fetch re
 Under the hood, tools are callable functions with well-defined inputs and outputs that get passed to a [chat model](/oss/langchain/models). The model decides when to invoke a tool based on the conversation context, and what input arguments to provide.
 
 <Tip>
-    For details on how models handle tool calls, see [Tool calling](/oss/langchain/models#tool-calling).
+For details on how models handle tool calls, see [Tool calling](/oss/langchain/models#tool-calling). Trace tool calls and debug errors with [LangSmith](https://smith.langchain.com)—follow the [tracing quickstart](/langsmith/trace-with-langchain) to get set up.
 </Tip>
 
 ## Create tools

--- a/src/oss/langgraph/persistence.mdx
+++ b/src/oss/langgraph/persistence.mdx
@@ -13,6 +13,10 @@ LangGraph has a built-in persistence layer that saves graph state as checkpoints
 When using the [Agent Server](/langsmith/agent-server), you don't need to implement or configure checkpointers manually. The server handles all persistence infrastructure for you behind the scenes.
 </Info>
 
+<Tip>
+Trace checkpointed state and debug how your agent resumes across sessions with [LangSmith](https://smith.langchain.com). Follow the [tracing quickstart](/langsmith/trace-with-langgraph) to get set up.
+</Tip>
+
 ## Why use persistence
 
 Persistence is required for the following features:

--- a/src/oss/langgraph/workflows-agents.mdx
+++ b/src/oss/langgraph/workflows-agents.mdx
@@ -14,6 +14,10 @@ This guide reviews common workflow and agent patterns.
 
 LangGraph offers several benefits when building agents and workflows, including [persistence](/oss/langgraph/persistence), [streaming](/oss/langgraph/streaming), and support for debugging as well as [deployment](/oss/langgraph/deploy).
 
+<Tip>
+Trace and compare these workflow patterns with [LangSmith](https://smith.langchain.com). Follow the [tracing quickstart](/langsmith/trace-with-langgraph) to see how data flows through each step.
+</Tip>
+
 ## Setup
 
 To build a workflow or agent, you can use [any chat model](/oss/integrations/chat) that supports structured outputs and tool calling. The following example uses Anthropic:


### PR DESCRIPTION
Merged back-to-back <Tip> callouts into single Tips on tools.mdx and quickstart.mdx, and replaced the vague "run above" reference in deepagents/quickstart.mdx with "to get set up" for consistency. All 11 changed OSS files pass Vale linting with 0 errors. 

Fixes DOC-1087