### PR TITLE
docs: clarify unsupported LangGraph JS build flags

### DIFF
--- a/src/langsmith/cli.mdx
+++ b/src/langsmith/cli.mdx
@@ -580,11 +580,7 @@ To build and run a valid application, the LangGraph CLI requires a JSON configur
     | `-t, --tag TEXT`     |                  | **Required**. Tag for the Docker image. Example: `langgraph build -t my-image`                                               |
     | `--pull / --no-pull` | `--pull`         | Build with latest remote Docker image. Use `--no-pull` for running the LangSmith API server with locally built images. |
     | `-c, --config FILE`  | `langgraph.json` | Path to configuration file declaring dependencies, graphs and environment variables.                                         |
-    | `--build-command TEXT`<sup>*</sup> |  | Build command to run. Runs from the directory where your `langgraph.json` file lives. Example: `langgraph build --build-command "yarn run turbo build"` |
-    | `--install-command TEXT`<sup>*</sup> |  | Install command to run. Runs from the directory where you call `langgraph build` from. Example: `langgraph build --install-command "yarn install"` |
     | `--help`             |                  | Display command documentation.                                                                                               |
-
-    <sup>*</sup>Only supported for JS deployments, will have no impact on Python deployments.
     </Tab>
     <Tab title="JS">
     Build LangSmith API server Docker image.

--- a/src/langsmith/cli.mdx
+++ b/src/langsmith/cli.mdx
@@ -580,7 +580,11 @@ To build and run a valid application, the LangGraph CLI requires a JSON configur
     | `-t, --tag TEXT`     |                  | **Required**. Tag for the Docker image. Example: `langgraph build -t my-image`                                               |
     | `--pull / --no-pull` | `--pull`         | Build with latest remote Docker image. Use `--no-pull` for running the LangSmith API server with locally built images. |
     | `-c, --config FILE`  | `langgraph.json` | Path to configuration file declaring dependencies, graphs and environment variables.                                         |
+    | `--build-command TEXT`<sup>*</sup> |  | Build command to run. Runs from the directory where your `langgraph.json` file lives. Example: `langgraph build --build-command "yarn run turbo build"` |
+    | `--install-command TEXT`<sup>*</sup> |  | Install command to run. Runs from the directory where you call `langgraph build` from. Example: `langgraph build --install-command "yarn install"` |
     | `--help`             |                  | Display command documentation.                                                                                               |
+
+    <sup>*</sup>Only supported for JS deployments, will have no impact on Python deployments.
     </Tab>
     <Tab title="JS">
     Build LangSmith API server Docker image.

--- a/src/langsmith/monorepo-support.mdx
+++ b/src/langsmith/monorepo-support.mdx
@@ -109,7 +109,7 @@ langgraph build -t my-customer-support-agent
 ```
 ```bash JS
 # Run from the root of the monorepo
-langgraph build -t my-customer-support-agent -c agents/customer-support/langgraph.json --build-command "yarn run turbo build" --install-command "yarn install"
+langgraph build -t my-customer-support-agent -c agents/customer-support/langgraph.json
 ```
 </CodeGroup>
 
@@ -121,11 +121,9 @@ The Python build process:
 
 The JavaScript build process:
 1. Uses the directory you called `langgraph build` from (the monorepo root in this case) as the build context.
-2. Automatically detects your package manager (yarn, npm, pnpm, bun)
-3. Runs the appropriate install command.
-    - If you have one or both of a custom build/install command it will run from the directory you called `langgraph build` from.
-    - Otherwise, it will run from the directory where the `langgraph.json` file is located.
-4. Optionally runs a custom build command from the directory where the `langgraph.json` file is located (only if you pass the `--build-command` flag).
+2. Automatically detects your package manager (yarn, npm, pnpm, bun).
+3. Runs the appropriate install flow based on your project configuration.
+4. Uses the `langgraph.json` file to locate the application being built.
 
 ## Tips and best practices
 

--- a/src/langsmith/monorepo-support.mdx
+++ b/src/langsmith/monorepo-support.mdx
@@ -123,7 +123,7 @@ The JavaScript build process:
 1. Uses the directory you called `langgraph build` from (the monorepo root in this case) as the build context.
 2. Automatically detects your package manager (yarn, npm, pnpm, bun).
 3. Runs the appropriate install flow based on your project configuration.
-4. Uses the `langgraph.json` file to locate the application being built.
+4. Uses the directory containing `langgraph.json` to locate the app being built.
 
 ## Tips and best practices
 


### PR DESCRIPTION
## Overview
Clarifies LangGraph JS CLI build documentation by removing unsupported `--build-command` and `--install-command` usage from the JS-facing monorepo guidance and aligning the CLI reference with current JS CLI behavior.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- GitHub issue: fixes #1347
- Feature PR:

- Linear issue:
- Slack thread:

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes
I verified the current JS CLI behavior locally with:

- `npx.cmd @langchain/langgraph-cli --version` → `1.2.1+js`
- `npx.cmd @langchain/langgraph-cli build --help`

The current JS CLI help does not list `--build-command` or `--install-command`, so this PR removes those flags from JS-facing documentation and simplifies the monorepo example accordingly.