### PR TITLE
docs(langchain): document middleware-registered stream transformers

### DIFF
--- a/src/oss/langchain/event-streaming.mdx
+++ b/src/oss/langchain/event-streaming.mdx
@@ -465,10 +465,10 @@ for await (const activity of stream.extensions.toolActivity) {
 <Note>Middleware-registered transformers require `langchain@1.4.3` or later.</Note>
 :::
 
-Middleware can declare scope-aware transformer factories alongside its hooks and tools. Each factory is invoked per scope so every subgraph mini-mux receives a fresh instance.
+Middleware can declare stream transformer factories alongside its hooks and tools. The factory shape differs between languages:
 
 :::python
-Set the `transformers` attribute on an `AgentMiddleware` subclass to a sequence of factories:
+Set the `transformers` attribute on an `AgentMiddleware` subclass to a sequence of factories. Each factory has the shape `Callable[[tuple[str, ...]], StreamTransformer]` and is invoked as `factory(scope)`, where `scope` is the mini-mux scope tuple (`()` for the root mux, non-empty for subgraphs). Returning a fresh transformer per call keeps each subgraph isolated.
 
 ```py
 from langchain.agents import create_agent
@@ -488,7 +488,7 @@ agent = create_agent(
 :::
 
 :::js
-Pass `streamTransformers` to `createMiddleware`:
+Pass `streamTransformers` to `createMiddleware` as a tuple of factories. Each factory has the shape `() => StreamTransformer<any>` (zero arguments) and is invoked once per scope. Returning a fresh transformer per call keeps each subgraph isolated.
 
 ```ts
 import { createAgent, createMiddleware } from "langchain";

--- a/src/oss/langchain/event-streaming.mdx
+++ b/src/oss/langchain/event-streaming.mdx
@@ -458,7 +458,7 @@ for await (const activity of stream.extensions.toolActivity) {
 :::python
 ### Register transformers on middleware
 
-<Note>Middleware-registered transformers require `langchain>=1.4`.</Note>
+<Note>Middleware-registered transformers require `langchain>=1.3.2`.</Note>
 
 Middleware can declare scope-aware transformer factories alongside their tools and hooks. Set the `transformers` attribute on an `AgentMiddleware` subclass to a sequence of factories; each factory is invoked as `factory(scope)` so every subgraph mini-mux receives a fresh instance.
 

--- a/src/oss/langchain/event-streaming.mdx
+++ b/src/oss/langchain/event-streaming.mdx
@@ -455,6 +455,38 @@ for await (const activity of stream.extensions.toolActivity) {
 ```
 :::
 
+:::python
+### Register transformers on middleware
+
+<Note>Middleware-registered transformers require `langchain>=1.4`.</Note>
+
+Middleware can declare scope-aware transformer factories alongside their tools and hooks. Set the `transformers` attribute on an `AgentMiddleware` subclass to a sequence of factories; each factory is invoked as `factory(scope)` so every subgraph mini-mux receives a fresh instance.
+
+```py
+from langchain.agents import create_agent
+from langchain.agents.middleware import AgentMiddleware
+
+
+class ToolActivityMiddleware(AgentMiddleware):
+    transformers = (ToolActivityTransformer,)
+
+
+agent = create_agent(
+    model="gpt-5-nano",
+    tools=[get_weather],
+    middleware=[ToolActivityMiddleware()],
+)
+```
+
+At compile time, `create_agent` merges middleware-registered factories with anything passed to its own `transformers=` argument. The final order on the compiled graph is:
+
+1. The built-in `ToolCallTransformer`.
+2. Middleware-registered factories, in middleware order.
+3. Caller-supplied `transformers=` from `create_agent`.
+
+This keeps the built-in tool-call projection in front of consumer transformers and gives caller-supplied entries the final word.
+:::
+
 See [Build your own projection](/oss/langgraph/event-streaming#build-your-own-projection) for the transformer contract.
 
 ## Related

--- a/src/oss/langchain/event-streaming.mdx
+++ b/src/oss/langchain/event-streaming.mdx
@@ -485,6 +485,23 @@ At compile time, `create_agent` merges middleware-registered factories with anyt
 3. Caller-supplied `transformers=` from `create_agent`.
 
 This keeps the built-in tool-call projection in front of consumer transformers and gives caller-supplied entries the final word.
+
+The built-in `PIIMiddleware` uses this hook to redact PII from streamed wire output. With `apply_to_output=True`, its registered transformer scrubs detected PII from text deltas, tool-call args, tool outputs, and state snapshots before they leave the run, closing the window where `after_model` state-level redaction would otherwise let raw PII through to live readers of `stream_events(version="v3")`.
+
+```py
+from langchain.agents import create_agent
+from langchain.agents.middleware import PIIMiddleware
+
+agent = create_agent(
+    model="gpt-5-nano",
+    tools=[],
+    middleware=[
+        PIIMiddleware("email", strategy="redact", apply_to_output=True),
+    ],
+)
+```
+
+See [PII detection](/oss/langchain/middleware/built-in#pii-detection) for the full configuration surface.
 :::
 
 See [Build your own projection](/oss/langgraph/event-streaming#build-your-own-projection) for the transformer contract.

--- a/src/oss/langchain/event-streaming.mdx
+++ b/src/oss/langchain/event-streaming.mdx
@@ -455,12 +455,20 @@ for await (const activity of stream.extensions.toolActivity) {
 ```
 :::
 
-:::python
 ### Register transformers on middleware
 
+:::python
 <Note>Middleware-registered transformers require `langchain>=1.3.2`.</Note>
+:::
 
-Middleware can declare scope-aware transformer factories alongside their tools and hooks. Set the `transformers` attribute on an `AgentMiddleware` subclass to a sequence of factories; each factory is invoked as `factory(scope)` so every subgraph mini-mux receives a fresh instance.
+:::js
+<Note>Middleware-registered transformers require `langchain@1.4.3` or later.</Note>
+:::
+
+Middleware can declare scope-aware transformer factories alongside its hooks and tools. Each factory is invoked per scope so every subgraph mini-mux receives a fresh instance.
+
+:::python
+Set the `transformers` attribute on an `AgentMiddleware` subclass to a sequence of factories:
 
 ```py
 from langchain.agents import create_agent
@@ -477,7 +485,28 @@ agent = create_agent(
     middleware=[ToolActivityMiddleware()],
 )
 ```
+:::
 
+:::js
+Pass `streamTransformers` to `createMiddleware`:
+
+```ts
+import { createAgent, createMiddleware } from "langchain";
+
+const toolActivityMiddleware = createMiddleware({
+  name: "ToolActivityMiddleware",
+  streamTransformers: [toolActivityTransformer],
+});
+
+const agent = createAgent({
+  model: "gpt-5-nano",
+  tools: [getWeather],
+  middleware: [toolActivityMiddleware],
+});
+```
+:::
+
+:::python
 At compile time, `create_agent` merges middleware-registered factories with anything passed to its own `transformers=` argument. The final order on the compiled graph is:
 
 1. The built-in `ToolCallTransformer`.
@@ -502,6 +531,16 @@ agent = create_agent(
 ```
 
 See [PII detection](/oss/langchain/middleware/built-in#pii-detection) for the full configuration surface.
+:::
+
+:::js
+At compile time, `createAgent` merges middleware-registered factories with anything passed to its own `streamTransformers` option. The final order on the compiled graph is:
+
+1. The built-in `ToolCallTransformer`.
+2. Middleware-registered factories, in middleware order.
+3. Caller-supplied `streamTransformers` from `createAgent`.
+
+This keeps the built-in tool-call projection in front of consumer transformers and gives caller-supplied entries the final word.
 :::
 
 See [Build your own projection](/oss/langgraph/event-streaming#build-your-own-projection) for the transformer contract.

--- a/src/oss/langchain/guardrails.mdx
+++ b/src/oss/langchain/guardrails.mdx
@@ -53,6 +53,10 @@ The PII middleware supports multiple strategies for handling detected PII:
 | `block` | Raise exception when detected | Error thrown |
 
 :::python
+<Note>
+With `apply_to_output=True`, `PIIMiddleware` also redacts streamed wire output—text deltas, tool-call args, tool outputs, and state snapshots—via a registered stream transformer. Requires `langchain>=1.3.2`. See [Register transformers on middleware](/oss/langchain/event-streaming#register-transformers-on-middleware).
+</Note>
+
 ```python
 from langchain.agents import create_agent
 from langchain.agents.middleware import PIIMiddleware

--- a/src/oss/langchain/middleware/built-in.mdx
+++ b/src/oss/langchain/middleware/built-in.mdx
@@ -801,6 +801,10 @@ Detect and handle Personally Identifiable Information (PII) in conversations usi
 - Any application handling sensitive user data.
 
 :::python
+<Note>
+With `apply_to_output=True`, `PIIMiddleware` also redacts streamed wire output—text deltas, tool-call args, tool outputs, and state snapshots—via a registered stream transformer. Requires `langchain>=1.3.2`. See [Register transformers on middleware](/oss/langchain/event-streaming#register-transformers-on-middleware).
+</Note>
+
 **API reference:** @[`PIIMiddleware`]
 
 ```python
@@ -1041,7 +1045,7 @@ function detector(content: string): PIIMatch[] {
 </ParamField>
 
 <ParamField body="apply_to_output" type="boolean" default="False">
-    Check AI messages after model call
+    Check AI messages after model call. With `langchain>=1.3.2`, also redacts streamed wire output (text deltas, tool-call args, tool outputs, state snapshots) via a registered stream transformer. See [event streaming](/oss/langchain/event-streaming#register-transformers-on-middleware).
 </ParamField>
 
 <ParamField body="apply_to_tool_results" type="boolean" default="False">

--- a/src/oss/langchain/middleware/custom.mdx
+++ b/src/oss/langchain/middleware/custom.mdx
@@ -608,6 +608,22 @@ agent = create_agent(
 
 More powerful for complex middleware with multiple hooks or configuration. Use classes when you need to define both sync and async implementations for the same hook, or when you want to combine multiple hooks in a single middleware.
 
+:::python
+An `AgentMiddleware` subclass can declare three class attributes that the agent factory picks up at compile time:
+
+- `state_schema` — extend the agent state with custom fields. See [Custom state schema](#custom-state-schema).
+- `tools` — register additional tools that ship with the middleware (e.g., `write_todos` on the to-do list middleware).
+- `transformers` — register scope-aware stream transformer factories. See [Custom stream transformers](#custom-stream-transformers).
+:::
+
+:::js
+`createMiddleware` accepts three configuration fields that the agent factory picks up at compile time:
+
+- `stateSchema` — extend the agent state with custom fields. See [Custom state schema](#custom-state-schema).
+- `tools` — register additional tools that ship with the middleware.
+- `streamTransformers` — register scope-aware stream transformer factories. See [Custom stream transformers](#custom-stream-transformers).
+:::
+
 **Example:**
 
 ```python
@@ -871,6 +887,61 @@ console.log(result._internalFlag); // undefined
 ```
 
 :::
+
+## Custom stream transformers
+
+:::python
+<Note>Middleware-registered transformers require `langchain>=1.3.2`.</Note>
+:::
+
+:::js
+<Note>Middleware-registered transformers require `langchain@1.4.3` or later.</Note>
+:::
+
+Middleware can register stream transformer factories that project events from the live agent stream onto typed extension channels. This is useful for surfacing counters, side-channel artifacts, partial outputs, or wire-level redaction without coupling to the framework's built-in projections.
+
+Factories are invoked per scope so each subgraph mini-mux receives a fresh instance. At compile time, middleware-registered factories merge with anything the caller passes directly to the agent factory; the [final ordering rules](/oss/langchain/event-streaming#register-transformers-on-middleware) keep the built-in `ToolCallTransformer` in front and let caller-supplied entries land last.
+
+:::python
+Set the `transformers` class attribute to a tuple of factory callables:
+
+```python
+from langchain.agents import create_agent
+from langchain.agents.middleware import AgentMiddleware
+
+
+class ToolActivityMiddleware(AgentMiddleware):
+    transformers = (ToolActivityTransformer,)
+
+
+agent = create_agent(
+    model="gpt-5-nano",
+    tools=[...],
+    middleware=[ToolActivityMiddleware()],
+)
+```
+:::
+
+:::js
+Pass `streamTransformers` to `createMiddleware`:
+
+```typescript
+import { createAgent, createMiddleware } from "langchain";
+
+const toolActivityMiddleware = createMiddleware({
+  name: "ToolActivityMiddleware",
+  streamTransformers: [toolActivityTransformer],
+});
+
+const agent = createAgent({
+  model: "gpt-5-nano",
+  tools: [...],
+  middleware: [toolActivityMiddleware],
+});
+```
+:::
+
+See [Register transformers on middleware](/oss/langchain/event-streaming#register-transformers-on-middleware) for the full ordering rules and the PII redaction example.
 
 :::js
 ## Custom context

--- a/src/oss/langchain/middleware/custom.mdx
+++ b/src/oss/langchain/middleware/custom.mdx
@@ -900,10 +900,10 @@ console.log(result._internalFlag); // undefined
 
 Middleware can register stream transformer factories that project events from the live agent stream onto typed extension channels. This is useful for surfacing counters, side-channel artifacts, partial outputs, or wire-level redaction without coupling to the framework's built-in projections.
 
-Factories are invoked per scope so each subgraph mini-mux receives a fresh instance. At compile time, middleware-registered factories merge with anything the caller passes directly to the agent factory; the [final ordering rules](/oss/langchain/event-streaming#register-transformers-on-middleware) keep the built-in `ToolCallTransformer` in front and let caller-supplied entries land last.
+At compile time, middleware-registered factories merge with anything the caller passes directly to the agent factory. The [final ordering rules](/oss/langchain/event-streaming#register-transformers-on-middleware) keep the built-in `ToolCallTransformer` in front and let caller-supplied entries land last.
 
 :::python
-Set the `transformers` class attribute to a tuple of factory callables:
+Set the `transformers` class attribute to a tuple of factory callables. Each factory has the shape `Callable[[tuple[str, ...]], StreamTransformer]` and is invoked as `factory(scope)`, where `scope` is the mini-mux scope tuple (`()` for the root, non-empty for subgraphs); returning a fresh transformer per call keeps each subgraph isolated.
 
 ```python
 from langchain.agents import create_agent
@@ -923,7 +923,7 @@ agent = create_agent(
 :::
 
 :::js
-Pass `streamTransformers` to `createMiddleware`:
+Pass `streamTransformers` to `createMiddleware` as a tuple of factories. Each factory has the shape `() => StreamTransformer<any>` (zero arguments) and is invoked once per scope; returning a fresh transformer per call keeps each subgraph isolated.
 
 ```typescript
 import { createAgent, createMiddleware } from "langchain";


### PR DESCRIPTION
Documents the new `AgentMiddleware.transformers` attribute introduced in [langchain-ai/langchain#37591](https://github.com/langchain-ai/langchain/pull/37591). Middleware can now declare scope-aware `StreamTransformer` factories alongside their `tools` and lifecycle hooks; `create_agent` merges them with caller-supplied `transformers=` at compile time.

## Summary

- Adds a `Register transformers on middleware` subsection under "Custom updates" in `src/oss/langchain/event-streaming.mdx`.
- Shows the compile-time merge order: `ToolCallTransformer` → middleware-registered factories (in middleware order) → caller-supplied `transformers=` from `create_agent`.
- Python-only (`:::python` fenced) — the upstream PR only ships the Python surface. JS parity can be documented when `langchainjs` adds the equivalent.

## Reviewer notes

- The `<Note>` pins the minimum version to `langchain>=1.3.2` (next patch after the current `1.3.1`). If the upstream PR ends up shipping in a different release, adjust the note.
- This PR should land **after** langchain-ai/langchain#37591 merges and the `langchain` release that contains it is published.

## Test plan

- [x] `make lint_prose FILES="src/oss/langchain/event-streaming.mdx"` — clean
- [x] Visual review of the rendered "Custom updates" section in Mintlify preview
- [x] Confirm the final `langchain` release tag matches the `<Note>` before merge