### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.8.7

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -4526,7 +4526,7 @@
             "type": "string",
             "enum": ["sync", "async", "exit"],
             "title": "Durability",
-            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/persistence#durability-modes) for more details.",
+            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/durable-execution#durability-modes) for more details.",
             "default": "async"
           }
         },
@@ -4706,7 +4706,7 @@
             "type": "string",
             "enum": ["sync", "async", "exit"],
             "title": "Durability",
-            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/persistence#durability-modes) for more details.",
+            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/durable-execution#durability-modes) for more details.",
             "default": "async"
           }
         },
@@ -5263,7 +5263,7 @@
             "type": "string",
             "enum": ["sync", "async", "exit"],
             "title": "Durability",
-            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/persistence#durability-modes) for more details.",
+            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/durable-execution#durability-modes) for more details.",
             "default": "async"
           }
         },
@@ -5454,7 +5454,7 @@
             "type": "string",
             "enum": ["sync", "async", "exit"],
             "title": "Durability",
-            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/persistence#durability-modes) for more details.",
+            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/durable-execution#durability-modes) for more details.",
             "default": "async"
           }
         },
@@ -6593,7 +6593,7 @@
             "type": "string",
             "enum": ["sync", "async", "exit"],
             "title": "Durability",
-            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/persistence#durability-modes) for more details.",
+            "description": "Durability level for the run. Must be one of `sync`, `async`, or `exit`. See [durability modes](https://docs.langchain.com/oss/python/langgraph/durable-execution#durability-modes) for more details.",
             "default": "async"
           }
         },


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.8.7**

This update was automatically generated by the sync workflow in the langgraph-api repository.