### PR TITLE
langsmith(observability): replace Polly quicklink with Engine

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -271,7 +271,7 @@
                 "langsmith/observability-quickstart",
                 "langsmith/observability-concepts",
                 "langsmith/observability-llm-tutorial",
-                "langsmith/polly-observability",
+                "langsmith/engine",
                 {
                   "group": "Tracing setup",
                   "pages": [
@@ -437,8 +437,7 @@
                   "pages": [
                     "langsmith/dashboards",
                     "langsmith/alerts",
-                    "langsmith/insights",
-                    "langsmith/engine"
+                    "langsmith/insights"
                   ]
                 },
                 {

--- a/src/langsmith/observability.mdx
+++ b/src/langsmith/observability.mdx
@@ -76,12 +76,12 @@ LangSmith works with many frameworks and providers. Browse [available integratio
 </CardGroup>
 
 <Card
-  title="Analyze traces with Polly"
-  icon="sparkles"
-  href="/langsmith/polly"
+  title="Find and fix failures with Engine"
+  icon="engine"
+  href="/langsmith/engine"
   arrow="true"
 >
-  LangSmith's built-in AI assistant analyzes your traces and surfaces insights about performance, errors, and quality—without manual investigation.
+  Automatically detect recurring issues in your traces, diagnose their root cause, and resolve them with LangSmith Engine.
 </Card>
 
 For terminology and core concepts, refer to [Observability concepts](/langsmith/observability-concepts).


### PR DESCRIPTION
## Summary

- Replaces the "Analyze traces with Polly" Card on the Observability overview page with a "Find and fix failures with Engine" Card linking to `/langsmith/engine`
- Moves `langsmith/engine` in `docs.json` from the "Monitoring & alerting" group to the top-level Observability tab pages (alongside concepts and tutorial), replacing `langsmith/polly-observability`

## Why

Engine is now the featured AI-powered observability tool on this page; Polly's entry remains accessible via the Get started tab's Tools section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)