### PR TITLE
oss: remove langchain-community document loader from knowledge base tutorial

### DIFF
--- a/src/oss/langchain/knowledge-base.mdx
+++ b/src/oss/langchain/knowledge-base.mdx
@@ -10,7 +10,7 @@ import VectorstoreTabsJS from '/snippets/vectorstore-tabs-js.mdx';
 
 ## Overview
 
-This tutorial will familiarize you with LangChain's [document loader](/oss/integrations/document_loaders), [embedding](/oss/integrations/embeddings), and [vector store](/oss/integrations/vectorstores) abstractions. These abstractions are designed to support retrieval of data--  from (vector) databases and other sources -- for integration with LLM workflows. They are important for applications that fetch data to be reasoned over as part of model inference, as in the case of retrieval-augmented generation, or [RAG](/oss/langchain/retrieval).
+This tutorial will familiarize you with LangChain's [embedding](/oss/integrations/embeddings) and [vector store](/oss/integrations/vectorstores) abstractions. These abstractions are designed to support retrieval of data--  from (vector) databases and other sources -- for integration with LLM workflows. They are important for applications that fetch data to be reasoned over as part of model inference, as in the case of retrieval-augmented generation, or [RAG](/oss/langchain/retrieval).
 
 Here we will build a search engine over a PDF document. This will allow us to retrieve passages in the PDF that are similar to an input query. The guide also includes a minimal RAG implementation on top of the search engine.
 
@@ -18,7 +18,7 @@ Here we will build a search engine over a PDF document. This will allow us to re
 
 This guide focuses on retrieval of text data. We will cover the following concepts:
 
