### PR TITLE
docs(sandboxes): default creation to server runtime

### DIFF
--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -154,7 +154,7 @@ import { SandboxClient } from "langsmith/sandbox";
 
 const client = new SandboxClient();
 
-await client.createSandbox(undefined, {
+await client.createSandbox({
   name: "openai-sandbox",
   proxyConfig: {
     rules: [
@@ -282,7 +282,7 @@ import { SandboxClient } from "langsmith/sandbox";
 
 const client = new SandboxClient();
 
-await client.createSandbox(undefined, {
+await client.createSandbox({
   name: "callback-sandbox",
   proxyConfig: {
     callbacks: [

--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -40,7 +40,6 @@ curl -X POST "$LANGSMITH_ENDPOINT/api/v2/sandboxes/boxes" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "snapshot_id": "<snapshot-uuid>",
     "name": "openai-sandbox",
     "wait_for_ready": true,
     "proxy_config": {
@@ -72,7 +71,6 @@ curl -X POST "$LANGSMITH_ENDPOINT/api/v2/sandboxes/boxes" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
-    "snapshot_id": "<snapshot-uuid>",
     "name": "multi-api-sandbox",
     "wait_for_ready": true,
     "proxy_config": {
@@ -132,7 +130,6 @@ from langsmith.sandbox import SandboxClient
 client = SandboxClient()
 
 client.create_sandbox(
-    snapshot_id=SNAPSHOT_ID,
     name="openai-sandbox",
     proxy_config={
         "rules": [
@@ -157,7 +154,7 @@ import { SandboxClient } from "langsmith/sandbox";
 
 const client = new SandboxClient();
 
-await client.createSandbox(snapshotId, {
+await client.createSandbox(undefined, {
   name: "openai-sandbox",
   proxyConfig: {
     rules: [
@@ -260,7 +257,6 @@ from langsmith.sandbox import SandboxClient
 client = SandboxClient()
 
 client.create_sandbox(
-    snapshot_id=SNAPSHOT_ID,
     name="callback-sandbox",
     proxy_config={
         "callbacks": [
@@ -286,7 +282,7 @@ import { SandboxClient } from "langsmith/sandbox";
 
 const client = new SandboxClient();
 
-await client.createSandbox(snapshotId, {
+await client.createSandbox(undefined, {
   name: "callback-sandbox",
   proxyConfig: {
     callbacks: [

--- a/src/langsmith/sandbox-cli.mdx
+++ b/src/langsmith/sandbox-cli.mdx
@@ -36,16 +36,10 @@ langsmith --format pretty sandbox list
 
 ## End-to-end workflow
 
-Every sandbox boots from a snapshot. Build a snapshot from a Docker image, create a sandbox from that snapshot, then run commands inside it:
+The normal path is to create a sandbox with the server's default runtime, then run commands inside it:
 
 ```bash
-langsmith sandbox snapshot build python-slim \
-  --docker-image python:3.12-slim \
-  --capacity 4gb \
-  --wait
-
 langsmith sandbox create my-vm \
-  --snapshot-id <SNAPSHOT_ID> \
   --vcpus 2 \
   --memory 1gb \
   --wait
@@ -100,11 +94,10 @@ langsmith sandbox snapshot delete <SNAPSHOT_ID>
 
 ## Manage sandboxes
 
-Create a sandbox from a snapshot:
+Create a sandbox with the default runtime. Add `--snapshot-id` only when you want to boot from a reusable custom snapshot:
 
 ```bash
 langsmith sandbox create my-vm \
-  --snapshot-id <SNAPSHOT_ID> \
   --vcpus 4 \
   --memory 1gb \
   --rootfs-capacity 8gb \
@@ -264,7 +257,7 @@ The sandbox image must run `sshd` on port `22`. If `sshd` is not running, `ssh-s
 | `langsmith sandbox snapshot get <snapshot-id>` | Inspect a snapshot. |
 | `langsmith sandbox snapshot wait <snapshot-id>` | Wait for a snapshot to become ready. |
 | `langsmith sandbox snapshot delete <snapshot-id>` | Delete a snapshot. |
-| `langsmith sandbox create <name> --snapshot-id <snapshot-id>` | Create a sandbox from a snapshot. |
+| `langsmith sandbox create <name>` | Create a sandbox with the default runtime. |
 | `langsmith sandbox list` | List sandboxes. |
 | `langsmith sandbox get <name>` | Inspect a sandbox. |
 | `langsmith sandbox update <name>` | Update sandbox resources or proxy config. |

--- a/src/langsmith/sandbox-cli.mdx
+++ b/src/langsmith/sandbox-cli.mdx
@@ -36,7 +36,7 @@ langsmith --format pretty sandbox list
 
 ## End-to-end workflow
 
-The normal path is to create a sandbox with the server's default runtime, then run commands inside it:
+Create a sandbox, then run commands inside it:
 
 ```bash
 langsmith sandbox create my-vm \

--- a/src/langsmith/sandbox-sdk.mdx
+++ b/src/langsmith/sandbox-sdk.mdx
@@ -34,7 +34,7 @@ npm install ws
 
 ## Create and run a sandbox
 
-Omitting `snapshot_id` / `snapshotId` is the normal path. The server creates the sandbox from its default runtime. Pass a snapshot ID or name only when you want to boot from a reusable custom filesystem image; see [Snapshots](/langsmith/sandbox-snapshots) for that flow.
+Pass a snapshot ID or name when you want to boot from a reusable custom filesystem image; see [Snapshots](/langsmith/sandbox-snapshots) for that flow.
 
 <CodeGroup>
 

--- a/src/langsmith/sandbox-sdk.mdx
+++ b/src/langsmith/sandbox-sdk.mdx
@@ -34,7 +34,7 @@ npm install ws
 
 ## Create and run a sandbox
 
-Every sandbox boots from a **snapshot** — a filesystem image backed by a Docker image. Pick an existing snapshot or create a new one (see [Snapshots](/langsmith/sandbox-snapshots) for the full build / capture / CRUD flow); every example below uses a `snapshot_id` / `snapshotId` you already have.
+Omitting `snapshot_id` / `snapshotId` is the normal path. The server creates the sandbox from its default runtime. Pass a snapshot ID or name only when you want to boot from a reusable custom filesystem image; see [Snapshots](/langsmith/sandbox-snapshots) for that flow.
 
 <CodeGroup>
 
@@ -44,11 +44,8 @@ from langsmith.sandbox import SandboxClient
 # Client uses LANGSMITH_ENDPOINT and LANGSMITH_API_KEY from environment
 client = SandboxClient()
 
-# Pick an existing snapshot, or build one with client.create_snapshot(...)
-snapshot_id = "550e8400-e29b-41d4-a716-446655440000"
-
-# Create a sandbox from the snapshot and run code
-with client.sandbox(snapshot_id=snapshot_id) as sb:
+# Create a sandbox with the default runtime and run code
+with client.sandbox() as sb:
     result = sb.run("python -c 'print(2 + 2)'")
     print(result.stdout)  # "4\n"
     print(result.success)  # True
@@ -60,11 +57,8 @@ import { SandboxClient } from "langsmith/sandbox";
 // Client uses LANGSMITH_ENDPOINT and LANGSMITH_API_KEY from environment
 const client = new SandboxClient();
 
-// Pick an existing snapshot, or build one with client.createSnapshot(...)
-const snapshotId = "550e8400-e29b-41d4-a716-446655440000";
-
-// Create a sandbox from the snapshot and run code
-const sandbox = await client.createSandbox(snapshotId);
+// Create a sandbox with the default runtime and run code
+const sandbox = await client.createSandbox();
 const result = await sandbox.run("node -e 'console.log(2 + 2)'");
 console.log(result.stdout); // "4\n"
 
@@ -81,7 +75,7 @@ Every `run()` call returns an `ExecutionResult` with `stdout`, `stderr`, `exit_c
 <CodeGroup>
 
 ```python Python
-with client.sandbox(snapshot_id=snapshot_id) as sb:
+with client.sandbox() as sb:
     result = sb.run("echo 'Hello, World!'")
 
     print(result.stdout)     # "Hello, World!\n"
@@ -96,7 +90,7 @@ with client.sandbox(snapshot_id=snapshot_id) as sb:
 ```
 
 ```ts TypeScript
-const sandbox = await client.createSandbox(snapshotId);
+const sandbox = await client.createSandbox();
 try {
   const result = await sandbox.run("echo 'Hello, World!'");
 
@@ -127,7 +121,7 @@ For long-running commands, stream output in real time using callbacks or a `Comm
 ```python Python
 import sys
 
-with client.sandbox(snapshot_id=snapshot_id) as sb:
+with client.sandbox() as sb:
     result = sb.run(
         "make build",
         timeout=600,
@@ -155,7 +149,7 @@ Set `wait=False` to get a `CommandHandle` for full control over the output strea
 <CodeGroup>
 
 ```python Python
-with client.sandbox(snapshot_id=snapshot_id) as sb:
+with client.sandbox() as sb:
     handle = sb.run("make build", timeout=600, wait=False)
 
     print(f"Command ID: {handle.command_id}")
@@ -196,7 +190,7 @@ console.log(`Exit code: ${result.exit_code}`);
 <CodeGroup>
 
 ```python Python
-with client.sandbox(snapshot_id=snapshot_id) as sb:
+with client.sandbox() as sb:
     handle = sb.run(
         "python -c 'name = input(\"Name: \"); print(f\"Hello {name}\")'",
         timeout=30,
@@ -230,7 +224,7 @@ Kill a running command:
 <CodeGroup>
 
 ```python Python
-with client.sandbox(snapshot_id=snapshot_id) as sb:
+with client.sandbox() as sb:
     handle = sb.run("python server.py", timeout=0, wait=False)
 
     for chunk in handle:
@@ -258,7 +252,7 @@ If a client disconnects, reconnect using the command ID:
 <CodeGroup>
 
 ```python Python
-with client.sandbox(snapshot_id=snapshot_id) as sb:
+with client.sandbox() as sb:
     handle = sb.run("make build", timeout=600, wait=False)
     command_id = handle.command_id
 
@@ -289,7 +283,7 @@ Read and write files in the sandbox:
 <CodeGroup>
 
 ```python Python
-with client.sandbox(snapshot_id=snapshot_id) as sb:
+with client.sandbox() as sb:
     # Write a file
     sb.write("/app/script.py", "print('Hello from file!')")
 
@@ -306,7 +300,7 @@ with client.sandbox(snapshot_id=snapshot_id) as sb:
 ```
 
 ```ts TypeScript
-const sandbox = await client.createSandbox(snapshotId);
+const sandbox = await client.createSandbox();
 try {
   // Write a file (string content)
   await sandbox.write("/app/script.py", "print('Hello from file!')");
@@ -351,19 +345,17 @@ populates `stopped_at` and starts the deletion timer.
 
 ```python Python
 # Default retention (server defaults: 10-min idle stop, 14-day delete)
-with client.sandbox(snapshot_id=snapshot_id) as sb:
+with client.sandbox() as sb:
     sb.run("echo hello")
 
 # Aggressive: stop after 5 min idle, delete 1 hour after stop
 sb = client.create_sandbox(
-    snapshot_id=snapshot_id,
     idle_ttl_seconds=300,
     delete_after_stop_seconds=3600,
 )
 
 # Long-running: never auto-stop, delete 7 days after manual stop
 sb = client.create_sandbox(
-    snapshot_id=snapshot_id,
     idle_ttl_seconds=0,
     delete_after_stop_seconds=604800,
 )
@@ -378,16 +370,16 @@ sb = client.update_sandbox(
 
 ```ts TypeScript
 // Default retention (server defaults applied)
-const sandbox = await client.createSandbox(snapshotId);
+const sandbox = await client.createSandbox();
 
 // Aggressive: stop after 5 min idle, delete 1 hour after stop
-const sb = await client.createSandbox(snapshotId, {
+const sb = await client.createSandbox(undefined, {
   idleTtlSeconds: 300,
   deleteAfterStopSeconds: 3600,
 });
 
 // Long-running: never auto-stop, delete 7 days after manual stop
-const longRunning = await client.createSandbox(snapshotId, {
+const longRunning = await client.createSandbox(undefined, {
   idleTtlSeconds: 0,
   deleteAfterStopSeconds: 604800,
 });
@@ -413,7 +405,7 @@ The sandbox daemon manages command session lifecycles with two timeout mechanism
 <CodeGroup>
 
 ```python Python
-with client.sandbox(snapshot_id=snapshot_id) as sb:
+with client.sandbox() as sb:
     # Long-running task: 30-min idle timeout, 1-hour session TTL
     handle = sb.run(
         "python train.py",
@@ -434,7 +426,7 @@ with client.sandbox(snapshot_id=snapshot_id) as sb:
 ```
 
 ```ts TypeScript
-const sandbox = await client.createSandbox(snapshotId);
+const sandbox = await client.createSandbox();
 try {
   // Long-running task: 30-min idle timeout, 1-hour session TTL
   const handle = await sandbox.run("python train.py", {
@@ -465,7 +457,7 @@ Set `kill_on_disconnect=True` (Python) or `killOnDisconnect: true` (TypeScript) 
 Access an HTTP service running inside a sandbox via an authenticated URL. You can open it in a browser, call it from code, or share it with a teammate.
 
 ```python
-with client.sandbox(snapshot_id=snapshot_id) as sb:
+with client.sandbox() as sb:
     sb.run("python -m http.server 8000", timeout=0, wait=False)
 
     svc = sb.service(port=8000)
@@ -530,7 +522,7 @@ from langsmith.sandbox import AsyncSandboxClient
 
 async def main():
     async with AsyncSandboxClient() as client:
-        async with await client.sandbox(snapshot_id=snapshot_id) as sb:
+        async with await client.sandbox() as sb:
             result = await sb.run("python -c 'print(1 + 1)'")
             print(result.stdout)  # "2\n"
 
@@ -569,7 +561,7 @@ tracing_env = {
     "LANGSMITH_PROJECT": "my-sandbox-traces",
 }
 
-with client.sandbox(snapshot_id=snapshot_id) as sandbox:
+with client.sandbox() as sandbox:
     sandbox.run("pip install langsmith", timeout=120, env=tracing_env)
     result = sandbox.run("python3 my_agent.py", env=tracing_env)
     print(result.stdout)
@@ -587,7 +579,7 @@ const tracingEnv = {
   LANGSMITH_PROJECT: "my-sandbox-traces",
 };
 
-const sandbox = await client.createSandbox(snapshotId);
+const sandbox = await client.createSandbox();
 try {
   await sandbox.run("pip install langsmith", { timeout: 120, env: tracingEnv });
   const result = await sandbox.run("python3 my_agent.py", { env: tracingEnv });
@@ -624,7 +616,7 @@ from langsmith.sandbox import (
 )
 
 try:
-    with client.sandbox(snapshot_id=snapshot_id) as sb:
+    with client.sandbox() as sb:
         result = sb.run("sleep 999", timeout=10)
 except CommandTimeoutError as e:
     print(f"Command timed out: {e}")

--- a/src/langsmith/sandbox-sdk.mdx
+++ b/src/langsmith/sandbox-sdk.mdx
@@ -373,13 +373,13 @@ sb = client.update_sandbox(
 const sandbox = await client.createSandbox();
 
 // Aggressive: stop after 5 min idle, delete 1 hour after stop
-const sb = await client.createSandbox(undefined, {
+const sb = await client.createSandbox({
   idleTtlSeconds: 300,
   deleteAfterStopSeconds: 3600,
 });
 
 // Long-running: never auto-stop, delete 7 days after manual stop
-const longRunning = await client.createSandbox(undefined, {
+const longRunning = await client.createSandbox({
   idleTtlSeconds: 0,
   deleteAfterStopSeconds: 604800,
 });

--- a/src/langsmith/sandbox-service-urls.mdx
+++ b/src/langsmith/sandbox-service-urls.mdx
@@ -17,7 +17,7 @@ from langsmith.sandbox import SandboxClient
 
 client = SandboxClient()
 
-with client.sandbox(snapshot_id=SNAPSHOT_ID) as sb:
+with client.sandbox() as sb:
     handle = sb.run("python -m http.server 8000", timeout=0, wait=False)
 
     svc = sb.service(port=8000)
@@ -137,7 +137,7 @@ from langsmith.sandbox import SandboxClient
 
 client = SandboxClient()
 
-with client.sandbox(snapshot_id=SNAPSHOT_ID) as sb:
+with client.sandbox() as sb:
     sb.write("/app/main.py", """
 from fastapi import FastAPI
 

--- a/src/langsmith/sandbox-snapshots.mdx
+++ b/src/langsmith/sandbox-snapshots.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Snapshots
 description: Build and capture reusable filesystem images for sandboxes.
 ---
 
-A **snapshot** is a reusable filesystem bundle backed by a Docker image. The normal sandbox creation path omits a snapshot and uses the server's default runtime. Build or capture a snapshot only when you want to boot sandboxes from a custom filesystem image.
+A **snapshot** is a reusable filesystem bundle backed by a Docker image. Build or capture a snapshot when you want to boot sandboxes from a custom filesystem image.
 
 You can also capture a snapshot from a running sandbox—install packages, write data files, or configure state, then snapshot the result and reuse it as a new starting point.
 

--- a/src/langsmith/sandbox-snapshots.mdx
+++ b/src/langsmith/sandbox-snapshots.mdx
@@ -141,7 +141,7 @@ sb = client.create_sandbox(snapshot_name="ml-ready")
 ```
 
 ```ts TypeScript
-const sb = await client.createSandbox(undefined, { snapshotName: "ml-ready" });
+const sb = await client.createSandbox({ snapshotName: "ml-ready" });
 ```
 
 </CodeGroup>

--- a/src/langsmith/sandbox-snapshots.mdx
+++ b/src/langsmith/sandbox-snapshots.mdx
@@ -1,10 +1,10 @@
 ---
 title: Sandbox snapshots
 sidebarTitle: Snapshots
-description: Build and capture snapshots—the filesystem images every sandbox boots from.
+description: Build and capture reusable filesystem images for sandboxes.
 ---
 
-A **snapshot** is a filesystem bundle backed by a Docker image. It is the required input to every sandbox: `createSandbox` / `create_sandbox` always takes a snapshot, either by ID (`snapshot_id` / `snapshotId`) or by name (`snapshot_name` / `snapshotName`). Build a snapshot once, then boot as many sandboxes from it as you need.
+A **snapshot** is a reusable filesystem bundle backed by a Docker image. The normal sandbox creation path omits a snapshot and uses the server's default runtime. Build or capture a snapshot only when you want to boot sandboxes from a custom filesystem image.
 
 You can also capture a snapshot from a running sandbox—install packages, write data files, or configure state, then snapshot the result and reuse it as a new starting point.
 
@@ -146,7 +146,7 @@ const sb = await client.createSandbox(undefined, { snapshotName: "ml-ready" });
 
 </CodeGroup>
 
-Pass exactly one of `snapshot_id` / `snapshot_name` (or `snapshotId` / `snapshotName` in TypeScript).
+Pass at most one of `snapshot_id` / `snapshot_name` (or `snapshotId` / `snapshotName` in TypeScript). Omit both to use the default runtime.
 </Tip>
 
 ### Tune capture timing

--- a/src/snippets/deepagents-sandbox-basic-py.mdx
+++ b/src/snippets/deepagents-sandbox-basic-py.mdx
@@ -156,7 +156,7 @@
         from langsmith.sandbox import SandboxClient
 
         client = SandboxClient()
-        ls_sandbox = client.create_sandbox(template_name="my-template")
+        ls_sandbox = client.create_sandbox()
         backend = LangSmithSandbox(sandbox=ls_sandbox)
 
         agent = create_deep_agent(


### PR DESCRIPTION
## Summary

Update sandbox docs to present omitted snapshot id/name as the normal default-runtime path. Keep snapshots documented as optional reusable custom filesystem images.

## Test Plan

- [x] none