### PR TITLE
Fix wrong default port of postgres DB in short term memory docs

### DIFF
--- a/src/oss/langchain/short-term-memory.mdx
+++ b/src/oss/langchain/short-term-memory.mdx
@@ -90,7 +90,7 @@ from langchain.agents import create_agent
 from langgraph.checkpoint.postgres import PostgresSaver  # [!code highlight]
 
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 with PostgresSaver.from_conn_string(DB_URI) as checkpointer:
     checkpointer.setup() # auto create tables in PostgreSQL
     agent = create_agent(
@@ -104,7 +104,7 @@ with PostgresSaver.from_conn_string(DB_URI) as checkpointer:
 ```ts
 import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
 
-const DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+const DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
 const checkpointer = PostgresSaver.fromConnString(DB_URI);
 ```
 :::


### PR DESCRIPTION
## Overview
Fix the wrong default port number of postgres DB in the short term memory docs
## Type of change
Update existing documentation / Fix typo/bug/link/formatting


## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
from the docs of postgres db
<img width="416" height="75" alt="image" src="https://github.com/user-attachments/assets/77c10136-9848-4de9-b239-8d5e59260eae" />
