### PR TITLE
docs(langsmith-remote-mcp): add AWS region, extract reusable region URL snippet

### DIFF
--- a/src/langsmith/langsmith-remote-mcp.mdx
+++ b/src/langsmith/langsmith-remote-mcp.mdx
@@ -3,18 +3,17 @@ title: LangSmith Remote MCP
 description: Connect MCP-compatible clients to LangSmith over OAuth—no API key, no self-hosting, no header configuration.
 ---
 
+import SaasRegionUrls from '/snippets/langsmith/saas-region-urls.mdx';
+
 The LangSmith Remote MCP is a [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) server hosted by LangSmith. It exposes the same tools as the [standalone LangSmith MCP Server](/langsmith/langsmith-mcp-server) (conversation history, prompts, runs and traces, datasets, experiments, billing) but with OAuth-based authentication, so MCP-compatible clients connect directly without an API key, a separate deployment, or any header configuration.
 
 <Note>
-**LangSmith Cloud (SaaS) only.** The Remote MCP is available only on LangSmith Cloud (`api.smith.langchain.com` and `eu.api.smith.langchain.com`). [Self-hosted LangSmith](/langsmith/self-hosted) deployments should continue to use the [standalone LangSmith MCP Server](/langsmith/langsmith-mcp-server).
+**LangSmith Cloud (SaaS) only.** The Remote MCP is available on all LangSmith Cloud regions (`api.smith.langchain.com`, `eu.api.smith.langchain.com`, and `aws.api.smith.langchain.com`). [Self-hosted LangSmith](/langsmith/self-hosted) deployments should continue to use the [standalone LangSmith MCP Server](/langsmith/langsmith-mcp-server).
 </Note>
 
 ## Endpoints
 
-| Region | URL |
-|--------|-----|
-| Cloud (US) | `https://api.smith.langchain.com/mcp` |
-| Cloud (EU) | `https://eu.api.smith.langchain.com/mcp` |
+<SaasRegionUrls suffix="/mcp" />
 
 The server discovers the rest of its OAuth metadata via [RFC 8414](https://datatracker.ietf.org/doc/html/rfc8414) at `/.well-known/oauth-authorization-server` on the same host, so a compliant MCP client only needs the URL in the table.
 

--- a/src/snippets/langsmith/saas-region-urls.mdx
+++ b/src/snippets/langsmith/saas-region-urls.mdx
@@ -1,0 +1,7 @@
+{/* Pass `suffix` to append a path (e.g. "/mcp") to each URL. */}
+
+| Region | URL |
+|--------|-----|
+| US (GCP) | <code>https://api.smith.langchain.com{suffix}</code> |
+| EU (GCP) | <code>https://eu.api.smith.langchain.com{suffix}</code> |
+| US (AWS) | <code>https://aws.api.smith.langchain.com{suffix}</code> |


### PR DESCRIPTION
## Summary

- Surface the US (AWS) endpoint (`aws.api.smith.langchain.com/mcp`) on the Remote MCP page alongside US (GCP) and EU (GCP).
- Extract the region table to a new reusable snippet `src/snippets/langsmith/saas-region-urls.mdx` that takes a `suffix` prop (e.g. `/mcp`, `/api/v1/runs`, or empty) — first prop-receiving snippet in the docs, opens the door to consolidating the same table that's currently inlined across `cloud.mdx`, `cicd-pipeline-example.mdx`, and others.

## Test plan

- [x] Mintlify dev server renders the table on `/langsmith/langsmith-remote-mcp` with all three URLs and `/mcp` suffix
- [x] Vale (`make lint_prose`) clean — verified locally
- [x] No broken links introduced