### PR TITLE
docs(event-streaming): fix raw event payload, text-delta type, and async examples

### DIFF
--- a/src/oss/deepagents/event-streaming.mdx
+++ b/src/oss/deepagents/event-streaming.mdx
@@ -357,7 +357,8 @@ for await (const event of stream) {
 
   const block = data.delta ?? {};
   if (block.type === "text-delta") {
-    const source = event.params.namespace.length > 0 ? "subagent" : "coordinator";
+    const isSubagent = event.params.namespace.some((seg) => seg.startsWith("tools:"));
+    const source = isSubagent ? "subagent" : "coordinator";
     console.log(`[${source}] ${block.text}`);
   }
 }

--- a/src/oss/deepagents/event-streaming.mdx
+++ b/src/oss/deepagents/event-streaming.mdx
@@ -345,6 +345,25 @@ for event in stream:
 ```
 :::
 
+:::js
+```ts
+const stream = await agent.streamEvents(input, { version: "v3" });
+
+for await (const event of stream) {
+  if (event.method !== "messages") continue;
+
+  const data = event.params.data;
+  if (data.event !== "content-block-delta") continue;
+
+  const block = data.delta ?? {};
+  if (block.type === "text-delta") {
+    const source = event.params.namespace.length > 0 ? "subagent" : "coordinator";
+    console.log(`[${source}] ${block.text}`);
+  }
+}
+```
+:::
+
 ## Subagents versus subgraphs
 
 `stream.subgraphs` shows graph execution structure. `stream.subagents` shows product-level Deep Agents task delegations. Use `stream.subagents` for user-facing UI because it hides internal graph nodes and exposes the subagent concept directly.

--- a/src/oss/deepagents/event-streaming.mdx
+++ b/src/oss/deepagents/event-streaming.mdx
@@ -332,7 +332,7 @@ for event in stream:
     if event.get("method") != "messages":
         continue
 
-    payload = event["params"]["data"][0]  # 2-tuple; [0] is a protocol event dict or a message object
+    payload = event["params"]["data"][0]
     if not isinstance(payload, dict):
         continue
     if payload.get("event") != "content-block-delta":

--- a/src/oss/deepagents/event-streaming.mdx
+++ b/src/oss/deepagents/event-streaming.mdx
@@ -264,7 +264,26 @@ for await (const subagent of stream.subagents) {
 Coordinator and subagent output often interleave. Consume projections concurrently when you need live UI updates.
 
 :::python
-Use `stream.interleave(...)` when you want one sync loop over multiple projections:
+For concurrent consumption in async code, use `astream_events` with `asyncio.gather`:
+
+```py
+import asyncio
+
+stream = agent.astream_events(input, version="v3")
+
+async def consume_coordinator():
+    async for message in stream.messages:
+        print("[coordinator]", message.text)
+
+async def consume_subagents():
+    async for subagent in stream.subagents:
+        async for message in subagent.messages:
+            print(f"[{subagent.name}]", message.text)
+
+await asyncio.gather(consume_coordinator(), consume_subagents())
+```
+
+For synchronous code, use `stream.interleave(...)` instead:
 
 ```py
 stream = agent.stream_events(input, version="v3")
@@ -313,12 +332,12 @@ for event in stream:
     if event.get("method") != "messages":
         continue
 
-    payload = event["params"]["data"]
+    payload = event["params"]["data"][0]  # data is a (event_dict, metadata) tuple
     if payload.get("event") != "content-block-delta":
         continue
 
     block = payload.get("delta") or {}
-    if block.get("type") == "text":
+    if block.get("type") == "text-delta":
         source = "subagent" if event["params"]["namespace"] else "coordinator"
         print(f"[{source}] {block['text']}", end="", flush=True)
 ```

--- a/src/oss/deepagents/event-streaming.mdx
+++ b/src/oss/deepagents/event-streaming.mdx
@@ -269,16 +269,16 @@ For concurrent consumption in async code, use `astream_events` with `asyncio.gat
 ```py
 import asyncio
 
-stream = agent.astream_events(input, version="v3")
+stream = await agent.astream_events(input, version="v3")
 
 async def consume_coordinator():
     async for message in stream.messages:
-        print("[coordinator]", message.text)
+        print("[coordinator]", await message.text)
 
 async def consume_subagents():
     async for subagent in stream.subagents:
         async for message in subagent.messages:
-            print(f"[{subagent.name}]", message.text)
+            print(f"[{subagent.name}]", await message.text)
 
 await asyncio.gather(consume_coordinator(), consume_subagents())
 ```

--- a/src/oss/deepagents/event-streaming.mdx
+++ b/src/oss/deepagents/event-streaming.mdx
@@ -332,7 +332,7 @@ for event in stream:
     if event.get("method") != "messages":
         continue
 
-    payload = event["params"]["data"][0]  # data is a (event_dict, metadata) tuple
+    payload = event["params"]["data"][0]  # 2-tuple; [0] is a protocol event dict or a message object
     if not isinstance(payload, dict):
         continue
     if payload.get("event") != "content-block-delta":