-- [Documents and document loaders](/oss/integrations/document_loaders);
+- [Documents](https://reference.langchain.com/python/langchain-core/documents);
 - [Text splitters](/oss/integrations/splitters);
 - [Embeddings](/oss/integrations/embeddings);
 - [Vector stores](/oss/integrations/vectorstores) and [retrievers](/oss/integrations/retrievers).
@@ -29,17 +29,17 @@ This guide focuses on retrieval of text data. We will cover the following concep
 
 :::python
 
-This tutorial requires the `langchain-community` and `pypdf` packages:
+This tutorial reads a PDF using the `pypdf` package:
 
 <CodeGroup>
 ```bash pip
-pip install langchain-community pypdf
+pip install pypdf
 ```
 ```bash conda
-conda install langchain-community pypdf -c conda-forge
+conda install pypdf -c conda-forge
 ```
 ```bash uv
-uv add langchain-community pypdf
+uv add pypdf
 ```
 </CodeGroup>
 
@@ -47,17 +47,17 @@ uv add langchain-community pypdf
 
 :::js
 
-This guide requires `@langchain/community` and `pdf-parse`:
+This guide reads a PDF using the `pdf-parse` package:
 
 <CodeGroup>
 ```bash npm
-npm i @langchain/community pdf-parse
+npm i pdf-parse
 ```
 ```bash yarn
-yarn add @langchain/community pdf-parse
+yarn add pdf-parse
 ```
 ```bash pnpm
-pnpm add @langchain/community pdf-parse
+pnpm add pdf-parse
 ```
 </CodeGroup>
 
@@ -92,7 +92,7 @@ os.environ["LANGSMITH_API_KEY"] = getpass.getpass()
 
 :::
 
-## 1. Documents and document loaders
+## 1. Documents
 
 LangChain implements a @[Document] abstraction, which is intended to represent a unit of text and associated metadata. It has three attributes:
 
@@ -145,129 +145,123 @@ const documents = [
 ```
 :::
 
-However, the LangChain ecosystem implements [document loaders](/oss/integrations/document_loaders) that integrate with hundreds of common sources. This makes it easy to incorporate data from these sources into your AI application.
+## 2. Embeddings
 
-### Loading documents
+Vector search is a common way to store and search over unstructured data (such as unstructured text). The idea is to store numeric vectors that are associated with the text. Given a query, we can [embed](/oss/integrations/embeddings) it as a vector of the same dimension and use vector similarity metrics (such as cosine similarity) to identify related text.
 
-Let's load a PDF into a sequence of @[`Document`] objects. [Here is a sample PDF](https://github.com/langchain-ai/langchain/blob/v0.3/docs/docs/example_data/nke-10k-2023.pdf) -- a 10-k filing for Nike from 2023. We can consult the LangChain documentation for [available PDF document loaders](/oss/integrations/document_loaders/#pdfs).
+LangChain supports embeddings from [dozens of providers](/oss/integrations/embeddings/). These models specify how text should be converted into a numeric vector. Let's select a model:
+
+:::python
+<EmbeddingsTabsPy />
+
+```python
+vector_1 = embeddings.embed_query(documents[0].page_content)
+vector_2 = embeddings.embed_query(documents[1].page_content)
+
+assert len(vector_1) == len(vector_2)
+print(f"Generated vectors of length {len(vector_1)}\n")
+print(vector_1[:10])
+```
+:::
+:::js
+<EmbeddingsTabsJS />
+
+```typescript
+const vector1 = await embeddings.embedQuery(documents[0].pageContent);
+const vector2 = await embeddings.embedQuery(documents[1].pageContent);
+
+assert vector1.length === vector2.length;
+console.log(`Generated vectors of length ${vector1.length}\n`);
+console.log(vector1.slice(0, 10));
+```
+:::
+
+```text
+Generated vectors of length 1536
+
+[-0.008586574345827103, -0.03341241180896759, -0.008936782367527485, -0.0036674530711025, 0.010564599186182022, 0.009598285891115665, -0.028587326407432556, -0.015824200585484505, 0.0030416189692914486, -0.012899317778646946]
+```
+Armed with a model for generating text embeddings, we can next store them in a special data structure that supports efficient similarity search.
+
+## 3. Vector stores
+
+LangChain @[VectorStore] objects contain methods for adding text and @[`Document`] objects to the store, and querying them using various similarity metrics. They are often initialized with [embedding](/oss/integrations/embeddings) models, which determine how text data is translated to numeric vectors.
+
+LangChain includes a suite of [integrations](/oss/integrations/vectorstores) with different vector store technologies. Some vector stores are hosted by a provider (e.g., various cloud providers) and require specific credentials to use; some (such as [Postgres](/oss/integrations/vectorstores/pgvector)) run in separate infrastructure that can be run locally or via a third-party; others can run in-memory for lightweight workloads. Let's select a vector store:
+
+:::python
+<VectorstoreTabsPy />
+:::
+:::js
+<VectorstoreTabsJS />
+:::
+
+### Seeding the vector store
+
+Let's seed the store with content from a PDF. [Here is a sample PDF](https://github.com/langchain-ai/langchain/blob/v0.3/docs/docs/example_data/nke-10k-2023.pdf) -- a 10-k filing for Nike from 2023. We'll read the PDF directly with a small helper and split it into smaller chunks before indexing.
 
 :::python
 ```python
-from langchain_community.document_loaders import PyPDFLoader
+import pypdf
+from langchain_core.documents import Document
+
+
+# Below is a minimal helper for demonstration purposes.
+def load_pdf_pages(file_path: str) -> list[Document]:
+    reader = pypdf.PdfReader(file_path)
+    return [
+        Document(
+            page_content=page.extract_text() or "",
+            metadata={"source": file_path, "page": i},
+        )
+        for i, page in enumerate(reader.pages)
+    ]
+
 
 file_path = "../example_data/nke-10k-2023.pdf"
-loader = PyPDFLoader(file_path)
-
-docs = loader.load()
-
+docs = load_pdf_pages(file_path)
 print(len(docs))
 ```
-```text
-107
-```
-
-`PyPDFLoader` loads one @[`Document`] object per PDF page. For each, we can easily access:
-
-- The string content of the page;
-- Metadata containing the file name and page number.
 :::
 :::js
 ```typescript
-import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf";
+import { readFileSync } from "node:fs";
+import { Document } from "@langchain/core/documents";
+import { PDFParse } from "pdf-parse";
 
-const loader = new PDFLoader("../../data/nke-10k-2023.pdf");
+// Below is a minimal helper for demonstration purposes.
+async function loadPdfPages(filePath: string): Promise<Document[]> {
+  const parser = new PDFParse({
+    data: new Uint8Array(readFileSync(filePath)),
+  });
+  try {
+    const { pages } = await parser.getText();
+    return pages.map(
+      (page) =>
+        new Document({
+          pageContent: page.text,
+          metadata: { source: filePath, page: page.num - 1 },
+        })
+    );
+  } finally {
+    await parser.destroy();
+  }
+}
 
-const docs = await loader.load();
+const filePath = "../../data/nke-10k-2023.pdf";
+const docs = await loadPdfPages(filePath);
 console.log(docs.length);
 ```
+:::
+
 ```text
 107
 ```
 
-`PDFLoader` loads one @[`Document`] object per PDF page. For each, we can easily access:
-
-- The string content of the page;
-- Metadata containing the file name and page number.
-:::
+A page may be too coarse a representation for retrieval and downstream question-answering. Further splitting helps ensure that the meanings of relevant portions of the document are not "washed out" by surrounding text. We use [`RecursiveCharacterTextSplitter`](/oss/integrations/splitters), which recursively splits a document using common separators like new lines until each chunk is the appropriate size. This is the recommended text splitter for generic text use cases.
 
 :::python
-```python
-print(f"{docs[0].page_content[:200]}\n")
-print(docs[0].metadata)
-```
-```python
-Table of Contents
-UNITED STATES
-SECURITIES AND EXCHANGE COMMISSION
-Washington, D.C. 20549
-FORM 10-K
-(Mark One)
-☑ ANNUAL REPORT PURSUANT TO SECTION 13 OR 15(D) OF THE SECURITIES EXCHANGE ACT OF 1934
-FO
-
-{'source': '../example_data/nke-10k-2023.pdf', 'page': 0}
-```
-:::
-:::js
-```typescript
-console.log(docs[0].pageContent.slice(0, 200));
-```
-```text
-Table of Contents
-UNITED STATES
-SECURITIES AND EXCHANGE COMMISSION
-Washington, D.C. 20549
-FORM 10-K
-(Mark One)
-☑ ANNUAL REPORT PURSUANT TO SECTION 13 OR 15(D) OF THE SECURITIES EXCHANGE ACT OF 1934
-FO
-```
-```typescript
-console.log(docs[0].metadata);
-```
-```javascript
-{
-  source: '../../data/nke-10k-2023.pdf',
-  pdf: {
-    version: '1.10.100',
-    info: {
-      PDFFormatVersion: '1.4',
-      IsAcroFormPresent: false,
-      IsXFAPresent: false,
-      Title: '0000320187-23-000039',
-      Author: 'EDGAR Online, a division of Donnelley Financial Solutions',
-      Subject: 'Form 10-K filed on 2023-07-20 for the period ending 2023-05-31',
-      Keywords: '0000320187-23-000039; ; 10-K',
-      Creator: 'EDGAR Filing HTML Converter',
-      Producer: 'EDGRpdf Service w/ EO.Pdf 22.0.40.0',
-      CreationDate: "D:20230720162200-04'00'",
-      ModDate: "D:20230720162208-04'00'"
-    },
-    metadata: null,
-    totalPages: 107
-  },
-  loc: { pageNumber: 1 }
-}
-```
-:::
-
-### Splitting
-
-For both information retrieval and downstream question-answering purposes, a page may be too coarse a representation. Our goal in the end will be to retrieve @[`Document`] objects that answer an input query, and further splitting our PDF will help ensure that the meanings of relevant portions of the document are not "washed out" by surrounding text.
-
-We can use [text splitters](/oss/integrations/splitters) for this purpose. Here we will use a simple text splitter that partitions based on characters. We will split our documents into chunks of 1000 characters
-with 200 characters of overlap between chunks. The overlap helps
-mitigate the possibility of separating a statement from important
-context related to it. We use the
-`RecursiveCharacterTextSplitter`,
-which will recursively split the document using common separators like
-new lines until each chunk is the appropriate size. This is the
-recommended text splitter for generic text use cases.
-
-:::python
-We set `add_start_index=True` so that the character index where each
-split Document starts within the initial Document is preserved as
-metadata attribute “start_index”.
+We set `add_start_index=True` so that the character index where each split Document starts within the initial Document is preserved as metadata attribute `start_index`.
 
 ```python
 from langchain_text_splitters import RecursiveCharacterTextSplitter
@@ -299,59 +293,7 @@ console.log(allSplits.length);
 514
 ```
 
-
-## 2. Embeddings
-
-Vector search is a common way to store and search over unstructured data (such as unstructured text). The idea is to store numeric vectors that are associated with the text. Given a query, we can [embed](/oss/integrations/embeddings) it as a vector of the same dimension and use vector similarity metrics (such as cosine similarity) to identify related text.
-
-LangChain supports embeddings from [dozens of providers](/oss/integrations/embeddings/). These models specify how text should be converted into a numeric vector. Let's select a model:
-
-:::python
-<EmbeddingsTabsPy />
-
-```python
-vector_1 = embeddings.embed_query(all_splits[0].page_content)
-vector_2 = embeddings.embed_query(all_splits[1].page_content)
-
-assert len(vector_1) == len(vector_2)
-print(f"Generated vectors of length {len(vector_1)}\n")
-print(vector_1[:10])
-```
-:::
-:::js
-<EmbeddingsTabsJS />
-
-```typescript
-const vector1 = await embeddings.embedQuery(allSplits[0].pageContent);
-const vector2 = await embeddings.embedQuery(allSplits[1].pageContent);
-
-assert vector1.length === vector2.length;
-console.log(`Generated vectors of length ${vector1.length}\n`);
-console.log(vector1.slice(0, 10));
-```
-:::
-
-```text
-Generated vectors of length 1536
-
-[-0.008586574345827103, -0.03341241180896759, -0.008936782367527485, -0.0036674530711025, 0.010564599186182022, 0.009598285891115665, -0.028587326407432556, -0.015824200585484505, 0.0030416189692914486, -0.012899317778646946]
-```
-Armed with a model for generating text embeddings, we can next store them in a special data structure that supports efficient similarity search.
-
-## 3. Vector stores
-
-LangChain @[VectorStore] objects contain methods for adding text and @[`Document`] objects to the store, and querying them using various similarity metrics. They are often initialized with [embedding](/oss/integrations/embeddings) models, which determine how text data is translated to numeric vectors.
-
-LangChain includes a suite of [integrations](/oss/integrations/vectorstores) with different vector store technologies. Some vector stores are hosted by a provider (e.g., various cloud providers) and require specific credentials to use; some (such as [Postgres](/oss/integrations/vectorstores/pgvector)) run in separate infrastructure that can be run locally or via a third-party; others can run in-memory for lightweight workloads. Let's select a vector store:
-
-:::python
-<VectorstoreTabsPy />
-:::
-:::js
-<VectorstoreTabsJS />
-:::
-
-Having instantiated our vector store, we can now index the documents.
+We can now index the chunks into the vector store.
 
 :::python
 ```python
@@ -644,11 +586,6 @@ Retrievers can easily be incorporated into more complex applications, such as [r
 ## Next steps
 
 You've now seen how to build a semantic search engine over a PDF document.
-
-For more on document loaders:
-
-- [Overview](/oss/langchain/retrieval)
-- [Available integrations](/oss/integrations/document_loaders/)
 
 For more on embeddings:
 


### PR DESCRIPTION
Removes overview of document loaders entirely; in-lines a helper function for demonstration purposes to load PDFs into `Document` objects.