### PR TITLE
docs(middleware): LangGraph workflow composition section

### DIFF
--- a/src/oss/langchain/middleware/overview.mdx
+++ b/src/oss/langchain/middleware/overview.mdx
@@ -66,6 +66,57 @@ Middleware exposes hooks before and after each of those steps:
     className="rounded-lg mx-auto"
 />
 
+## Use middleware inside a LangGraph workflow
+
+Middleware is not a separate runtime—it compiles down into the same [LangGraph](/oss/langgraph/overview) nodes and edges that power @[`create_agent`]. Because `create_agent` returns a compiled graph, you can drop the whole agent (middleware and all) into a larger `StateGraph` as a node or subgraph, and every middleware hook continues to run.
+
+Reach for this pattern when the surrounding topology is more than a standard "loop until done"—for example, classifying input before routing to one of several agents, fanning out work in parallel, or stitching agent calls together with deterministic steps.
+
+:::python
+```python
+from langchain.agents import create_agent
+from langchain.agents.middleware import HumanInTheLoopMiddleware
+from langgraph.graph import START, MessagesState, StateGraph
+
+email_agent = create_agent(
+    model="claude-sonnet-4-6",
+    tools=[read_email, send_email],
+    middleware=[HumanInTheLoopMiddleware(interrupt_on={"send_email": True})],
+)
+
+graph = (
+    StateGraph(MessagesState)
+    .add_node("classify", classify_node)
+    .add_node("email_agent", email_agent)
+    .add_edge(START, "classify")
+    .add_conditional_edges("classify", route)
+    .compile()
+)
+```
+:::
+
+:::js
+```typescript
+import { createAgent, humanInTheLoopMiddleware } from "langchain";
+import { StateGraph, MessagesAnnotation, START } from "@langchain/langgraph";
+
+const emailAgent = createAgent({
+  model: "claude-sonnet-4-6",
+  tools: [readEmail, sendEmail],
+  middleware: [humanInTheLoopMiddleware({ interruptOn: { send_email: true } })],
+});
+
+const graph = new StateGraph(MessagesAnnotation)
+  .addNode("classify", classifyNode)
+  .addNode("email_agent", emailAgent)
+  .addEdge(START, "classify")
+  .addConditionalEdges("classify", route)
+  .compile();
+```
+:::
+
+The HITL interrupt, summarization, PII redaction, retries, and any custom hooks all travel with the agent node. See [Use subgraphs](/oss/langgraph/use-subgraphs) for the full set of composition patterns, including per-invocation versus per-thread persistence.
+
 ## Additional resources
 
 <CardGroup cols={2}>

--- a/src/oss/langchain/middleware/overview.mdx
+++ b/src/oss/langchain/middleware/overview.mdx
@@ -76,9 +76,9 @@ Reach for this pattern when the surrounding topology is more than a standard "lo
 
 :::python
 ```python
-from langchain.agents import create_agent
+from langchain.agents import AgentState, create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware
-from langgraph.graph import START, MessagesState, StateGraph
+from langgraph.graph import START, StateGraph
 
 # Assumes read_email, send_email, classify_node, and route are defined elsewhere.
 email_agent = create_agent(
@@ -88,7 +88,7 @@ email_agent = create_agent(
 )
 
 graph = (
-    StateGraph(MessagesState)
+    StateGraph(AgentState)
     .add_node("classify", classify_node)
     .add_node("email_agent", email_agent)
     .add_edge(START, "classify")
@@ -100,8 +100,8 @@ graph = (
 
 :::js
 ```typescript
-import { createAgent, humanInTheLoopMiddleware } from "langchain";
-import { StateGraph, MessagesAnnotation, START } from "@langchain/langgraph";
+import { AgentState, createAgent, humanInTheLoopMiddleware } from "langchain";
+import { StateGraph, START } from "@langchain/langgraph";
 
 // Assumes readEmail, sendEmail, classifyNode, and route are defined elsewhere.
 // readEmail / sendEmail are registered with name: "read_email" / "send_email".
@@ -111,7 +111,7 @@ const emailAgent = createAgent({
   middleware: [humanInTheLoopMiddleware({ interruptOn: { send_email: true } })],
 });
 