--- a/src/oss/deepagents/event-streaming.mdx
+++ b/src/oss/deepagents/event-streaming.mdx
@@ -333,13 +333,15 @@ for event in stream:
         continue
 
     payload = event["params"]["data"][0]  # data is a (event_dict, metadata) tuple
+    if not isinstance(payload, dict):
+        continue
     if payload.get("event") != "content-block-delta":
         continue
 
     block = payload.get("delta") or {}
     if block.get("type") == "text-delta":
         source = "subagent" if event["params"]["namespace"] else "coordinator"
-        print(f"[{source}] {block['text']}", end="", flush=True)
+        print(f"[{source}] {block['text']}")
 ```
 :::
 

--- a/src/oss/langchain/event-streaming.mdx
+++ b/src/oss/langchain/event-streaming.mdx
@@ -372,7 +372,25 @@ const finalState = await stream.output;
 ## Multiple projections
 
 :::python
-Use `stream.interleave(...)` when you want one sync loop over multiple projections:
+For concurrent consumption in async code, use `astream_events` with `asyncio.gather`:
+
+```py
+import asyncio
+
+stream = agent.astream_events(input, version="v3")
+
+async def consume_messages():
+    async for message in stream.messages:
+        print(message.text)
+
+async def consume_tool_calls():
+    async for call in stream.tool_calls:
+        print(call.tool_name, call.input)
+
+await asyncio.gather(consume_messages(), consume_tool_calls())
+```
+
+For synchronous code, use `stream.interleave(...)` instead:
 
 ```py
 stream = agent.stream_events(input, version="v3")

--- a/src/oss/langchain/event-streaming.mdx
+++ b/src/oss/langchain/event-streaming.mdx
@@ -377,11 +377,11 @@ For concurrent consumption in async code, use `astream_events` with `asyncio.gat
 ```py
 import asyncio
 
-stream = agent.astream_events(input, version="v3")
+stream = await agent.astream_events(input, version="v3")
 
 async def consume_messages():
     async for message in stream.messages:
-        print(message.text)
+        print(await message.text)
 
 async def consume_tool_calls():
     async for call in stream.tool_calls:

--- a/src/oss/langgraph/event-streaming.mdx
+++ b/src/oss/langgraph/event-streaming.mdx
@@ -205,9 +205,29 @@ const finalState = await stream.output;
 ## Stream multiple projections
 
 :::python
-Use `stream.interleave(...)` to consume multiple projections in strict arrival order in synchronous Python code:
+For concurrent consumption in async code, use `astream_events` with `asyncio.gather`:
 
 ```py
+import asyncio
+
+stream = graph.astream_events(input, version="v3")
+
+async def consume_messages():
+    async for message in stream.messages:
+        print(f"[llm] node={message.node}")
+
+async def consume_subgraphs():
+    async for subgraph in stream.subgraphs:
+        print(f"[subgraph] path={subgraph.path}")
+
+await asyncio.gather(consume_messages(), consume_subgraphs())
+```
+
+For synchronous code, use `stream.interleave(...)` to consume multiple projections in strict arrival order:
+
+```py
+stream = graph.stream_events(input, version="v3")
+
 for name, item in stream.interleave("values", "messages", "subgraphs"):
     if name == "values":
         print(f"[state] keys={list(item)}")

--- a/src/oss/langgraph/event-streaming.mdx
+++ b/src/oss/langgraph/event-streaming.mdx
@@ -408,7 +408,9 @@ for event in stream:
     if event["method"] != "messages":
         continue
 
-    data = event["params"]["data"]
+    data = event["params"]["data"][0]
+    if not isinstance(data, dict):
+        continue
     if data.get("event") != "content-block-delta":
         continue
 

--- a/src/oss/langgraph/event-streaming.mdx
+++ b/src/oss/langgraph/event-streaming.mdx
@@ -210,7 +210,7 @@ For concurrent consumption in async code, use `astream_events` with `asyncio.gat
 ```py
 import asyncio
 
-stream = graph.astream_events(input, version="v3")
+stream = await graph.astream_events(input, version="v3")
 
 async def consume_messages():
     async for message in stream.messages:


### PR DESCRIPTION
## Summary

- **deepagents**: fix raw protocol event iteration in the "Consume concurrently" section — `event["params"]["data"]` is a `(event_dict, metadata)` tuple so the payload is at `data[0]`, and the delta type is `"text-delta"` not `"text"`
- **all three pages** (deepagents, langchain, langgraph): reframe the Python multiple-projections section to lead with the async path (`astream_events` + `asyncio.gather`) and relegate `stream.interleave()` to a sync-only fallback
- **async examples verified**: `astream_events()` returns a coroutine and requires `await`; `message.text` in async projections is an `AsyncProjection` and also requires `await` — both confirmed by running the examples against the live API

## Test plan

- [x] All three async examples (deepagents, langchain, langgraph) run successfully against live API
- [x] Raw event structure confirmed: `data` is a 2-tuple, `data[0]` is the event dict, delta type is `"text-delta"`
- [x] `make lint_prose` passes on all changed files