### PR TITLE
Fix syntax error (missing bracket) in structured-output.mdx

### DIFF
--- a/src/oss/langchain/structured-output.mdx
+++ b/src/oss/langchain/structured-output.mdx
@@ -21,6 +21,7 @@ def create_agent(
         type[StructuredResponseT],
         None,
     ]
+)
 ```
 
 ## Response format


### PR DESCRIPTION
## Overview
a round bracket is missing in the docs of structured output

## Type of change

Update existing documentation / Fix typo/bug/link/formatting

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed


## Additional notes
<img width="432" height="213" alt="image" src="https://github.com/user-attachments/assets/22b5f1e8-9985-422c-8f12-2ceddbd96f37" />
