### PR TITLE
docs(langgraph/add-memory): add Oracle checkpointer and store examples

### DIFF
--- a/src/oss/langgraph/add-memory.mdx
+++ b/src/oss/langgraph/add-memory.mdx
@@ -508,7 +508,7 @@ with PostgresSaver.from_conn_string(DB_URI) as checkpointer:  # [!code highlight
 
     <Note>
     **Setup**
-    To use the [Oracle checkpointer](https://pypi.org/project/langgraph-oracledb/), you will need an Oracle Database 23ai instance. A local container (for example `gvenzl/oracle-free:23-slim`) or an Oracle Autonomous Database in OCI both work.
+    To use the [Oracle checkpointer](https://pypi.org/project/langgraph-oracledb/), you will need an Oracle AI Database instance. A local container (for example `gvenzl/oracle-free:23-slim`) or an Oracle Autonomous Database in OCI both work.
     </Note>
 
     <Tip>
@@ -1317,7 +1317,7 @@ with PostgresStore.from_conn_string(DB_URI) as store:  # [!code highlight]
 
     <Note>
     **Setup**
-    To use the [Oracle store](https://pypi.org/project/langgraph-oracledb/), you will need an Oracle Database 23ai instance — the vector index used for semantic `search` requires [Oracle AI Vector Search](https://docs.oracle.com/en/database/oracle/oracle-database/23/vecse/), which is only available in 23ai.
+    To use the [Oracle store](https://pypi.org/project/langgraph-oracledb/), you will need an Oracle AI Database instance — the vector index used for semantic `search` requires [Oracle AI Vector Search](https://docs.oracle.com/en/database/oracle/oracle-database/23/vecse/).
     </Note>
 
     <Tip>

--- a/src/oss/langgraph/add-memory.mdx
+++ b/src/oss/langgraph/add-memory.mdx
@@ -500,6 +500,110 @@ with PostgresSaver.from_conn_string(DB_URI) as checkpointer:  # [!code highlight
         </Tab>
     </Tabs>
 </Accordion>
+
+<Accordion title="Example: using Oracle checkpointer">
+  ```
+  pip install -U langgraph langgraph-oracledb
+  ```
+
+    <Note>
+    **Setup**
+    To use the [Oracle checkpointer](https://pypi.org/project/langgraph-oracledb/), you will need an Oracle Database 23ai instance. A local container (for example `gvenzl/oracle-free:23-slim`) or an Oracle Autonomous Database in OCI both work.
+    </Note>
+
+    <Tip>
+    You need to call `checkpointer.setup()` the first time you're using the Oracle checkpointer.
+    </Tip>
+
+    <Tabs>
+        <Tab title="Sync">
+      ```python
+      from langchain.chat_models import init_chat_model
+      from langgraph.graph import StateGraph, MessagesState, START
+      from langgraph_oracledb.checkpoint.oracle import OracleSaver  # [!code highlight]
+
+      model = init_chat_model(model="claude-haiku-4-5-20251001")
+
+      DB_URI = "user/password@localhost:1521/FREEPDB1"
+      with OracleSaver.from_conn_string(DB_URI) as checkpointer:  # [!code highlight]
+          # checkpointer.setup()
+
+          def call_model(state: MessagesState):
+              response = model.invoke(state["messages"])
+              return {"messages": response}
+
+          builder = StateGraph(MessagesState)
+          builder.add_node(call_model)
+          builder.add_edge(START, "call_model")
+
+          graph = builder.compile(checkpointer=checkpointer)  # [!code highlight]
+
+          config = {
+              "configurable": {
+                  "thread_id": "1"  # [!code highlight]
+              }
+          }
+
+          for chunk in graph.stream(
+              {"messages": [{"role": "user", "content": "hi! I'm bob"}]},
+              config,  # [!code highlight]
+              stream_mode="values"
+          ):
+              chunk["messages"][-1].pretty_print()
+
+          for chunk in graph.stream(
+              {"messages": [{"role": "user", "content": "what's my name?"}]},
+              config,  # [!code highlight]
+              stream_mode="values"
+          ):
+              chunk["messages"][-1].pretty_print()
+```
+        </Tab>
+        <Tab title="Async">
+      ```python
+      from langchain.chat_models import init_chat_model
+      from langgraph.graph import StateGraph, MessagesState, START
+      from langgraph_oracledb.checkpoint.oracle import AsyncOracleSaver  # [!code highlight]
+
+      model = init_chat_model(model="claude-haiku-4-5-20251001")
+
+      DB_URI = "user/password@localhost:1521/FREEPDB1"
+      async with AsyncOracleSaver.from_conn_string(DB_URI) as checkpointer:  # [!code highlight]
+          # await checkpointer.setup()
+
+          async def call_model(state: MessagesState):
+              response = await model.ainvoke(state["messages"])
+              return {"messages": response}
+
+          builder = StateGraph(MessagesState)
+          builder.add_node(call_model)
+          builder.add_edge(START, "call_model")
+
+          graph = builder.compile(checkpointer=checkpointer)  # [!code highlight]
+
+          config = {
+              "configurable": {
+                  "thread_id": "1"  # [!code highlight]
+              }
+          }
+
+          async for chunk in graph.astream(
+              {"messages": [{"role": "user", "content": "hi! I'm bob"}]},
+              config,  # [!code highlight]
+              stream_mode="values"
+          ):
+              chunk["messages"][-1].pretty_print()
+
+          async for chunk in graph.astream(
+              {"messages": [{"role": "user", "content": "what's my name?"}]},
+              config,  # [!code highlight]
+              stream_mode="values"
+          ):
+              chunk["messages"][-1].pretty_print()
+```
+        </Tab>
+    </Tabs>
+</Accordion>
 :::
 
 ### Use in subgraphs
@@ -1198,6 +1302,199 @@ with PostgresStore.from_conn_string(DB_URI) as store:  # [!code highlight]
               config,
               stream_mode="values",
               context=Context(user_id="1"),  # [!code highlight]
+          ):
+              chunk["messages"][-1].pretty_print()
+```
+        </Tab>
+    </Tabs>
+</Accordion>
+
+<Accordion title="Example: using Oracle store">
+
+  ```
+  pip install -U langgraph langgraph-oracledb langchain-openai
+  ```
+
+    <Note>
+    **Setup**
+    To use the [Oracle store](https://pypi.org/project/langgraph-oracledb/), you will need an Oracle Database 23ai instance — the vector index used for semantic `search` requires [Oracle AI Vector Search](https://docs.oracle.com/en/database/oracle/oracle-database/23/vecse/), which is only available in 23ai.
+    </Note>
+
+    <Tip>
+    You need to call `store.setup()` and `checkpointer.setup()` the first time you're using the Oracle store and checkpointer.
+    </Tip>
+
+    <Tabs>
+        <Tab title="Sync">
+      ```python
+      import uuid
+
+      from langchain.chat_models import init_chat_model
+      from langchain.embeddings import init_embeddings
+      from langchain_core.runnables import RunnableConfig
+      from langgraph.graph import StateGraph, MessagesState, START
+      from langgraph.store.base import BaseStore
+      from langgraph_oracledb.checkpoint.oracle import OracleSaver
+      from langgraph_oracledb.store.oracle import OracleStore  # [!code highlight]
+
+      model = init_chat_model(model="claude-haiku-4-5-20251001")
+      embeddings = init_embeddings("openai:text-embedding-3-small")
+
+      DB_URI = "user/password@localhost:1521/FREEPDB1"
+
+      with (
+          OracleStore.from_conn_string(  # [!code highlight]
+              DB_URI,
+              index={"embed": embeddings, "dims": 1536},  # [!code highlight]
+          ) as store,
+          OracleSaver.from_conn_string(DB_URI) as checkpointer,
+      ):
+          store.setup()
+          checkpointer.setup()
+
+          def call_model(
+              state: MessagesState,
+              config: RunnableConfig,
+              *,
+              store: BaseStore,  # [!code highlight]
+          ):
+              user_id = config["configurable"]["user_id"]
+              namespace = ("memories", user_id)
+              memories = store.search(namespace, query=str(state["messages"][-1].content))  # [!code highlight]
+              info = "\n".join([d.value["data"] for d in memories])
+              system_msg = f"You are a helpful assistant talking to the user. User info: {info}"
+
+              # Store new memories if the user asks the model to remember
+              last_message = state["messages"][-1]
+              if "remember" in last_message.content.lower():
+                  memory = "User name is Bob"
+                  store.put(namespace, str(uuid.uuid4()), {"data": memory})  # [!code highlight]
+
+              response = model.invoke(
+                  [{"role": "system", "content": system_msg}] + state["messages"]
+              )
+              return {"messages": response}
+
+          builder = StateGraph(MessagesState)
+          builder.add_node(call_model)
+          builder.add_edge(START, "call_model")
+
+          graph = builder.compile(
+              checkpointer=checkpointer,
+              store=store,  # [!code highlight]
+          )
+
+          config = {
+              "configurable": {
+                  "thread_id": "1",  # [!code highlight]
+                  "user_id": "1",  # [!code highlight]
+              }
+          }
+          for chunk in graph.stream(
+              {"messages": [{"role": "user", "content": "Hi! Remember: my name is Bob"}]},
+              config,  # [!code highlight]
+              stream_mode="values",
+          ):
+              chunk["messages"][-1].pretty_print()
+
+          config = {
+              "configurable": {
+                  "thread_id": "2",  # [!code highlight]
+                  "user_id": "1",
+              }
+          }
+
+          for chunk in graph.stream(
+              {"messages": [{"role": "user", "content": "what is my name?"}]},
+              config,  # [!code highlight]
+              stream_mode="values",
+          ):
+              chunk["messages"][-1].pretty_print()
+```
+        </Tab>
+        <Tab title="Async">
+      ```python
+      import uuid
+
+      from langchain.chat_models import init_chat_model
+      from langchain.embeddings import init_embeddings
+      from langchain_core.runnables import RunnableConfig
+      from langgraph.graph import StateGraph, MessagesState, START
+      from langgraph.store.base import BaseStore
+      from langgraph_oracledb.checkpoint.oracle import AsyncOracleSaver
+      from langgraph_oracledb.store.oracle import AsyncOracleStore  # [!code highlight]
+
+      model = init_chat_model(model="claude-haiku-4-5-20251001")
+      embeddings = init_embeddings("openai:text-embedding-3-small")
+
+      DB_URI = "user/password@localhost:1521/FREEPDB1"
+
+      async with (
+          AsyncOracleStore.from_conn_string(  # [!code highlight]
+              DB_URI,
+              index={"embed": embeddings, "dims": 1536},  # [!code highlight]
+          ) as store,
+          AsyncOracleSaver.from_conn_string(DB_URI) as checkpointer,
+      ):
+          await store.setup()
+          await checkpointer.setup()
+
+          async def call_model(
+              state: MessagesState,
+              config: RunnableConfig,
+              *,
+              store: BaseStore,  # [!code highlight]
+          ):
+              user_id = config["configurable"]["user_id"]
+              namespace = ("memories", user_id)
+              memories = await store.asearch(namespace, query=str(state["messages"][-1].content))  # [!code highlight]
+              info = "\n".join([d.value["data"] for d in memories])
+              system_msg = f"You are a helpful assistant talking to the user. User info: {info}"
+
+              # Store new memories if the user asks the model to remember
+              last_message = state["messages"][-1]
+              if "remember" in last_message.content.lower():
+                  memory = "User name is Bob"
+                  await store.aput(namespace, str(uuid.uuid4()), {"data": memory})  # [!code highlight]
+
+              response = await model.ainvoke(
+                  [{"role": "system", "content": system_msg}] + state["messages"]
+              )
+              return {"messages": response}
+
+          builder = StateGraph(MessagesState)
+          builder.add_node(call_model)
+          builder.add_edge(START, "call_model")
+
+          graph = builder.compile(
+              checkpointer=checkpointer,
+              store=store,  # [!code highlight]
+          )
+
+          config = {
+              "configurable": {
+                  "thread_id": "1",  # [!code highlight]
+                  "user_id": "1",  # [!code highlight]
+              }
+          }
+          async for chunk in graph.astream(
+              {"messages": [{"role": "user", "content": "Hi! Remember: my name is Bob"}]},
+              config,  # [!code highlight]
+              stream_mode="values",
+          ):
+              chunk["messages"][-1].pretty_print()
+
+          config = {
+              "configurable": {
+                  "thread_id": "2",  # [!code highlight]
+                  "user_id": "1",
+              }
+          }
+
+          async for chunk in graph.astream(
+              {"messages": [{"role": "user", "content": "what is my name?"}]},
+              config,  # [!code highlight]
+              stream_mode="values",
           ):
               chunk["messages"][-1].pretty_print()
 ```
@@ -2455,7 +2752,7 @@ await checkpointer.deleteThread(threadId);
 
 ## Database management
 
-If you are using any database-backed persistence implementation (such as Postgres or Redis) to store short and/or long-term memory, you will need to run migrations to set up the required schema before you can use it with your database.
+If you are using any database-backed persistence implementation (such as Postgres, Redis, or Oracle) to store short and/or long-term memory, you will need to run migrations to set up the required schema before you can use it with your database.
 
 By convention, most database-specific libraries define a `setup()` method on the checkpointer or store instance that runs the required migrations. However, you should check with your specific implementation of @[`BaseCheckpointSaver`] or @[`BaseStore`] to confirm the exact method name and usage.
 


### PR DESCRIPTION
## Overview

Adds Oracle equivalents to the existing Postgres / MongoDB / Redis accordions in `src/oss/langgraph/add-memory.mdx`, using the [`langgraph-oracledb`](https://pypi.org/project/langgraph-oracledb/) package maintained by Oracle at [`oracle/langchain-oracle`](https://github.com/oracle/langchain-oracle/tree/main/libs/langgraph-oracledb).

**Checkpointer accordion** (after Redis checkpointer):
- Sync / Async tabs with `OracleSaver` and `AsyncOracleSaver`
- Note about Oracle AI Database requirement (local container `gvenzl/oracle-free:23-slim` or Oracle Autonomous Database in OCI both work)
- Tip about calling `checkpointer.setup()` the first time

**Store accordion** (after Redis store):
- Sync / Async tabs with `OracleStore` and `AsyncOracleStore`
- `index={embed, dims}` config showing semantic search backed by Oracle AI Vector Search
- Note linking to the Oracle AI Vector Search docs (the index requires it)

Also updates the "Database management" footer to list Oracle alongside Postgres and Redis.

The version suffix (`23ai`) was intentionally dropped from the user-facing notes to match Oracle's current product naming and avoid baking a version number into the docs that will age out.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: n/a
- Feature PR: n/a — the underlying package is already published; this PR only adds documentation parallel to the other backends already listed.

## Checklist

- [x] I have read the contributing guidelines
- [ ] I have tested my changes locally using `docs dev` — not run locally; the changes are MDX-only and follow the exact structure / Mintlify components used by the adjacent Postgres / Redis / MongoDB accordions
- [x] All code examples follow the package's public API (`OracleSaver` / `AsyncOracleSaver` from `langgraph_oracledb.checkpoint.oracle`; `OracleStore` / `AsyncOracleStore` from `langgraph_oracledb.store.oracle`) — verified against the published source
- [x] I have used root relative paths for internal links
- [x] No `src/docs.json` update needed (existing page)

## Additional notes

Imports and method signatures used in the examples were cross-checked against the package's published `__init__.py` exports and class signatures in `oracle/langchain-oracle@main`. The examples mirror the existing Postgres / Redis equivalents one-for-one so behaviour parity is easy to review side-by-side.

**AI disclosure:** An AI agent (Claude) assisted with verifying the docs against the upstream package and with drafting this PR description. The MDX changes themselves were authored by me; the AI's role was verification and PR scaffolding.