### PR TITLE
docs(frontend): cover v1 useStream in @langchain/{react,vue,svelte,angular}

### DIFF
--- a/src/oss/deepagents/frontend/overview.mdx
+++ b/src/oss/deepagents/frontend/overview.mdx
@@ -95,6 +95,19 @@ function App() {
 }
 ```
 
+`useStream` is available for React, Vue, Svelte, and Angular in v1 of each package:
+
+```ts
+import { useStream } from "@langchain/react";   // React
+import { useStream } from "@langchain/vue";      // Vue
+import { useStream } from "@langchain/svelte";   // Svelte
+import { useStream } from "@langchain/angular";  // Angular
+```
+
+import RequiresUseStreamServer from '/snippets/oss/requires-usestream-server.mdx';
+
+<RequiresUseStreamServer />
+
 ## Patterns
 
 <CardGroup cols={3}>

--- a/src/oss/javascript/releases/langgraph-v1.mdx
+++ b/src/oss/javascript/releases/langgraph-v1.mdx
@@ -99,19 +99,46 @@ The low-level `toLangGraphEventStream` helper has been removed. Streaming respon
 
 See the [migration guide](/oss/migrate/langgraph-v1#event-stream-encoding) for more information.
 
-### Custom transports in `useStream`
+### `useStream` v1 in `@langchain/{react,vue,svelte,angular}`
 
-The React `useStream` hook now supports pluggable transports so you can have more control over the network layer without changing UI code.
+`@langchain/react`, `@langchain/vue`, `@langchain/svelte`, and `@langchain/angular` v1 rebuild `useStream` on a v2-native streaming protocol. The hook moved out of `@langchain/langgraph-sdk/react` and into framework-specific packages, and most of the new surface area ships as companion selector hooks (or framework-equivalent composables/injectables) that subscribe only while a component is mounted.
 
-```typescript
-const stream = useStream({
-  transport: new FetchStreamTransport({
+<Note>
+v1 is a breaking release. The new protocol requires `langgraph-api>=0.9.0rc1` on the server and bundles `@langchain/langgraph-sdk>=1.9.0` as a dependency (installed automatically). If you can't upgrade the server yet, pin to the pre-v1 release of your frontend package (`@langchain/react@0.3`, `@langchain/vue@0.4`, `@langchain/svelte@0.4`, or `@langchain/angular@0.4`).
+</Note>
+
+Highlights:
+
+- **Always-on root projections.** `values`, `messages`, `toolCalls`, and `interrupts` are live on the root return without extra wiring or stream-mode configuration.
+- **Selector hooks for namespaced data.** `useChannel`, `useExtension`, `useMessageMetadata`, `useSubmissionQueue`, and per-subagent selectors open ref-counted subscriptions on mount and release them on unmount, so namespaced data only streams to components that need it.
+- **Automatic re-attach.** The session-based transport reconnects on remount; no more `reconnectOnMount` / `joinStream` dance.
+- **Multimodal media streams.** Built-in assembly for audio, images, video, and files via `useAudioPlayer`, `useVideoPlayer`, `useMediaURL`, and matching selectors.
+- **Suspense and Error Boundary integration.** `useSuspenseStream` hands the initial hydration phase to `<Suspense>` and surfaces non-streaming errors to Error Boundaries.
+- **Pluggable transports.** Implement `AgentServerAdapter` to route streaming traffic over a custom backend, WebSocket, or proxy without changing UI code.
+- **Strongly typed agent inference.** `useStream<typeof agent>()` unwraps state, tool calls, and subagent state maps directly from the agent's type, including custom state keys and headless tools.
+
+```tsx
+import {
+  useStream,
+  useSubmissionQueue,
+  useSuspenseStream,
+} from "@langchain/react";
+
+function Chat() {
+  const stream = useStream<typeof agent>({
     apiUrl: "http://localhost:2024",
-  }),
-});
+    assistantId: "agent",
+  });
+
+  // Always-on projections from the root.
+  const { messages, toolCalls, interrupts } = stream;
+
+  // Scoped selector — opens a subscription only while this component is mounted.
+  const queue = useSubmissionQueue(stream);
+}
 ```
 
-Learn how to integrate and customize the hook: [Integrate LangGraph into your React application](/oss/langgraph/ui).
+Vue exposes the same data through composables (`provideStream`, `useStreamContext`, selector composables); Angular ships matching helpers (`injectStream`, `provideStream`, `injectProjection`, selector injectables). See the [LangChain frontend overview](/oss/langchain/frontend/overview) for end-to-end patterns and the per-framework package README for the full surface.
 
 ## Reporting issues
 

--- a/src/oss/langchain/frontend/overview.mdx
+++ b/src/oss/langchain/frontend/overview.mdx
@@ -110,7 +110,7 @@ function Chat() {
 
 </CodeGroup>
 
-`useStream` is available for React, Vue, Svelte, and Angular:
+`useStream` is available for React, Vue, Svelte, and Angular in v1 of each package:
 
 ```ts
 import { useStream } from "@langchain/react";   // React
@@ -118,6 +118,12 @@ import { useStream } from "@langchain/vue";      // Vue
 import { useStream } from "@langchain/svelte";   // Svelte
 import { useStream } from "@langchain/angular";  // Angular
 ```
+
+import RequiresUseStreamServer from '/snippets/oss/requires-usestream-server.mdx';
+
+<RequiresUseStreamServer />
+
+For what's new in the v1 hook—selector hooks, always-on root projections, Suspense, multimodal media, pluggable transports—see [What's new in LangGraph v1: Frontend SDK enhancements](/oss/releases/langgraph-v1#frontend-sdk-enhancements).
 
 ## Patterns
 

--- a/src/oss/langchain/frontend/overview.mdx
+++ b/src/oss/langchain/frontend/overview.mdx
@@ -123,7 +123,11 @@ import RequiresUseStreamServer from '/snippets/oss/requires-usestream-server.mdx
 
 <RequiresUseStreamServer />
 
+:::js
+
 For what's new in the v1 hook—selector hooks, always-on root projections, Suspense, multimodal media, pluggable transports—see [What's new in LangGraph v1: Frontend SDK enhancements](/oss/releases/langgraph-v1#frontend-sdk-enhancements).
+
+:::
 
 ## Patterns
 

--- a/src/oss/langgraph/frontend/overview.md
+++ b/src/oss/langgraph/frontend/overview.md
@@ -106,6 +106,19 @@ function Pipeline() {
 }
 ```
 
+`useStream` is available for React, Vue, Svelte, and Angular in v1 of each package:
+
+```ts
+import { useStream } from "@langchain/react";   // React
+import { useStream } from "@langchain/vue";      // Vue
+import { useStream } from "@langchain/svelte";   // Svelte
+import { useStream } from "@langchain/angular";  // Angular
+```
+
+import RequiresUseStreamServer from '/snippets/oss/requires-usestream-server.mdx';
+
+<RequiresUseStreamServer />
+
 ## Patterns
 
 <CardGroup cols={2}>

--- a/src/oss/langgraph/streaming.mdx
+++ b/src/oss/langgraph/streaming.mdx
@@ -1028,7 +1028,7 @@ for await (const [mode, chunk] of await graph.stream(
 
 #### Use tool progress in React with `useStream`
 
-The `useStream` hook from `@langchain/langgraph-sdk/react` exposes a `toolProgress` array when you include `"tools"` in your stream modes. Each entry is a `ToolProgress` object that tracks the current state of a running tool:
+The `useStream` hook from `@langchain/react` exposes a `toolProgress` array when you include `"tools"` in your stream modes. Each entry is a `ToolProgress` object that tracks the current state of a running tool:
 
 | Field | Description |
 |-------|-------------|
@@ -1041,7 +1041,7 @@ The `useStream` hook from `@langchain/langgraph-sdk/react` exposes a `toolProgre
 | `error` | The error, set on `on_tool_error` |
 
 ```typescript
-import { useStream } from "@langchain/langgraph-sdk/react";
+import { useStream } from "@langchain/react";
 
 function Chat() {
   const stream = useStream({
@@ -1162,7 +1162,7 @@ export const agent = createAgent({
 **React component with progress cards:**
 
 ```typescript
-import { useStream } from "@langchain/langgraph-sdk/react";
+import { useStream } from "@langchain/react";
 
 function TravelPlanner() {
   const stream = useStream<typeof agent>({

--- a/src/snippets/oss/requires-usestream-server.mdx
+++ b/src/snippets/oss/requires-usestream-server.mdx
@@ -1,0 +1,5 @@
+<Note>
+**`@langchain/react`, `@langchain/vue`, `@langchain/svelte`, and `@langchain/angular` v1 is a breaking release.** The new `useStream` hook ships a v2-native streaming protocol that requires `langgraph-api>=0.9.0rc1` on the [LangGraph Agent Server](/langsmith/local-server). Upgrade with `pip install -U "langgraph-api>=0.9.0rc1"`, or run a recent `langgraph dev` from `langgraph-cli`.
+
+If you'd rather not upgrade the server yet, pin your frontend package to the pre-v1 release—`@langchain/react@0.3`, `@langchain/vue@0.4`, `@langchain/svelte@0.4`, or `@langchain/angular@0.4`—which talk to the legacy streaming protocol.
+</Note>


### PR DESCRIPTION
## Summary

- `@langchain/react`, `@langchain/vue`, `@langchain/svelte`, and `@langchain/angular` v1 ship a v2-native `useStream` hook. The new protocol requires `langgraph-api>=0.9.0rc1` on the [LangGraph Agent Server](https://docs.langchain.com/langsmith/local-server) and bundles `@langchain/langgraph-sdk>=1.9.0`.
- Adds a shared `requires-usestream-server.mdx` snippet (breaking-change warning + downgrade path: pin `@langchain/react@0.3` / `@langchain/vue@0.4` / `@langchain/svelte@0.4` / `@langchain/angular@0.4` to stay on the legacy protocol) and embeds it in the LangChain, LangGraph, and Deep Agents frontend overviews.
- Expands the existing "Frontend SDK enhancements" section in `src/oss/javascript/releases/langgraph-v1.mdx` with the new v1 surface — always-on root projections, selector hooks, automatic re-attach, multimodal media, Suspense + Error Boundaries, pluggable transports, agent-brand inference — including a short React example and a pointer to the Vue/Angular equivalents.
- Replaces three stale `@langchain/langgraph-sdk/react` imports in `src/oss/langgraph/streaming.mdx` with `@langchain/react`.

The LangChain frontend overview is the canonical patterns page and now links out to the v1 release notes for the "what's new" content rather than duplicating it (following the convention used elsewhere in `src/oss/`).