### PR TITLE
docs: Add pr402 payment tools integration

### DIFF
--- a/src/oss/python/integrations/tools/pr402.mdx
+++ b/src/oss/python/integrations/tools/pr402.mdx
@@ -1,0 +1,41 @@
+---
+title: "pr402 integration"
+description: "Give LangChain agents the ability to autonomously pay for HTTP services on Solana using the pr402/x402 protocol."
+---
+
+This guide provides a quick overview for getting started with the pr402 [tool](/oss/langchain/tools). The `langchain-pr402` package lets any LangChain agent autonomously pay for HTTP resources that return `402 Payment Required`, using USDC on Solana.
+
+## Overview
+
+### Integration details
+
+| Class | Package | Serializable | [JS support](https://js.langchain.com) | Version |
+| :--- | :--- | :---: | :---: | :---: |
+| `X402GetTool`, `X402PostTool`, `X402BalanceTool` | [`langchain-pr402`](https://pypi.org/project/langchain-pr402/) | ❌ | ❌ | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-pr402?style=flat-square&label=%20) |
+
+### Tool features
+
+- **`X402GetTool`**: GET requests with automatic HTTP 402 payment handling
+- **`X402PostTool`**: POST requests with automatic HTTP 402 payment handling
+- **`X402BalanceTool`**: Check the agent's Solana wallet address and SOL/USDC balance
+
+---
+
+## Setup
+
+To use pr402 tools, you need a funded Solana wallet (keypair). No external API key is required — the agent signs transactions locally.
+
+### Credentials
+
+pr402 does not use an API key. Instead, provide your Solana keypair as a list of byte-integers:
+
+```python
+import os
+import json
+
+# From environment variable (recommended)
+keypair_bytes = json.loads(os.environ["SOLANA_PRIVATE_KEY"])
+
+# Or from a keypair file (local development only)
+# with open("agent-keypair.json") as f:
+#     keypair_bytes = json.load(f)

--- a/src/oss/python/integrations/tools/pr402.mdx
+++ b/src/oss/python/integrations/tools/pr402.mdx
@@ -23,7 +23,7 @@ This guide provides a quick overview for getting started with the pr402 [tool](/
 
 ## Setup
 
-To use pr402 tools, you need a funded Solana wallet (keypair). No external API key is required — the agent signs transactions locally.
+To use pr402 tools, you need a funded Solana wallet (keypair). No external API key is required—the agent signs transactions locally.
 
 ### Credentials
 


### PR DESCRIPTION
Adds an integration documentation page for langchain-pr402, a third-party package that gives LangChain agents the ability to autonomously pay for HTTP resources using the pr402/x402 protocol on Solana.

Package: pip install langchain-pr402 Source: https://github.com/miraland-labs/langchain-pr402 Requires: Python ≥ 3.10

What it does
X402GetTool / X402PostTool — Make HTTP requests that automatically handle 402 Payment Required responses by signing a Solana USDC micro-payment and retrying.
X402BalanceTool — Lets the agent check its own wallet address and SOL/USDC balance.
Why
AI agents currently cannot pay for premium APIs or compute without human intervention. These tools solve this by giving any LangChain agent a Solana wallet capable of sub-second USDC micro-payments via the open x402 protocol.

Checklist
 Uses the official tools template from src/oss/python/integrations/tools/TEMPLATE.mdx
 Package is published on PyPI
 No Jupyter notebooks (uses .mdx as recommended)
 Follows existing integration page patterns (Discord, DuckDuckGo)
