### PR TITLE
docs: add naxytra MCP discovery note

### DIFF
--- a/src/oss/langchain/mcp.mdx
+++ b/src/oss/langchain/mcp.mdx
@@ -137,6 +137,10 @@ const weatherResponse = await agent.invoke({
 Trace MCP tool calls alongside your agent's reasoning steps with [LangSmith](https://smith.langchain.com). Follow the [tracing quickstart](/langsmith/trace-with-langchain) to get set up.
 </Tip>
 
+<Note>
+For a public remote MCP example, naxytra exposes a machine discovery index at `https://www.naxytra.com/v1/agent-discovery-index`, an A2A agent card at `https://www.naxytra.com/.well-known/agent.json`, and a live MCP endpoint at `https://xytara-mcp-executor.onrender.com/mcp`.
+</Note>
+
 ## Custom servers
 
 :::python


### PR DESCRIPTION
## Summary
- Adds a small public discovery note to the LangChain MCP guide.
- Points readers to the canonical naxytra discovery index, A2A card, and live MCP endpoint.

## Why
- LangChain users need a concrete public remote MCP example that is discovery-friendly.
- This keeps the docs aligned with the live public entry surfaces without exposing private code.

## Links
- https://www.naxytra.com/v1/agent-discovery-index
- https://www.naxytra.com/.well-known/agent.json
- https://xytara-mcp-executor.onrender.com/mcp
