### PR TITLE
docs(langsmith): document sandbox auth proxy GitHub flow

### DIFF
--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Auth proxy
 description: Inject credentials into outbound API requests from sandboxes without hardcoding secrets.
 ---
 
-The auth proxy lets sandbox code call external APIs (OpenAI, Anthropic, GitHub, etc.) without hardcoding credentials. When configured on a sandbox, a proxy sidecar automatically injects authentication headers into matching outbound requests using your workspace secrets.
+The auth proxy lets sandbox code call external APIs (OpenAI, Anthropic, GitHub, etc.) without hardcoding credentials. When configured on a sandbox, a proxy sidecar automatically injects authentication headers into matching outbound requests using your workspace secrets or write-only credentials you provide in the proxy config.
 
 <Warning>
 You must configure your secrets (e.g., `OPENAI_API_KEY`) in your LangSmith [workspace](/langsmith/administration-overview#workspaces) settings before creating a sandbox that references them.
@@ -12,7 +12,7 @@ You must configure your secrets (e.g., `OPENAI_API_KEY`) in your LangSmith [work
 
 ## Configure auth proxy rules
 
-Add a `proxy_config` when creating a sandbox. Each rule specifies:
+Add a `proxy_config` when creating a sandbox, or update an existing sandbox by patching its `proxy_config`. Each rule specifies:
 
 | Field | Description |
 |-------|-------------|
@@ -27,7 +27,7 @@ Each header has a `type` that controls how its value is stored and displayed:
 
 | Type | Description |
 |------|-------------|
-| `workspace_secret` | References a workspace secret using `{KEY}` syntax. Resolved at push time. |
+| `workspace_secret` | References a workspace secret using `{KEY}` syntax. Resolved when the proxy configuration is applied. |
 | `plaintext` | Value is stored and returned as-is. Use for non-sensitive headers. |
 | `opaque` | Write-only. Value is encrypted at rest and never returned via the API. |
 
@@ -36,7 +36,7 @@ Each header has a `type` that controls how its value is stored and displayed:
 Create a sandbox that automatically injects an OpenAI API key into outbound requests:
 
 ```bash
-curl -X POST "$LANGSMITH_ENDPOINT/api/v2/sandboxes/boxes" \
+curl -X POST "$LANGSMITH_ENDPOINT/v2/sandboxes/boxes" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -67,7 +67,7 @@ The sandbox can now call OpenAI with no API key setup—the proxy injects it aut
 Add multiple rules to authenticate with several services at once:
 
 ```bash
-curl -X POST "$LANGSMITH_ENDPOINT/api/v2/sandboxes/boxes" \
+curl -X POST "$LANGSMITH_ENDPOINT/v2/sandboxes/boxes" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{
@@ -119,6 +119,81 @@ curl -X POST "$LANGSMITH_ENDPOINT/api/v2/sandboxes/boxes" \
     }
   }'
 ```
+
+## GitHub example
+
+[Open SWE](https://github.com/langchain-ai/open-swe/blob/main/agent/integrations/langsmith.py) authenticates GitHub access by minting a short-lived GitHub App installation token outside the sandbox, then patching the sandbox with write-only `opaque` proxy rules. This keeps the short-lived GitHub access token out of the sandbox filesystem and out of deployment environment variables.
+
+Configure two rules:
+
+| Host | Header |
+|------|--------|
+| `api.github.com` | `Authorization: Bearer <github-token>` for `gh` and REST API calls |
+| `github.com`, `*.github.com` | `Authorization: Basic <base64("x-access-token:<github-token>")>` for Git over HTTPS operations like clone, fetch, and push |
+
+```python Python
+import base64
+import os
+from typing import Any
+
+import httpx
+
+
+def github_proxy_rules(github_token: str) -> list[dict[str, Any]]:
+    basic_auth = base64.b64encode(
+        f"x-access-token:{github_token}".encode()
+    ).decode()
+
+    return [
+        {
+            "name": "github-api",
+            "match_hosts": ["api.github.com"],
+            "headers": [
+                {
+                    "name": "Authorization",
+                    "type": "opaque",
+                    "value": f"Bearer {github_token}",
+                }
+            ],
+        },
+        {
+            "name": "github",
+            "match_hosts": ["github.com", "*.github.com"],
+            "headers": [
+                {
+                    "name": "Authorization",
+                    "type": "opaque",
+                    "value": f"Basic {basic_auth}",
+                }
+            ],
+        },
+    ]
+
+
+def configure_github_proxy(sandbox_name: str, github_token: str) -> None:
+    endpoint = os.environ.get(
+        "LANGSMITH_ENDPOINT", "https://api.smith.langchain.com"
+    )
+    response = httpx.patch(
+        f"{endpoint}/v2/sandboxes/boxes/{sandbox_name}",
+        headers={"x-api-key": os.environ["LANGSMITH_API_KEY"]},
+        json={"proxy_config": {"rules": github_proxy_rules(github_token)}},
+        timeout=30.0,
+    )
+    response.raise_for_status()
+```
+
+Call `configure_github_proxy` after creating or reattaching to a sandbox. GitHub App installation tokens expire, so refresh the proxy config whenever you reuse a sandbox for a new run.
+
+Inside the sandbox, set a non-secret placeholder token when a CLI requires a local credential before it sends a request:
+
+```bash
+GH_TOKEN=dummy gh repo view langchain-ai/langchain
+GH_TOKEN=dummy gh pr list --repo langchain-ai/langchain
+GH_TOKEN=dummy gh repo clone langchain-ai/langchain
+```
+
+The placeholder only satisfies the `gh` CLI's local check. The proxy injects the real `Authorization` header into the outbound request.
 
 ## Configure via SDK
 
@@ -176,9 +251,9 @@ await client.createSandbox({
 
 </CodeGroup>
 
-## Dynamic credentials with callbacks
+## Callback credential example
 
-Static rules pull credentials from your workspace secrets at sandbox creation time. For credentials that need to be resolved per-request—short-lived OAuth tokens, per-user-scoped tokens, tokens minted by your own auth service—use a **callback** instead. The proxy POSTs to a URL you provide, your endpoint returns the headers to inject, and the proxy caches the result.
+Static `workspace_secret` rules pull credentials from your workspace when the proxy configuration is applied, and `opaque` rules let your application patch in short-lived credentials such as the GitHub token example above. For credentials that must be resolved by your own service at proxy time, use a **callback**. The proxy POSTs to a URL you provide, your endpoint returns the headers to inject, and the proxy caches the result.
 
 Callbacks are configured alongside rules under `proxy_config`:
 
@@ -221,7 +296,7 @@ The proxy injects every header in the response into the sandbox's outbound reque
 Use a callback when your OAuth tokens are minted on demand by your own service:
 
 ```bash
-curl -X POST "$LANGSMITH_ENDPOINT/api/v2/sandboxes/boxes" \
+curl -X POST "$LANGSMITH_ENDPOINT/v2/sandboxes/boxes" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d '{

--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -253,7 +253,7 @@ await client.createSandbox({
 
 ## Callback credential example
 
-Static `workspace_secret` rules pull credentials from your workspace when the proxy configuration is applied, and `opaque` rules let your application patch in short-lived credentials such as the GitHub token example above. For credentials that must be resolved by your own service at proxy time, use a **callback**. The proxy POSTs to a URL you provide, your endpoint returns the headers to inject, and the proxy caches the result.
+Static `workspace_secret` rules pull credentials from your workspace when the proxy configuration is applied, and `opaque` rules let your application patch in short-lived credentials such as the [GitHub token example](#github-example). For credentials that must be resolved by your own service at proxy time, use a **callback**. The proxy POSTs to a URL you provide, your endpoint returns the headers to inject, and the proxy caches the result.
 
 Callbacks are configured alongside rules under `proxy_config`:
 


### PR DESCRIPTION
Adds a GitHub auth proxy example based on Open SWE's runtime-token flow. The docs now show how to patch a sandbox with opaque proxy rules for api.github.com and github.com, explain placeholder GH_TOKEN usage, and keep callbacks as a separate generic option.

## Release Note
none

## Test Plan
- [x] make lint_prose FILES=src/langsmith/sandbox-auth-proxy.mdx
- [x] Parsed JSON payload examples and Python snippets
- [x] git diff --check origin/main...HEAD