### PR TITLE
fix(ci): treat open-swe bot as internal contributor

### DIFF
--- a/.github/workflows/tag-external-contributions.yml
+++ b/.github/workflows/tag-external-contributions.yml
@@ -44,15 +44,14 @@ jobs:
           github-token: ${{ steps.app-token.outputs.token }}
           script: |
             const { owner, repo } = context.repo;
-            const author = context.payload.sender.login;
-            const internalAuthors = new Set([
-              'app/open-swe',
-              'open-swe',
+            const sender = context.payload.sender;
+            const author = sender.login;
+            const internalBots = new Set([
               'open-swe[bot]',
             ]);
 
-            if (internalAuthors.has(author.toLowerCase())) {
-              console.log(`User ${author} is hardcoded as internal`);
+            if (sender.type === 'Bot' && internalBots.has(author)) {
+              console.log(`Bot ${author} is hardcoded as internal`);
               core.setOutput('is-external', 'false');
               return;
             }

--- a/.github/workflows/tag-external-contributions.yml
+++ b/.github/workflows/tag-external-contributions.yml
@@ -45,6 +45,17 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const author = context.payload.sender.login;
+            const internalAuthors = new Set([
+              'app/open-swe',
+              'open-swe',
+              'open-swe[bot]',
+            ]);
+
+            if (internalAuthors.has(author.toLowerCase())) {
+              console.log(`User ${author} is hardcoded as internal`);
+              core.setOutput('is-external', 'false');
+              return;
+            }
 
             try {
               // Check if the author is a member of the langchain-ai organization


### PR DESCRIPTION
The `tag-external-contributions` workflow was incorrectly flagging PRs authored by the `open-swe` bot as external contributions. Hardcode `open-swe`, `app/open-swe`, and `open-swe[bot]` as internal authors so the job skips the org-membership API call and labels them correctly.

## Changes
- Add `internalAuthors` `Set` with `open-swe` variants to the `github-script` step in `.github/workflows/tag-external-contributions.yml`
- Short-circuit the external-contributor check before the `org.getMembershipForUser` call when the PR author matches any of the hardcoded bot identities
