### PR TITLE
Revert "deprecate hybrid deployment option (#3898)"

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -887,7 +887,7 @@
                   ]
                 },
                 {
-                  "group": "Hybrid (deprecated)",
+                  "group": "Hybrid",
                   "pages": [
                     "langsmith/hybrid",
                     "langsmith/deploy-hybrid"

--- a/src/langsmith/aws-self-hosted.mdx
+++ b/src/langsmith/aws-self-hosted.mdx
@@ -4,7 +4,7 @@ sidebarTitle: AWS
 icon: "brand-aws"
 ---
 
-When running LangSmith on [Amazon Web Services (AWS)](https://aws.amazon.com/), you can set up in [full self-hosted](/langsmith/self-hosted) mode. Full self-hosted mode deploys a complete LangSmith platform with observability functionality as well as the option to create [agent deployments](/langsmith/deployment).
+When running LangSmith on [Amazon Web Services (AWS)](https://aws.amazon.com/), you can set up in either [full self-hosted](/langsmith/self-hosted) or [hybrid](/langsmith/hybrid) mode. Full self-hosted mode deploys a complete LangSmith platform with observability functionality as well as the option to create [agent deployments](/langsmith/deployment). Hybrid mode includes just the infrastructure to run agents in a data plane within your cloud, while our SaaS provides the control plane and observability functionality.
 
 This page provides:
 
@@ -63,7 +63,7 @@ After completing these initial setup steps, you can review the complete AWS arch
 
 ## Reference architecture
 
-We recommend leveraging AWS's managed services to provide a scalable, secure, and resilient platform. The following architecture applies to self-hosted deployments and aligns with the [AWS Well-Architected Framework](https://aws.amazon.com/architecture/well-architected/):
+We recommend leveraging AWS's managed services to provide a scalable, secure, and resilient platform. The following architecture applies to both self-hosted and hybrid and aligns with the [AWS Well-Architected Framework](https://aws.amazon.com/architecture/well-architected/):
 
 ![Architecture diagram showing AWS relations to LangSmith services](/langsmith/images/aws-architecture-self-hosted.png)
 
@@ -75,6 +75,7 @@ We recommend leveraging AWS's managed services to provide a scalable, secure, an
   - ClickHouse + [Amazon EBS](https://aws.amazon.com/ebs/): analytics and trace storage.
     - We recommend using an [externally managed ClickHouse solution](/langsmith/self-host-external-clickhouse) unless security or compliance reasons
     prevent you from doing so.
+    - ClickHouse is not required for hybrid deployments.
   - [Amazon S3](https://aws.amazon.com/s3/): object storage for trace artifacts and telemetry.
 
 - <Icon icon="sparkles" /> **LLM integration:** Optionally proxy requests to [Amazon Bedrock](https://aws.amazon.com/bedrock/) or [Amazon SageMaker](https://aws.amazon.com/sagemaker/) for LLM inference.

--- a/src/langsmith/azure-self-hosted.mdx
+++ b/src/langsmith/azure-self-hosted.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Azure
 icon: "brand-windows"
 ---
 
-When running LangSmith on [Microsoft Azure](https://azure.microsoft.com/), you can set up in [full self-hosted](/langsmith/self-hosted) mode. Full self-hosted mode deploys a complete LangSmith platform with observability functionality as well as the option to create agent deployments.
+When running LangSmith on [Microsoft Azure](https://azure.microsoft.com/), you can set up in either [full self-hosted](/langsmith/self-hosted) or [hybrid](/langsmith/hybrid) mode. Full self-hosted mode deploys a complete LangSmith platform with observability functionality as well as the option to create agent deployments. Hybrid mode entails just the infrastructure to run agents in a data plane within your cloud, while our SaaS provides the control plane and observability functionality.
 
 This page provides:
 
@@ -63,7 +63,7 @@ After completing these initial setup steps, you can review the complete Azure ar
 
 ## Reference architecture
 
-We recommend using Azure's managed services to provide a scalable, secure, and resilient platform. The following architecture applies to self-hosted deployments:
+We recommend using Azure's managed services to provide a scalable, secure, and resilient platform. The following architecture applies to both self-hosted and hybrid deployments:
 
 ![Architecture diagram showing Azure relations to LangSmith services](/langsmith/images/azure-architecture-self-hosted.png)
 
@@ -71,7 +71,7 @@ We recommend using Azure's managed services to provide a scalable, secure, and r
 - **Storage services**: The platform requires persistent storage for traces, metadata and caching. On Azure the recommended services are:
     - <Icon icon="database" /> **[Azure Database for PostgreSQL (Flexible Server)](https://azure.microsoft.com/en-us/products/postgresql/)** for transactional data (e.g., runs, projects). Azure's high-availability options provision a standby replica in another zone; data is synchronously committed to both primary and standby servers. LangSmith requires PostgreSQL version 14 or higher.
     - <Icon icon="database" /> **[Azure Managed Redis](https://azure.microsoft.com/en-us/products/managed-redis/)** for queues and caching. Best practices include storing small values and breaking large objects into multiple keys, using pipelining to maximize throughput and ensuring the client and server reside in the same region. You can also use [Azure Cache for Redis](https://azure.microsoft.com/en-us/products/cache), running either in single-instance or cluster mode. LangSmith requires Redis OSS version 5 or higher.
-    - <Icon icon="chart-line" /> **ClickHouse** for high-volume analytics of traces. We recommend using an [externally managed ClickHouse solution](/langsmith/self-host-external-clickhouse). If, for security or compliance reasons, that is not an option, deploy a ClickHouse cluster on AKS using the open-source operator. Ensure replication across [availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview) for durability.
+    - <Icon icon="chart-line" /> **ClickHouse** for high-volume analytics of traces. We recommend using an [externally managed ClickHouse solution](/langsmith/self-host-external-clickhouse). If, for security or compliance reasons, that is not an option, deploy a ClickHouse cluster on AKS using the open-source operator. Ensure replication across [availability zones](https://learn.microsoft.com/en-us/azure/reliability/availability-zones-overview) for durability. Clickhouse is not required for a hybrid deployment.
     - <Icon icon="cube" /> **[Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs/)** for large artifacts. Use redundant storage configurations such as read-access geo-redundant (RA-GRS) or geo-zone-redundant (RA-GZRS) storage and design applications to read from the secondary region during an outage.
 
 ## Compute and networking on Azure

--- a/src/langsmith/cicd-pipeline-example.mdx
+++ b/src/langsmith/cicd-pipeline-example.mdx
@@ -149,7 +149,7 @@ While this example uses GitHub, the CI/CD pipeline works with other Git hosting 
 LangSmith supports multiple deployment methods, depending on how your [LangSmith instance is hosted](/langsmith/platform-setup):
 
 - <Icon icon="cloud" /> **Cloud LangSmith**: Direct GitHub integration.
-- <Icon icon="server" /> **Self-hosted**: Container registry-based deployments.
+- <Icon icon="server" /> **Self-Hosted/Hybrid**: Container registry-based deployments.
 
 The deployment flow starts by modifying your agent implementation. At minimum, you must have a [`langgraph.json`](/langsmith/application-structure) and dependency file in your project (`requirements.txt` or `pyproject.toml`). Use the `langgraph dev` CLI tool to check for errors—fix any errors; otherwise, the deployment will succeed when deployed to LangSmith Deployment.
 
@@ -163,7 +163,7 @@ graph TD
     D -->|No| F[Choose LangSmith Instance]
 
     F --> G[Cloud LangSmith]
-    F --> H[Self-hosted LangSmith]
+    F --> H[Self-Hosted/Hybrid LangSmith]
 
     subgraph "Cloud LangSmith"
         G --> I[Method 1: Connect GitHub Repo in UI]
@@ -172,7 +172,7 @@ graph TD
         J --> L[Deploy via Control Plane API]
     end
 
-    subgraph "Self-hosted LangSmith"
+    subgraph "Self-Hosted/Hybrid LangSmith"
         H --> S[Build Docker Image langgraph build]
         S --> T[Push to Container Registry]
         T --> U{Deploy via?}
@@ -268,7 +268,7 @@ Deploy your agent using the LangSmith deployment interface:
 
 **Supported deployments:**
 - <Icon icon="cloud" /> **Cloud LangSmith**: Direct GitHub integration with dropdown menu
-- <Icon icon="server" /> **Self-hosted LangSmith**: Specify your image URI in the Image Path field (e.g., `docker.io/username/my-agent:latest`)
+- <Icon icon="server" /> **Self-Hosted/Hybrid LangSmith**: Specify your image URI in the Image Path field (e.g., `docker.io/username/my-agent:latest`)
 
 <Info>
 **Benefits:**
@@ -285,7 +285,7 @@ Deploy using the Control Plane API with different approaches for each deployment
 - Use the Control Plane API to create deployments by pointing to your GitHub repository
 - No Docker image building required for cloud deployments
 
-**For self-hosted LangSmith:**
+**For Self-Hosted/Hybrid LangSmith:**
 ```bash
 # Build Docker image
 langgraph build -t my-agent:latest
@@ -298,7 +298,7 @@ You can push to any container registry (Docker Hub, AWS ECR, Azure ACR, Google G
 
 **Supported deployments:**
 - <Icon icon="cloud" /> **Cloud LangSmith**: Use the Control Plane API to create deployments from your GitHub repository
-- <Icon icon="server" /> **Self-hosted LangSmith**: Use the Control Plane API to create deployments from your container registry
+- <Icon icon="server" /> **Self-Hosted/Hybrid LangSmith**: Use the Control Plane API to create deployments from your container registry
 
 See the [LangGraph CLI build documentation](/langsmith/cli#build) for more details.
 

--- a/src/langsmith/control-plane.mdx
+++ b/src/langsmith/control-plane.mdx
@@ -42,7 +42,7 @@ A revision is an iteration of a deployment. When a new deployment is created, an
 
 A listener is an instance of a ["listener" application](/langsmith/data-plane#listener-application). A listener contains metadata about the application (e.g. version) and metadata about the compute infrastructure where it can deploy to (e.g. Kubernetes namespaces).
 
-The listener data model applies to self-hosted deployments that use a control plane.
+The listener data model only applies for [Hybrid](/langsmith/hybrid) and [Self-Hosted](/langsmith/self-hosted) deployments.
 
 ## Control plane features
 
@@ -66,7 +66,7 @@ Once a deployment is created, the deployment type cannot be changed.
 
 <Info>
 **Self-Hosted Deployment**
-Resources for self-hosted deployments can be fully customized. Deployment types are only applicable for [Cloud](/langsmith/cloud) deployments.
+Resources for [Hybrid](/langsmith/hybrid) and [Self-Hosted](/langsmith/self-hosted) deployments can be fully customized. Deployment types are only applicable for [Cloud](/langsmith/cloud) deployments.
 </Info>
 
 #### Production
@@ -105,7 +105,7 @@ There is no direct access to the database. All access to the database occurs thr
 The database is never deleted until the deployment itself is deleted.
 
 <Info>
-A custom Postgres instance can be configured for [self-hosted](/langsmith/self-hosted) deployments.
+A custom Postgres instance can be configured for [Hybrid](/langsmith/hybrid) and [Self-Hosted](/langsmith/self-hosted) deployments.
 </Info>
 
 ### Asynchronous deployment

--- a/src/langsmith/data-plane.mdx
+++ b/src/langsmith/data-plane.mdx
@@ -96,7 +96,7 @@ The maximum payload size for all requests sent to [Cloud](/langsmith/cloud) depl
 ### Custom PostgreSQL
 
 <Info>
-Custom PostgreSQL instances are only available for [self-hosted](/langsmith/self-hosted) deployments.
+Custom PostgreSQL instances are only available for [hybrid](/langsmith/hybrid) and [self-hosted](/langsmith/self-hosted) deployments.
 </Info>
 
 A custom PostgreSQL instance can be used instead of the [one automatically created by the control plane](/langsmith/control-plane#database-provisioning). Specify the [`POSTGRES_URI_CUSTOM`](/langsmith/env-var#postgres_uri_custom) environment variable to use a custom PostgreSQL instance.
@@ -106,7 +106,7 @@ Multiple deployments can share the same PostgreSQL instance. For example, for `D
 ### Custom Redis
 
 <Info>
-Custom Redis instances are only available for [Self-Hosted](/langsmith/self-hosted) deployments.
+Custom Redis instances are only available for [Hybrid](/langsmith/hybrid) and [Self-Hosted](/langsmith/self-hosted) deployments.
 </Info>
 
 A custom Redis instance can be used instead of the one automatically created by the control plane. Specify the [REDIS_URI_CUSTOM](/langsmith/env-var#redis_uri_custom) environment variable to use a custom Redis instance.
@@ -127,7 +127,7 @@ See [Configure checkpointer backend](/langsmith/configure-checkpointer) for setu
 
 Agent Server is automatically configured to send traces to LangSmith. See the table below for details with respect to each deployment option.
 
-| Cloud | Hybrid (Deprecated) | Self-Hosted |
+| Cloud | Hybrid | Self-Hosted |
 |------------|------------------------|----------------------|
 | Required<br />Trace to LangSmith SaaS. | Optional<br />Disable tracing or trace to LangSmith SaaS. | Optional<br />Disable tracing, trace to LangSmith SaaS, or trace to Self-Hosted LangSmith. |
 
@@ -135,7 +135,7 @@ Agent Server is automatically configured to send traces to LangSmith. See the ta
 
 Agent Server is automatically configured to report telemetry metadata for billing purposes. See the table below for details with respect to each deployment option.
 
-| Cloud | Hybrid (Deprecated) | Self-Hosted |
+| Cloud | Hybrid | Self-Hosted |
 |------------|------------------------|----------------------|
 | Telemetry sent to LangSmith SaaS. | Telemetry sent to LangSmith SaaS. | Self-reported usage (audit) for air-gapped license key.<br />Telemetry sent to LangSmith SaaS for LangSmith License Key. |
 
@@ -143,6 +143,6 @@ Agent Server is automatically configured to report telemetry metadata for billin
 
 Agent Server is automatically configured to perform license key validation. See the table below for details with respect to each deployment option.
 
-| Cloud | Hybrid (Deprecated) | Self-Hosted |
+| Cloud | Hybrid | Self-Hosted |
 |------------|------------------------|----------------------|
 | LangSmith API Key validated against LangSmith SaaS. | LangSmith API Key validated against LangSmith SaaS. | Air-gapped license key or Platform License Key validated against LangSmith SaaS. |

--- a/src/langsmith/deploy-hybrid.mdx
+++ b/src/langsmith/deploy-hybrid.mdx
@@ -5,14 +5,8 @@ icon: "cloud"
 description: Connect a self-hosted data plane to the managed LangSmith control plane for hybrid agent deployment.
 ---
 
-<Warning>
-The Hybrid deployment model is deprecated. Do not use it for new deployments.
-
-For new deployments, use [Self-hosted](/langsmith/self-hosted) or [Cloud](/langsmith/cloud).
-</Warning>
-
 <Info>
-The Hybrid deployment option requires an [Enterprise](https://langchain.com/pricing) plan.
+The Hybrid deployment option requires an [Enterprise](https://langchain.com/pricing) plan. [Get a demo](https://www.langchain.com/contact-sales) to learn more.
 </Info>
 
 The [**hybrid**](/langsmith/hybrid) model lets you run the [data plane](/langsmith/data-plane) (your Agent Server deployments and agent workloads) in your own cloud, while LangChain hosts and manages the [control plane](/langsmith/control-plane) (the LangSmith UI and orchestration). This setup gives you the flexibility of self-hosting your runtime environments with the convenience of a managed LangSmith instance.
@@ -99,6 +93,14 @@ The following steps describe how to connect your self-hosted data plane to the m
     ```
 
     Your hybrid infrastructure is now ready to create deployments.
+
+### Configuring additional data planes in the same cluster
+To create a data plane in a different namespace in the same cluster, repeat the above steps and pass a `-n` option to `helm upgrade` to specify a different namespace.
+
+**When installing multiple data planes in the same cluster, it is very important to follow the rules below:**
+1. The `config.watchNamespaces` list should never intersect with other installations `config.watchNamespaces`. For example, if installation A is watching namespaces `foo,bar`, installation B cannot watch either `foo` or `bar`. Multiple operators or listeners watching the same namespace will lead to unexpected behavior. This means that multiple LangSmith workspaces cannot deploy to the same namespace! Please review the [cluster organization](/langsmith/hybrid#kubernetes-cluster-organization) section to understand this better.
+2. It is required to use the [Gateway API](/langsmith/self-host-ingress#option-2%3A-gateway-api) or an [Istio Gateway](/langsmith/self-host-ingress#option-3%3A-istio-gateway). Relying on the [standard ingress](/langsmith/self-host-ingress#option-1%3A-standard-ingress) resource can cause conflicts with Ingress objects created by other data planes in the same cluster. Because behavior in these cases depends on the specific ingress controller, this may result in unpredictable or undesired outcomes.
+
 
 ## Next steps
 

--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -816,6 +816,63 @@ polly:
 
 ## Optional configuration
 
+### Configure additional data planes
+
+In addition to the data plane created above, you can create more data planes in different Kubernetes clusters or in the same cluster under a different namespace. There are different ways to achieve this, so implement the solution that works best for your use case.
+
+#### Prerequisites
+
+<Steps>
+  <Step title="Review cluster organization">
+    Read through the cluster organization guide in the [hybrid deployment documentation](/langsmith/hybrid#listeners) to understand how to organize this for your use case.
+  </Step>
+
+  <Step title="Verify hybrid prerequisites">
+    Verify the prerequisites in the [hybrid section](/langsmith/deploy-hybrid#prerequisites) for the new cluster. In step 5 of the [prerequisites](/langsmith/deploy-hybrid#prerequisites), configure egress to your [self-hosted LangSmith instance](/langsmith/self-host-usage#configuring-the-application-you-want-to-use-with-langsmith) instead of `https://api.host.langchain.com` and `https://api.smith.langchain.com`.
+  </Step>
+
+  <Step title="Enable the feature in Postgres">
+    Run the following against your LangSmith Postgres instance to enable this feature. Note the workspace ID for later steps.
+
+    ```sql
+    update organizations set config = config || '{"enable_lgp_listeners_page": true}' where id = '<org id here>';
+    update tenants set config = config || '{"langgraph_remote_reconciler_enabled": true}' where id = '<workspace id here>';
+    ```
+  </Step>
+</Steps>
+
+#### Deploy to a different cluster
+
+<Steps>
+  <Step title="Follow the hybrid setup guide">
+    Follow steps 2 to 6 in the [hybrid setup guide](/langsmith/deploy-hybrid#setup). Set `config.langsmithWorkspaceId` to the workspace ID from the previous step.
+  </Step>
+  <Step title="(Optional) Add more data planes to the same cluster">
+    To add more than one data plane to the same cluster, follow the instructions for [configuring additional data planes in the same cluster](/langsmith/deploy-hybrid#configuring-additional-data-planes-in-the-same-cluster).
+  </Step>
+</Steps>
+
+#### Deploy to a different namespace in the same cluster
+
+<Steps>
+  <Step title="Update your config">
+    In your [`langsmith_config.yaml`](/langsmith/kubernetes#configure-your-helm-charts), make the following modifications:
+    - Set `operator.watchNamespaces` to the current namespace your self-hosted LangSmith instance is running in. This prevents conflicts with the operator added by the new data plane.
+    - Use the [Gateway API](/langsmith/self-host-ingress#option-2%3A-gateway-api) or an [Istio Gateway](/langsmith/self-host-ingress#option-3%3A-istio-gateway). Adjust your `langsmith_config.yaml` accordingly.
+  </Step>
+  <Step title="Apply the changes">
+    ```bash
+    helm upgrade -i langsmith langchain/langsmith --values langsmith_config.yaml --version <version> -n <namespace> --wait --debug
+    ```
+  </Step>
+  <Step title="Follow the hybrid setup guide">
+    Follow steps 2 to 6 in the [hybrid setup guide](/langsmith/deploy-hybrid#setup). Set `config.langsmithWorkspaceId` to the workspace ID from the previous step. Set `config.watchNamespaces` to a different namespace than the one used by the existing data plane.
+  </Step>
+  <Step title="(Optional) Configure log access">
+    Configure access for the control plane to read Agent Server deployment logs from the new namespace. See [Read Agent Server logs from other namespaces](#read-agent-server-logs-from-other-namespaces).
+  </Step>
+</Steps>
+
 ### Configure authentication for private registries
 
 If your [Agent Server deployments](/langsmith/agent-server) will use images from private container registries (for example, AWS ECR, Azure ACR, or GCP Artifact Registry), configure image pull secrets. This configuration applies to all deployments automatically, allowing them to authenticate with your private registry.

--- a/src/langsmith/deploy-with-control-plane.mdx
+++ b/src/langsmith/deploy-with-control-plane.mdx
@@ -2,22 +2,24 @@
 title: Deploy with control plane
 sidebarTitle: With control plane
 icon: "cloud-upload"
-description: Build Docker images and deploy applications to self-hosted LangSmith instances using the control plane UI.
+description: Build Docker images and deploy applications to hybrid or self-hosted LangSmith instances using the control plane UI.
 ---
 
-This guide shows you how to deploy your applications to [self-hosted](/langsmith/self-hosted) instances with a [control plane](/langsmith/control-plane). With a control plane, you build Docker images locally, push them to a registry that your Kubernetes cluster can access, and deploy them with the [LangSmith UI](https://smith.langchain.com).
+This guide shows you how to deploy your applications to [hybrid](/langsmith/hybrid) or [self-hosted](/langsmith/self-hosted) instances with a [control plane](/langsmith/control-plane). With a control plane, you build Docker images locally, push them to a registry that your Kubernetes cluster has access to, and deploy them with the [LangSmith UI](https://smith.langchain.com).
 
 <Note>
 **This guide is for deploying applications, not setting up infrastructure.**
 
-Before using this guide, you must have already completed infrastructure setup: **[Enable LangSmith Deployment](/langsmith/deploy-self-hosted-full-platform)** for self-hosted with control plane.
+Before using this guide, you must have already completed infrastructure setup:
+- **[Hybrid setup](/langsmith/deploy-hybrid)**: For hybrid hosting.
+- **[Enable LangSmith Deployment](/langsmith/deploy-self-hosted-full-platform)**: For self-hosted with control plane.
 
 If you haven't set up your infrastructure yet, start with the [Platform setup section](/langsmith/platform-setup).
 </Note>
 
 ## Overview
 
-Applications deployed to self-hosted LangSmith instances with a control plane use Docker images. In this guide, the application deployment workflow is:
+Applications deployed to hybrid or self-hosted LangSmith instances with control plane use Docker images. In this guide, the application deployment workflow is:
 
 1. Test your application locally using `langgraph dev` or [Studio](/langsmith/studio).
 1. Build a Docker image using the `langgraph build` command.
@@ -26,81 +28,80 @@ Applications deployed to self-hosted LangSmith instances with a control plane us
 
 ## Prerequisites
 
-Before completing this guide, you need the following:
+Before completing this guide, you'll need the following:
 
 - Completed infrastructure setup to enable your [data plane](/langsmith/data-plane) to receive application deployments:
+  - [Hybrid setup](/langsmith/deploy-hybrid): Installs data plane components (listener, operator, CRDs) in your Kubernetes cluster that connect to LangChain's managed control plane.
   - [Enable LangSmith Deployment](/langsmith/deploy-self-hosted-full-platform): Enables LangSmith Deployment on your self-hosted LangSmith instance.
 - Access to the [LangSmith UI](https://smith.langchain.com) with LangSmith Deployment enabled.
 - A container registry accessible by your Kubernetes cluster. If using a private registry that requires authentication, you must configure image pull secrets as part of your infrastructure setup. Refer to [Private registry authentication](#private-registry-authentication).
 
-<Steps>
-  <Step title="Test locally">
-    Before deploying, test your application locally. You can use the [LangGraph CLI](/langsmith/cli#dev) to run an Agent server in development mode:
+## Step 1. Test locally
 
-    ```bash
-    langgraph dev
-    ```
+Before deploying, test your application locally. You can use the [LangGraph CLI](/langsmith/cli#dev) to run an Agent server in development mode:
 
-    For a full guide local testing, refer to the [Local server quickstart](/langsmith/local-dev-testing).
-  </Step>
+```bash
+langgraph dev
+```
 
-  <Step title="Build Docker image">
-    Build a Docker image of your application using the [`langgraph build`](/langsmith/cli#build) command:
+For a full guide local testing, refer to the [Local server quickstart](/langsmith/local-dev-testing).
 
-    ```bash
-    langgraph build -t my-image
-    ```
+## Step 2. Build Docker image
 
-    Build command options include:
+Build a Docker image of your application using the [`langgraph build`](/langsmith/cli#build) command:
 
-    | Option | Default | Description |
-    |--------|---------|-------------|
-    | `-t, --tag TEXT` | Required | Tag for the Docker image |
-    | `--platform TEXT` | | Target platform(s) to build for (e.g., `linux/amd64,linux/arm64`) |
-    | `--pull / --no-pull` | `--pull` | Build with latest remote Docker image |
-    | `-c, --config FILE` | `langgraph.json` | Path to configuration file |
+```bash
+langgraph build -t my-image
+```
 
-    Example with platform specification:
+Build command options include:
 
-    ```bash
-    langgraph build --platform linux/amd64 -t my-image:v1.0.0
-    ```
+| Option | Default | Description |
+|--------|---------|-------------|
+| `-t, --tag TEXT` | Required | Tag for the Docker image |
+| `--platform TEXT` | | Target platform(s) to build for (e.g., `linux/amd64,linux/arm64`) |
+| `--pull / --no-pull` | `--pull` | Build with latest remote Docker image |
+| `-c, --config FILE` | `langgraph.json` | Path to configuration file |
 
-    For full details, see the [CLI reference](/langsmith/cli#build).
-  </Step>
+Example with platform specification:
 
-  <Step title="Push to container registry">
-    Push your image to a container registry accessible by your Kubernetes cluster. The specific commands depend on your registry provider.
+```bash
+langgraph build --platform linux/amd64 -t my-image:v1.0.0
+```
 
-    <Tip>
-    Tag your images with version information (e.g., `my-registry.com/my-app:v1.0.0`) to make rollbacks easier.
-    </Tip>
-  </Step>
+For full details, see the [CLI reference](/langsmith/cli#build).
 
-  <Step title="Deploy with the control plane UI">
-    The [control plane UI](/langsmith/control-plane#control-plane-ui) allows you to create and manage deployments, view logs and metrics, and update configurations. To create a new deployment in the [LangSmith UI](https://smith.langchain.com):
+## Step 3. Push to container registry
 
-    1. In the left-hand navigation panel, select **Deployments**.
-    1. In the top-right corner, select **+ New Deployment**.
-    1. In the deployment configuration panel, provide:
-       - **Image URL**: The full image URL you pushed in the previous step.
-       - **Listener/Compute ID**: Select the listener configured for your infrastructure.
-       - **Namespace**: The Kubernetes namespace to deploy to.
-       - **Environment variables**: Any required configuration (API keys, etc.).
-       - Other deployment settings as needed.
-    1. Select **Submit**.
+Push your image to a container registry accessible by your Kubernetes cluster. The specific commands depend on your registry provider.
 
-    The control plane will coordinate with your [data plane](/langsmith/data-plane) listener to deploy your application.
+<Tip>
+Tag your images with version information (e.g., `my-registry.com/my-app:v1.0.0`) to make rollbacks easier.
+</Tip>
 
-    After creating a deployment, the infrastructure is [provisioned asynchronously](/langsmith/control-plane#asynchronous-deployment). Deployment can take up to several minutes, with initial deployments taking longer due to database creation.
+## Step 4. Deploy with the control plane UI
 
-    From the control plane UI, you can view build logs, server logs, and deployment metrics including CPU/memory usage, replicas, and API performance. For more details, refer to the [control plane monitoring documentation](/langsmith/control-plane#monitoring).
+The [control plane UI](/langsmith/control-plane#control-plane-ui) allows you to create and manage deployments, view logs and metrics, and update configurations. To create a new deployment in the [LangSmith UI](https://smith.langchain.com):
 
-    <Note>
-    A [LangSmith Observability tracing project](/langsmith/observability) is automatically created for each deployment with the same name as the deployment. Tracing environment variables are set automatically by the control plane.
-    </Note>
-  </Step>
-</Steps>
+1. In the left-hand navigation panel, select **Deployments**.
+1. In the top-right corner, select **+ New Deployment**.
+1. In the deployment configuration panel, provide:
+   - **Image URL**: The full image URL you pushed in [Step 3](#step-3-push-to-container-registry).
+   - **Listener/Compute ID**: Select the listener configured for your infrastructure.
+   - **Namespace**: The Kubernetes namespace to deploy to.
+   - **Environment variables**: Any required configuration (API keys, etc.).
+   - Other deployment settings as needed.
+1. Select **Submit**.
+
+The control plane will coordinate with your [data plane](/langsmith/data-plane) listener to deploy your application.
+
+After creating a deployment, the infrastructure is [provisioned asynchronously](/langsmith/control-plane#asynchronous-deployment). Deployment can take up to several minutes, with initial deployments taking longer due to database creation.
+
+From the control plane UI, you can view build logs, server logs, and deployment metrics including CPU/memory usage, replicas, and API performance. For more details, refer to the [control plane monitoring documentation](/langsmith/control-plane#monitoring).
+
+<Note>
+A [LangSmith Observability tracing project](/langsmith/observability) is automatically created for each deployment with the same name as the deployment. Tracing environment variables are set automatically by the control plane.
+</Note>
 
 ## Update deployment
 
@@ -125,7 +126,10 @@ If your container registry requires authentication (e.g., AWS ECR, Azure ACR, GC
 **This configuration is done at the infrastructure level, not per-deployment.** Once configured, all deployments automatically inherit the registry credentials.
 </Note>
 
-To configure your self-hosted deployment, configure `imagePullSecrets` in your LangSmith Helm chart's `values.yaml` file. See the detailed steps in the [Enable LangSmith Deployment guide](/langsmith/deploy-self-hosted-full-platform).
+The configuration steps depend on your deployment type:
+
+- **Self-hosted with control plane**: Configure `imagePullSecrets` in your LangSmith Helm chart's `values.yaml` file. See the detailed steps in the [Enable LangSmith Deployment guide](/langsmith/deploy-self-hosted-full-platform).
+- **Hybrid**: Configure `imagePullSecrets` in your `langgraph-dataplane-values.yaml` file using the same format.
 
 For detailed steps on creating image pull secrets for different registry providers, refer to the [Kubernetes documentation on pulling images from private registries](https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/).
 

--- a/src/langsmith/enterprise.mdx
+++ b/src/langsmith/enterprise.mdx
@@ -20,6 +20,9 @@ Choose how to host LangSmith to match your infrastructure and data residency req
   <Card title="Cloud" icon="cloud" href="/langsmith/cloud">
     Host LangSmith in LangSmith's managed cloud with US or EU data residency.
   </Card>
+  <Card title="Hybrid" icon="topology-complex" href="/langsmith/hybrid">
+    Run the control plane in LangSmith's cloud and your data plane in your own VPC for full data isolation.
+  </Card>
   <Card title="Self-hosted" icon="server-2" href="/langsmith/self-hosted">
     Deploy LangSmith entirely within your own infrastructure using Docker Compose or Kubernetes.
   </Card>

--- a/src/langsmith/env-var.mdx
+++ b/src/langsmith/env-var.mdx
@@ -199,8 +199,8 @@ See [Configure checkpointer backend](/langsmith/configure-checkpointer) for deta
 ## `POSTGRES_URI_CUSTOM`
 
 <Info>
-**Only for self-hosted**
-Custom Postgres instances are only available for [Self-Hosted](/langsmith/self-hosted) deployments.
+**Only for Hybrid and Self-Hosted**
+Custom Postgres instances are only available for [Hybrid](/langsmith/hybrid) and [Self-Hosted](/langsmith/self-hosted) deployments.
 </Info>
 
 Specify `POSTGRES_URI_CUSTOM` to use a custom Postgres instance. The value of `POSTGRES_URI_CUSTOM` must be a valid [Postgres connection URI](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS).
@@ -249,8 +249,8 @@ Defaults to `''`.
 ## `REDIS_URI_CUSTOM`
 
 <Info>
-**Only for self-hosted**
-Custom Redis instances are only available for [Self-Hosted](/langsmith/self-hosted) deployments.
+**Only for Hybrid and Self-Hosted**
+Custom Redis instances are only available for [Hybrid](/langsmith/hybrid) and [Self-Hosted](/langsmith/self-hosted) deployments.
 </Info>
 
 Specify `REDIS_URI_CUSTOM` to use a custom Redis instance. The value of `REDIS_URI_CUSTOM` must be a valid [Redis connection URI](https://redis-py.readthedocs.io/en/stable/connections.html#redis.Redis.from_url).

--- a/src/langsmith/gcp-self-hosted.mdx
+++ b/src/langsmith/gcp-self-hosted.mdx
@@ -4,7 +4,7 @@ sidebarTitle: GCP
 icon: "brand-google"
 ---
 
-When running LangSmith on [Google Cloud Platform (GCP)](https://cloud.google.com/), you can set up in [full self-hosted](/langsmith/self-hosted) mode. Full self-hosted mode deploys a complete LangSmith platform with observability functionality as well as the option to create agent deployments.
+When running LangSmith on [Google Cloud Platform (GCP)](https://cloud.google.com/), you can set up in either [full self-hosted](/langsmith/self-hosted) or [hybrid](/langsmith/hybrid) mode. Full self-hosted mode deploys a complete LangSmith platform with observability functionality as well as the option to create agent deployments. Hybrid mode entails just the infrastructure to run agents in a data plane within your cloud, while our SaaS provides the control plane and observability functionality.
 
 This page provides:
 
@@ -63,7 +63,7 @@ After completing these initial setup steps, you can review the complete GCP arch
 
 ## Reference architecture
 
-We recommend leveraging GCP's managed services to provide a scalable, secure, and resilient platform. The following architecture applies to self-hosted deployments and aligns with the [Google Cloud Well-Architected Framework](https://docs.cloud.google.com/architecture/framework):
+We recommend leveraging GCP's managed services to provide a scalable, secure, and resilient platform. The following architecture applies to both self-hosted and hybrid and aligns with the [Google Cloud Well-Architected Framework](https://docs.cloud.google.com/architecture/framework):
 
 ![Architecture diagram showing GCP relations to LangSmith services](/langsmith/images/gcp-architecture-self-hosted.png)
 
@@ -75,6 +75,7 @@ We recommend leveraging GCP's managed services to provide a scalable, secure, an
   - ClickHouse + [Persistent Disks](https://cloud.google.com/compute/docs/disks): analytics and trace storage.
     - We recommend using an [externally managed ClickHouse solution](/langsmith/self-host-external-clickhouse) unless security or compliance reasons
     prevent you from doing so.
+    - ClickHouse is not required for hybrid deployments.
   - [Cloud Storage](https://cloud.google.com/storage): object storage for trace artifacts and telemetry.
 
 - <Icon icon="sparkles" /> **LLM integration:** Optionally proxy requests to [Vertex AI](https://cloud.google.com/vertex-ai) for LLM inference.

--- a/src/langsmith/home.mdx
+++ b/src/langsmith/home.mdx
@@ -110,7 +110,7 @@ Once your account and API key are ready, choose a quickstart to begin building w
         arrow="true"
         cta="Choose how to set up LangSmith"
     >
-        Use LangSmith in managed cloud or in a self-hosted environment to match your infrastructure and compliance needs.
+        Use LangSmith in managed cloud, in a self-hosted environment, or hybrid to match your infrastructure and compliance needs.
     </Card>
 
     <Card icon="shield-lock" title="Security & compliance" href="https://trust.langchain.com/" arrow="true" cta="Visit Trust Center">

--- a/src/langsmith/hybrid.mdx
+++ b/src/langsmith/hybrid.mdx
@@ -3,14 +3,8 @@ title: Hybrid
 sidebarTitle: Overview
 ---
 
-<Warning>
-The Hybrid deployment model is deprecated. Do not use it for new deployments.
-
-For new deployments, use [Self-hosted](/langsmith/self-hosted) or [Cloud](/langsmith/cloud).
-</Warning>
-
 <Info>
-The hybrid option requires an [Enterprise](https://langchain.com/pricing) plan.
+The hybrid option requires an [Enterprise](https://langchain.com/pricing) plan. [Get a demo](https://www.langchain.com/contact-sales) to learn more.
 </Info>
 
 The **hybrid** model splits LangSmith infrastructure between LangChain's cloud and yours:
@@ -73,3 +67,36 @@ In order to enable this egress, you may need to update internal firewall rules o
 <Warning>
 AWS/Azure PrivateLink or GCP Private Service Connect is currently not supported. This traffic will go over the internet.
 </Warning>
+
+## Listeners
+
+In the hybrid option, one or more ["listener" applications](/langsmith/data-plane#listener-application) can run depending on how your LangSmith workspaces and Kubernetes clusters are organized.
+
+### Kubernetes cluster organization
+- One or more listeners can run in a Kubernetes cluster.
+- A listener can deploy into one or more namespaces in that cluster.
+- Multiple listeners cannot deploy to the same namespace.
+- Cluster owners are responsible for planning listener layout and Agent Server deployments.
+
+### LangSmith workspace organization
+- A workspace can be associated with one or more listeners.
+- A listener can only be associated with one workspace. LangSmith workspace to listener is a one-to-many relationship.
+- A workspace can only deploy to Kubernetes clusters where all of its listeners are deployed.
+
+## Use cases
+
+Here are some common listener configurations (not strict requirements):
+
+### Each LangSmith workspace → separate Kubernetes cluster
+- Cluster `alpha` runs workspace `A`
+- Cluster `beta` runs workspace `B`
+
+### One cluster, one namespace per workspace
+- Cluster `alpha`, namespace `1` runs workspace `A`
+- Cluster `alpha`, namespace `2` runs workspace `B`
+
+### Separate clusters, with shared “dev” cluster
+- Cluster `alpha` runs workspace `A`
+- Cluster `beta` runs workspace `B`
+- Cluster `dev` runs workspaces `A` and `B`
+- Both workspaces have two listeners; cluster `dev` has two listener deployments

--- a/src/langsmith/langsmith-cli.mdx
+++ b/src/langsmith/langsmith-cli.mdx
@@ -92,7 +92,7 @@ Optionally, set a default project for queries:
 export LANGSMITH_PROJECT="my-default-project"
 ```
 
-If you're using LangSmith [self-hosted](/langsmith/self-hosted), also set the endpoint:
+If you're using LangSmith [self-hosted](/langsmith/self-hosted) or [hybrid](/langsmith/hybrid), also set the endpoint:
 
 ```bash
 export LANGSMITH_ENDPOINT="https://your-langsmith-instance.com"

--- a/src/langsmith/local-dev-testing.mdx
+++ b/src/langsmith/local-dev-testing.mdx
@@ -484,6 +484,7 @@ Now that you have a LangGraph app running locally, you're ready to deploy it:
 
 **Choose a hosting option for LangSmith:**
 - [**Cloud**](/langsmith/cloud): Fastest setup, fully managed (recommended).
+- [**Hybrid**](/langsmith/hybrid): <Tooltip tip="The runtime environment where your Agent Servers and agents execute.">Data plane</Tooltip> in your cloud, <Tooltip tip="The LangSmith UI and APIs for managing deployments.">control plane</Tooltip> managed by LangChain.
 - [**Self-hosted**](/langsmith/self-hosted): Full control in your infrastructure.
 
 For more details, refer to the [Platform setup comparison](/langsmith/platform-setup).

--- a/src/langsmith/manage-trace.mdx
+++ b/src/langsmith/manage-trace.mdx
@@ -19,7 +19,7 @@ To stop comparing, close the pane or click on **Stop comparing** in the upper ri
 <Warning>
 **Sharing a trace publicly will make it accessible to anyone with the link. Make sure you're not sharing sensitive information.**
 
-If your [self-hosted](/langsmith/self-hosted) LangSmith deployment is within a VPC, then the public link is accessible only to members authenticated within your VPC. For enhanced security, we recommend configuring your instance with a private URL accessible only to users with access to your network.
+If your [self-hosted](/langsmith/self-hosted) or [hybrid](/langsmith/hybrid) LangSmith deployment is within a VPC, then the public link is accessible only to members authenticated within your VPC. For enhanced security, we recommend configuring your instance with a private URL accessible only to users with access to your network.
 </Warning>
 
 To share a trace publicly:

--- a/src/langsmith/platform-setup.mdx
+++ b/src/langsmith/platform-setup.mdx
@@ -14,16 +14,17 @@ If you want to deploy an agent application, the [Agent deployment section](/lang
 
 ## Choose how to set up LangSmith
 
-You can deploy LangSmith in one of two modes:
+You can deploy LangSmith in one of three modes:
 - [**Cloud**](/langsmith/cloud): fully managed by LangChain
+- [**Hybrid**](/langsmith/hybrid): LangChain manages the <Tooltip tip="The LangSmith UI and APIs for managing deployments.">control plane</Tooltip>; you host the <Tooltip tip="The runtime environment where your Agent Servers and agents execute.">data plane</Tooltip>
 - [**Self-hosted**](/langsmith/self-hosted): you manage the full stack within your infrastructure
 
 <Callout>
-Self-hosted deployment is available on Enterprise plan. [Get a demo](https://www.langchain.com/contact-sales) to learn more.
+Hybrid and self-hosted deployment options are available on Enterprise plan. [Get a demo](https://www.langchain.com/contact-sales) to learn more.
 </Callout>
 
 
-<Columns cols={2}>
+<Columns cols={3}>
   <Card
     title="Cloud"
     icon="cloud"
@@ -32,6 +33,15 @@ Self-hosted deployment is available on Enterprise plan. [Get a demo](https://www
     cta="Get started"
   >
     Fully managed observability, evaluation, prompt engineering, and application deployment. Deploy from GitHub with automated CI/CD.
+  </Card>
+
+  <Card
+    title="Hybrid"
+    icon="cloud"
+    href="/langsmith/hybrid"
+    cta="Set up Hybrid"
+  >
+    **(Enterprise)** Observability, evaluation, prompt engineering, and application deployment with your applications running in your infrastructure.
   </Card>
 
   <Card
@@ -49,18 +59,18 @@ Self-hosted deployment is available on Enterprise plan. [Get a demo](https://www
 
 Refer to the following table for a comparison:
 
-| Feature | **Cloud** | **Self-Hosted** |
-|---------|-----------|-----------------|
-| **Infrastructure location** | LangChain's cloud | Your cloud |
-| **Who manages updates** | LangChain | You |
-| **Who manages CI/CD for your apps** | LangChain | You |
-| **Can deploy applications?** | ✅ Yes | ✅ Yes (with LangSmith Deployment enabled) |
-| **Observability data location** | LangChain cloud | Your cloud |
-| **[Pricing](https://www.langchain.com/pricing)** | Plus tier | Enterprise |
-| **Best for** | Quick setup, managed infrastructure | Full control, data isolation |
+| Feature | **Cloud** | **Hybrid** | **Self-Hosted** |
+|---------|-----------|------------|-----------------|
+| **Infrastructure location** | LangChain's cloud | Split: Control plane in LangChain cloud, data plane in your cloud | Your cloud |
+| **Who manages updates** | LangChain | LangChain (control plane), You (data plane) | You |
+| **Who manages CI/CD for your apps** | LangChain | You | You |
+| **Can deploy applications?** | ✅ Yes | ✅ Yes | ✅ Yes (with LangSmith Deployment enabled) |
+| **Observability data location** | LangChain cloud | LangChain cloud | Your cloud |
+| **[Pricing](https://www.langchain.com/pricing)** | Plus tier | Enterprise | Enterprise |
+| **Best for** | Quick setup, managed infrastructure | Data residency requirements + managed control plane | Full control, data isolation |
 
 <Tip>
-You can [run an Agent Server locally](/langsmith/local-dev-testing) for testing and development.
+You can [run an Agent Server locally for free](/langsmith/local-dev-testing) for testing and development.
 </Tip>
 
 ### Related

--- a/src/langsmith/reference.mdx
+++ b/src/langsmith/reference.mdx
@@ -78,6 +78,6 @@ The following sections provide API references and SDK documentation for LangSmit
     icon="server"
     href="/langsmith/server-api-ref"
   >
-    API references for self-hosted LangSmith deployments.
+    API references for self-hosted and hybrid LangSmith deployments.
   </Card>
 </CardGroup>


### PR DESCRIPTION
This reverts commit 85a22e711ded9d4152dd50a595ac4ca245a0cce7.

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
