### PR TITLE
Fix all wrong default port number of postgres db in long term memory docs and sample code

### DIFF
--- a/.github/workflows/test-code-samples.yml
+++ b/.github/workflows/test-code-samples.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - "src/code-samples/**"
       - ".github/workflows/test-code-samples.yml"
+  workflow_dispatch:
   schedule:
     # Run every Sunday at 00:00 UTC
     - cron: "0 0 * * 0"
@@ -19,6 +20,9 @@ concurrency:
 
 jobs:
   test-code-samples:
+    # GitHub does not expose repository secrets to workflows triggered from fork PRs.
+    # These tests require provider API keys for some samples, so skip on forks.
+    if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.fork == false)
     runs-on: ubuntu-latest
     timeout-minutes: 15
     services:

--- a/src/code-samples/conftest.py
+++ b/src/code-samples/conftest.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import time
 
-_DEFAULT_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+_DEFAULT_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 
 
 def get_postgres_uri() -> str:
@@ -77,7 +77,7 @@ def get_postgres_uri() -> str:
                     "-e",
                     "POSTGRES_DB=postgres",
                     "-p",
-                    "5442:5432",
+                    "5432:5432",
                     "pgvector/pgvector:pg17",
                 ],
                 check=True,

--- a/src/code-samples/langchain/long-term-memory-create-agent-postgres.py
+++ b/src/code-samples/langchain/long-term-memory-create-agent-postgres.py
@@ -3,7 +3,7 @@ from langchain.agents import create_agent
 from langchain_core.runnables import Runnable
 from langgraph.store.postgres import PostgresStore  # type: ignore[import-not-found]
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 # :remove-start:
 import sys
 from pathlib import Path

--- a/src/code-samples/langchain/long-term-memory-create-agent-postgres.ts
+++ b/src/code-samples/langchain/long-term-memory-create-agent-postgres.ts
@@ -4,7 +4,7 @@ import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
 
 const DB_URI =
   process.env.POSTGRES_URI ??
-  "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+  "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
 const store = PostgresStore.fromConnString(DB_URI);
 await store.setup();
 

--- a/src/code-samples/langchain/long-term-memory-read-tool-postgres.py
+++ b/src/code-samples/langchain/long-term-memory-read-tool-postgres.py
@@ -12,7 +12,7 @@ class Context:
     user_id: str
 
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 # :remove-start:
 import os
 import sys

--- a/src/code-samples/langchain/long-term-memory-read-tool-postgres.ts
+++ b/src/code-samples/langchain/long-term-memory-read-tool-postgres.ts
@@ -5,7 +5,7 @@ import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
 
 const DB_URI =
   process.env.POSTGRES_URI ??
-  "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+  "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
 const store = PostgresStore.fromConnString(DB_URI);
 // :remove-start:
 // Drop old store tables if they exist (prior version used different schema).