-const graph = new StateGraph(MessagesAnnotation)
+const graph = new StateGraph(AgentState)
   .addNode("classify", classifyNode)
   .addNode("emailAgent", emailAgent)
   .addEdge(START, "classify")

--- a/src/oss/langchain/middleware/overview.mdx
+++ b/src/oss/langchain/middleware/overview.mdx
@@ -68,9 +68,11 @@ Middleware exposes hooks before and after each of those steps:
 
 ## Use middleware inside a LangGraph workflow
 
-Middleware is not a separate runtime—it compiles down into the same [LangGraph](/oss/langgraph/overview) nodes and edges that power @[`create_agent`]. Because `create_agent` returns a compiled graph, you can drop the whole agent (middleware and all) into a larger `StateGraph` as a node or subgraph, and every middleware hook continues to run.
+Middleware is not a separate runtime: hooks run inside the compiled [LangGraph](/oss/langgraph/overview) that @[`create_agent`] returns. You can drop the whole agent (middleware and all) into a larger @[StateGraph] as a node or subgraph, and every middleware hook continues to run.
 
-Reach for this pattern when the surrounding topology is more than a standard "loop until done"—for example, classifying input before routing to one of several agents, fanning out work in parallel, or stitching agent calls together with deterministic steps.
+Reach for this pattern when the surrounding topology is more than a standard "loop until done": classifying input before routing to one of several agents, fanning out work in parallel, or stitching agent calls together with deterministic steps.
+
+`HumanInTheLoopMiddleware` matches against each tool's `.name`. In Python, `@tool`-decorated functions take their name from the function (so the key below is `"send_email"`); in TypeScript, the key matches the `name` you pass to `tool({...}, { name })`.
 
 :::python
 ```python
@@ -78,6 +80,7 @@ from langchain.agents import create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware
 from langgraph.graph import START, MessagesState, StateGraph
 
+# Assumes read_email, send_email, classify_node, and route are defined elsewhere.
 email_agent = create_agent(
     model="claude-sonnet-4-6",
     tools=[read_email, send_email],
@@ -100,6 +103,8 @@ graph = (
 import { createAgent, humanInTheLoopMiddleware } from "langchain";
 import { StateGraph, MessagesAnnotation, START } from "@langchain/langgraph";
 
+// Assumes readEmail, sendEmail, classifyNode, and route are defined elsewhere.
+// readEmail / sendEmail are registered with name: "read_email" / "send_email".
 const emailAgent = createAgent({
   model: "claude-sonnet-4-6",
   tools: [readEmail, sendEmail],
@@ -108,14 +113,14 @@ const emailAgent = createAgent({
 
 const graph = new StateGraph(MessagesAnnotation)
   .addNode("classify", classifyNode)
-  .addNode("email_agent", emailAgent)
+  .addNode("emailAgent", emailAgent)
   .addEdge(START, "classify")
   .addConditionalEdges("classify", route)
   .compile();
 ```
 :::
 
-The HITL interrupt, summarization, PII redaction, retries, and any custom hooks all travel with the agent node. See [Use subgraphs](/oss/langgraph/use-subgraphs) for the full set of composition patterns, including per-invocation versus per-thread persistence.
+The HITL interrupt, summarization, PII redaction, retries, and any custom hooks all travel with the agent node. See [Use subgraphs](/oss/langgraph/use-subgraphs) for the full set of composition patterns, including subgraph checkpointer scoping (per-invocation versus per-thread).
 
 ## Additional resources
 


### PR DESCRIPTION
Added a new section to the middleware overview explaining that `create_agent` returns a compiled LangGraph, which means an agent configured with middleware can be dropped into a larger `StateGraph` as a node or subgraph. Includes Python and TypeScript examples showing how to compose an agent with HITL and other middleware alongside classification and routing steps.

## Changes

- **Document agent reuse in larger LangGraph topologies** — new section on `src/oss/langchain/middleware/overview.mdx` clarifies that middleware hooks (HITL, retries, PII redaction, etc.) continue to run when the agent is used as a subgraph node, and points readers to the subgraph composition guide.