### PR TITLE
fix(frontend): broken OpenUI repository link

### DIFF
--- a/src/oss/langchain/frontend/integrations/openui.mdx
+++ b/src/oss/langchain/frontend/integrations/openui.mdx
@@ -3,7 +3,7 @@ title: OpenUI
 description: Generate complete, interactive dashboards and reports using the OpenUI component library and openui-lang
 ---
 
-[OpenUI](https://github.com/openuidev) is a generative UI library that lets a language model produce complete, interactive UIs in a declarative format called **openui-lang**. Instead of returning a chat message, the agent returns a component tree with cards, charts, tables, tabs, and forms that the `Renderer` turns into a real React UI.
+[OpenUI](https://github.com/thesysdev/openui) is a generative UI library that lets a language model produce complete, interactive UIs in a declarative format called **openui-lang**. Instead of returning a chat message, the agent returns a component tree with cards, charts, tables, tabs, and forms that the `Renderer` turns into a real React UI.
 
 This integration is well-suited for data-rich outputs like reports, dashboards, and data explorers, where the model is both the data analyst and the UI designer.
 


### PR DESCRIPTION
## Overview
OpenUI repository seems to be at https://github.com/thesysdev/openui now and the current link in [frontend documentation](https://docs.langchain.com/oss/python/langchain/frontend/integrations/openui) is broken.

## Type of change

**Type:** Fix link

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed