### PR TITLE
docs(langsmith/sandboxes): drop private-preview banners and migrate JS import path

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -225,7 +225,6 @@
                     {
                       "group": "Sandboxes",
                       "icon": "box",
-                      "tag": "Private preview",
                       "pages": [
                         "langsmith/sandboxes",
                         "langsmith/sandbox-snapshots",

--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -4,10 +4,6 @@ sidebarTitle: Auth proxy
 description: Inject credentials into outbound API requests from sandboxes without hardcoding secrets.
 ---
 
-import SandboxPreview from "/snippets/langsmith/sandbox-preview-warning.mdx";
-
-<SandboxPreview />
-
 The auth proxy lets sandbox code call external APIs (OpenAI, Anthropic, GitHub, etc.) without hardcoding credentials. When configured on a sandbox, a proxy sidecar automatically injects authentication headers into matching outbound requests using your workspace secrets.
 
 <Warning>
@@ -157,7 +153,7 @@ client.create_sandbox(
 ```
 
 ```ts TypeScript
-import { SandboxClient } from "langsmith/experimental/sandbox";
+import { SandboxClient } from "langsmith/sandbox";
 
 const client = new SandboxClient();
 
@@ -286,7 +282,7 @@ client.create_sandbox(
 ```
 
 ```ts TypeScript
-import { SandboxClient } from "langsmith/experimental/sandbox";
+import { SandboxClient } from "langsmith/sandbox";
 
 const client = new SandboxClient();
 

--- a/src/langsmith/sandbox-cli.mdx
+++ b/src/langsmith/sandbox-cli.mdx
@@ -3,11 +3,7 @@ title: Sandbox CLI
 description: Create, inspect, connect to, and tunnel into LangSmith sandboxes from the command line.
 ---
 
-import SandboxPreview from "/snippets/langsmith/sandbox-preview-warning.mdx";
-
-<SandboxPreview />
-
-The [LangSmith CLI](/langsmith/langsmith-cli) includes experimental sandbox commands for creating snapshots, booting sandboxes, running commands, opening interactive shells, and tunneling TCP connections into a sandbox.
+The [LangSmith CLI](/langsmith/langsmith-cli) includes sandbox commands for creating snapshots, booting sandboxes, running commands, opening interactive shells, and tunneling TCP connections into a sandbox.
 
 Sandbox CLI commands require LangSmith CLI `v0.2.26` or later.
 

--- a/src/langsmith/sandbox-permissions.mdx
+++ b/src/langsmith/sandbox-permissions.mdx
@@ -4,10 +4,6 @@ sidebarTitle: Permissions
 description: Control who in your workspace can interact with a sandbox after it has been created.
 ---
 
-import SandboxPreview from "/snippets/langsmith/sandbox-preview-warning.mdx";
-
-<SandboxPreview />
-
 Each sandbox has a recorded **creator**, the workspace member whose API key or session created it. By default, only the creator can run commands, read or write files, open tunnels, or reach service URLs on that sandbox. Other workspace members need the `sandboxes:exec` [permission](/langsmith/rbac) to interact with sandboxes they did not create. Sandboxes are never reachable from workspaces other than the one they were created in.
 
 ## Who can do what

--- a/src/langsmith/sandbox-sdk.mdx
+++ b/src/langsmith/sandbox-sdk.mdx
@@ -4,10 +4,6 @@ sidebarTitle: SDK usage
 description: Create and manage sandboxes programmatically with the Python or TypeScript SDK.
 ---
 
-import SandboxPreview from "/snippets/langsmith/sandbox-preview-warning.mdx";
-
-<SandboxPreview />
-
 The [LangSmith SDK](/langsmith/reference) provides a programmatic interface to create and interact with sandboxes.
 
 ## Install
@@ -16,10 +12,10 @@ The [LangSmith SDK](/langsmith/reference) provides a programmatic interface to c
 
 ```bash Python
 # uv
-uv add "langsmith[sandbox] @ git+https://github.com/langchain-ai/langsmith-sdk#subdirectory=python"
+uv add "langsmith[sandbox]"
 
 # pip
-pip install "langsmith[sandbox] @ git+https://github.com/langchain-ai/langsmith-sdk#subdirectory=python"
+pip install "langsmith[sandbox]"
 ```
 
 ```bash TypeScript
@@ -59,7 +55,7 @@ with client.sandbox(snapshot_id=snapshot_id) as sb:
 ```
 
 ```ts TypeScript
-import { SandboxClient } from "langsmith/experimental/sandbox";
+import { SandboxClient } from "langsmith/sandbox";
 
 // Client uses LANGSMITH_ENDPOINT and LANGSMITH_API_KEY from environment
 const client = new SandboxClient();
@@ -580,7 +576,7 @@ with client.sandbox(snapshot_id=snapshot_id) as sandbox:
 ```
 
 ```ts TypeScript
-import { SandboxClient } from "langsmith/experimental/sandbox";
+import { SandboxClient } from "langsmith/sandbox";
 
 const client = new SandboxClient();
 
@@ -646,7 +642,7 @@ import {
   LangSmithSandboxConnectionError,
   LangSmithCommandTimeoutError,
   LangSmithQuotaExceededError,
-} from "langsmith/experimental/sandbox";
+} from "langsmith/sandbox";
 
 try {
   const sandbox = await client.createSandbox("not-a-real-snapshot");
@@ -665,5 +661,5 @@ try {
 </CodeGroup>
 
 <Note>
-For more details, see the sandbox SDK reference on GitHub for [Python](https://github.com/langchain-ai/langsmith-sdk/tree/main/python/langsmith/sandbox) or [TypeScript](https://github.com/langchain-ai/langsmith-sdk/tree/main/js/src/experimental/sandbox).
+For more details, see the sandbox SDK reference on GitHub for [Python](https://github.com/langchain-ai/langsmith-sdk/tree/main/python/langsmith/sandbox) or [TypeScript](https://github.com/langchain-ai/langsmith-sdk/tree/main/js/src/sandbox).
 </Note>

--- a/src/langsmith/sandbox-service-urls.mdx
+++ b/src/langsmith/sandbox-service-urls.mdx
@@ -4,10 +4,6 @@ sidebarTitle: Service URLs
 description: Access HTTP services running inside sandboxes via authenticated URLs, from a browser or programmatically.
 ---
 
-import SandboxPreview from "/snippets/langsmith/sandbox-preview-warning.mdx";
-
-<SandboxPreview />
-
 Service URLs let you access an HTTP service running inside a sandbox (a REST API, a Streamlit app, a Jupyter notebook, API documentation) without tunnels, port forwarding, or CLI tools. Each sandbox + port combination gets its own URL that you can open in a browser, call from code, or share with a teammate.
 
 ![Service URLs view](/images/langsmith/sandboxes/sb-service-feature.png)

--- a/src/langsmith/sandbox-snapshots.mdx
+++ b/src/langsmith/sandbox-snapshots.mdx
@@ -4,10 +4,6 @@ sidebarTitle: Snapshots
 description: Build and capture snapshots—the filesystem images every sandbox boots from.
 ---
 
-import SandboxPreview from "/snippets/langsmith/sandbox-preview-warning.mdx";
-
-<SandboxPreview />
-
 A **snapshot** is a filesystem bundle backed by a Docker image. It is the required input to every sandbox: `createSandbox` / `create_sandbox` always takes a snapshot, either by ID (`snapshot_id` / `snapshotId`) or by name (`snapshot_name` / `snapshotName`). Build a snapshot once, then boot as many sandboxes from it as you need.
 
 You can also capture a snapshot from a running sandbox—install packages, write data files, or configure state, then snapshot the result and reuse it as a new starting point.
@@ -35,7 +31,7 @@ print(snapshot.id)
 ```
 
 ```ts TypeScript
-import { SandboxClient } from "langsmith/experimental/sandbox";
+import { SandboxClient } from "langsmith/sandbox";
 
 const client = new SandboxClient();
 

--- a/src/langsmith/sandboxes.mdx
+++ b/src/langsmith/sandboxes.mdx
@@ -4,11 +4,7 @@ sidebarTitle: Overview
 description: Use managed sandboxes to safely execute code and interact with the filesystem in isolated environments.
 ---
 
-import SandboxPreview from "/snippets/langsmith/sandbox-preview-warning.mdx";
-
 Sandboxes are isolated environments that allow agents to safely execute potentially risky operations—like running arbitrary code or interacting with the filesystem—without affecting your main infrastructure.
-
-<SandboxPreview />
 
 From the [LangSmith homepage](https://smith.langchain.com), select **Sandboxes** to manage all your sandbox resources.
 

--- a/src/snippets/langsmith/sandbox-preview-warning.mdx
+++ b/src/snippets/langsmith/sandbox-preview-warning.mdx
@@ -1,3 +1,0 @@
-<Warning>
-Sandboxes are in private preview. APIs and features may change as we iterate. [Sign up for the waitlist](https://www.langchain.com/langsmith-sandboxes-waitlist?ref=docs.langchain.com) to get access.
-</Warning>


### PR DESCRIPTION
## Overview

The LangSmith Sandboxes docs surface still carries private-preview signaling: a `<SandboxPreview />` callout on every page, a `Private preview` group tag in the nav, an "experimental" qualifier in the CLI intro, a git+https install for the Python SDK, and TypeScript code samples still importing from `langsmith/experimental/sandbox`. This PR removes all of those signals and migrates the TypeScript import path to the new GA entrypoint.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Feature PRs:
  - langchain-ai/langsmith-sdk#2884 — Python SDK: removes the import-time `FutureWarning` (no API change).
  - langchain-ai/langsmith-sdk#2885 — TypeScript SDK: renames `langsmith/experimental/sandbox` → `langsmith/sandbox` (breaking import path change).

## Changes

- `src/docs.json` — remove `"tag": "Private preview"` from the Sandboxes nav group.
- `src/snippets/langsmith/sandbox-preview-warning.mdx` — deleted.
- `src/langsmith/sandboxes.mdx`, `sandbox-snapshots.mdx`, `sandbox-service-urls.mdx`, `sandbox-auth-proxy.mdx`, `sandbox-permissions.mdx`, `sandbox-cli.mdx`, `sandbox-sdk.mdx` — remove the `import SandboxPreview ...;` line and the `<SandboxPreview />` element.
- `src/langsmith/sandbox-cli.mdx` — drop "experimental" from the opening sentence ("includes experimental sandbox commands" → "includes sandbox commands").
- `src/langsmith/sandbox-sdk.mdx` — replace the git+https install with the published install:
  ```bash
  uv add "langsmith[sandbox]"
  pip install "langsmith[sandbox]"
  ```
- `src/langsmith/sandbox-sdk.mdx`, `sandbox-snapshots.mdx`, `sandbox-auth-proxy.mdx` — migrate TypeScript code samples from `langsmith/experimental/sandbox` to `langsmith/sandbox` (5 occurrences total) and update the GitHub source link in `sandbox-sdk.mdx` from `js/src/experimental/sandbox` to `js/src/sandbox`.

## Sequencing

This PR should land **after**:

1. A `langsmith` PyPI release that ships the `[sandbox]` extra (so the new install instruction resolves), and
2. A `langsmith` npm release containing the renamed `./sandbox` entrypoint from langchain-ai/langsmith-sdk#2885 (so the TypeScript code samples resolve for readers).

If either release is still pending when this PR is reviewed, hold the merge or revert the relevant section.

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `make broken-links` (no broken links) and `make lint_prose` (no Vale errors/warnings on the 7 changed pages)
- [x] All code examples have been tested and work correctly *(install instructions and import paths verified against the matching langsmith-sdk PRs)*
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed *(removed `Private preview` tag; page list unchanged)*

## Additional notes

Authored with AI agent assistance.

Made with [Cursor](https://cursor.com)