### PR TITLE
fix(docs): prioritize interrupts in SQL agent streaming examples

### DIFF
--- a/src/oss/langgraph/sql-agent.mdx
+++ b/src/oss/langgraph/sql-agent.mdx
@@ -871,15 +871,13 @@ for step in agent.stream(
     config,
     stream_mode="values",
 ):
-    if "messages" in step:
-        step["messages"][-1].pretty_print()
-    elif "__interrupt__" in step:
+    if "__interrupt__" in step:
         action = step["__interrupt__"][0]
         print("INTERRUPTED:")
         for request in action.value:
             print(json.dumps(request, indent=2))
-    else:
-        pass
+    elif "messages" in step:
+        step["messages"][-1].pretty_print()
 ```
 :::
 :::js
@@ -934,15 +932,13 @@ for step in agent.stream(
     config,
     stream_mode="values",
 ):
-    if "messages" in step:
-        step["messages"][-1].pretty_print()
-    elif "__interrupt__" in step:
+    if "__interrupt__" in step:
         action = step["__interrupt__"][0]
         print("INTERRUPTED:")
         for request in action.value:
             print(json.dumps(request, indent=2))
-    else:
-        pass
+    elif "messages" in step:
+        step["messages"][-1].pretty_print()
 ```
 :::
 :::js


### PR DESCRIPTION
## Summary

Fixes the SQL agent tutorial streaming example where the interrupt handling branch becomes unreachable when using stream_mode="values".

Since streamed steps may contain both:
- messages
- __interrupt__

the previous condition order caused the interrupt branch to never execute.

This PR updates the example logic to prioritize interrupt handling before message printing in both affected Python examples.

## Changes
- Reordered conditional checks in sql-agent.mdx
- Removed unreachable else: pass
- No runtime or library behavior changes (docs-only fix)

## Related Issues/PRs
Fixes #37251