### PR TITLE
docs(sandboxes): add sandbox runtime access permissions page

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -231,6 +231,7 @@
                         "langsmith/sandbox-snapshots",
                         "langsmith/sandbox-service-urls",
                         "langsmith/sandbox-auth-proxy",
+                        "langsmith/sandbox-permissions",
                         "langsmith/sandbox-cli",
                         "langsmith/sandbox-sdk"
                       ]

--- a/src/langsmith/sandbox-permissions.mdx
+++ b/src/langsmith/sandbox-permissions.mdx
@@ -1,0 +1,52 @@
+---
+title: Sandbox access permissions
+sidebarTitle: Permissions
+description: Control who in your workspace can interact with a sandbox after it has been created.
+---
+
+import SandboxPreview from "/snippets/langsmith/sandbox-preview-warning.mdx";
+
+<SandboxPreview />
+
+Each sandbox has a recorded **creator**, the workspace member whose API key or session created it. By default, only the creator can run commands, read or write files, open tunnels, or reach service URLs on that sandbox. Other workspace members need the `sandboxes:exec` [permission](/langsmith/rbac) to interact with sandboxes they did not create. Sandboxes are never reachable from workspaces other than the one they were created in.
+
+## Who can do what
+
+| Caller | Default | With `sandboxes:exec` |
+| --- | --- | --- |
+| Sandbox creator | ✅ All runtime actions | ✅ All runtime actions |
+| Other workspace member | ❌ Denied | ✅ All runtime actions |
+| Different workspace | ❌ Hidden (treated as not found) | ❌ Hidden (treated as not found) |
+
+"Runtime actions" covers the four ways you interact with a running sandbox after creation:
+
+- **Execute** a command (`langsmith sandbox exec`, `SandboxClient.exec`)
+- **File** operations (read, write, list paths inside the sandbox)
+- **Tunnel** a TCP port back to your machine (`langsmith sandbox tunnel`)
+- **Proxy** requests through a [service URL](/langsmith/sandbox-service-urls)
+
+Lifecycle operations—creating, listing, updating, deleting sandboxes—continue to use the existing `sandboxes:create` / `sandboxes:read` / `sandboxes:update` / `sandboxes:delete` permissions. Those are unchanged.
+
+## Denied requests
+
+When a request is denied, the sandbox returns `HTTP 403` with a body that names the rule that fired:
+
+```json
+{
+  "detail": {
+    "error": "Forbidden",
+    "message": "sandbox access denied: not the creator and missing sandboxes:exec"
+  }
+}
+```
+
+Requests for a sandbox that exists in another workspace return `404 Not Found` rather than `403`, so the response does not reveal whether the sandbox exists elsewhere.
+
+## Sharing a sandbox
+
+You have two ways to let teammates work with a sandbox you own:
+
+1. **Grant `sandboxes:exec`** to a custom role and assign that role in the workspace. Anyone with the role can interact with every sandbox in the workspace.
+2. **Use a [service URL](/langsmith/sandbox-service-urls)** for HTTP services running inside the sandbox. Service URLs use their own access tokens and do not require the recipient to be a workspace member.
+
+For ad-hoc collaboration the service-URL approach is usually simpler; reach for `sandboxes:exec` when a teammate needs broad access to operate sandboxes they did not create.

--- a/src/langsmith/sandboxes.mdx
+++ b/src/langsmith/sandboxes.mdx
@@ -30,6 +30,10 @@ From the [LangSmith homepage](https://smith.langchain.com), select **Sandboxes**
   Inject credentials into outbound API requests without hardcoding secrets.
 </Card>
 
+<Card title="Permissions" icon="user-lock" href="/langsmith/sandbox-permissions">
+  Control which workspace members can interact with a sandbox after it is created.
+</Card>
+
 <Card title="CLI" icon="terminal-2" href="/langsmith/sandbox-cli">
   Build snapshots, manage sandboxes, open consoles, and tunnel TCP ports from the command line.
 </Card>


### PR DESCRIPTION
## Summary

Documents the creator-private runtime authz mode that's now on for sandboxes across dev / staging / prod (us) / eu-prod (rolled out via langchain-ai/langchainplus#24496-#24498 and langchain-ai/deployments#29249, #29260, #29261).

Adds a new dedicated page (`/langsmith/sandbox-permissions`) covering:

- Who can interact with a sandbox at runtime by default (creator only) and how to broaden access (`sandboxes:exec` workspace permission).
- The four runtime actions covered: exec, file, tunnel, proxy.
- Cross-workspace isolation (sandboxes in another workspace surface as 404).
- Denied-request shape (`HTTP 403` with reason).
- Sharing patterns: `sandboxes:exec` for broad access, service URLs for ad-hoc HTTP sharing.

Also adds a Permissions card on the Sandboxes overview and registers the page in the Sandboxes sidebar group in `src/docs.json`.

## Test plan

- [x] `make lint_prose` passes locally (✅).
- [x] Preview build renders the new page under `Tools > Sandboxes > Permissions`.
- [x] Cross-link to `/langsmith/rbac` (for the `sandboxes:exec` permission concept) and `/langsmith/sandbox-service-urls` (for the alternative sharing path) resolves.