### PR TITLE
docs: clarify recursion limit wording in LangGraph graph API

### DIFF
--- a/src/oss/langgraph/graph-api.mdx
+++ b/src/oss/langgraph/graph-api.mdx
@@ -1442,13 +1442,13 @@ The current step counter is accessible in `config.metadata.langgraph_step` withi
 
 :::python
 
-The step counter is stored in `config["metadata"]["langgraph_step"]`. The recursion limit check follows the logic: `step > stop` where `stop = step + recursion_limit + 1`. When the limit is exceeded, LangGraph raises a `GraphRecursionError`.
+The step counter is stored in `config["metadata"]["langgraph_step"]`. LangGraph increments this counter as the graph executes and raises a `GraphRecursionError` once the configured `recursion_limit` is exceeded.
 
 :::
 
 :::js
 
-The step counter is stored in `config.metadata.langgraph_step`. The recursion limit check follows the logic: `step > stop` where `stop = step + recursionLimit + 1`. When the limit is exceeded, LangGraph raises a `GraphRecursionError`.
+The step counter is stored in `config.metadata.langgraph_step`. LangGraph increments this counter as the graph executes and raises a `GraphRecursionError` once the configured `recursionLimit` is exceeded.
 
 :::
 


### PR DESCRIPTION
## Overview
Clarifies the recursion limit explanation in the LangGraph Graph API docs by removing a confusing formula and replacing it with a simpler description of the user-visible behavior.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- GitHub issue: fixes #1563
- Feature PR:

- Linear issue:
- Slack thread:

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes
This is a docs-only wording clarification in `src/oss/langgraph/graph-api.mdx` for the "Accessing and handling the recursion counter" section. I also validated the change locally with a successful docs build using `uv run pipeline build`.