### PR TITLE
docs: add self-hosted LangSmith disaster recovery guide

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -834,6 +834,7 @@
                           "pages": [
                             "langsmith/self-host-usage",
                             "langsmith/self-host-upgrades",
+                            "langsmith/self-host-disaster-recovery",
                             "langsmith/self-host-egress",
                             "langsmith/self-host-organization-charts",
                             "langsmith/langsmith-managed-clickhouse",

--- a/src/langsmith/self-host-disaster-recovery.mdx
+++ b/src/langsmith/self-host-disaster-recovery.mdx
@@ -1,0 +1,283 @@
+---
+title: Disaster recovery for self-hosted LangSmith
+sidebarTitle: Disaster recovery
+---
+
+This page describes how to plan, configure, and operate disaster recovery (DR) for a self-hosted LangSmith observability and evaluation deployment. It covers what data must be protected, where it lives, how to back it up, and how to recover the platform after a regional or zonal failure.
+
+<Note>
+**Shared responsibility.** For self-hosted deployments you are responsible for backups, replication, restore testing, and recovery procedures for every component, including LangSmith pods and all backing data stores. LangChain is responsible only for the LangSmith software itself. For the equivalent SaaS responsibilities, see the [Shared responsibility model](/langsmith/shared-responsibility-model).
+</Note>
+
+<Tip>
+If you have not already, read [Scalability and resilience](/langsmith/scalability-and-resilience) for the architectural primitives (stateless services, queue heartbeats, exactly-once semantics) that this page assumes.
+</Tip>
+
+## What you are recovering
+
+A self-hosted LangSmith deployment is composed of stateless services backed by four state stores. Recovery planning is almost entirely about the state stores. The stateless services can be recreated at any time by reapplying the Helm chart.
+
+| Layer | Components | State? | Recovery action |
+|-------|------------|--------|-----------------|
+| LangSmith services | `langsmith-frontend`, `langsmith-backend`, `langsmith-platform-backend`, `langsmith-queue`, `langsmith-ingest-queue`, `langsmith-playground`, `langsmith-ace-backend` | Stateless | Reinstall the Helm chart |
+| PostgreSQL | Operational data: orgs, workspaces, users, API keys, datasets, prompts, projects, deployments metadata | **Durable** | Restore from backup or replica |
+| ClickHouse | Traces and feedback (high volume analytical data) | **Durable** | Restore from backup or replica |
+| Blob storage (S3/GCS/Azure Blob) | Run inputs, outputs, errors, manifests, extras, events, attachments (when enabled) | **Durable** | Restore from versioned bucket or replica |
+| Redis (or Valkey) | Ephemeral queue state, pub/sub, cache, run heartbeats | Ephemeral | Reprovision; no restore required |
+| Kubernetes objects | Helm values, `Secret`s, TLS material, IRSA / Workload Identity bindings | Configuration | Re-apply from source control or back up cluster state |
+
+<Warning>
+All four data stores must be protected. Restoring Postgres without ClickHouse and blob storage (or vice versa) produces an inconsistent installation. References from Postgres to runs in ClickHouse and to objects in blob storage break across the divergence point. Always take coordinated backups, or use point-in-time recovery (PITR) targets that are close together across stores.
+</Warning>
+
+## Plan your RPO and RTO
+
+Before designing your DR architecture, define two targets:
+
+- **Recovery Point Objective (RPO):** the maximum amount of data loss your organization can tolerate, measured in time. With managed Postgres PITR, RPO is typically less than 5 minutes. With nightly snapshots only, RPO can be up to 24 hours.
+- **Recovery Time Objective (RTO):** the maximum time you can take to restore service after a failure. A warm cross-region replica can deliver RTO in minutes; a cold restore from snapshot can take hours, especially for large ClickHouse datasets.
+
+The deployment patterns below assume one of three target profiles:
+
+| Profile | Typical RPO | Typical RTO | Approach |
+|---------|-------------|-------------|----------|
+| Snapshot-only | 6 to 24 hours | Hours | Daily managed backups of each store. Lowest cost, longest restore. |
+| Multi-AZ HA | Seconds | Minutes (zone failure) | Synchronous standby in another AZ for Postgres and ClickHouse, Multi-AZ Redis, zone-redundant blob storage. Standard production posture. |
+| Cross-region DR | Minutes | Minutes to an hour | Asynchronous replication of Postgres, ClickHouse, and blob storage to a second region; standby Kubernetes cluster ready to scale up. Highest cost, fastest recovery from a regional outage. |
+
+## Postgres
+
+LangSmith uses PostgreSQL as the primary store for operational and transactional data. **All communication with Postgres uses retries for retry-able errors**, so a brief outage during failover usually does not surface as user-visible errors. A prolonged outage will render the LangSmith API unavailable.
+
+### Use a managed service
+
+We strongly recommend running Postgres on a managed service in production. Managed services provide automated backups, PITR, and HA failover out of the box. See [Connect external Postgres](/langsmith/self-host-external-postgres) for setup.
+
+<Tabs>
+  <Tab title="AWS">
+    Run [Amazon RDS for PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/CHAP_GettingStarted.CreatingConnecting.PostgreSQL.html) or [Aurora PostgreSQL](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/Aurora.Overview.html) in Multi-AZ mode.
+
+    - **Backups:** Enable [automated backups](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_WorkingWithAutomatedBackups.html) with a retention window that matches your compliance posture (7 to 35 days is typical).
+    - **PITR:** Automated backups include PITR within the retention window.
+    - **HA:** Multi-AZ deployments maintain a synchronous standby in a second availability zone with automatic failover.
+    - **Cross-region DR:** For Aurora, configure an [Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html). For RDS, use [cross-region read replicas](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.XRgn.html) or copy automated snapshots to a secondary region.
+    - **Encryption:** Enable storage encryption with a customer-managed [KMS](https://aws.amazon.com/kms/) key.
+  </Tab>
+  <Tab title="GCP">
+    Run [Cloud SQL for PostgreSQL](https://cloud.google.com/sql/docs/postgres) with [high availability](https://cloud.google.com/sql/docs/postgres/high-availability) enabled.
+
+    - **Backups:** Enable [automated backups](https://cloud.google.com/sql/docs/postgres/backup-recovery/backups) with PITR.
+    - **HA:** Regional instances replicate synchronously to a standby in a second zone.
+    - **Cross-region DR:** Configure [cross-region read replicas](https://cloud.google.com/sql/docs/postgres/replication/cross-region-replicas) and promote them on regional failure.
+    - **Encryption:** Use [Cloud KMS customer-managed encryption keys](https://docs.cloud.google.com/sql/docs/postgres/cmek).
+  </Tab>
+  <Tab title="Azure">
+    Run [Azure Database for PostgreSQL Flexible Server](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/overview) with zone-redundant HA.
+
+    - **Backups:** Enable [automatic backups](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-backup-restore) with geo-redundant backup storage.
+    - **HA:** Zone-redundant HA maintains a synchronous standby in a different availability zone.
+    - **Cross-region DR:** Use [read replicas](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-read-replicas) in a secondary region for promotion on regional failure.
+  </Tab>
+</Tabs>
+
+### In-cluster Postgres
+
+If you must run Postgres in-cluster from the bundled chart, you are responsible for backing up the underlying PersistentVolume. Snapshot the PVC on a regular cadence using your CSI driver's snapshot class, and copy snapshots to object storage or a different region. **This path is not recommended for production.**
+
+## ClickHouse
+
+ClickHouse holds the high-volume trace and feedback data and is typically the largest data store in a LangSmith deployment. Backups and replication need to be planned for cost and restore-time impact.
+
+### Managed ClickHouse
+
+The fastest path to a resilient ClickHouse is a managed option. See [Connect external ClickHouse](/langsmith/self-host-external-clickhouse).
+
+- **[LangSmith Managed ClickHouse](/langsmith/langsmith-managed-clickhouse):** LangChain operates the ClickHouse cluster, including backups and replication. VPC peering connects it to your LangSmith installation.
+- **[ClickHouse Cloud](https://clickhouse.cloud/):** Provides built-in backups, replication, and HA. Available on AWS, GCP, and Azure marketplaces.
+
+### Self-managed replicated cluster
+
+If you self-manage ClickHouse for compliance or air-gap reasons, use a replicated cluster. A single-node ClickHouse instance cannot meet a meaningful RPO.
+
+- Configure a multi-node ClickHouse cluster with replication via [Keeper or ZooKeeper](https://clickhouse.com/docs/architecture/replication).
+- Set the `cluster` value in the LangSmith chart so migrations create `Replicated` table engines from the start. **Clustered setups must be configured against a fresh schema**, you cannot convert a standalone instance to clustered later.
+- Spread replicas across availability zones.
+- Schedule [`BACKUP TABLE` or `BACKUP DATABASE`](https://clickhouse.com/docs/operations/backup) to object storage on a frequency matching your RPO.
+- For cross-region DR, replicate the backup bucket to a secondary region, or run a second ClickHouse cluster in the DR region and replicate via [`remote()` table functions](https://clickhouse.com/docs/sql-reference/table-functions/remote) or external pipelines.
+
+For an example replicated configuration, see the [replicated ClickHouse example](https://github.com/langchain-ai/helm/blob/main/charts/langsmith/examples/replicated-clickhouse/README.md) in the Helm repo.
+
+<Warning>
+Restoring ClickHouse can take significantly longer than restoring Postgres at the same data volume because trace tables are large. Account for this when setting your RTO. Validate restore time on a representative dataset during DR drills.
+</Warning>
+
+## Blob storage
+
+If you have enabled [blob storage](/langsmith/self-host-blob-storage) (recommended for production), your run inputs, outputs, errors, manifests, extras, events, and attachments live in S3, GCS, or Azure Blob Storage. Cloud blob services are durable by design, but you should still configure protection against accidental deletion and regional outages.
+
+<Tabs>
+  <Tab title="AWS">
+    - Enable [S3 Versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Versioning.html) to protect against accidental deletes and overwrites.
+    - Enable [MFA Delete](https://docs.aws.amazon.com/AmazonS3/latest/userguide/MultiFactorAuthenticationDelete.html) for high-security buckets.
+    - For cross-region DR, configure [Cross-Region Replication (CRR)](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html) to a bucket in your DR region.
+    - Use [S3 Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html) for write-once-read-many (WORM) retention.
+    - Encrypt with [SSE-KMS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingKMSEncryption.html). LangSmith supports passing a specific KMS key ARN, see [KMS encryption header support](/langsmith/self-host-blob-storage#kms-encryption-header-support).
+  </Tab>
+  <Tab title="GCP">
+    - Enable [Object Versioning](https://cloud.google.com/storage/docs/object-versioning) on the bucket.
+    - Use [dual-region or multi-region buckets](https://cloud.google.com/storage/docs/locations) for geo-redundancy.
+    - For cross-region DR, use [Storage Transfer Service](https://cloud.google.com/storage-transfer-service) or [Object Lifecycle Management](https://cloud.google.com/storage/docs/lifecycle) with replication policies.
+    - Encrypt with [Customer-Managed Encryption Keys (CMEK)](https://cloud.google.com/storage/docs/encryption/customer-managed-keys).
+  </Tab>
+  <Tab title="Azure">
+    - Choose a [redundancy tier](https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy) that matches your DR objectives. Use **RA-GRS** or **RA-GZRS** for cross-region read access during a primary region outage.
+    - Enable [soft delete and blob versioning](https://learn.microsoft.com/en-us/azure/storage/blobs/soft-delete-blob-overview).
+    - Encrypt with a [customer-managed key in Key Vault](https://learn.microsoft.com/en-us/azure/storage/common/customer-managed-keys-overview).
+  </Tab>
+</Tabs>
+
+<Warning>
+**Keep TTL lifecycle rules in your DR bucket.** If you copy data to a DR bucket, replicate the lifecycle rules for `ttl_s/`, `ttl_l/`, and any custom `ttl_XXd/` prefixes too. Missing rules in the DR bucket will cause data to be retained indefinitely after failover. See [TTL configuration](/langsmith/self-host-blob-storage#ttl-configuration).
+</Warning>
+
+## Redis
+
+Redis stores ephemeral metadata, queue state, and cross-instance pub/sub. **No durable data is stored in Redis, so you do not need to back it up.** Communication with Redis is retried for retry-able errors. The recovery design is to make Redis highly available within the active region and to reprovision it from scratch in the DR region.
+
+- Use the managed service for your cloud: [Amazon ElastiCache](https://aws.amazon.com/elasticache/redis/), [Google Cloud Memorystore](https://cloud.google.com/memorystore), or [Azure Cache for Redis](https://azure.microsoft.com/en-us/products/cache).
+- Enable Multi-AZ failover.
+- For cross-region DR, provision a fresh Redis instance in the DR region during failover; do **not** reuse an active region's Redis URI in the new cluster.
+
+<Warning>
+Each LangSmith installation must use its own dedicated Redis instance. **Do not share a Redis instance across two installations**, including a primary and a DR replica that may both be active at any point. Sharing Redis causes deployment tasks to be routed to the wrong cluster. See [Connect external Redis](/langsmith/self-host-external-redis).
+</Warning>
+
+## Kubernetes configuration and secrets
+
+The Helm chart values, Kubernetes `Secret`s, and identity bindings are as important as your data backups. A complete restore requires both.
+
+- **Helm values:** Store `values.yaml` in source control. Track per-environment overrides separately.
+- **Image versions:** Pin the LangSmith chart version and image tags so a recovery installs the same software version. See [Self-host upgrades](/langsmith/self-host-upgrades) and [Dependency versions](/langsmith/self-host-dependency-versions).
+- **Secrets:** LangSmith reads database, blob, and licensing credentials from Kubernetes `Secret`s. Mirror these to your DR cluster's secret manager ([AWS Secrets Manager](https://aws.amazon.com/secrets-manager/), [GCP Secret Manager](https://cloud.google.com/secret-manager), or [Azure Key Vault](https://azure.microsoft.com/en-us/products/key-vault/)). See [Use an existing secret](/langsmith/self-host-using-an-existing-secret).
+- **TLS material:** If you terminate TLS at the LangSmith ingress, back up the certificate and key, or reissue from your private CA in the DR region. See [Custom TLS certificates](/langsmith/self-host-custom-tls-certificates).
+- **IRSA / Workload Identity bindings:** Recreate IAM roles and service-account bindings in the DR region; service account ARNs and annotations are region-scoped.
+- **License key:** Keep the LangSmith license key alongside other recovery secrets.
+
+## Reference deployment patterns
+
+### Single region with Multi-AZ HA (recommended baseline)
+
+This is the minimum production posture and protects against zonal failures. It does not protect against a regional outage.
+
+- Kubernetes node pools across at least two availability zones.
+- Postgres in Multi-AZ HA mode (RDS Multi-AZ, Cloud SQL HA, or Flexible Server zone-redundant).
+- ClickHouse as a managed service, or a 3-node replicated cluster spread across AZs.
+- Redis with Multi-AZ failover enabled.
+- Blob storage with versioning enabled and a redundancy tier of at least zone-redundant.
+- Daily snapshots of every data store retained for at least 7 days.
+
+### Cross-region active/passive DR
+
+This protects against a regional outage. It is significantly more expensive but is the right pattern for tier-1 deployments.
+
+- A second Kubernetes cluster in the DR region with the LangSmith Helm chart installed but scaled to a low replica count (warm) or zero (cold).
+- Postgres cross-region replica (RDS or Aurora cross-region replica, Cloud SQL cross-region replica, Azure Flexible Server cross-region replica). Promote on failover.
+- ClickHouse Cloud or LangSmith Managed ClickHouse with a region failover plan, **or** a replicated self-managed ClickHouse cluster in the DR region with backups copied from the primary.
+- Blob storage replicated to a DR bucket with versioning and matching lifecycle rules.
+- Redis provisioned fresh in the DR region during failover.
+- DNS managed by [Route 53](https://aws.amazon.com/route53/), [Cloud DNS](https://cloud.google.com/dns), or [Azure DNS](https://azure.microsoft.com/en-us/products/dns/) with health checks and failover policies pointing at the LangSmith frontend ingress in each region.
+
+<Note>
+LangSmith is a single-write platform. A cross-region deployment should be **active/passive**, not active/active. Writing to both regions concurrently against the same logical installation is not supported and will produce data inconsistency.
+</Note>
+
+## Recovery procedures
+
+### Restore after a zonal failure
+
+In a single-region Multi-AZ deployment, zonal failures are handled automatically by your cloud provider:
+
+1. Managed Postgres fails over to its standby in another AZ. LangSmith pods reconnect via the cluster endpoint after retry.
+2. Managed Redis fails over similarly. LangSmith retries reconnect automatically.
+3. Kubernetes reschedules LangSmith pods on healthy nodes in remaining AZs. Verify that node pools and Horizontal Pod Autoscaler limits allow this headroom.
+4. Verify ingest by submitting a test trace from the SDK and confirming it appears in the UI.
+
+### Restore after a regional failure
+
+This is the cross-region failover runbook. Adapt to your specific infrastructure.
+
+<Steps>
+  <Step title="Declare failover">
+    Confirm the primary region is unavailable. Communicate to stakeholders that you are failing over and what the expected RTO is.
+  </Step>
+  <Step title="Promote data stores">
+    Promote the Postgres cross-region replica to primary in the DR region. For ClickHouse Cloud or LangSmith Managed ClickHouse, initiate the documented region failover. For self-managed ClickHouse, restore the latest backup into the DR cluster (this is typically the longest step).
+  </Step>
+  <Step title="Repoint blob storage">
+    Update the LangSmith Helm `config.blobStorage.bucketName` and `apiURL` to point at the DR bucket. Confirm the bucket has the same TTL lifecycle rules. See [Blob storage configuration](/langsmith/self-host-blob-storage#configuration).
+  </Step>
+  <Step title="Provision Redis">
+    Create a fresh managed Redis instance in the DR region. Update the LangSmith Helm `redis.external` values to point at it. **Do not import dumps from the primary Redis**; provision empty.
+  </Step>
+  <Step title="Scale the DR cluster">
+    If running warm/cold, scale the LangSmith deployments to their production replica counts. Apply any pending Helm value updates from source control.
+  </Step>
+  <Step title="Run smoke tests">
+    Submit a test trace, verify it lands in ClickHouse and (if blob storage is enabled) in the DR bucket. Open the UI and confirm traces, datasets, and projects load. Validate authentication. See [Diagnostics](/langsmith/diagnostics-self-hosted).
+  </Step>
+  <Step title="Cut DNS over">
+    Update DNS to route traffic to the DR ingress. Communicate the cutover to stakeholders.
+  </Step>
+  <Step title="Plan failback">
+    Once the primary region is healthy, plan a controlled failback. This is typically scheduled into a maintenance window and involves rebuilding the primary as the new DR replica before swapping again.
+  </Step>
+</Steps>
+
+### Restore from snapshot
+
+If you have lost the primary data store entirely and need to restore from snapshot:
+
+<Steps>
+  <Step title="Stop ingestion">
+    Scale `langsmith-queue` and `langsmith-ingest-queue` to zero so no new traces are written while you restore.
+  </Step>
+  <Step title="Restore Postgres">
+    Restore the Postgres backup to a new instance or perform PITR to the latest pre-incident timestamp. Update the LangSmith Helm `postgres.external` connection details to point to the restored instance.
+  </Step>
+  <Step title="Restore ClickHouse">
+    Restore the most recent ClickHouse backup that aligns in time with the Postgres restore point. Restore time scales with data size.
+  </Step>
+  <Step title="Restore blob storage">
+    If you lost blob data (rare), restore versioned objects from S3/GCS/Azure or copy from a replicated DR bucket.
+  </Step>
+  <Step title="Resume ingestion">
+    Scale `langsmith-queue` and `langsmith-ingest-queue` back to production replica counts. Submit a smoke-test trace and verify it lands.
+  </Step>
+</Steps>
+
+<Warning>
+Always restore Postgres, ClickHouse, and blob storage to the closest possible coordinated point in time. Restoring Postgres to a more recent point than ClickHouse can produce dangling project references and missing traces in the UI.
+</Warning>
+
+## Testing your DR plan
+
+A backup is only as good as the last successful restore. Schedule the following exercises:
+
+- **Quarterly:** Restore Postgres and ClickHouse snapshots into a non-production environment and run the [diagnostics tooling](/langsmith/diagnostics-self-hosted) and a smoke trace test. Measure actual restore time and confirm it is within RTO.
+- **Twice yearly:** Perform a full cross-region failover drill against a staging installation. Promote the replica, repoint blob storage, scale the DR cluster, run smoke tests, and roll back.
+- **On every chart upgrade:** Verify that the upgrade path does not invalidate your DR plan (for example, schema migrations applied only to the primary will need to replicate to the DR replica). See [Self-host upgrades](/langsmith/self-host-upgrades).
+
+## Related pages
+
+- [Scalability and resilience](/langsmith/scalability-and-resilience)
+- [Shared responsibility model](/langsmith/shared-responsibility-model)
+- [Connect external Postgres](/langsmith/self-host-external-postgres)
+- [Connect external ClickHouse](/langsmith/self-host-external-clickhouse)
+- [Connect external Redis](/langsmith/self-host-external-redis)
+- [Enable blob storage](/langsmith/self-host-blob-storage)
+- [Self-host upgrades](/langsmith/self-host-upgrades)
+- [Use an existing secret](/langsmith/self-host-using-an-existing-secret)
+- [Diagnostics for self-hosted](/langsmith/diagnostics-self-hosted)
+- [AWS self-hosted reference architecture](/langsmith/aws-self-hosted)
+- [GCP self-hosted reference architecture](/langsmith/gcp-self-hosted)
+- [Azure self-hosted reference architecture](/langsmith/azure-self-hosted)

--- a/src/langsmith/self-host-disaster-recovery.mdx
+++ b/src/langsmith/self-host-disaster-recovery.mdx
@@ -3,7 +3,7 @@ title: Disaster recovery for self-hosted LangSmith
 sidebarTitle: Disaster recovery
 ---
 
-This page describes how to plan, configure, and operate disaster recovery (DR) for a self-hosted LangSmith observability and evaluation deployment. It covers what data must be protected, where it lives, how to back it up, and how to recover the platform after a regional or zonal failure.
+This page describes how to plan, configure, and operate disaster recovery (DR) for self-hosted LangSmith Observability and Evaluation. It covers what data must be protected, where it lives, how to back it up, and how to recover the platform after a regional or zonal failure.
 
 <Note>
 **Shared responsibility.** For self-hosted deployments you are responsible for backups, replication, restore testing, and recovery procedures for every component, including LangSmith pods and all backing data stores. LangChain is responsible only for the LangSmith software itself. For the equivalent SaaS responsibilities, see the [Shared responsibility model](/langsmith/shared-responsibility-model).

--- a/src/langsmith/self-host-disaster-recovery.mdx
+++ b/src/langsmith/self-host-disaster-recovery.mdx
@@ -27,7 +27,7 @@ Self-hosted LangSmith is composed of stateless services backed by four state sto
 | Kubernetes objects | Helm values, `Secret`s, TLS material, IRSA / Workload Identity bindings | Configuration | Re-apply from source control or back up cluster state |
 
 <Warning>
-All four data stores must be protected. Restoring Postgres without ClickHouse and blob storage (or vice versa) produces an inconsistent installation. References from Postgres to runs in ClickHouse and to objects in blob storage break across the divergence point. Always take coordinated backups, or use point-in-time recovery (PITR) targets that are close together across stores.
+All durable data stores must be protected together. Postgres, ClickHouse, and blob storage are the three stores that hold durable data; Redis is ephemeral and does not need to be backed up. Restoring Postgres without ClickHouse and blob storage (or vice versa) produces an inconsistent installation. References from Postgres to runs in ClickHouse and to objects in blob storage break across the divergence point. Always take coordinated backups, or use point-in-time recovery (PITR) targets that are close together across stores.
 </Warning>
 
 ## Plan your RPO and RTO
@@ -43,7 +43,7 @@ The following deployment patterns assume one of three target profiles:
 |---------|-------------|-------------|----------|
 | Snapshot-only | 6 to 24 hours | Hours | Daily managed backups of each store. Lowest cost, longest restore. |
 | Multi-AZ HA | Seconds | Minutes (zone failure) | Synchronous standby in another AZ for Postgres and ClickHouse, Multi-AZ Redis, zone-redundant blob storage. Standard production posture. |
-| Cross-region DR | Minutes | Minutes to an hour | Asynchronous replication of Postgres, ClickHouse, and blob storage to a second region; standby Kubernetes cluster ready to scale up. Highest cost, fastest recovery from a regional outage. |
+| Cross-region DR | Minutes to hours | Hours | Backups of Postgres, ClickHouse, and blob storage copied to a second region, restored on demand. Optionally a Postgres cross-region replica for a tighter Postgres RPO. Highest cost, slower recovery than Multi-AZ, but protects against a regional outage. |
 
 ## Postgres
 
@@ -102,8 +102,8 @@ If you self-manage ClickHouse for compliance or air-gap reasons, use a replicate
 - Configure a multi-node ClickHouse cluster with replication via [Keeper or ZooKeeper](https://clickhouse.com/docs/architecture/replication).
 - Set the `cluster` value in the LangSmith chart so migrations create `Replicated` table engines from the start. **Clustered setups must be configured against a fresh schema**, you cannot convert a standalone instance to clustered later.
 - Spread replicas across availability zones.
-- Schedule [`BACKUP TABLE` or `BACKUP DATABASE`](https://clickhouse.com/docs/operations/backup) to object storage on a frequency matching your RPO.
-- For cross-region DR, replicate the backup bucket to a secondary region, or run a second ClickHouse cluster in the DR region and replicate via [`remote()` table functions](https://clickhouse.com/docs/sql-reference/table-functions/remote) or external pipelines.
+- Schedule [`BACKUP TABLE` or `BACKUP DATABASE`](https://clickhouse.com/docs/operations/backup) to object storage on a frequency matching your RPO. The community [`clickhouse-backup`](https://github.com/Altinity/clickhouse-backup) tool is also a popular option for scheduled, incremental backups with built-in S3, GCS, and Azure Blob support.
+- For cross-region DR, copy the backup bucket to a secondary region. Cross-region ClickHouse replication is not generally supported in self-managed deployments and is not offered by ClickHouse Cloud either, so plan for a backup/restore failover model rather than a hot replica.
 
 For an example replicated configuration, see the [replicated ClickHouse example](https://github.com/langchain-ai/helm/blob/main/charts/langsmith/examples/replicated-clickhouse/README.md) in the Helm repo.
 
@@ -182,7 +182,7 @@ This protects against a regional outage. It is significantly more expensive but 
 
 - A second Kubernetes cluster in the DR region with the LangSmith Helm chart installed but scaled to a low replica count (warm) or zero (cold).
 - Postgres cross-region replica (RDS or Aurora cross-region replica, Cloud SQL cross-region replica, Azure Flexible Server cross-region replica). Promote on failover.
-- ClickHouse Cloud or LangSmith Managed ClickHouse with a region failover plan, **or** a replicated self-managed ClickHouse cluster in the DR region with backups copied from the primary.
+- ClickHouse Cloud or LangSmith Managed ClickHouse with a region failover plan, **or** ClickHouse backups copied to the DR region and restored into a fresh self-managed cluster on failover. Cross-region ClickHouse replication is not generally supported (ClickHouse Cloud does not offer it either), so plan for backup/restore rather than a hot DR replica.
 - Blob storage replicated to a DR bucket with versioning and matching lifecycle rules.
 - Redis provisioned fresh in the DR region during failover.
 - DNS managed by [Route 53](https://aws.amazon.com/route53/), [Cloud DNS](https://cloud.google.com/dns), or [Azure DNS](https://azure.microsoft.com/en-us/products/dns/) with health checks and failover policies pointing at the LangSmith frontend ingress in each region.

--- a/src/langsmith/self-host-disaster-recovery.mdx
+++ b/src/langsmith/self-host-disaster-recovery.mdx
@@ -51,7 +51,7 @@ LangSmith uses PostgreSQL as the primary store for operational and transactional
 
 ### Use a managed service
 
-We strongly recommend running Postgres on a managed service in production. Managed services provide automated backups, PITR, and HA failover out of the box. See [Connect external Postgres](/langsmith/self-host-external-postgres) for setup.
+We strongly recommend running Postgres on a managed service in production. Managed services provide built-in automated backups, PITR, and HA failover. For setup, refer to [Connect external Postgres](/langsmith/self-host-external-postgres).
 
 <Tabs>
   <Tab title="AWS">

--- a/src/langsmith/self-host-disaster-recovery.mdx
+++ b/src/langsmith/self-host-disaster-recovery.mdx
@@ -10,7 +10,7 @@ This page describes how to plan, configure, and operate disaster recovery (DR) f
 </Note>
 
 <Tip>
-If you have not already, read [Scalability and resilience](/langsmith/scalability-and-resilience) for the architectural primitives (stateless services, queue heartbeats, exactly-once semantics) that this page assumes.
+For details on the architectural primitives (stateless services, queue heartbeats, exactly-once semantics) that this page assumes, refer to [Scalability and resilience](/langsmith/scalability-and-resilience).
 </Tip>
 
 ## What you are recovering

--- a/src/langsmith/self-host-disaster-recovery.mdx
+++ b/src/langsmith/self-host-disaster-recovery.mdx
@@ -15,7 +15,7 @@ For details on the architectural primitives (stateless services, queue heartbeat
 
 ## What you are recovering
 
-A self-hosted LangSmith deployment is composed of stateless services backed by four state stores. Recovery planning is almost entirely about the state stores. The stateless services can be recreated at any time by reapplying the Helm chart.
+Self-hosted LangSmith is composed of stateless services backed by four state stores. Recovery planning is almost entirely about the state stores. You can recreate the stateless services at any time by reapplying the Helm chart.
 
 | Layer | Components | State | Recovery action |
 |-------|------------|--------|-----------------|

--- a/src/langsmith/self-host-disaster-recovery.mdx
+++ b/src/langsmith/self-host-disaster-recovery.mdx
@@ -17,7 +17,7 @@ For details on the architectural primitives (stateless services, queue heartbeat
 
 A self-hosted LangSmith deployment is composed of stateless services backed by four state stores. Recovery planning is almost entirely about the state stores. The stateless services can be recreated at any time by reapplying the Helm chart.
 
-| Layer | Components | State? | Recovery action |
+| Layer | Components | State | Recovery action |
 |-------|------------|--------|-----------------|
 | LangSmith services | `langsmith-frontend`, `langsmith-backend`, `langsmith-platform-backend`, `langsmith-queue`, `langsmith-ingest-queue`, `langsmith-playground`, `langsmith-ace-backend` | Stateless | Reinstall the Helm chart |
 | PostgreSQL | Operational data: orgs, workspaces, users, API keys, datasets, prompts, projects, deployments metadata | **Durable** | Restore from backup or replica |

--- a/src/langsmith/self-host-disaster-recovery.mdx
+++ b/src/langsmith/self-host-disaster-recovery.mdx
@@ -37,7 +37,7 @@ Before designing your DR architecture, define two targets:
 - **Recovery Point Objective (RPO):** the maximum amount of data loss your organization can tolerate, measured in time. With managed Postgres PITR, RPO is typically less than 5 minutes. With nightly snapshots only, RPO can be up to 24 hours.
 - **Recovery Time Objective (RTO):** the maximum time you can take to restore service after a failure. A warm cross-region replica can deliver RTO in minutes; a cold restore from snapshot can take hours, especially for large ClickHouse datasets.
 
-The deployment patterns below assume one of three target profiles:
+The following deployment patterns assume one of three target profiles:
 
 | Profile | Typical RPO | Typical RTO | Approach |
 |---------|-------------|-------------|----------|


### PR DESCRIPTION

**Self-hosted LangSmith disaster recovery guide**

  ## Summary

  Adds a new page, `Disaster recovery`, under **Self-hosted → Manage an installation**, consolidating the DR guidance that today is scattered across `scalability-and-resilience.mdx`, the per-cloud architecture pages, and the external-service pages (Postgres, ClickHouse, Redis, blob storage).

  The page covers:

 State inventory: what is durable vs. ephemeral across LangSmith services, Postgres, ClickHouse, Redis, blob storage, and Kubernetes config
RPO and RTO planning, with three target profiles (snapshot-only, Multi-AZ HA, cross-region DR)
Backup, replication, and PITR guidance for each data store, with AWS / GCP / Azure tabs for managed-service options
Recommended deployment patterns (Multi-AZ baseline, cross-region active/passive)

  ## Why
Self-hosted customers currently piece together DR plans from several pages and the shared responsibility model. Enterprise prospects and existing self-hosted customers regularly ask support for a consolidated reference. This page is the answer.

  ## Scope
Covers the LangSmith observability and evaluation surface (frontend, backend, platform backend, queue, ingest queue, Playground, ACE + Postgres / ClickHouse / Redis / blob storage). LangSmith Deployment (control plane + data plane) and Standalone Agent Server can be added in follow-up pages once we have explicit guidance for the operator, listener, and Agent Server pods.

  ## Release Note
Adds a Disaster recovery guide for self-hosted LangSmith covering backup, replication, and recovery procedures across Postgres, ClickHouse, Redis, and blob storage.
