### PR TITLE
Add documentation for LangSmith Engine webhooks

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -277,7 +277,6 @@
                 "langsmith/observability-concepts",
                 "langsmith/observability-llm-tutorial",
                 "langsmith/engine",
-                "langsmith/engine-webhooks",
                 {
                   "group": "Tracing setup",
                   "pages": [
@@ -418,7 +417,8 @@
                   "group": "Automations",
                   "pages": [
                     "langsmith/rules",
-                    "langsmith/webhooks"
+                    "langsmith/webhooks",
+                    "langsmith/engine-webhooks"
                   ]
                 },
                 {

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -135,5 +135,5 @@ Click the **Issue Settings** gear icon on the **Issues** tab to open the **Edit 
 - **Current month spend**: Total cost of LangSmith Engine runs for this project in the current calendar month.
 - **Code repository**: Update the connected GitHub repository or subfolder.
 - **Provider & API keys**: Pick a provider and supply its API key. The LangSmith Engine will use matching heavy and light models for the selected provider. Keys are stored as workspace secrets and shared with other features.
-- **Webhooks**: Configure webhooks to be notified when new issues are found at different priority levels.
+- **Webhooks**: Configure webhooks to be notified when new issues are found at different priority levels. See [Engine webhook events](/langsmith/engine-webhooks) for the event payload reference.
 - **Delete all issues**: This action cannot be undone. All issues and settings will be permanently removed.


### PR DESCRIPTION
- Modified docs.json, moved Engine webhook events down under Automations.
- Modified engine.mdx, added link to engine-webhooks.mdx.

Fixes DOC-1122
