### PR TITLE
docs(managed-deep-agents): preview-docs pass + production path shift

### DIFF
--- a/src/langsmith/deploy-managed-deep-agent.mdx
+++ b/src/langsmith/deploy-managed-deep-agent.mdx
@@ -22,7 +22,7 @@ Use Managed Deep Agents when you want to:
 - Create and manage deep agents programmatically.
 - Run long-running agents without standing up a custom agent server.
 - Stream runs and preserve durable thread state.
-- Use managed files and tools.
+- Use a managed file tree (instructions, skills, subagents, tools, and a `/memories/` workspace) without running your own storage.
 - Inspect traces and agent behavior in LangSmith.
 
 <Tip>
@@ -62,6 +62,8 @@ Managed Deep Agents keeps the familiar Deep Agents project shape. Keep these fil
 | `subagents/` | Contains subagent definitions for delegated work. |
 | `tools.json` | Configures tools for the managed agent. |
 
+When you submit these files in a create-agent or update-agent request, the platform stores them as a versioned **agent repo** in the [Context Hub](/langsmith/use-the-context-hub). Every update creates a new commit (returned as `revision` on the agent response). The runtime serves the file tree to the agent on every run, and the agent can also read and write files at run time — including a `/memories/` directory for durable cross-run state.
+
 For the API request, pass the agent instructions and tool configuration directly in the create-agent payload. Use the same `tools.json` shape when you configure tools:
 
 ```json
@@ -80,7 +82,7 @@ For the API request, pass the agent instructions and tool configuration directly
 }
 ```
 
-The `interrupt_config` map lets you require human approval for selected tools. The key combines the MCP server URL, tool name, and MCP server name.
+The `interrupt_config` map lets you require human approval for selected tools. Each key is `{mcp_server_url}::{tool_name}` (separator is two colons); trailing slashes on the URL are stripped before matching. Additional `::`-separated parts after the tool name (such as the MCP server display name shown in the example above) are accepted but ignored when matching. Set the value to `true` to require human approval before the tool runs, or `false` to allow it without interrupt.
 
 ## Create a managed agent
 
@@ -178,6 +180,45 @@ Use stream modes based on the experience you want to build:
 | `updates` | Incremental state updates as the agent works. |
 | `messages-tuple` | Token-level message output for chat UIs. |
 
+You can combine modes by passing multiple values in `stream_mode`. The runtime then interleaves events for each requested mode.
+
+### Event format
+
+Every stream starts with a `metadata` event carrying the run ID, then emits events whose names match the requested stream modes. Each event has a `data` payload of JSON.
+
+`values` mode emits a `values` event after every step, containing the full graph state:
+
+```txt
+event: metadata
+data: {"run_id":"019e2d68-6b49-7b62-9066-af25f4bb842e","attempt":1}
+
+event: values
+data: {"messages":[{"type":"human","content":"Research recent approaches to agent memory","id":"..."}],"files":{},"tools":[]}
+```
+
+`updates` mode emits an `updates` event per node, keyed by the node or middleware name that produced the delta. `null` values indicate the node ran without producing a state update:
+
+```txt
+event: metadata
+data: {"run_id":"019e2d68-e162-7e02-8848-b6d96d19b2ef","attempt":1}
+
+event: updates
+data: {"MemoryMiddleware.before_agent":null}
+
+event: updates
+data: {"model":{"messages":[{"type":"ai","content":"...","model_name":"claude-sonnet-4-6","usage_metadata":{"input_tokens":15499,"output_tokens":4}}]}}
+```
+
+`messages-tuple` mode emits a `messages` event (note the SSE event name is `messages`, not `messages-tuple`). Each payload is a `[chunk, metadata]` tuple — the chunk is a partial `AIMessageChunk`, and the metadata describes the node and run context:
+
+```txt
+event: metadata
+data: {"run_id":"019e2d68-ed9d-71d0-8aec-f8cdbd1f9f2e","attempt":1}
+
+event: messages
+data: [{"type":"AIMessageChunk","content":[{"text":"ok","type":"text","index":0}],"id":"lc_run--..."},{"langgraph_node":"model","ls_model_name":"claude-sonnet-4-6","ls_provider":"anthropic","run_id":"...","thread_id":"...","assistant_id":"..."}]
+```
+
 The run is traced in LangSmith. Open the trace to inspect messages, tool calls, files, subagent activity, and runtime behavior.
 
 ## Update the agent