@@ -56,7 +56,7 @@ await agent.invoke(
 async function main() {
   const DB_URI =
     process.env.POSTGRES_URI ||
-    "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+    "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
   const store = PostgresStore.fromConnString(DB_URI);
 
   try {

--- a/src/code-samples/langchain/long-term-memory-storage-postgres.py
+++ b/src/code-samples/langchain/long-term-memory-storage-postgres.py
@@ -10,7 +10,7 @@ def embed(texts: Sequence[str]) -> list[list[float]]:
     return [[1.0, 2.0] for _ in texts]
 
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 # :remove-start:
 import sys
 from pathlib import Path

--- a/src/code-samples/langchain/long-term-memory-storage-postgres.ts
+++ b/src/code-samples/langchain/long-term-memory-storage-postgres.ts
@@ -7,7 +7,7 @@ const embed = (texts: string[]): number[][] => {
 
 const DB_URI =
   process.env.POSTGRES_URI ??
-  "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+  "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
 const store = PostgresStore.fromConnString(DB_URI, {
   index: { embed, dims: 2 },
 });

--- a/src/code-samples/langchain/long-term-memory-write-tool-postgres.py
+++ b/src/code-samples/langchain/long-term-memory-write-tool-postgres.py
@@ -25,7 +25,7 @@ def save_user_info(user_info: UserInfo, runtime: ToolRuntime[Context]) -> str:
     return "Successfully saved user info."
 
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 # :remove-start:
 import os
 import sys

--- a/src/code-samples/langchain/long-term-memory-write-tool-postgres.ts
+++ b/src/code-samples/langchain/long-term-memory-write-tool-postgres.ts
@@ -5,7 +5,7 @@ import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
 
 const DB_URI =
   process.env.POSTGRES_URI ??
-  "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+  "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
 const store = PostgresStore.fromConnString(DB_URI);
 // :remove-start:
 // Drop tables from prior runs (Python samples use different schema; CI shares one DB)
@@ -54,7 +54,7 @@ console.log(result?.value);
 async function main() {
   const DB_URI =
     process.env.POSTGRES_URI ||
-    "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+    "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
   const store = PostgresStore.fromConnString(DB_URI);
 
   try {

--- a/src/oss/langgraph/add-memory.mdx
+++ b/src/oss/langgraph/add-memory.mdx
@@ -54,7 +54,7 @@ In production, use a checkpointer backed by a database:
 ```python
 from langgraph.checkpoint.postgres import PostgresSaver
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 with PostgresSaver.from_conn_string(DB_URI) as checkpointer:  # [!code highlight]
     builder = StateGraph(...)
     graph = builder.compile(checkpointer=checkpointer)  # [!code highlight]
@@ -67,7 +67,7 @@ with PostgresSaver.from_conn_string(DB_URI) as checkpointer:  # [!code highlight
     ```typescript
     import { PostgresSaver } from "@langchain/langgraph-checkpoint-postgres";
 
-    const DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+    const DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const checkpointer = PostgresSaver.fromConnString(DB_URI);
 
     const builder = new StateGraph(...);
@@ -108,7 +108,7 @@ with PostgresSaver.from_conn_string(DB_URI) as checkpointer:  # [!code highlight
 
       model = init_chat_model(model="claude-haiku-4-5-20251001")
 
-      DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+      DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
       with PostgresSaver.from_conn_string(DB_URI) as checkpointer:  # [!code highlight]
           # checkpointer.setup()
 
@@ -151,7 +151,7 @@ with PostgresSaver.from_conn_string(DB_URI) as checkpointer:  # [!code highlight
 
       model = init_chat_model(model="claude-haiku-4-5-20251001")
 
-      DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+      DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
       async with AsyncPostgresSaver.from_conn_string(DB_URI) as checkpointer:  # [!code highlight]
           # await checkpointer.setup()
 
@@ -209,7 +209,7 @@ with PostgresSaver.from_conn_string(DB_URI) as checkpointer:  # [!code highlight
 
   const model = new ChatAnthropic({ model: "claude-haiku-4-5-20251001" });
 
-  const DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+  const DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
   const checkpointer = PostgresSaver.fromConnString(DB_URI);
   // await checkpointer.setup();
 
@@ -696,7 +696,7 @@ In production, use a store backed by a database:
 ```python
 from langgraph.store.postgres import PostgresStore
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 with PostgresStore.from_conn_string(DB_URI) as store:  # [!code highlight]
     builder = StateGraph(...)
     graph = builder.compile(store=store)  # [!code highlight]
@@ -709,7 +709,7 @@ with PostgresStore.from_conn_string(DB_URI) as store:  # [!code highlight]
     ```typescript
     import { PostgresStore } from "@langchain/langgraph-checkpoint-postgres/store";
 
-    const DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+    const DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
 
     const builder = new StateGraph(...);
@@ -781,7 +781,7 @@ with PostgresStore.from_conn_string(DB_URI) as store:  # [!code highlight]
           )
           return {"messages": response}
 
-      DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+      DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 
       async with (
           AsyncPostgresStore.from_conn_string(DB_URI) as store,  # [!code highlight]
@@ -855,7 +855,7 @@ with PostgresStore.from_conn_string(DB_URI) as store:  # [!code highlight]
           )
           return {"messages": response}
 
-      DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+      DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 
       with (
           PostgresStore.from_conn_string(DB_URI) as store,  # [!code highlight]
@@ -938,7 +938,7 @@ with PostgresStore.from_conn_string(DB_URI) as store:  # [!code highlight]
     return { messages: [response] };
   };
 
-  const DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+  const DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
 
   const store = PostgresStore.fromConnString(DB_URI);
   const checkpointer = PostgresSaver.fromConnString(DB_URI);

--- a/src/snippets/code-samples/long-term-memory-create-agent-postgres-js.mdx
+++ b/src/snippets/code-samples/long-term-memory-create-agent-postgres-js.mdx
@@ -5,7 +5,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -22,7 +22,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -39,7 +39,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -56,7 +56,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -73,7 +73,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -90,7 +90,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -107,7 +107,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     

--- a/src/snippets/code-samples/long-term-memory-create-agent-postgres-py.mdx
+++ b/src/snippets/code-samples/long-term-memory-create-agent-postgres-py.mdx
@@ -3,7 +3,7 @@ from langchain.agents import create_agent
 from langchain_core.runnables import Runnable
 from langgraph.store.postgres import PostgresStore  # type: ignore[import-not-found]
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 
 with PostgresStore.from_conn_string(DB_URI) as store:
     store.setup()

--- a/src/snippets/code-samples/long-term-memory-read-tool-postgres-js.mdx
+++ b/src/snippets/code-samples/long-term-memory-read-tool-postgres-js.mdx
@@ -6,7 +6,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -51,7 +51,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -96,7 +96,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -141,7 +141,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -186,7 +186,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -231,7 +231,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -276,7 +276,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     

--- a/src/snippets/code-samples/long-term-memory-read-tool-postgres-py.mdx
+++ b/src/snippets/code-samples/long-term-memory-read-tool-postgres-py.mdx
@@ -12,7 +12,7 @@ class Context:
     user_id: str
 
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 
 with PostgresStore.from_conn_string(DB_URI) as store:
     store.setup()

--- a/src/snippets/code-samples/long-term-memory-storage-postgres-js.mdx
+++ b/src/snippets/code-samples/long-term-memory-storage-postgres-js.mdx
@@ -7,7 +7,7 @@ const embed = (texts: string[]): number[][] => {
 
 const DB_URI =
   process.env.POSTGRES_URI ??
-  "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+  "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
 const store = PostgresStore.fromConnString(DB_URI, {
   index: { embed, dims: 2 },
 });

--- a/src/snippets/code-samples/long-term-memory-storage-postgres-py.mdx
+++ b/src/snippets/code-samples/long-term-memory-storage-postgres-py.mdx
@@ -10,7 +10,7 @@ def embed(texts: Sequence[str]) -> list[list[float]]:
     return [[1.0, 2.0] for _ in texts]
 
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 
 with PostgresStore.from_conn_string(
     DB_URI,

--- a/src/snippets/code-samples/long-term-memory-write-tool-postgres-js.mdx
+++ b/src/snippets/code-samples/long-term-memory-write-tool-postgres-js.mdx
@@ -6,7 +6,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -50,7 +50,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -94,7 +94,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -138,7 +138,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -182,7 +182,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -226,7 +226,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     
@@ -270,7 +270,7 @@
     
     const DB_URI =
       process.env.POSTGRES_URI ??
-      "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable";
+      "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable";
     const store = PostgresStore.fromConnString(DB_URI);
     await store.setup();
     

--- a/src/snippets/code-samples/long-term-memory-write-tool-postgres-py.mdx
+++ b/src/snippets/code-samples/long-term-memory-write-tool-postgres-py.mdx
@@ -25,7 +25,7 @@ def save_user_info(user_info: UserInfo, runtime: ToolRuntime[Context]) -> str:
     return "Successfully saved user info."
 
 
-DB_URI = "postgresql://postgres:postgres@localhost:5442/postgres?sslmode=disable"
+DB_URI = "postgresql://postgres:postgres@localhost:5432/postgres?sslmode=disable"
 
 with PostgresStore.from_conn_string(DB_URI) as store:
     store.setup()


### PR DESCRIPTION
## Overview
fix all wrong default port of postgres in long term memory docs and sample code

## Type of change

Update existing documentation / Fix typo/bug/link/formatting


## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed


## Additional notes

