### PR TITLE
fix wrong default port number of postgres in long term memory docs

### DIFF
--- a/src/code-samples/langchain/long-term-memory-create-agent-postgres.py
+++ b/src/code-samples/langchain/long-term-memory-create-agent-postgres.py
@@ -3,7 +3,7 @@ from langchain.agents import create_agent
 from langchain_core.runnables import Runnable
 from langgraph.store.postgres import PostgresStore  # type: ignore[import-not-found]
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 # :remove-start:
 import sys
 from pathlib import Path

--- a/src/snippets/code-samples/long-term-memory-create-agent-postgres-js.mdx
+++ b/src/snippets/code-samples/long-term-memory-create-agent-postgres-js.mdx
@@ -2,13 +2,13 @@
     ```ts Google
     import { createAgent } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const agent = createAgent({
       model: "google-genai:gemini-3.1-pro-preview",
       tools: [],
@@ -19,13 +19,13 @@
     ```ts OpenAI
     import { createAgent } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const agent = createAgent({
       model: "openai:gpt-5.4",
       tools: [],
@@ -36,13 +36,13 @@
     ```ts Anthropic
     import { createAgent } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const agent = createAgent({
       model: "anthropic:claude-sonnet-4-6",
       tools: [],
@@ -53,13 +53,13 @@
     ```ts OpenRouter
     import { createAgent } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const agent = createAgent({
       model: "openrouter:anthropic/claude-sonnet-4-6",
       tools: [],
@@ -70,13 +70,13 @@
     ```ts Fireworks
     import { createAgent } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const agent = createAgent({
       model: "fireworks:accounts/fireworks/models/qwen3p5-397b-a17b",
       tools: [],
@@ -87,13 +87,13 @@
     ```ts Baseten
     import { createAgent } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const agent = createAgent({
       model: "baseten:zai-org/GLM-5",
       tools: [],
@@ -104,13 +104,13 @@
     ```ts Ollama
     import { createAgent } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const agent = createAgent({
       model: "ollama:devstral-2",
       tools: [],

--- a/src/snippets/code-samples/long-term-memory-create-agent-postgres-py.mdx
+++ b/src/snippets/code-samples/long-term-memory-create-agent-postgres-py.mdx
@@ -3,7 +3,7 @@ from langchain.agents import create_agent
 from langchain_core.runnables import Runnable
 from langgraph.store.postgres import PostgresStore  # type: ignore[import-not-found]
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 
 with PostgresStore.from_conn_string(DB_URI) as store:
     store.setup()

--- a/src/snippets/code-samples/long-term-memory-read-tool-postgres-js.mdx
+++ b/src/snippets/code-samples/long-term-memory-read-tool-postgres-js.mdx
@@ -3,20 +3,20 @@
     import * as z from "zod";
     import { createAgent, tool, type ToolRuntime } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const contextSchema = z.object({ userId: z.string() });
-    
+
     await store.put(["users"], "user_123", {
       name: "John Smith",
       language: "English",
     });
-    
+
     const getUserInfo = tool(
       async (_, runtime: ToolRuntime<unknown, z.infer<typeof contextSchema>>) => {
         const userId = runtime.context.userId;
@@ -30,14 +30,14 @@
         schema: z.object({}),
       },
     );
-    
+
     const agent = createAgent({
       model: "google-genai:gemini-3.1-pro-preview",
       tools: [getUserInfo],
       contextSchema,
       store,
     });
-    
+
     await agent.invoke(
       { messages: [{ role: "user", content: "look up user information" }] },
       { context: { userId: "user_123" } },
@@ -48,20 +48,20 @@
     import * as z from "zod";
     import { createAgent, tool, type ToolRuntime } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const contextSchema = z.object({ userId: z.string() });
-    
+
     await store.put(["users"], "user_123", {
       name: "John Smith",
       language: "English",
     });
-    
+
     const getUserInfo = tool(
       async (_, runtime: ToolRuntime<unknown, z.infer<typeof contextSchema>>) => {
         const userId = runtime.context.userId;
@@ -75,14 +75,14 @@
         schema: z.object({}),
       },
     );
-    
+
     const agent = createAgent({
       model: "openai:gpt-5.4",
       tools: [getUserInfo],
       contextSchema,
       store,
     });
-    
+
     await agent.invoke(
       { messages: [{ role: "user", content: "look up user information" }] },
       { context: { userId: "user_123" } },
@@ -93,20 +93,20 @@
     import * as z from "zod";
     import { createAgent, tool, type ToolRuntime } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const contextSchema = z.object({ userId: z.string() });
-    
+
     await store.put(["users"], "user_123", {
       name: "John Smith",
       language: "English",
     });
-    
+
     const getUserInfo = tool(
       async (_, runtime: ToolRuntime<unknown, z.infer<typeof contextSchema>>) => {
         const userId = runtime.context.userId;
@@ -120,14 +120,14 @@
         schema: z.object({}),
       },
     );
-    
+
     const agent = createAgent({
       model: "anthropic:claude-sonnet-4-6",
       tools: [getUserInfo],
       contextSchema,
       store,
     });
-    
+
     await agent.invoke(
       { messages: [{ role: "user", content: "look up user information" }] },
       { context: { userId: "user_123" } },
@@ -138,20 +138,20 @@
     import * as z from "zod";
     import { createAgent, tool, type ToolRuntime } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const contextSchema = z.object({ userId: z.string() });
-    
+
     await store.put(["users"], "user_123", {
       name: "John Smith",
       language: "English",
     });
-    
+
     const getUserInfo = tool(
       async (_, runtime: ToolRuntime<unknown, z.infer<typeof contextSchema>>) => {
         const userId = runtime.context.userId;
@@ -165,14 +165,14 @@
         schema: z.object({}),
       },
     );
-    
+
     const agent = createAgent({
       model: "openrouter:anthropic/claude-sonnet-4-6",
       tools: [getUserInfo],
       contextSchema,
       store,
     });
-    
+
     await agent.invoke(
       { messages: [{ role: "user", content: "look up user information" }] },
       { context: { userId: "user_123" } },
@@ -183,20 +183,20 @@
     import * as z from "zod";
     import { createAgent, tool, type ToolRuntime } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const contextSchema = z.object({ userId: z.string() });
-    
+
     await store.put(["users"], "user_123", {
       name: "John Smith",
       language: "English",
     });
-    
+
     const getUserInfo = tool(
       async (_, runtime: ToolRuntime<unknown, z.infer<typeof contextSchema>>) => {
         const userId = runtime.context.userId;
@@ -210,14 +210,14 @@
         schema: z.object({}),
       },
     );
-    
+
     const agent = createAgent({
       model: "fireworks:accounts/fireworks/models/qwen3p5-397b-a17b",
       tools: [getUserInfo],
       contextSchema,
       store,
     });
-    
+
     await agent.invoke(
       { messages: [{ role: "user", content: "look up user information" }] },
       { context: { userId: "user_123" } },
@@ -228,20 +228,20 @@
     import * as z from "zod";
     import { createAgent, tool, type ToolRuntime } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const contextSchema = z.object({ userId: z.string() });
-    
+
     await store.put(["users"], "user_123", {
       name: "John Smith",
       language: "English",
     });
-    
+
     const getUserInfo = tool(
       async (_, runtime: ToolRuntime<unknown, z.infer<typeof contextSchema>>) => {
         const userId = runtime.context.userId;
@@ -255,14 +255,14 @@
         schema: z.object({}),
       },
     );
-    
+
     const agent = createAgent({
       model: "baseten:zai-org/GLM-5",
       tools: [getUserInfo],
       contextSchema,
       store,
     });
-    
+
     await agent.invoke(
       { messages: [{ role: "user", content: "look up user information" }] },
       { context: { userId: "user_123" } },
@@ -273,20 +273,20 @@
     import * as z from "zod";
     import { createAgent, tool, type ToolRuntime } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const contextSchema = z.object({ userId: z.string() });
-    
+
     await store.put(["users"], "user_123", {
       name: "John Smith",
       language: "English",
     });
-    
+
     const getUserInfo = tool(
       async (_, runtime: ToolRuntime<unknown, z.infer<typeof contextSchema>>) => {
         const userId = runtime.context.userId;
@@ -300,14 +300,14 @@
         schema: z.object({}),
       },
     );
-    
+
     const agent = createAgent({
       model: "ollama:devstral-2",
       tools: [getUserInfo],
       contextSchema,
       store,
     });
-    
+
     await agent.invoke(
       { messages: [{ role: "user", content: "look up user information" }] },
       { context: { userId: "user_123" } },

--- a/src/snippets/code-samples/long-term-memory-read-tool-postgres-py.mdx
+++ b/src/snippets/code-samples/long-term-memory-read-tool-postgres-py.mdx
@@ -12,7 +12,7 @@ class Context:
     user_id: str
 
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 
 with PostgresStore.from_conn_string(DB_URI) as store:
     store.setup()

--- a/src/snippets/code-samples/long-term-memory-storage-postgres-js.mdx
+++ b/src/snippets/code-samples/long-term-memory-storage-postgres-js.mdx
@@ -7,7 +7,7 @@ const embed = (texts: string[]): number[][] => {
 
 const DB_URI =
   process.env.POSTGRES_URI ??
-  "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+  "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
 const store = PostgresStore.fromConnString(DB_URI, {
   index: { embed, dims: 2 },
 });

--- a/src/snippets/code-samples/long-term-memory-storage-postgres-py.mdx
+++ b/src/snippets/code-samples/long-term-memory-storage-postgres-py.mdx
@@ -10,7 +10,7 @@ def embed(texts: Sequence[str]) -> list[list[float]]:
     return [[1.0, 2.0] for _ in texts]
 
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 
 with PostgresStore.from_conn_string(
     DB_URI,

--- a/src/snippets/code-samples/long-term-memory-write-tool-postgres-js.mdx
+++ b/src/snippets/code-samples/long-term-memory-write-tool-postgres-js.mdx
@@ -3,17 +3,17 @@
     import * as z from "zod";
     import { tool, createAgent, type ToolRuntime } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const contextSchema = z.object({ userId: z.string() });
-    
+
     const UserInfo = z.object({ name: z.string() });
-    
+
     const saveUserInfo = tool(
       async (
         userInfo: z.infer<typeof UserInfo>,
@@ -26,19 +26,19 @@
       },
       { name: "save_user_info", description: "Save user info", schema: UserInfo },
     );
-    
+
     const agent = createAgent({
       model: "google-genai:gemini-3.1-pro-preview",
       tools: [saveUserInfo],
       contextSchema,
       store,
     });
-    
+
     await agent.invoke(
       { messages: [{ role: "user", content: "My name is John Smith" }] },
       { context: { userId: "user_123" } },
     );
-    
+
     const result = await store.get(["users"], "user_123");
     console.log(result?.value);
     ```
@@ -47,17 +47,17 @@
     import * as z from "zod";
     import { tool, createAgent, type ToolRuntime } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const contextSchema = z.object({ userId: z.string() });
-    
+
     const UserInfo = z.object({ name: z.string() });
-    
+
     const saveUserInfo = tool(
       async (
         userInfo: z.infer<typeof UserInfo>,
@@ -70,19 +70,19 @@
       },
       { name: "save_user_info", description: "Save user info", schema: UserInfo },
     );
-    
+
     const agent = createAgent({
       model: "openai:gpt-5.4",
       tools: [saveUserInfo],
       contextSchema,
       store,
     });
-    
+
     await agent.invoke(
       { messages: [{ role: "user", content: "My name is John Smith" }] },
       { context: { userId: "user_123" } },
     );
-    
+
     const result = await store.get(["users"], "user_123");
     console.log(result?.value);
     ```
@@ -91,17 +91,17 @@
     import * as z from "zod";
     import { tool, createAgent, type ToolRuntime } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const contextSchema = z.object({ userId: z.string() });
-    
+
     const UserInfo = z.object({ name: z.string() });
-    
+
     const saveUserInfo = tool(
       async (
         userInfo: z.infer<typeof UserInfo>,
@@ -114,19 +114,19 @@
       },
       { name: "save_user_info", description: "Save user info", schema: UserInfo },
     );
-    
+
     const agent = createAgent({
       model: "anthropic:claude-sonnet-4-6",
       tools: [saveUserInfo],
       contextSchema,
       store,
     });
-    
+
     await agent.invoke(
       { messages: [{ role: "user", content: "My name is John Smith" }] },
       { context: { userId: "user_123" } },
     );
-    
+
     const result = await store.get(["users"], "user_123");
     console.log(result?.value);
     ```
@@ -135,17 +135,17 @@
     import * as z from "zod";
     import { tool, createAgent, type ToolRuntime } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const contextSchema = z.object({ userId: z.string() });
-    
+
     const UserInfo = z.object({ name: z.string() });
-    
+
     const saveUserInfo = tool(
       async (
         userInfo: z.infer<typeof UserInfo>,
@@ -158,19 +158,19 @@
       },
       { name: "save_user_info", description: "Save user info", schema: UserInfo },
     );
-    
+
     const agent = createAgent({
       model: "openrouter:anthropic/claude-sonnet-4-6",
       tools: [saveUserInfo],
       contextSchema,
       store,
     });
-    
+
     await agent.invoke(
       { messages: [{ role: "user", content: "My name is John Smith" }] },
       { context: { userId: "user_123" } },
     );
-    
+
     const result = await store.get(["users"], "user_123");
     console.log(result?.value);
     ```
@@ -179,17 +179,17 @@
     import * as z from "zod";
     import { tool, createAgent, type ToolRuntime } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const contextSchema = z.object({ userId: z.string() });
-    
+
     const UserInfo = z.object({ name: z.string() });
-    
+
     const saveUserInfo = tool(
       async (
         userInfo: z.infer<typeof UserInfo>,
@@ -202,19 +202,19 @@
       },
       { name: "save_user_info", description: "Save user info", schema: UserInfo },
     );
-    
+
     const agent = createAgent({
       model: "fireworks:accounts/fireworks/models/qwen3p5-397b-a17b",
       tools: [saveUserInfo],
       contextSchema,
       store,
     });
-    
+
     await agent.invoke(
       { messages: [{ role: "user", content: "My name is John Smith" }] },
       { context: { userId: "user_123" } },
     );
-    
+
     const result = await store.get(["users"], "user_123");
     console.log(result?.value);
     ```
@@ -223,17 +223,17 @@
     import * as z from "zod";
     import { tool, createAgent, type ToolRuntime } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const contextSchema = z.object({ userId: z.string() });
-    
+
     const UserInfo = z.object({ name: z.string() });
-    
+
     const saveUserInfo = tool(
       async (
         userInfo: z.infer<typeof UserInfo>,
@@ -246,19 +246,19 @@
       },
       { name: "save_user_info", description: "Save user info", schema: UserInfo },
     );
-    
+
     const agent = createAgent({
       model: "baseten:zai-org/GLM-5",
       tools: [saveUserInfo],
       contextSchema,
       store,
     });
-    
+
     await agent.invoke(
       { messages: [{ role: "user", content: "My name is John Smith" }] },
       { context: { userId: "user_123" } },
     );
-    
+
     const result = await store.get(["users"], "user_123");
     console.log(result?.value);
     ```
@@ -267,17 +267,17 @@
     import * as z from "zod";
     import { tool, createAgent, type ToolRuntime } from "langchain";
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
-    
+
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
-    
+
     const contextSchema = z.object({ userId: z.string() });
-    
+
     const UserInfo = z.object({ name: z.string() });
-    
+
     const saveUserInfo = tool(
       async (
         userInfo: z.infer<typeof UserInfo>,
@@ -290,19 +290,19 @@
       },
       { name: "save_user_info", description: "Save user info", schema: UserInfo },
     );
-    
+
     const agent = createAgent({
       model: "ollama:devstral-2",
       tools: [saveUserInfo],
       contextSchema,
       store,
     });
-    
+
     await agent.invoke(
       { messages: [{ role: "user", content: "My name is John Smith" }] },
       { context: { userId: "user_123" } },
     );
-    
+
     const result = await store.get(["users"], "user_123");
     console.log(result?.value);
     ```

--- a/src/snippets/code-samples/long-term-memory-write-tool-postgres-py.mdx
+++ b/src/snippets/code-samples/long-term-memory-write-tool-postgres-py.mdx
@@ -25,7 +25,7 @@ def save_user_info(user_info: UserInfo, runtime: ToolRuntime[Context]) -> str:
     return "Successfully saved user info."
 
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 
 with PostgresStore.from_conn_string(DB_URI) as store:
     store.setup()


### PR DESCRIPTION
## Overview
fix all (i assumed) the wrong default port number of postgres in long term memory docs

## Type of change

Update existing documentation / Fix typo/bug/link/formatting

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed



## Additional notes
<img width="1300" height="68" alt="image" src="https://github.com/user-attachments/assets/4821f0a1-c63d-4f9e-86bd-c1d5cb83bb38" />