@@ -246,6 +287,10 @@ curl --request DELETE \
   --header "X-Api-Key: $LANGSMITH_API_KEY"
 ```
 
+<Warning>
+    Deleting an agent does not cascade to its threads. Existing threads remain queryable, but starting new runs on them returns `502`. Track and delete threads explicitly when you want to clean them up.
+</Warning>
+
 ## Inspect the result in LangSmith
 
 Managed Deep Agents runs are traced in LangSmith, so teams can debug behavior and inspect tool calls. Use traces to review:
@@ -255,6 +300,40 @@ Managed Deep Agents runs are traced in LangSmith, so teams can debug behavior an
 - Subagent activity.
 - Files and runtime state created during the run.
 
+## Limits and notes
+
+Operational notes that apply during the private preview. Behavior may change before general availability.
+
+### Supported models
+
+Pass model identifiers in the form `{provider}:{model_id}` — for example, `anthropic:claude-sonnet-4-6` or `openai:gpt-5.4-mini`. The runtime resolves models with @[`init_chat_model`], so any provider that `init_chat_model` supports is usable from Managed Deep Agents. See [Supported providers and models](/oss/langchain/models#supported-providers-and-models) for the current list.
+
+Values without a colon are interpreted as references to a saved Playground configuration rather than as model identifiers, so always supply the full `{provider}:{model_id}` form when configuring a model directly.
+
+### Thread retention
+
+Threads have no retention window or per-workspace cap during private preview. Create as many as you need; existing threads remain accessible for the duration of the preview.
+
+### Rate limits and quotas
+
+The Managed Deep Agents endpoints do not enforce per-key, per-workspace, or per-agent rate limits during private preview.
+
+### Deleting agents
+
+`DELETE /agents/{agent_id}` does not cascade to threads. Threads created against a deleted agent remain queryable but cannot start new runs — attempts return `502`. Track and delete threads explicitly when you want to clean them up, as covered in [Manage existing agents](#manage-existing-agents).
+
+### API stability
+
+Routes live under `/v1/deepagents`, but the surface is in private preview and may change in backwards-incompatible ways before general availability. Breaking changes are communicated to preview customers directly through the contact provided when access was granted.
+
+### SDKs
+
+REST is the only supported interface during private preview. SDK wrappers (Python and JavaScript) will follow soon.
+
+### Support and feedback
+
+Preview access includes direct support. The contact for bug reports and feature requests is included in the email you receive when access is granted.
+
 ## Built on open-source Deep Agents
 
 Deep Agents remains open source. Managed Deep Agents is the hosted path for teams that want the Deep Agents harness plus LangSmith-managed runtime infrastructure.
@@ -263,4 +342,6 @@ You can keep the agent definition in your repository, then use the Managed Deep 
 
 ## Private preview scope
 
-Managed Deep Agents does not mirror every LangSmith Deployment endpoint in private preview. Endpoint groups such as integrations, auth, triggers, skills, and sandboxes are not mirrored yet.
+Managed Deep Agents is available on LangSmith Cloud in the US region only during private preview. Self-hosted and Hybrid deployments are not supported, and EU and other regions will follow general availability.
+
+The API also does not mirror every LangSmith Deployment endpoint in private preview.

--- a/src/langsmith/managed-deep-agents-api.mdx
+++ b/src/langsmith/managed-deep-agents-api.mdx
@@ -32,6 +32,8 @@ X-Api-Key: <LANGSMITH_API_KEY>
 
 The private preview API uses `/v1/deepagents`.
 
+Routes are versioned at `/v1/`, but the surface is in private preview and may change in backwards-incompatible ways before general availability. See [API stability](/langsmith/deploy-managed-deep-agent#api-stability) for breaking-change communication.
+
 ## Resource groups
 
 | Resource group | Purpose |
@@ -42,4 +44,8 @@ The private preview API uses `/v1/deepagents`.
 
 ## Private preview scope
 
-Managed Deep Agents does not mirror every LangSmith Deployment endpoint in private preview. Endpoint groups such as integrations, auth, triggers, skills, and sandboxes are not mirrored yet.
+Managed Deep Agents is available on LangSmith Cloud in the US region only during private preview. Self-hosted and Hybrid deployments are not supported, and EU and other regions will follow general availability.
+
+The API also does not mirror every LangSmith Deployment endpoint in private preview. Endpoint groups such as integrations, auth, triggers, skills, and sandboxes are not mirrored yet.
+
+For operational notes — supported models, thread retention, rate limits, SDK availability, and support channels during preview — see [Limits and notes](/langsmith/deploy-managed-deep-agent#limits-and-notes) in the deploy guide.

--- a/src/langsmith/managed-deep-agents-openapi.json
+++ b/src/langsmith/managed-deep-agents-openapi.json
@@ -167,7 +167,7 @@
                     },
                     "runtime": {
                       "model": {
-                        "model_id": "claude-sonnet-4-6"
+                        "model_id": "anthropic:claude-sonnet-4-6"
                       }
                     },
                     "instructions": "You are a careful research assistant. Search for sources, keep notes, and return concise answers with citations.",
@@ -197,6 +197,44 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Agent"
+                },
+                "examples": {
+                  "basic": {
+                    "summary": "Research assistant with one tool",
+                    "value": {
+                      "id": "dfa71115-c971-4197-8f02-20826fbc6f40",
+                      "name": "research-assistant",
+                      "description": "Research assistant that can search the web and summarize sources.",
+                      "owner_id": "33499cf9-4c02-49af-909d-b8f42e051eab",
+                      "created_at": "2026-05-15T20:50:32.708302+00:00",
+                      "updated_at": "2026-05-15T20:50:32.708302+00:00",
+                      "permissions": {
+                        "identity": "personal",
+                        "visibility": "user",
+                        "tenant_access_level": "read"
+                      },
+                      "runtime": {
+                        "model": {
+                          "model_id": "anthropic:claude-sonnet-4-6"
+                        }
+                      },
+                      "revision": "13ac11f11da376e588cb84825ed88d05298f27aaaa90c6f694abf572f34161d9",
+                      "instructions": "You are a careful research assistant. Search for sources, keep notes, and return concise answers with citations.",
+                      "tools": {
+                        "tools": [
+                          {
+                            "name": "tavily_web_search",
+                            "mcp_server_url": "https://tools.langchain.com",
+                            "mcp_server_name": "Fleet",
+                            "display_name": "tavily_web_search"
+                          }
+                        ],
+                        "interrupt_config": {
+                          "https://tools.langchain.com::tavily_web_search::Fleet": true
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
@@ -373,7 +411,7 @@
       "delete": {
         "tags": ["Agents"],
         "summary": "Delete an agent",
-        "description": "Delete the agent and its associated state. The call is idempotent: deleting a non-existent agent returns `204`.",
+        "description": "Delete the agent. The call is idempotent: deleting a non-existent agent returns `204`. Deletion does not cascade to the agent's threads — existing threads remain queryable but cannot start new runs (attempts return `502`). Delete threads explicitly when you want to clean them up.",
         "operationId": "deleteManagedDeepAgent",
         "x-mint": {
           "href": "/langsmith/managed-deep-agents-api/agents/delete-agent",
@@ -454,6 +492,24 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/Thread"
+                },
+                "examples": {
+                  "basic": {
+                    "summary": "Thread bound to an agent",
+                    "value": {
+                      "id": "019e2d67-ff4d-7251-bce5-dfdec8e1991b",
+                      "agent_id": "",
+                      "status": "idle",
+                      "metadata": {
+                        "is_test_run": false,
+                        "ls_user_id": "33499cf9-4c02-49af-909d-b8f42e051eab",
+                        "skip_memory_write_protection": false,
+                        "tenant_id": "ebbaf2eb-769b-4505-aca2-d11de10372a4"
+                      },
+                      "created_at": "2026-05-15T20:50:50.832351+00:00",
+                      "updated_at": "2026-05-15T20:50:50.832351+00:00"
+                    }
+                  }
                 }
               }
             }
@@ -865,7 +921,7 @@
         "name": "X-User-Timezone",
         "in": "header",
         "required": false,
-        "description": "User timezone for runtime configuration stamping. Defaults to `UTC` when omitted.",
+        "description": "IANA timezone name (for example, `America/Los_Angeles`) stamped into the agent's runtime configuration when the agent is created or updated. The runtime uses this timezone to inject a localized current-date line into the agent's system prompt, so the agent reasons about dates in the user's local time. Optional. Defaults to `UTC` when omitted; invalid values fall back to `UTC`.",
         "schema": {
           "type": "string",
           "example": "America/Los_Angeles"
@@ -879,26 +935,72 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/ErrorResponse"
+            },
+            "examples": {
+              "missingRequiredField": {
+                "summary": "Required field missing",
+                "value": {
+                  "type": "https://docs.langchain.com/errors/missing_required_field",
+                  "code": "missing_required_field",
+                  "detail": "Set 'name' to a non-empty string: 'name' is required",
+                  "status": 400
+                }
+              },
+              "invalidRequestBody": {
+                "summary": "Malformed JSON body",
+                "value": {
+                  "type": "https://docs.langchain.com/errors/invalid_request_body",
+                  "code": "invalid_request_body",
+                  "detail": "Provide a valid JSON request body matching the documented schema",
+                  "status": 400
+                }
+              }
             }
           }
         }
       },
       "Unauthorized": {
-        "description": "Authentication required or invalid.",
+        "description": "Authentication required. The auth layer returns a simple `{\"error\": \"Unauthorized\"}` body that does not match the structured `ErrorResponse` shape used by other 4xx responses.",
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+              "type": "object",
+              "properties": {
+                "error": {
+                  "type": "string"
+                }
+              }
+            },
+            "examples": {
+              "missingApiKey": {
+                "summary": "No `X-Api-Key` header supplied",
+                "value": {
+                  "error": "Unauthorized"
+                }
+              }
             }
           }
         }
       },
       "Forbidden": {
-        "description": "The authenticated workspace does not have access to the resource or feature.",
+        "description": "The authenticated identity does not have access to the resource or feature. The auth layer returns a simple `{\"error\": \"Forbidden\"}` body that does not match the structured `ErrorResponse` shape used by other 4xx responses.",
         "content": {
           "application/json": {
             "schema": {
-              "$ref": "#/components/schemas/ErrorResponse"
+              "type": "object",
+              "properties": {
+                "error": {
+                  "type": "string"
+                }
+              }
+            },
+            "examples": {
+              "invalidApiKey": {
+                "summary": "API key is invalid or lacks workspace access",
+                "value": {
+                  "error": "Forbidden"
+                }
+              }
             }
           }
         }
@@ -909,6 +1011,17 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/ErrorResponse"
+            },
+            "examples": {
+              "agentNotFound": {
+                "summary": "Unknown agent ID",
+                "value": {
+                  "type": "https://docs.langchain.com/errors/agent_not_found",
+                  "code": "agent_not_found",
+                  "detail": "Verify the agent ID and that the calling identity has access: agent not found",
+                  "status": 404
+                }
+              }
             }
           }
         }
