### PR TITLE
add note about upgrading to 4.0.0

### DIFF
--- a/src/oss/python/integrations/callbacks/google_bigquery.mdx
+++ b/src/oss/python/integrations/callbacks/google_bigquery.mdx
@@ -160,7 +160,6 @@ def run_agent_example(project_id: str):
         # metadata['langgraph_node'] for per-sub-agent attribution.
     }
 
-    with handler.graph_context("travel_assistant", metadata=run_metadata):
         result = agent.invoke(
             {"messages": [HumanMessage(content=query)]},
             config={

--- a/src/oss/python/integrations/callbacks/google_bigquery.mdx
+++ b/src/oss/python/integrations/callbacks/google_bigquery.mdx
@@ -77,7 +77,6 @@ Pass `session_id`, `user_id`, and (optionally) `agent` via the `metadata` dictio
 <Note>
   LangGraph features such as `graph_name` and `graph_context()` require `langchain-google-community>=4.0.0`.
 </Note>
-
 import os
 from datetime import datetime
 

--- a/src/oss/python/integrations/callbacks/google_bigquery.mdx
+++ b/src/oss/python/integrations/callbacks/google_bigquery.mdx
@@ -41,7 +41,6 @@ The `BigQueryCallbackHandler` allows you to log events from LangChain and LangGr
   [BigQuery documentation](https://cloud.google.com/bigquery/pricing?e=48754805&hl=en#data-ingestion-pricing).
 </Warning>
 
-
 ## Installation
 
 You need to install `langchain-google-community` with `bigquery` extra dependencies. For this example, you will also need `langchain-google-genai` and `langgraph`.
@@ -67,7 +66,6 @@ For the callback handler to work properly, the principal (e.g., service account,
 - `roles/bigquery.dataEditor` at Table Level to write log/event data.
 - If using GCS offloading: `roles/storage.objectCreator` and `roles/storage.objectViewer` on the target bucket.
 
-
 ## Use with LangGraph agent
 
 To use the `BigQueryCallbackHandler` with a LangGraph agent, instantiate it with your Google Cloud project ID and dataset ID. The handler creates the events table (and per-event-type analytics views) on first run. Use the `graph_context()` method to track top-level invocation boundaries — it emits `INVOCATION_STARTING` on enter and `INVOCATION_COMPLETED` (or `INVOCATION_ERROR` on exception) with accurate latency.
@@ -77,6 +75,8 @@ Pass `session_id`, `user_id`, and (optionally) `agent` via the `metadata` dictio
 <Note>
   LangGraph features such as `graph_name` and `graph_context()` require `langchain-google-community>=4.0.0`.
 </Note>
+
+```python
 import os
 from datetime import datetime
 
@@ -417,7 +417,6 @@ sub-agent without any user changes.
 The `content` column contains a **JSON** object specific to the `event_type`.
 The `content_parts` column provides a structured view of the content, especially useful for images or offloaded data.
 
-
 <Note>
   **Content Truncation**
   - Variable content fields are truncated to `max_content_length` (configured in `BigQueryLoggerConfig`, default 500KB).
@@ -697,7 +696,6 @@ LIMIT 5;
   * "What are the most common tool calls?"
   * "Identify sessions with high token usage"
 </Note>
-
 
 ## Looker Studio Dashboard
 

--- a/src/oss/python/integrations/callbacks/google_bigquery.mdx
+++ b/src/oss/python/integrations/callbacks/google_bigquery.mdx
@@ -74,7 +74,10 @@ To use the `BigQueryCallbackHandler` with a LangGraph agent, instantiate it with
 
 Pass `session_id`, `user_id`, and (optionally) `agent` via the `metadata` dictionary in the `config` object when invoking the agent. If `agent` is not set, the handler auto-derives it from `metadata['langgraph_node']` so each sub-agent's events are correctly attributed.
 
-```python
+<Note>
+  LangGraph features such as `graph_name` and `graph_context()` require `langchain-google-community>=4.0.0`.
+</Note>
+
 import os
 from datetime import datetime
 
@@ -160,6 +163,7 @@ def run_agent_example(project_id: str):
         # metadata['langgraph_node'] for per-sub-agent attribution.
     }
 
+    with handler.graph_context("travel_assistant", metadata=run_metadata):
         result = agent.invoke(
             {"messages": [HumanMessage(content=query)]},
             config={


### PR DESCRIPTION
## Summary

Fixes broken code example in the BigQuery callback handler integration docs.

Closes #3509

## Problem

With `langchain-google-community==3.0.5`, the **Use with LangGraph Agent** 
section raises two errors:

**Error 1** — `graph_name` is not a valid constructor parameter:
TypeError: BigQueryCallbackHandler.__init__() got an unexpected keyword argument 'graph_name'

**Error 2** — `graph_context()` method does not exist:
AttributeError: 'BigQueryCallbackHandler' object has no attribute 'graph_context'

[screenshot attached below]

## Root Cause

The docs example references `graph_name` and `graph_context()` which were 
never part of the `BigQueryCallbackHandler` API in v3.0.5.

Actual constructor signature:
BigQueryCallbackHandler(project_id, dataset_id, table_id=None, config=None)

## Fix

- Removed non-existent `graph_name` argument from constructor
- Removed non-existent `graph_context()` context manager  
- Handler is passed directly via config={"callbacks": [handler]}

<img width="1468" height="606" alt="Screenshot 2026-05-21 095315" src="https://github.com/user-attachments/assets/adcfeff7-e156-4c7d-8436-adb9561cf53c" />
