### PR TITLE
Fix multiple H1 headings and malformed URL in export-backend.mdx

### DIFF
--- a/src/langsmith/export-backend.mdx
+++ b/src/langsmith/export-backend.mdx
@@ -16,7 +16,9 @@ Infrastructure refers to:
 * Collectors, such as [OpenTelemetry](https://opentelemetry.io/docs/collector/), [FluentBit](https://docs.fluentbit.io/manual) or [Prometheus](https://prometheus.io/).
 * Observability backends, such as [Datadog](https://www.datadoghq.com/) or the [Grafana](https://grafana.com/) ecosystem.
 
-# Logs: [OTel example](/langsmith/langsmith-collector#logs)
+## Logs
+
+For a reference setup, see the [OTel collector example](/langsmith/langsmith-collector#logs).
 
 All services that are part of the LangSmith self-hosted deployment write logs to their node's filesystem and to stdout. In order to access these logs, you need to set up your collector to read from either the filesystem or stdout. Most popular collectors support reading logs from filesystems.
 
@@ -24,9 +26,11 @@ All services that are part of the LangSmith self-hosted deployment write logs to
 * **FluentBit**: [Tail Input](https://docs.fluentbit.io/manual/pipeline/inputs/tail)
 * **Datadog**: [Kubernetes Log Collection](https://docs.datadoghq.com/containers/kubernetes/log/?tab=datadogoperator)
 
-# Metrics: [OTel example](/langsmith/langsmith-collector#metrics)
+## Metrics
 
-## LangSmith services
+For a reference setup, see the [OTel collector example](/langsmith/langsmith-collector#metrics).
+
+### LangSmith services
 
 The following LangSmith services expose metrics at an endpoint, in the Prometheus metrics format. The frontend does not currently expose metrics.
 
@@ -37,7 +41,7 @@ The following LangSmith services expose metrics at an endpoint, in the Prometheu
 
 You can use a [Prometheus](https://prometheus.io/docs/prometheus/latest/getting_started/#configure-prometheus-to-monitor-the-sample-targets) or [OpenTelemetry](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/receiver/prometheusreceiver) collector to scrape the endpoints, and export metrics to the backend of your choice.
 
-## Frontend Nginx
+### Frontend Nginx
 
 The frontend service exposes its Nginx metrics at the following endpoint: `langsmith-frontend.langsmith.svc.cluster.local:80/nginx_status`. You can either scrape them yourself, or bring up a [Prometheus Nginx exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-nginx-exporter).
 
@@ -45,17 +49,19 @@ The frontend service exposes its Nginx metrics at the following endpoint: `langs
 **The following sections apply for in-cluster databases only. If you are using external databases, you will need to configure exposing and fetching metrics.**
 </Warning>
 
-## Postgres + Redis
+### Postgres + Redis
 
 If you are using in-cluster Postgres/Redis instances, you can use a Prometheus exporter to expose metrics from your instance. You can deploy a [Postgres exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-postgres-exporter) and/or [Redis exporter](https://github.com/prometheus-community/helm-charts/tree/main/charts/prometheus-redis-exporter).
 
-## Clickhouse
+### Clickhouse
 
 The in-cluster Clickhouse is configured to expose metrics without the need for an exporter. You can use your collector to scrape metrics at `http://<langsmith_release_name>-clickhouse.<namespace>.svc.cluster.local:9363/metrics`
 
-# Traces: [OTel example](/langsmith/langsmith-collector#traces)
+## Traces
 
-The LangSmith Backend, Platform Backend, Playground and LangSmith Queue deployments have been instrumented to emit [Otel](https://opentelemetry.io/do/langsmith/observability-concepts/signals/traces/) traces. Tracing is toggled off by default, and can be enabled for all LangSmith services with the following in your `langsmith_config.yaml` (or equivalent) file:
+For a reference setup, see the [OTel collector example](/langsmith/langsmith-collector#traces).
+
+The LangSmith Backend, Platform Backend, Playground and LangSmith Queue deployments have been instrumented to emit [Otel](https://opentelemetry.io/docs/concepts/signals/traces/) traces. Tracing is toggled off by default, and can be enabled for all LangSmith services with the following in your `langsmith_config.yaml` (or equivalent) file:
 
 ```yaml
 config:


### PR DESCRIPTION
Modified export-backend.mdx, fixed headers and malformed URL.

Fixes DOC-1138