@@ -949,6 +1062,17 @@
           "application/json": {
             "schema": {
               "$ref": "#/components/schemas/ErrorResponse"
+            },
+            "examples": {
+              "upstreamAuthFailed": {
+                "summary": "Upstream runtime rejected the request (e.g. orphaned thread after agent deletion)",
+                "value": {
+                  "type": "https://docs.langchain.com/errors/upstream_auth_failed",
+                  "code": "upstream_auth_failed",
+                  "detail": "Verify that the calling identity is authorized for this organization: upstream agent runtime rejected the request",
+                  "status": 502
+                }
+              }
             }
           }
         }
@@ -1129,8 +1253,8 @@
         "properties": {
           "model_id": {
             "type": "string",
-            "description": "Model ID used to run the agent.",
-            "example": "claude-sonnet-4-6"
+            "description": "Model identifier used to run the agent. Use the form `{provider}:{model_name}` — for example, `anthropic:claude-sonnet-4-6` or `openai:gpt-5.4-mini`. Values without a colon are interpreted as references to a saved Playground configuration, not as direct model identifiers. See [Supported models](/langsmith/deploy-managed-deep-agent#supported-models) for the recognized provider prefixes.",
+            "example": "anthropic:claude-sonnet-4-6"
           }
         }
       },
@@ -1146,8 +1270,10 @@
           },
           "interrupt_config": {
             "type": "object",
-            "description": "Per-tool interrupt rules keyed by tool identifier. Use `{}` for no interrupts.",
-            "additionalProperties": true
+            "description": "Per-tool interrupt rules. Keys are tool identifiers in the form `{mcp_server_url}::{tool_name}` (separator is two colons). The URL is normalized with any trailing slash stripped, so `https://tools.example.com` and `https://tools.example.com/` match the same tool. Additional `::`-separated components after the tool name (such as the MCP server display name) are accepted but ignored when matching. A bare tool name with no `::` is also accepted as a fallback. Values are booleans: `true` requires a human-in-the-loop interrupt before the tool runs; `false` allows it without interrupt. Use `{}` for no interrupts.",
+            "additionalProperties": {
+              "type": "boolean"
+            }
           }
         }
       },
