### PR TITLE
docs: fix ambiguous wording in Chroma integration docs

### DIFF
--- a/src/oss/python/integrations/vectorstores/chroma.mdx
+++ b/src/oss/python/integrations/vectorstores/chroma.mdx
@@ -46,7 +46,7 @@ os.environ["LANGSMITH_TRACING"] = "true"
 
 ### Basic initialization
 
-Below is a basic initialization, including the use of a directory to save the data locally.
+The following example shows setting up an embedding function for Chroma, followed by configuring local persistence for storing vector data.
 
 <EmbeddingTabs/>
 


### PR DESCRIPTION
This updates the explanatory text in the Chroma integration docs to clarify that the example first sets up the embedding function and then configures local persistence in subsequent steps.

The previous wording could be interpreted as if the immediately shown code snippet handled both steps.

## Overview
Clarifies ambiguous wording in the Chroma integration documentation to better reflect the sequence of the example setup.
## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue: None
- Feature PR: None

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
This is a small documentation clarity improvement made via GitHub web edit for an existing docs page. No code examples or navigation structure were modified.