@@ -1356,7 +1482,8 @@
           },
           "skip_memory_write_protection": {
             "type": "boolean",
-            "description": "Lets runs on this thread bypass the default long-term-memory write protection."
+            "default": false,
+            "description": "Controls whether the runtime pauses for human approval before the agent writes to long-term memory on this thread. By default (`false`), the runtime raises a human-in-the-loop interrupt when the agent tries to write or edit files in its memory directory, so the user can approve or reject the write before it persists. Set to `true` to bypass that interrupt and let memory writes proceed immediately — useful for headless or unattended runs."
           }
         }
       },
@@ -1420,7 +1547,7 @@
           },
           "user_timezone": {
             "type": "string",
-            "description": "User timezone for runtime context.",
+            "description": "IANA timezone name (for example, `America/Los_Angeles`) for this run. The runtime uses it to inject a localized current-date line into the agent's system prompt, so the agent reasons about dates in the user's local time. Optional. Defaults to the timezone stamped on the agent (or `UTC` if none was set); invalid values fall back to `UTC`.",
             "example": "America/Los_Angeles"
           }
         },

--- a/src/oss/deepagents/code/overview.mdx
+++ b/src/oss/deepagents/code/overview.mdx
@@ -209,7 +209,7 @@ dcode --startup-cmd "git diff --stat" -n "Review these changes"
         | `dcode threads list [--agent NAME] [--limit N]` | List sessions (alias: `ls`). Default limit: 20. `-n` is a short flag for `--limit`. Additional flags: `--sort {created,updated}`, `--branch TEXT` (filter by git branch), `-v`/`--verbose` (show all columns including branch, created time, and initial prompt), `-r`/`--relative` (relative timestamps) |
         | `dcode threads delete ID`       | Delete a session. Supports `--dry-run` |
         | `dcode mcp login NAME [--config PATH]` | Run the OAuth login flow for an MCP server marked `auth: "oauth"`. See [MCP tools](/oss/deepagents/code/mcp-tools#oauth-login) |
-        | `deepagents deploy`             | Legacy deploy command for existing Deep Agents Deploy users. See [Legacy CLI deploy](/oss/deepagents/deploy/overview) |
+        | `deepagents deploy`             | Beta deploy command. New deployments should use [Managed Deep Agents](/langsmith/deploy-managed-deep-agent); see [CLI deploy (beta)](/oss/deepagents/deploy/overview) for the existing CLI surface |
 
         All management subcommands support `--json` for machine-readable output. See [command-line options](#command-line-options) for details.
 

--- a/src/oss/deepagents/deploy/overview.mdx
+++ b/src/oss/deepagents/deploy/overview.mdx
@@ -1,13 +1,13 @@
 ---
-title: Legacy CLI deploy
-description: Reference for existing Deep Agents CLI deployment users.
+title: CLI deploy (beta)
+description: Beta CLI for bundling and deploying a Deep Agents project to LangSmith.
 ---
 
-`deepagents deploy` is a legacy beta CLI deployment path for users already using Deep Agents Deploy. It takes your agent configuration and files and deploys them together as a [LangSmith Deployment](/langsmith/deployment).
+<Note>
+    The `deepagents deploy` CLI was a beta surface that has been deprecated in favor of [Managed Deep Agents](/langsmith/deploy-managed-deep-agent), an API-first hosted runtime for creating, running, and operating deep agents in LangSmith (currently in private preview, [join the waitlist](https://www.langchain.com/langsmith-managed-deep-agents-waitlist)). The CLI experience is expected to consolidate around Managed Deep Agents over time, so expect breaking changes if you build on this CLI today.
+</Note>
 
-<Warning>
-    For new deployments, use [Managed Deep Agents](/langsmith/deploy-managed-deep-agent). Managed Deep Agents is in private preview and provides an API-first hosted runtime for creating, running, and operating deep agents. [Join the waitlist](https://www.langchain.com/langsmith-managed-deep-agents-waitlist) to request access.
-</Warning>
+`deepagents deploy` bundles your agent configuration and files and deploys them as a [LangSmith Deployment](/langsmith/deployment).
 
 LangSmith Deployments are horizontally scalable servers with 30+ endpoints including MCP, A2A, Agent Protocol, human-in-the-loop, and memory APIs. Built on open standards:
 

--- a/src/oss/deepagents/going-to-production.mdx
+++ b/src/oss/deepagents/going-to-production.mdx
@@ -32,7 +32,7 @@ This page covers:
 
 ![Managed Deep Agents packages your agent configuration, tools, and runtime settings for LangSmith](/oss/images/deepagents/production/deepagents-deploy-config.png)
 
-There are two hosted paths for Deep Agents. [Managed Deep Agents](/langsmith/deploy-managed-deep-agent) (private preview) provides an API-first runtime for creating, running, and operating deep agents in LangSmith. You can also configure a [LangSmith Deployment](/langsmith/deployment) directly when you need custom application code, custom routes, advanced authentication, or full Agent Server APIs. Either path provisions the infrastructure your agent needs: [assistants](/langsmith/assistants), [threads](/langsmith/use-threads), [runs](/langsmith/runs), a store, and a checkpointer, so you don't have to set these up yourself. It also gives you [authentication](/langsmith/auth), [webhooks](/langsmith/use-webhooks), [cron jobs](/langsmith/cron-jobs), and [observability](/langsmith/observability) out of the box, and can expose your agent via [MCP](/langsmith/server-mcp) or [A2A](/langsmith/server-a2a).
+The recommended path for taking a Deep Agent to production is [Managed Deep Agents](/langsmith/deploy-managed-deep-agent), an API-first hosted runtime for creating, running, and operating deep agents in LangSmith. Managed Deep Agents is currently in private preview ([join the waitlist](https://www.langchain.com/langsmith-managed-deep-agents-waitlist)). For teams that need custom application code, custom routes, advanced authentication, or full Agent Server APIs, you can configure a [LangSmith Deployment](/langsmith/deployment) directly. Either path provisions the infrastructure your agent needs: [threads](/langsmith/use-threads), [runs](/langsmith/runs), a store, and a checkpointer, so you don't have to set these up yourself. A traditional LangSmith Deployment also gives you [authentication](/langsmith/auth), [webhooks](/langsmith/use-webhooks), [cron jobs](/langsmith/cron-jobs), and [observability](/langsmith/observability) out of the box, and can expose your agent via [MCP](/langsmith/server-mcp) or [A2A](/langsmith/server-a2a).
 
 All code snippets on this page use the following `langgraph.json` unless otherwise specified:
 
@@ -86,7 +86,6 @@ When your agent serves multiple users, you need to handle three concerns: verify
 - Return filters so users only see their own resources
 - Deny access with HTTP 403 for unauthorized operations
 
-If you deploy with the CLI, the [`[auth]`](/oss/deepagents/deploy#auth) section in `deepagents.toml` wires up Clerk, Supabase, or anonymous auth for you, and the [`[frontend]`](/oss/deepagents/deploy#frontend) section reuses the same configuration to gate the bundled chat UI.
 For a step-by-step tutorial, see [Make conversations private](/langsmith/resource-auth). For a walkthrough, watch the [custom auth video](https://www.youtube.com/watch?v=DkNqgCz8cjE).
 
 How you [scope memory](#scoping) and [execution environments](#execution-environment) determines what data is shared between users. See the sections below for details.
@@ -202,8 +201,7 @@ Shared memory (assistant, user, or organization scope) is a vector for prompt in
 
 ### Configuration
 
-In Deep Agents, memory is stored as files in a virtual filesystem. By default, files are scoped to a single thread (conversation) and not shared across threads. 
-If you deploy with [`deepagents deploy`](/oss/deepagents/deploy), per-user writable memory is built in: a `user/AGENTS.md` template under your project root is automatically scoped per authenticated user. See [User Memory](/oss/deepagents/deploy#user-memory) for the CLI shortcut and [Subagents](/oss/deepagents/deploy#subagents) for per-subagent isolated namespaces.
+In Deep Agents, memory is stored as files in a virtual filesystem. By default, files are scoped to a single thread (conversation) and not shared across threads.
 Otherwise, to share memory across threads, route a path like `/memories/` to a @[StoreBackend] that writes to the LangGraph [Store](/langsmith/custom-store). Use a @[CompositeBackend] to give the agent both thread-scoped scratch space and cross-thread [long-term memory](/oss/deepagents/memory).
 
 :::python
@@ -431,10 +429,6 @@ For the full list of backends and how to build custom ones, see [backends](/oss/
 ### Sandboxes
 
 If your agent needs to run code (not just read and write files), use a [sandbox](/oss/deepagents/sandboxes). Sandboxes provide both a filesystem and an `execute` tool for running shell commands, all inside an isolated container. This isolation also protects your host: if the agent's code exhausts memory or crashes, only the sandbox is affected. Your server keeps running.
-
-<Tip>
-For CLI-based deploys, declare your sandbox provider, template, image, and scope under [`[sandbox]`](/oss/deepagents/deploy#sandbox) in `deepagents.toml`—the bundler installs the matching `langchain-*` package and wires the sandbox into the deployed agent for you.
-</Tip>
 
 #### Lifecycle
 
@@ -822,7 +816,7 @@ Sandboxes are isolated containers, so environment variables from your host aren'
 
 The `${SECRET_KEY}` references resolve against secrets stored in your LangSmith [workspace settings](/langsmith/set-up-hierarchy#configure-workspace-settings). Configure secrets there before creating a template that references them.
 
-**Workspace secrets.** For API keys that don't need proxy-based injection (e.g., keys used by the agent server itself, not sandbox code), store them as [workspace secrets](/langsmith/set-up-hierarchy#configure-workspace-settings) in LangSmith. These are available as environment variables at runtime for all agents in the workspace. If you deploy via the CLI, the [`.env` file](/oss/deepagents/deploy#environment-variables) alongside `deepagents.toml` is uploaded with your bundle for agent-server keys; reserve the auth proxy for anything sandbox code calls.
+**Workspace secrets.** For API keys that don't need proxy-based injection (e.g., keys used by the agent server itself, not sandbox code), store them as [workspace secrets](/langsmith/set-up-hierarchy#configure-workspace-settings) in LangSmith. These are available as environment variables at runtime for all agents in the workspace.
 
 <Warning>
 Avoid passing secrets into sandboxes via environment variables or file uploads. Agents can read any accessible file or environment variable inside the sandbox, including credentials. The auth proxy keeps secrets out of the sandbox entirely.
@@ -831,10 +825,6 @@ Avoid passing secrets into sandboxes via environment variables or file uploads. 
 ## Guardrails
 
 Agents in production run autonomously, which means they can loop indefinitely, hit rate limits, or process user data that contains sensitive information. Deep Agents provide two layers of protection:
-
-<Note>
-Custom middleware is not currently configurable through [`deepagents deploy`](/oss/deepagents/deploy#limitations)). To apply the middleware patterns below, deploy directly via [LangSmith Deployments](/langsmith/deployment) with your own agent module.
-</Note>
 
 - **[Permissions](/oss/deepagents/permissions)**: declarative allow/deny rules that control which files and directories the agent can read or write. Use permissions to isolate the agent to a working directory, protect sensitive files, or enforce read-only memory.
 - **[Middleware](/oss/langchain/middleware/built-in)**: hooks that wrap model and tool calls for rate limiting, error handling, and data privacy.
@@ -986,10 +976,6 @@ For the complete list of available middleware, see [prebuilt middleware](/oss/la
 ## Frontend
 
 Deep Agents use [`useStream`](/oss/langchain/frontend/overview) to connect your UI to the agent backend. `useStream` is a frontend hook (available for React, Vue, Svelte, and Angular) that streams messages, subagent progress, and custom state from your agent in real time.
-
-<Tip>
-If you don't need a custom UI, [`deepagents deploy`](/oss/deepagents/deploy) ships a prebuilt React chat UI mounted at `/app` on your deployment URL—see [`[frontend]`](/oss/deepagents/deploy#frontend) for the configuration. The bundled UI handles streaming, thread picking, live todos/files/subagent panels, and Clerk/Supabase/anonymous auth out of the box.
-</Tip>
 
 Locally, `useStream` points at `http://localhost:2024`. In production, point it at your [LangSmith Deployment](/langsmith/deployment) and configure reconnection so users don't lose progress if their connection drops.
 


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
- **Managed Deep Agents preview docs.** Closes the docs gaps from the preview review: new "Limits and notes" section (supported models, thread retention, rate limits, DELETE cascade, API stability, SDKs, support), response/error examples in the OpenAPI spec, tightened field descriptions (`user_timezone`, `skip_memory_write_protection`, `interrupt_config` key format, `model_id`), stream event shapes per `stream_mode`, trace navigation under the `fleet` project, and the agent file tree named as a Context Hub agent repo.
- **Production path shift.** `going-to-production.mdx` now leads with Managed Deep Agents as the recommended path. `deepagents/deploy.mdx` is reframed from "Legacy CLI deploy" to "CLI deploy (beta)" with a Note that points to MDA without calling the CLI deprecated. Inline mentions throughout the production guide are marked as the beta CLI surface.
<!-- For LangChain employees, if applicable: -->
- Linear issue: https://linear.app/langchain/issue/DOC-1119/thorough-docs-review-of-managed-deep-agents-private-preview-docs
- Slack thread: https://langchain.slack.com/archives/C09M16GJNNP/p1778886311507949

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
