### PR TITLE
Backfill release-image markers into the self-hosted changelog

### DIFF
--- a/src/langsmith/self-hosted-changelog.mdx
+++ b/src/langsmith/self-hosted-changelog.mdx
@@ -15,7 +15,7 @@ rss: true
 <Update label="2026-05-20" tags={["self-hosted"]} rss={{ title: "2026-05-20 - self-hosted" }}>
 ## langsmith-0.8.31
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.8.30. Refer to the [langsmith-0.8.30](#langsmith-0830) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.8.31.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.8.31/langsmith-0.8.31.tgz)
 </Update>
@@ -45,20 +45,7 @@ rss: true
 <Update label="2026-05-14" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.13
 
-- Improved the UI by widening the 'Enabled' column in automations table to prevent header truncation.
-- Added a scrollable filter dropdown in MCP server, enhancing user experience with dropdowns.
-- Updated the evaluator template packs and added analytics tracking for templates/cards selection in the frontend.
-- Introduced async agents and added agent cost breakdown table, improving agent management.
-- Fixed various UI bugs including polly button icon interaction, trace layout on full-page view, and evaluator column dropdown.
-- Enhanced evaluator capabilities by adding options for sorting, searching, and filtering in the evaluators table.
-- Added user-friendly features: back button on full page trace view, feedback banner for evaluator reuse, and clone button visibility based on permissions.
-- Improved the performance of session stats queries by removing dead joins.
-- Introduced several security-related features, such as URL allowlist enforcement for JWT injection and handling non-SSO logins for users with multiple SSO provider records.
-- Enhanced authentication functionality by adding additional SSO groups columns and provisioning methods to identities.
-- Provided new integrations and model support, including Salesforce tool support and Google Calendar tool enhancements in the agent builder.
-- Enhanced tracking and analysis with features like token usage insights and new logging for environment configurations.
-- Improved self-hosted support with enhancements in audit logging, database migrations, and infrastructure setups.
-- Introduced new API endpoints for various frontend and backend functionalities, including a new endpoint for online self-hosted licenses.
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.12. Refer to the [langsmith-0.15.0-rc.12](#langsmith-0150-rc12) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.13.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.13/langsmith-0.15.0-rc.13.tgz)
 </Update>
@@ -97,42 +84,42 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2026-05-11" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.10
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.10.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.10/langsmith-0.15.0-rc.10.tgz)
 </Update>
 <Update label="2026-05-09" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.9
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.9.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.9/langsmith-0.15.0-rc.9.tgz)
 </Update>
 <Update label="2026-05-08" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.8
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.8.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.8/langsmith-0.15.0-rc.8.tgz)
 </Update>
 <Update label="2026-05-08" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.7
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.7.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.7/langsmith-0.15.0-rc.7.tgz)
 </Update>
 <Update label="2026-05-06" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.6
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.6.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.6/langsmith-0.15.0-rc.6.tgz)
 </Update>
 <Update label="2026-05-05" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.5
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.5.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.5/langsmith-0.15.0-rc.5.tgz)
 </Update>
@@ -156,70 +143,140 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2026-05-01" tags={["self-hosted"]}>
 ## langsmith-0.14.5
 
-- Internal improvements and maintenance updates
+- Fixed the agent-builder failure to start on v14 self-hosted 0.14.6 due to the `langgraph-api 0.8.3` base image bundling `LangSmith 0.7.37`, which removed `SandboxTemplate`, by pinning `LangSmith<0.7.34` to downgrade to a compatible version.
 
 **Download the Helm chart:** [`langsmith-0.14.5.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.5/langsmith-0.14.5.tgz)
 </Update>
 <Update label="2026-04-30" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.3
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.1. Refer to the [langsmith-0.15.0-rc.1](#langsmith-0150-rc1) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.3.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.3/langsmith-0.15.0-rc.3.tgz)
 </Update>
 <Update label="2026-04-29" tags={["self-hosted"]}>
 ## langsmith-0.14.3
 
-- Internal improvements and maintenance updates
+- Fixed silent corruption of `traceId`, `spanId`, and `parentSpanId` for OTLP/JSON (`Content-Type: application/json`) trace ingestion.
+- Reduced Microsoft Graph permission requirements for Microsoft 365 docs and Teams private-message tools.
 
 **Download the Helm chart:** [`langsmith-0.14.3.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.3/langsmith-0.14.3.tgz)
 </Update>
 <Update label="2026-04-24" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.2
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.1. Refer to the [langsmith-0.15.0-rc.1](#langsmith-0150-rc1) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.2.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.2/langsmith-0.15.0-rc.2.tgz)
 </Update>
 <Update label="2026-04-24" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.1
 
-- Internal improvements and maintenance updates
+- Fixed truncation issue by widening the 'Enabled' column in the automations table for better header visibility.
+- Updated details view header for improved user experience.
+- Improved performance by removing dead run_stats_facets join from session stats queries.
+- Fixed MCP server filter dropdown to make it scrollable.
+- Added 'user cost' table and toggle for agent/user view in the fleet.
+- Enhanced security by adding URL allowlist enforcement for JWT injection.
+- Added ability to sort evaluators by creation and update time in the backend.
+- Added 'Feedback Key' filtering in the evaluators table for more precise searches.
+- Showed back button on the full-page trace view to enhance navigation.
+- Fixed audit-logs and various performance improvements for lower latency.
+- Enhanced UI by showing 'Feedback Key' in evaluator column dropdown.
+- Added session insights, views, metadata, and dashboard endpoints to improve data accessibility.
+- Fixed file creation issues to prevent active interrupt state clearance.
+- Provided async support for agents in the fleet to improve reliability.
+- Fixed issues with agent cloning that previously caused flow issues.
+- Added spend limit enforcement and the ability to track usage, enhancing cost management features.
+- Made more efficient use of resources with new skill memory-store mirror updates in fleets.
+- Improved evaluator reuse UX for users with better management of evaluator actions on issue generation.
+- Enhanced security features by preventing sub-agents from triggering unauthorized actions.
+- Optimized memory and resource management in the agent builder chat.
+- Improved evaluator trace detail navigation by preserving search model in URLs.
+- Upgraded per-environment favicon colors for clarity in staging and dev environments.
+- Performance improvements in session sync reducing resource usage.
+- Added default agent name support in usage dashboard for clarity in report generation.
+- Made UI improvements to evaluator details for a smoother experience.
+- Enabled auto-wake and auto-stop for Sandbox environments to save resources.
+- Integrated tracing tool functionality in issue creation for better context and reliability.
+- Added "create agent manually" button to navigation for easier agent management.
+- Enhanced memory management tools UI for better approval process visualization.
+- Fixed tool usage table and improved its performance for a better UX.
+- Enabled auditing for sensitive data access endpoints for enhanced security compliance.
+- Improved tracing project name display in usage dashboard for better project clarity.
+- Introduced keyboard shortcuts in the editor page for rapid interaction.
+- Set default MSP cron schedule as standard to reduce manual setup effort.
+- Added integration user flow with prompt messages for smooth operation and understanding.
+- Fixed default tracing project selection to Fleet to prevent inconsistencies.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.1.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.1/langsmith-0.15.0-rc.1.tgz)
 </Update>
 <Update label="2026-04-20" tags={["self-hosted"]}>
 ## langsmith-0.14.2
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.14.0. Refer to the [langsmith-0.14.0](#langsmith-0140) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.14.2.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.2/langsmith-0.14.2.tgz)
 </Update>
 <Update label="2026-04-20" tags={["self-hosted"]}>
 ## langsmith-0.14.1
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.14.0. Refer to the [langsmith-0.14.0](#langsmith-0140) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.14.1.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.1/langsmith-0.14.1.tgz)
 </Update>
 <Update label="2026-04-20" tags={["self-hosted"]}>
 ## langsmith-0.14.0
 
-- Internal improvements and maintenance updates
+LangSmith Self-Hosted v0.14 brings **Polly** (our AI assistant for traces and runs) to self-hosted, takes **ABAC and audit logs** GA (on by default), and enables the **LLM Auth Proxy** by default with URL allowlisting and richer JWT claims. Admins get **unified model configurations** shared across Agent Builder, Polly, Insights, Playground, and Evaluators, and fine-grained **Prompt Owners** for locking down who can promote or delete individual prompts. Evaluators gain **multi-modal support** and workspaces can now set **cost alerts** on tracing projects. Playground model support expands (Anthropic via Vertex AI, custom Azure models, Bedrock inference profiles, Gemini 3.1 Pro, GPT-5.3 / 5.4, Baseten + GLM-5), and new agent tools and triggers land for Google Sheets & Docs, Outlook, Teams, and Salesforce SOQL. On the infrastructure side, v0.14 adds **GCS Workload Identity** support for blob storage, **Valkey** as a drop-in Redis replacement, and a pre-upgrade migration hook for safer rollouts.
+
+Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access to everything. To book time with LangChain support for your upgrade, contact `support@langchain.dev`.
+
+### Breaking changes
+
+- Fixed an issue where `host-backend` wasn't picking up `commonEnv`. This may result in duplicate environment variables that need to be removed.
+
+### Infrastructure changes
+
+- Migrations now run as a `Pre-upgrade` hook prior to image versions rolling out. This will prevent issues when migrations fail.
+- **GCS Workload Identity support** — authenticate to GCS blob storage using cloud-native workload identity instead of long-lived credentials.
+- **Valkey support** — Valkey can now be used as a drop-in replacement for Redis.
+
+### New features
+
+- **Polly on self-hosted** — our AI assistant for understanding traces, runs, and evaluator feedback is now available in self-hosted.
+- **ABAC and audit logs GA** — Attribute-Based Access Control and audit logs are enabled by default for self-hosted deployments.
+- **LLM Auth Proxy on by default** — URL allowlist prevents credential forwarding to unintended hosts, and JWTs now carry `organization_name` and `workspace_name` claims.
+- **Unified model configurations** — Agent Builder, Polly, Insights, Playground, and Evaluators now share a single set of model configs, with workspace-admin controls over model access across all AI features.
+- **Prompt Owners** — designate a specific group of users with fine-grained permission to promote or delete individual prompts, without granting broader org access.
+- **Multi-modal evaluators** — pass attachments and base64 content (images, audio, PDFs) directly into evaluators.
+- **Cost alerts on tracing projects** — set alerts on tracing project-level costs alongside existing LangSmith alerts.
+- **Expanded playground model support** — Anthropic via Vertex AI, custom Azure models, Bedrock inference profiles and configurable base URLs, Gemini 3.1 Pro, GPT-5.3 / 5.4 (now default), and Baseten + GLM-5.
+- **New agent tools and triggers** — Google Sheets and Docs, Outlook mail and calendar, Microsoft Teams, Salesforce SOQL, Gmail OAuth v2 with refresh tokens, and an Outlook Trigger.
+- **Insights enhancements** — scheduled Insights reports, categories trending over time, full feedback comments in analysis, and a lower minimum job interval (6h → 1h).
+- **Annotation and review upgrades** — required reviewers per queue, pairwise queues that honor `reviewer_access_mode`, an "Assigned to me" filter, per-annotator CSV export, and bulk table actions.
+- **Prompt Hub and tool registry** — commit tag search, model select in template creation, a workspace-scoped tool registry API, and a private registry UI.
+- **Evaluator workflow improvements** — prebuilt LLM evaluators use strict structured outputs by default, evaluators support tagging and reuse, retries no longer lose scores, and a new API runs playground experiments programmatically.
+- **Custom iframe output renderer** — drag-to-resize HTML chart outputs in experiments and trace views.
+- **Thread and inbox UX** — auto-generated thread titles, redesigned run details in threads, session-level feedback stats, keyboard shortcuts, and filtering out internal helper threads.
+
+### Admin changes
+
+- **Granular usage reporting** — granular billable usage APIs that allow you to retrieve detailed trace usage data broken down by workspace, project, user, or API key.
 
 **Download the Helm chart:** [`langsmith-0.14.0.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.0/langsmith-0.14.0.tgz)
 </Update>
 <Update label="2026-04-17" tags={["self-hosted"]}>
 ## langsmith-0.13.43
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.42. Refer to the [langsmith-0.13.42](#langsmith-01342) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.43.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.43/langsmith-0.13.43.tgz)
 </Update>
 <Update label="2026-04-14" tags={["self-hosted"]}>
 ## langsmith-0.13.42
 
-- Internal improvements and maintenance updates
+- Fixed issue in metadata filtering to recognize json.Number as a primitive type, improving data ingestion accuracy.
 
 **Download the Helm chart:** [`langsmith-0.13.42.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.42/langsmith-0.13.42.tgz)
 </Update>
@@ -233,350 +290,792 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2026-04-09" tags={["self-hosted"]}>
 ## langsmith-0.13.40
 
-- Internal improvements and maintenance updates
+- Added support for mTLS configuration to enhance self-hosted security.
+- Improved the loading speed of the Fleet interface.
+- Fixed a bug in the tracing UI that caused intermittent display issues.
+- Added support for Redis Cluster, improving scalability for self-hosted deployments.
+- Improved PostgreSQL IAM integration for better database management in self-hosted instances.
 
 **Download the Helm chart:** [`langsmith-0.13.40.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.40/langsmith-0.13.40.tgz)
 </Update>
 <Update label="2026-04-07" tags={["self-hosted"]}>
 ## langsmith-0.13.39
 
-- Internal improvements and maintenance updates
+- Users can now run experiments without `projects:create`, decoupling experiment execution from project governance controls.
+- Added skeleton loading state when switching between agent chat threads instead of a blank chat input.
+- Improved the Fleet Arcade integrations page to display correct actions and clearer backend states.
+- Arcade gateway installs now automatically sanitize invalid MCP server names before adding them to a workspace.
+- Users can now see assigned reviewers as name chips in the annotation queue list and filter to queues they are assigned to via an "Assigned to me" button.
+- Improved run details hover on the trace tree for less flicker when clicking or moving quickly between rows.
+- Fixed a timeout when generating Insights reports with feedback enabled on high-volume workspaces.
+- Arcade integrations now show a permission error instead of a generic upstream failure when a connected user lacks access to the configured Arcade project.
+- Added a clickable ID badge to the experiment detail page header for easy copying of the experiment ID.
+- LLM auth proxy JWTs now include `organization_name` and `workspace_name` claims.
+- Added dataset split selection to the evaluator playground, allowing users to run evaluator experiments on specific dataset splits.
+- Fixed experiment comparison view showing contradictory improvement arrows and regression cell colors for composite scores.
+- Fixed a bug where deleting traces from pre-compression multipart blob storage objects could corrupt byte ranges for other traces in the same object, causing 416 errors when reading their payloads.
+- Fixed crash when viewing a tool run in an in-progress trace.
+- Lowered Insights job schedule minimum interval from 6 hours to 1 hour, configurable via `CLIO_SCHEDULE_MIN_INTERVAL_SECONDS` environment variable.
+- LLM auth proxy now supports Insights (CLIO) service identity for JWT-based LLM authentication.
+- Fixed subagent files not being deleted from hub repo memory when subagents are removed in the agent editor.
+- Simplified Arcade workspace connection status to show "Workspace configured" instead of the confusing "Connected account" label with a redundant badge.
+- Fixed a bug where expanding a tool call in the run detail view and scrolling away caused it to collapse back when scrolled into view again.
+- Agent file reads (clone, inspect, startup) now correctly use the hub as the source of truth when hub memory is enabled.
+- Fixed custom output rendering (HTML charts via iframe) not working in the redesigned experiment detail panes.
+- Allowed usage of LLM Auth Proxy in self-hosted by default.
+- Sessions facets raw path now returns input/output KV facets when `RUNS_LITE_STATS_TENANTS` is enabled, matching the Python backend behavior.
+- Click-to-copy tooltips (e.g. project ID) now respond to clicks on the tooltip content itself, not just the trigger badge.
+- Improved MCP server authorization enforcement in the platform backend.
+- Added Baseten as a model provider with GLM-5 support.
+- Improved LLM inference efficiency by reducing date precision in system prompts from minute-level to date-only.
+- Fixed Polly losing trace context when a trace page is expanded to full page view.
+- Added a unified files sidebar to Fleet chat, accessible via a "Files" button in the header, to browse, search, create, rename, move, and preview all agent-generated files in one panel.
+- Added `SSRF_ALLOW_PRIVATE_IPS_WEBHOOKS`, `SSRF_ALLOW_PRIVATE_IPS_MCP_SERVERS`, and `SSRF_ALLOW_PRIVATE_IPS_TOOLS` environment variables to allow self-hosted deployments to connect to services on private IP ranges.
+- Added `get_current_time` tool to Polly so relative time expressions in filter queries resolve correctly.
+- Reference outputs are now always visible in the experiment trace detail view, fixing an issue where they were hidden for some organizations.
+- Fixed agent OAuth connections failing with "Unknown provider" errors for non-personal agents.
+- Added Base URL configuration support for Bedrock models in the playground and model configurations, enabling custom endpoint URLs for proxy or gateway deployments.
+- Added sign out button back to the settings page sidebar.
+- The run rules list endpoint now returns `backfill_id` when backfill progress is requested.
+- SSO users can no longer see or accept pending invites to organizations other than their own SSO organization.
+- Fleet webhook execution now uses a dedicated endpoint instead of the MCP proxy.
+- Added session-level feedback stats to the sessions API for parity with the Python backend.
+- Improved MCP proxy authorization and URL safety checks for agent runtime requests.
 
 **Download the Helm chart:** [`langsmith-0.13.39.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.39/langsmith-0.13.39.tgz)
 </Update>
 <Update label="2026-04-03" tags={["self-hosted"]}>
 ## langsmith-0.13.38
 
-- Internal improvements and maintenance updates
+- Fixed MCP OAuth tools (e.g., Hex, Notion) failing on self-hosted deployments when `HOST_BACKEND_ENDPOINT_PUBLIC` lacked an `https://` scheme.
+- Insights agent now includes full feedback comments when analyzing traces.
+- Removed the legacy Feed page in Fleet; Inbox is now the default thread view for all tenants.
+- Fixed a permission error that blocked users from creating evaluators when using the evaluator reuse feature.
+- Org admins can now grant Model Configuration management to workspace editors and custom roles via Settings > Roles.
+- Pairwise annotation queues now respect `reviewer_access_mode`: completion/archive logic gates on assigned reviewers only, and GET responses include `assigned_reviewers`.
+- Agent chat messages are no longer grouped into a collapsible "Completed N steps" container. A single copy dropdown on the last AI message of each turn lets you copy just the response or all steps including tool outputs.
+- Fixed pagination in the waterfall view for thread traces, where threads with more than 20 turns now load additional traces when scrolling.
+- Fixed "Empty Message" text appearing in the agent editor chat when AI invokes tools without accompanying text.
+- Added Salesforce SOQL query tool to Fleet, enabling agents to query Salesforce data via OAuth.
+- Annotation queue run list items now show reviewer names and avatars when hovering over the review stats badge.
+- Go session stats now return `feedback_key`, `feedback_key_score`, `feedback_value`, and `feedback_source` facets in `run_facets`, matching the Python backend.
+- Fixed `/info` endpoint returning 401 when `infoEndpointAuthRequired` is enabled with SSO authentication.
+- Added a documentation link button to the "Trigger Webhook" section in the Save prompt dialog for easier access to webhook docs.
+- Fixed layout shift in agent chat caused by the copy button unmounting during streaming.
 
 **Download the Helm chart:** [`langsmith-0.13.38.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.38/langsmith-0.13.38.tgz)
 </Update>
 <Update label="2026-04-01" tags={["self-hosted"]}>
 ## langsmith-0.13.37
 
-- Internal improvements and maintenance updates
+- Added URL allowlist for the LLM Auth Proxy to prevent credential forwarding to unintended hosts.
+- Enabled audit logs by default for self-hosted deployments.
+- MCP servers now respect granular RBAC permissions in the UI; users only see actions their role allows.
+- Enabled ABAC by default for self-hosted deployments.
+- Fixed low-frequency SmithDB ingestion errors ("incomplete chunked payload") during multipart uploads when the HTTP body is truncated.
+- Fixed a bug with OpenAI tools rendering.
 
 **Download the Helm chart:** [`langsmith-0.13.37.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.37/langsmith-0.13.37.tgz)
 </Update>
 <Update label="2026-03-30" tags={["self-hosted"]}>
 ## langsmith-0.13.36
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-01332) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.36.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.36/langsmith-0.13.36.tgz)
 </Update>
 <Update label="2026-03-27" tags={["self-hosted"]}>
 ## langsmith-0.13.35
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-01332) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.35.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.35/langsmith-0.13.35.tgz)
 </Update>
 <Update label="2026-03-27" tags={["self-hosted"]}>
 ## langsmith-0.13.34
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-01332) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.34.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.34/langsmith-0.13.34.tgz)
 </Update>
 <Update label="2026-03-27" tags={["self-hosted"]}>
 ## langsmith-0.13.33
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-01332) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.33.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.33/langsmith-0.13.33.tgz)
 </Update>
 <Update label="2026-03-27" tags={["self-hosted"]}>
 ## langsmith-0.13.32
 
-- Internal improvements and maintenance updates
+- Added ability for users to find account labels for first-class providers.
+- Fixed issue where switching alerts did not switch charts accordingly.
+- Fixed key error for experiments with attachments.
+- Added dismiss button functionality to the agentify banner.
+- Improved responsiveness in run details header and compare traces.
+- Added truncate property to feedback chips list to respond to container width.
+- Fixed subpixel bleed on body rows in the repetition summary table.
+- Fixed race condition in AQ run archive check.
+- Patched 9 medium security alerts and 4 high security alerts.
+- Renamed Metadata to Attributes in the comparison detail pane.
+- Enabled toggle panel size button in RepetitionDetailPane.
+- Updated model cards in the frontend.
+- Fixed issue to load prompt picker when opening playground from experiments table.
+- Properly disabled environment promotion buttons for users without tag permissions.
+- Enabled granular usage rollup cron for self-hosted instances.
+- Onboarded more CUD operations for audit logs.
+- Added Ashby integration migration to Agent Builder.
+- Improved performance by parallelizing graph loading and eliminating redundant MCP fetches in Agent Builder.
+- Automatically expanded/collapsed keys for improved UI.
+- Fixed blue hover state for trace comparison divider.
+- Avoided MITM races during sandbox startup with Smithbox proxy.
+- Fixed bar height calculation in the granular usage chart.
+- Added Dynatrace webhook integration for alerts.
+- Displayed toast notification on "run now" button click in Forge.
+- Handled non-string resource fields in MCP OAuth discovery.
+- Added feedback banner for experiment sidebar redesign.
+- Added example attachments to experiment detail panes.
+- Wired Arcade integration to real OAuth flow in Agent Builder.
+- Fixed loading flash in host revisions table during revalidation.
+- Fixed imports in host backend for truststore.
+- Added request context to authentication middleware error log in Agent Builder.
+- Fixed editing prompt feature in evaluator.
+- Fetched full run data in new experiment detail pane.
 
 **Download the Helm chart:** [`langsmith-0.13.32.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.32/langsmith-0.13.32.tgz)
 </Update>
 <Update label="2026-03-23" tags={["self-hosted"]}>
 ## langsmith-0.13.31
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.28. Refer to the [langsmith-0.13.28](#langsmith-01328) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.31.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.31/langsmith-0.13.31.tgz)
 </Update>
 <Update label="2026-03-23" tags={["self-hosted"]}>
 ## langsmith-0.13.30
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.28. Refer to the [langsmith-0.13.28](#langsmith-01328) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.30.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.30/langsmith-0.13.30.tgz)
 </Update>
 <Update label="2026-03-21" tags={["self-hosted"]}>
 ## langsmith-0.13.29
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.28. Refer to the [langsmith-0.13.28](#langsmith-01328) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.29.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.29/langsmith-0.13.29.tgz)
 </Update>
 <Update label="2026-03-21" tags={["self-hosted"]}>
 ## langsmith-0.13.28
 
-- Internal improvements and maintenance updates
+- Fixed ABAC permission checks to improve self-hosted instance functionality.
+- Enhanced agent builder by handling DotDict in decrypting passthrough headers.
+- Improved fleet logo for better dark mode support.
+- Updated Slack reauthorization required message with link to integrations page in Agent Builder.
+- Added network allow-deny list feature.
+- Introduced new access control UI for the sandbox proxy.
+- Fixed GCS workload identity in storage and added copy health check.
+- Reduced concurrency and added timeout for scheduled insights jobs.
+- Enhanced frontend performance by reducing the number of preload chunks during initial load.
+- Added caching for `/info` and `/auth/v1/user` responses in localStorage to improve frontend performance.
+- Enabled JWT generation for auth-proxy in playground service for enhanced security.
+- Recreated feedbacks index in the backend for storage optimization.
+- Implemented gating for workspace skill editing by repo ownership in the Agent Builder.
+- Added static TTL expiry for sandbox claims for improved management.
+- Enabled Slack channels for personal agents in Agent Builder.
+- Adjusted frontend contrast for run status icons in light mode for better visibility.
+- Implemented JWT generation for LLM-as-judge evals to enhance evaluation security.
+- Always display creator name on agent workspace cards for better transparency.
+- Reordered inbox tabs to improve navigation.
+- Supported Google IAP session refresh in self-hosted environments.
+- Replaced MUI checkboxes in various sections to improve UI consistency.
+- Improved experimental evaluator SAQ timeouts matching online eval paths for better performance.
+- Supported RDS DB instance on k8s platform for enhanced infrastructure flexibility.
+- Loaded LLM auth proxy JWT signing key from `LANGSMITH_SIGNING_JWKS` to align with security standards.
+- Improved run detail dropdown design for a better user experience.
+- Added service key authentication to runs, sessions, and sandbox endpoints for enhanced security.
+- Added LangChain vendor extractor to enhance message processing capabilities.
+- Fixed parsing errors related to cache reads impacting costs for better performance metrics.
+- Introduced support for specifying environment variables from secret references for improved configuration management.
 
 **Download the Helm chart:** [`langsmith-0.13.28.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.28/langsmith-0.13.28.tgz)
 </Update>
 <Update label="2026-03-18" tags={["self-hosted"]}>
 ## langsmith-0.13.27
 
-- Internal improvements and maintenance updates
+- Organization admins can now edit member display names inline from the members table in Settings.
+- Multipart ingestion requests no longer accept Inputs, Outputs, or Events as inline fields. These must be sent as dedicated out-of-band parts.
+- Tracing support email on the Home page error banner is now a clickable mailto link.
+- Improved run details tab highlighting so selected sections stay correctly highlighted near scroll boundaries.
+- Improved keyboard shortcut rendering in the chat assistant tooltip.
+- Fixed connect/disconnect button on Slack integrations.
+- Added prompt environments support.
 
 **Download the Helm chart:** [`langsmith-0.13.27.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.27/langsmith-0.13.27.tgz)
 </Update>
 <Update label="2026-03-13" tags={["self-hosted"]}>
 ## langsmith-0.13.26
 
-- Internal improvements and maintenance updates
+- Sub-agents spawned during Fleet conversations now display real-time status cards inline in the chat, with a detail sidebar showing the sub-agent's live timeline, tool calls, and results.
+- Prebuilt LLM evaluators now use strict structured output mode by default. Strict mode automatically toggles when switching between OpenAI and non-OpenAI model providers.
+- Fixed a bug where online evaluator scores were lost when the evaluation succeeded on a retry but the total job time exceeded the queue timeout.
+- Deleting a run from an annotation queue now fully removes it instead of incorrectly marking it as completed.
+- Included per-annotator feedback in experiments CSV export.
+- Uploading dataset examples with invalid UTF-8 in inputs or outputs now returns a 422 error instead of a 500.
+- Reduced CPU and memory requirements for dev and dev_free self-hosted deployments.
+- Reject insecure default JWT secret at startup for improved security.
+- Updated brand colors for neutral backgrounds and surfaces.
+- Renamed prompt usage example label from "Use object in LangChain" to "Use Programmatically".
+- Fixed agent zip upload to correctly place cron schedules in the Schedule section.
+- Inbox now sorts the All tab by recency and properly wraps long messages in preview.
+- Fixed chat assistant tooltips rendering behind the chatbox.
+- Added ABAC authorization middleware.
 
 **Download the Helm chart:** [`langsmith-0.13.26.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.26/langsmith-0.13.26.tgz)
 </Update>
 <Update label="2026-03-12" tags={["self-hosted"]}>
 ## langsmith-0.13.25
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.24. Refer to the [langsmith-0.13.24](#langsmith-01324) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.25.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.25/langsmith-0.13.25.tgz)
 </Update>
 <Update label="2026-03-10" tags={["self-hosted"]}>
 ## langsmith-0.13.24
 
-- Internal improvements and maintenance updates
+- Added rich markdown editor with toolbar and slash commands in Fleet.
+- Added skill creation flow with page entry and navigation in Fleet.
+- Annotation queue CSV exports now include per-annotator feedback scores and a reviewer notes column.
+- Fixed dataset metadata filters not matching number fields across pages.
+- Fixed datasets table only showing first page of results on tall screens.
+- Alert like/notlike filters on error, inputs, and outputs now correctly match individual tokens instead of the full phrase.
+- Fixed `list_runs` tool crashing when the LangSmith API returns an error.
+- Fixed stray artifact in system prompt for Gemini models.
+- Accepting an organization invite now navigates to the newly joined organization.
+- Improved Playground auto-scroll during streaming output.
+- Added workspace scope display for personal API keys.
+- Bumped Python to 3.13 and pinned OpenSSL to resolve security vulnerabilities.
+- Blocked shell injection characters in build/install commands.
+- Improved Polly assistant understanding of traces and runs.
+- Fixed baseline experiment stats not showing on initial page load.
+- Fixed duplicated x-axis date labels on the insights time series chart.
+- Re-enabled ABAC for listing datasets.
+- Added ABAC runs delete endpoint.
 
 **Download the Helm chart:** [`langsmith-0.13.24.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.24/langsmith-0.13.24.tgz)
 </Update>
 <Update label="2026-03-07" tags={["self-hosted"]}>
 ## langsmith-0.13.23
 
-- Internal improvements and maintenance updates
+- Patched security vulnerabilities in smith-frontend.
+- Patched security vulnerabilities in smith-polly.
+- Fixed a code injection vulnerability.
+- Restricted `--allow-run` to only the deno binary in smith-ace.
+- Fixed XSS vulnerability by escaping URLs in the RichTextEditor.
+- Fixed Playground functionality in self-hosted environments.
 
 **Download the Helm chart:** [`langsmith-0.13.23.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.23/langsmith-0.13.23.tgz)
 </Update>
 <Update label="2026-03-06" tags={["self-hosted"]}>
 ## langsmith-0.13.21
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.20. Refer to the [langsmith-0.13.20](#langsmith-01320) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.21.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.21/langsmith-0.13.21.tgz)
 </Update>
 <Update label="2026-03-06" tags={["self-hosted"]}>
 ## langsmith-0.13.20
 
-- Internal improvements and maintenance updates
+- Added JSON/YAML syntax highlighting to experiment comparison for better readability.
+- Improved thread trace opening behavior in the frontend, removing the need for an expand button.
+- Eliminated n+1 query issue in the backend for listing personal access tokens, improving performance.
+- Fixed support for OpenAI compatible endpoints with smith-polly integration.
+- Timed out bulk exports stuck in `CREATED` status to avoid indefinite processing.
+- Addressed issue where service identity access was blocked from creating repository endpoints.
+- Recorded hub prompt commit in experiment session metadata for better session tracking.
+- Improved authentication for /sessions shadow queries.
+- Updated backend deployments with ABAC (Attribute-Based Access Control).
+- Enhanced UI with projects and runs write permissions support.
+- Added support for new models: GPT-5.4 and GPT-5.4 pro.
+- Fixed large attachment image preview issue for better UI experience.
+- Made GPT-5.4 the default OpenAI playground model, simplifying model selection.
+- Increased maximum tags displayed in `RunTags` component for better visibility.
+- Added models and prompts columns to experiments table, enhancing data insights.
+- Resolved agent builder runs rejection issue when limit settings were changed.
+- Fixed float errors in /sessions go endpoint for improved data handling.
+- Returned fetched value when Redis cache `SET` fails, improving reliability.
+- Enabled AWS IAM role support for agent builder, Polly, and Insights features.
+- Redesigned custom chart CRUD in the frontend, enhancing user satisfaction.
+- Introduced prompt filtering in the experiments table for targeted data analysis.
+- Updated inbox counts and thread fetching logic in Agent Builder for real-time information.
+- Added a feature to group experiments by prompt for streamlined data management.
 
 **Download the Helm chart:** [`langsmith-0.13.20.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.20/langsmith-0.13.20.tgz)
 </Update>
 <Update label="2026-03-06" tags={["self-hosted"]}>
 ## langsmith-0.13.19
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.18. Refer to the [langsmith-0.13.18](#langsmith-01318) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.19.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.19/langsmith-0.13.19.tgz)
 </Update>
 <Update label="2026-03-05" tags={["self-hosted"]}>
 ## langsmith-0.13.18
 
-- Internal improvements and maintenance updates
+- Introduced a redesigned run details view in threads for improved user experience.
+- Fixed an issue where popovers were covering other content in the UI.
+- Added Microsoft Outlook Calendar Tools to the Agent Builder for integration.
+- Addressed bugs related to agent chat popups and placeholders in the Agent Builder.
+- Improved support for disabling feedback comment filtering in self-hosted instances.
+- Enhanced performance with improved code splitting in the frontend.
+- Added model support for GPT 5.3 instant and GPT-5.3-chat-latest.
+- Introduced a new single_run filter type for more refined querying.
+- Added ability to read insights reports and show insights categories over time.
+- Added drag-to-resize functionality with persistence in custom iframe output renderer.
+- Enhanced security with more robust user migration processes.
+- Enabled tagging support for evaluators and enhanced their reuse functionality.
+- Fixed issues with session expired warnings after logout.
+- Enhanced UI components for better user interaction in the playground and feedback tagging.
+- Improved metadata handling in datasets and fixed overflow issues.
+- Introduced support for Microsoft Teams Tools in the Agent Builder.
+- Implemented better handling for OAuth provider updates.
+- Added new /orgs/current/info endpoint to the platform-backend for more robust organizational information retrieval.
+- Introduced compatibility testing for session API with added safety checks for PostgreSQL and Redis connections.
+- Added functionality to bind Slack agents dynamically, enhancing the integration experience.
 
 **Download the Helm chart:** [`langsmith-0.13.18.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.18/langsmith-0.13.18.tgz)
 </Update>
 <Update label="2026-03-03" tags={["self-hosted"]}>
 ## langsmith-0.13.17
 
-- Internal improvements and maintenance updates
+- Fixed a bug in the executor deployment handling for new operator versions.
+- Added a setting to filter out internal helper threads from the inbox.
+- Improved the evaluator's page by providing context to Polly's feedback.
+- Forced trace filtering for dataset code evaluators to enhance stability.
+- Updated OAuth mode management, restricting changes during updates.
+- Fixed an issue with experiment cell colors to enhance user clarity.
+- Improved the usage configuration modal to utilize a new TTL endpoint for trace retention.
+- Addressed a bug where workspace invites were not displaying correctly in the UI.
+- Applied brand color adjustments in dark mode and various UI elements.
+- Enhanced OAuth callback security by preventing potential reflected XSS vulnerabilities.
+- Added a dynamic OAuth feature for user management.
+- Fixed a bug preventing filter updates when certain conditions were met.
+- Implemented rebranding updates for the auth screen.
+- Added a feature to collapse sidebar automatically on small viewports.
+- Fixed issues with variable handling in playground evaluate mode.
+- Enhanced the Agent Builder with infinite scroll and improved inbox fetching.
+- Added a new Outlook Trigger feature in the Agent Builder.
+- Upgraded agent-builder to use websockets and new OpenAI model API (gpt-5.3-codex).
+- Fixed auto-save on API key during onboarding process.
+- Resolved issues causing errors in the playground due to empty placeholders.
+- Updated frontend with a new logo for favicon.
+- Fixed authorization bugs in cron deployment for Gmail/Outlook.
+- Updated styling in various UI components, including studio button and index column behavior.
+- Enhanced onboarding snippets for better integration with Langchain Python.
+- Added support for [custom separators in SCIM group names](/langsmith/user-management#configure-custom-separator).
 
 **Download the Helm chart:** [`langsmith-0.13.17.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.17/langsmith-0.13.17.tgz)
 </Update>
 <Update label="2026-02-26" tags={["self-hosted"]}>
 ## langsmith-0.13.16
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.15. Refer to the [langsmith-0.13.15](#langsmith-01315) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.16.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.16/langsmith-0.13.16.tgz)
 </Update>
 <Update label="2026-02-26" tags={["self-hosted"]}>
 ## langsmith-0.13.15
 
-- Internal improvements and maintenance updates
+- Added rebranded primary colors to button under feature flag in the frontend UI.
+- Replaced dataset autocomplete with tag input to improve user experience.
+- Auto-hide and position Models column in the frontend based on data.
+- Fixed revalidation conflict in the Smith frontend.
+- Improved workspace model configurations to prevent text overflow with tooltips.
+- Surfaced Models option in Group By popover under a feature flag.
+- Supported loading ChatAnthropicVertex model configs in Smith-Polly.
+- Added "No matching filters" message for empty search results in Filter Component Select V2.
+- Enabled navigating automatically to insights with global scroll support.
+- Resolved issues with playground and evaluators provider selector not filtering out disabled providers.
+- Improved messaging mode user experience and styling.
+- Implemented Raw Query Mode for Inline Filters.
+- Allow `secret_key_ref` to be `None` in `K8sEnvVarSource` for backend improvements.
+- Fixed agent builder UI to wrap question text on narrow viewports and dismiss "Add API Key to Get Started" dialog.
+- Updated UX to match evaluator button height with tool button pattern.
+- Persisted selected model in local storage for a consistent UI experience.
+- Auto-generated thread titles for improved thread management.
+- Enhanced backend by gating secrets access with granular RBAC permissions.
+- Implemented Outlook Email Tools in the Agent Builder.
+- Improved keyboard shortcuts in the inbox feature of the Agent Builder UI.
 
 **Download the Helm chart:** [`langsmith-0.13.15.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.15/langsmith-0.13.15.tgz)
 </Update>
 <Update label="2026-02-24" tags={["self-hosted"]}>
 ## langsmith-0.13.14
 
-- Internal improvements and maintenance updates
+- Fixed agent generation interruptions and handling, improving stability in the user experience.
+- Fixed long feedback header text overflow when dragged to the last column.
+- Added OAuth connections for built-in tools and providers on the tool page.
+- Fixed crashes occurring on the run details page.
+- Fixed onboarding dialog not fetching tools unnecessarily.
+- Updated agent builder frontend to show real-time run count.
+- Added private registry UI to the frontend.
+- Enhanced support for SerializedConstructor model configs in playground and insights.
+- Added Gemini 3.1 Pro model to playground and backend model lists.
+- Fixed tool registry crash in the playground.
+- Added support for Gmail authentication improvements, including refresh token capability.
+- Added new API endpoints for running playground experiments using a new service.
+- Improved UI for trace filters with version 2 UX using Filterbar.
+- Enhanced syntax highlighting to match Figma design for standardization.
+- Supported Gmail OAuth v2 with cron logic for higher reliability.
+- Added new models column in the experiment view with updated filtering options.
+- Supported multiple paths for query shadowing log improvements.
+- Added UIs for managing and editing model API key names in the playground.
 
 **Download the Helm chart:** [`langsmith-0.13.14.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.14/langsmith-0.13.14.tgz)
 </Update>
 <Update label="2026-02-14" tags={["self-hosted"]}>
 ## langsmith-0.13.13
 
-- Internal improvements and maintenance updates
+- Reverted the PostgreSQL version to v14.7 and the Redis version to v7. This fixes breaking changes introduced in langsmith-0.13.10.
+- Fixed internal error details being leaked in 5xx responses to enhance security.
+- Improved View UI by moving SaveViewButton from ViewDropdown and changing SaveForm to a modal for better usability.
+- Added model select dropdown to the template creation flow for enhanced user experience.
+- Added warning for duplicate URLs when creating MCP server to prevent configuration errors.
+- Added user context to agents and sub-agents for better feature functionality.
+- Added support for SerializedConstructor model configs in the playground for improved flexibility.
+- Enhanced UI by showing categorical feedback in experiment view config and hiding the sort icon.
+- Improved playground and experiment views by fixing cell alignment.
+- Added image upload support to facilitate better asset management.
+- Added onboarding dialog to general-purpose agent for improved user guidance.
+- Added spinner to loading triggers skeleton for better loading indication.
 
 **Download the Helm chart:** [`langsmith-0.13.13.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.13/langsmith-0.13.13.tgz)
 </Update>
 <Update label="2026-02-12" tags={["self-hosted"]}>
 ## langsmith-0.13.12
 
-- Internal improvements and maintenance updates
+- Improved button sizes and filter chip alignment in the InlineFilters UX.
+- Added commit tags search and display to the Prompt Hub.
+- Fixed issue with viewing experiments having objects for feedback scores.
+- Enhanced tracing for the deploy_image task.
+- Added a search bar for the new consolidated filter dropdown.
+- Added environment variable for globally disabling personal access token creation.
+- Added cost charts feature.
+- Improved homepage styling and fixed related design issues.
+- Fixed issues with rerendering in General Purpose API (GPA).
+- Improved system to count PENDING, RETRY, and FAILED transactions in self-hosted offline usage reporting.
+- Enhanced the agent builder to localize the current date to the user's timezone.
+- Added Bedrock inference profile dropdown to the playground.
+- Improved error detection and messaging for server issues in agent-chat.
+- Fixed styling issues including email count in invite modal and load state display in the agent editor.
+- Implemented initial design for a tools page with feature flags.
+- Added icon-only filter popover mode to the frontend filter UI.
+- Added beacon endpoint for Self Hosted Agent Builder Runs Limiting.
+- Enable new Granular Usage tab for reporting billable usage by workspace, project, user, and API key (enable with `DEFAULT_ORG_FEATURE_ENABLE_GRANULAR_USAGE_REPORTING=true` and `GRANULAR_USAGE_TABLE_ENABLED=true` environment variables in `commonEnv`)
 
 **Download the Helm chart:** [`langsmith-0.13.12.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.12/langsmith-0.13.12.tgz)
 </Update>
 <Update label="2026-02-12" tags={["self-hosted"]}>
 ## langsmith-0.13.11
 
-- Internal improvements and maintenance updates
+- Improved Agent Builder by using persisted simple model config.
+- Fixed UI for Playground with better message block and tool button consistency.
+- Added a search bar for the new consolidated filter dropdown.
+- Fixed agent builder model selector for users without 'workspaces:manage' permission.
+- Added file upload feature for General Purpose Agent.
+- Added button to create General Purpose Agent.
+- Enhanced the Playground by preserving baseline setting in URL on page reload.
+- Improved Playground experiment table UI and alignment.
+- Fixed bulk deletion of datasets to update the table correctly.
+- Added new API: workspace-scoped tool registry API.
+- Improved support for multifield runFields.
+- Enhanced insights scheduler with backend changes.
+- Added ability to navigate pages in Polly and an initial set of base evaluations.
+- Added tracing enhancements to Agent Builder, including tool call tracing.
+- Integrated changes to support custom model configs temporarily.
 
 **Download the Helm chart:** [`langsmith-0.13.11.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.11/langsmith-0.13.11.tgz)
 </Update>
 <Update label="2026-02-10" tags={["self-hosted"]}>
 ## langsmith-0.13.10
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.9. Refer to the [langsmith-0.13.9](#langsmith-0139) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.10.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.10/langsmith-0.13.10.tgz)
 </Update>
 <Update label="2026-02-09" tags={["self-hosted"]}>
 ## langsmith-0.13.9
 
-- Internal improvements and maintenance updates
+- Fixed sorting of workspaces alphabetically in the new switcher to improve user experience.
+- Improved playground with new tool modal design and model config popup windows for enhanced usability.
+- Fixed issue with creating tags being idempotent.
+- Modified Agent Builder to cache MCP tools list, session ID, and OAuth tokens for better performance.
+- Fixed updated error message for exhausted agent builder runs.
+- Fixed routing configuration for the agent builder /allow-run API endpoint.
+- Fixed spacing of home page tables for improved UI.
+- Fixed issue with datasets repeatedly fetching if empty.
+- Fixed edit access for API keys for non-admin users.
+- Added cost and token columns in the experiment view for better data insights.
+- Fixed an issue where the Slack trigger was dropping messages due to authentication errors.
+- Fixed boolean feedback values handling in comparison table cells.
+- Updated service key subject for API calls to /allow-run for accurate authentication.
+- Improved agent builder to use persisted simple model config.
+- Fixed error state handling for OAuth login failures.
+- Enhanced agent builder by ensuring threads display errors on reconnect in agent chat.
+- Fixed UI to ensure the footer menu closes on organization switch.
+- Improved tagging authentication by using specific resource auth.
+- Enhanced UI to prevent closing the pane from within the app selector dropdown.
+- Fixed potential SQL injection risks in feedback and annotation queue listing.
+- Added a 15-second timeout to the OAuth HTTP client for improved connection reliability.
 
 **Download the Helm chart:** [`langsmith-0.13.9.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.9/langsmith-0.13.9.tgz)
 </Update>
 <Update label="2026-02-06" tags={["self-hosted"]}>
 ## langsmith-0.13.7
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.6. Refer to the [langsmith-0.13.6](#langsmith-0136) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.7.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.7/langsmith-0.13.7.tgz)
 </Update>
 <Update label="2026-02-05" tags={["self-hosted"]}>
 ## langsmith-0.13.6
 
-- Internal improvements and maintenance updates
+- Fixed an issue with truncated large numbers affecting the user interface.
+- Improved error string conversion from S3 to enhance error handling.
+- Updated Filters UX to save DateTimeRange, improving user experience.
+- Fixed UUID conversion to ensure consistent general agent identification.
+- Fixed agent ID conversion to always use a string instead of UUID for stability.
+- Enhanced the experiment comparison view by showing custom computed columns.
+- Fixed chat preview for langchain-shaped output for better user experience.
+- Improved caching mechanisms and authentication control planes' RetryableHTTP.
+- Fixed the issue of incorrect tenant usage when bootstrapping agents.
+- Improved user interface by adjusting page padding to remove visual obstructions.
+- Updated wording for trace-related inquiries to improve clarity.
+- Enhanced large field uploads to S3 for single run POST/PATCH endpoints.
 
 **Download the Helm chart:** [`langsmith-0.13.6.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.6/langsmith-0.13.6.tgz)
 </Update>
 <Update label="2026-02-05" tags={["self-hosted"]}>
 ## langsmith-0.13.5
 
-- Internal improvements and maintenance updates
+- Fixed regression on cloning prebuilt dashboards to enhance user experience.
+- Updated Filters UX to match new mocks and improved the view dropdown.
+- Fixed Agent Builder by converting `UUID` to `str` before JSON encoding to prevent errors.
+- Added an updated insights sidebar for a more informative UI.
+- Implemented bulk actions for tables to improve data management efficiency.
+- Added a redesigned feedback banner for annotation queue in the frontend.
+- Provided option to require feedback in the Smith frontend to enhance user communication.
+- Limited Agent Builder template list to 2 rows for better usability.
+- Fixed cursor jumping issue when editing agent builder skill name and description.
+- Solved SSO+SCIM issue, always provisioning users to workspaces.
+- Fixed Slack Auth disconnecting issue for workspace users.
+- Enhanced missing tool experience in the Agent Builder by adjusting prompts.
+- Prevented session fixation in self-hosted OAuth for enhanced security.
+- Fixed the 'view run' regression in the annotation queue redesign in Smith frontend.
+- Reduced gRPC streaming chunk size from 1MB to 64KB for improved performance.
+- Added download zip button inside the Agent Builder Explorer.
+- Enhanced tracing URLs allowed by adding them to the Datadog RUM config.
 
 **Download the Helm chart:** [`langsmith-0.13.5.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.5/langsmith-0.13.5.tgz)
 </Update>
 <Update label="2026-02-04" tags={["self-hosted"]}>
 ## langsmith-0.13.4
 
-- Internal improvements and maintenance updates
+- Fixed the toggle functionality for all column sections when clicking the Columns header.
+- Fixed failure to edit SSO settings
+- Improved frontend performance by using BarSeries instead of AnimatedBarSeries for granular usage tabs.
+- Added a Cmd + Enter hotkey to the new annotation queue for enhanced user interaction.
+- Added an option in the playground UI to mitigate loading errors by defaulting to `use_responses_api=true`.
+- Added support for custom Azure models.
+- Updated the playground UI for improved user experience.
+- Improved studio chat UX with auto-resize textarea and keyboard shortcuts.
+- Fixed prompt saving issue with incorrect naming.
+- Improved visibility and user experience by making search icons larger and tracking navigation of AQ, prompts, and deployments.
+- Enhanced UI for the Agent Builder with the introduction of a new Diff UI with context lines.
+- Enabled accurate Y-axis margins using d3 nice ticks for better frontend visualization.
+- Allowed the 'recently added to' section to pop over in the 'add to dataset' UI.
+- Added pagination to the dashboard select view for better usability.
+- Added support to limit long-lived TTL options and expose them in the org TTL settings endpoint.
+- Fixed a bug with streaming flicker using the responses API in the playground.
+- Enhanced the annotation queue user experience with custom output rendering in new queues.
+- Optimized dataset session comparison using example_ids filtering for better performance.
+- Provided a download ZIP file button in the Agent Builder for user convenience.
+- Added a streamlined loading state for the Agent Builder's agent generator graph.
+- Allowed updating and creating SSO settings specifically in self-hosted environments.
+- Added support for displaying SCIM user's `displayName` attribute.
+
+These changes improve user interaction, enhance system performance, and expand support for custom models and infrastructure, benefiting self-hosted deployments.
 
 **Download the Helm chart:** [`langsmith-0.13.4.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.4/langsmith-0.13.4.tgz)
 </Update>
 <Update label="2026-01-26" tags={["self-hosted"]}>
 ## langsmith-0.13.3
 
-- Internal improvements and maintenance updates
+- Improved streaming to accumulate streamed delta data without loss.
+- Added Google Sheets/Docs tools integration.
+- Enhanced UX for OAuth servers in settings.
+- Made view trace links more obvious in the UI.
+- Resolved multiple bugs and performance issues in Agent Builder, including writing self-hosted Agent Builder runs to a single project and collapsing subagent tool cards by default.
+- Improved experiment UI, now showing experiment descriptions on the single experiment page and fixing a blank page issue when accessing experiments via public URL.
+- Enhanced UX by solving bulk export flakiness and allowing updating of bulk export destination credentials.
+- Improved inline filter UX with multiple bug fixes and added edit functionality.
+- Added support for configurable run input/output preview paths on the backend.
+- Introduced new workspace management permissions for managing members' access.
+- Optimized Agent Builder to reduce network calls.
+- Added Action Menu to MyAgents Navlink in Agent Builder.
+- Improved frontend performance, including solving slowness when loading authentication status.
+- Enhanced Agent Builder with the API Key Needed Label/Button and collapsed action cluster features.
+- Resolved playground tool modal overflow issue.
+- Improved security by fixing frontend vulnerability in remix run router and clearing URLs on logout to prevent workspace misdirection.
+- Updated API to use invoices for monthly burndown tracking and added support for V2 API.
+- Improved frontend to handle malformed LLM outputs gracefully.
+- Improved date/time selection UI by allowing bold "Last time" values for DateTimeRangePicker component.
 
 **Download the Helm chart:** [`langsmith-0.13.3.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.3/langsmith-0.13.3.tgz)
 </Update>
 <Update label="2026-01-21" tags={["self-hosted"]}>
 ## langsmith-0.13.2
 
-- Internal improvements and maintenance updates
+- Fixed content-type validation for dataset uploads to improve data handling.
+- Improved the new annotation queue page with a pretty JSON editor and message list editor.
+- Enabled better handling of retriable ingest errors on QueueRunPayloads.
+- Fixed Cron Trigger updates in the Agent Builder UI.
+- Added support for Redis Cluster, enhancing scalability for self-hosted setups.
+- Fixed OAuth account takeover vulnerability to enhance security.
+- Improved rendering of raw output in the playground.
+- Added new inline UX filters and a View Dropdown component for enhanced user interaction.
+- Increased line-height on XS Text variant to prevent clipping issues in the frontend.
 
 **Download the Helm chart:** [`langsmith-0.13.2.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.2/langsmith-0.13.2.tgz)
 </Update>
 <Update label="2026-01-16" tags={["self-hosted"]}>
 ## langsmith-0.13.1
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.13.0. Refer to the [langsmith-0.13.0](#langsmith-0130) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.1.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.1/langsmith-0.13.1.tgz)
 </Update>
 <Update label="2026-01-16" tags={["self-hosted"]}>
 ## langsmith-0.13.0
 
-- Internal improvements and maintenance updates
+- Added support for [Agent Builder](/langsmith/fleet/index) in self-hosted deployments
+- Added configurable trace TTL for long-lived traces
+- Added ability to conditionally enable OAuth tools and triggers
+- Added sample application creation during onboarding
+- Fixed feedback pagination and auto-pagination bugs
+- Fixed trace drawer skeleton not appearing immediately
 
 **Download the Helm chart:** [`langsmith-0.13.0.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.0/langsmith-0.13.0.tgz)
 </Update>
 <Update label="2026-01-12" tags={["self-hosted"]}>
 ## langsmith-0.12.37
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.12.36. Refer to the [langsmith-0.12.36](#langsmith-01236) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.37.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.37/langsmith-0.12.37.tgz)
 </Update>
 <Update label="2026-01-09" tags={["self-hosted"]}>
 ## langsmith-0.12.36
 
-- Internal improvements and maintenance updates
+- Added support for custom MCP servers with OAuth in Agent Builder
+- Added ability to view and edit memory files in Agent Builder
+- Added support for attachments in the frontend
+- Improved streaming tree performance in trace viewer
+- Fixed scroll behavior in trace tree
+- Fixed unicode truncation issues in trace display
+- Fixed onboarding screen showing incorrectly when runs exist
+- Increased maximum automation rules per workspace to 200
 
 **Download the Helm chart:** [`langsmith-0.12.36.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.36/langsmith-0.12.36.tgz)
 </Update>
 <Update label="2026-01-08" tags={["self-hosted"]}>
 ## langsmith-0.12.35
 
-- Internal improvements and maintenance updates
+- Added per-bar highlighting for feedback charts in experiments
+- Added Agent Builder activity feed
+- Changed experiment chip to hover card for better usability
+- Fixed agents appearing in random sidebar positions
+- Fixed tool modal nesting issue in playground
+- Fixed diff mode fallback on comparison page
+- Fixed race condition in OAuth authentication requests
 
 **Download the Helm chart:** [`langsmith-0.12.35.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.35/langsmith-0.12.35.tgz)
 </Update>
 <Update label="2025-12-26" tags={["self-hosted"]}>
 ## langsmith-0.12.34
 
-- Internal improvements and maintenance updates
+- Added Redis IAM authentication support for GCP and Azure
+- Added self-serve audit logs in OCSF format
+- Added hide column option to experiment outputs header
+- Added message_user tool to the tool server
+- Improved trace tree loading speed
+- Allowed basic auth installations to disable invites via API
+- Fixed tenant ID handling in navigation
+- Fixed scrolling in Agent Builder templates view
+- Fixed Gmail account connection limit tooltip
+- Fixed user view preference persistence on page load
+- Fixed tab wrapping in UI
+- Made feedback charts visible by default
+- Made SCIM group name matching case-insensitive
 
 **Download the Helm chart:** [`langsmith-0.12.34.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.34/langsmith-0.12.34.tgz)
 </Update>
 <Update label="2025-12-20" tags={["self-hosted"]}>
 ## langsmith-0.12.33
 
-- Internal improvements and maintenance updates
+- Security fix: fixed Studio vulnerability to malicious `baseUrl` param by requiring user-defined allowed origins
+- Allow enabling invites alongside JIT provisioning for SSO (OAuth with Client Secret mode only)
+- Added self-serve audit logs for administrative actions (Private Preview)
 
 **Download the Helm chart:** [`langsmith-0.12.33.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.33/langsmith-0.12.33.tgz)
 </Update>
 <Update label="2025-12-12" tags={["self-hosted"]}>
 ## langsmith-0.12.32
 
-- Internal improvements and maintenance updates
+- Added IAM connection support for PostgreSQL (AWS only).
+- Added GPT-5.2 model support to the playground.
+- Added support for setting memory limits on executor pods.
 
 **Download the Helm chart:** [`langsmith-0.12.32.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.32/langsmith-0.12.32.tgz)
 </Update>
 <Update label="2025-12-11" tags={["self-hosted"]}>
 ## langsmith-0.12.31
 
-- Internal improvements and maintenance updates
+- Improved error messages for basic authentication misconfiguration.
+- Added organization operator role support.
+- Fixed issues with streaming datasets endpoint.
 
 **Download the Helm chart:** [`langsmith-0.12.31.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.31/langsmith-0.12.31.tgz)
 </Update>
 <Update label="2025-12-09" tags={["self-hosted"]}>
 ## langsmith-0.12.30
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.12.29. Refer to the [langsmith-0.12.29](#langsmith-01229) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.30.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.30/langsmith-0.12.30.tgz)
 </Update>
 <Update label="2025-12-08" tags={["self-hosted"]}>
 ## langsmith-0.12.29
 
-- Internal improvements and maintenance updates
+- Added mTLS (mutual TLS) support for ClickHouse connections to enhance security for database communication.
 
 **Download the Helm chart:** [`langsmith-0.12.29.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.29/langsmith-0.12.29.tgz)
 </Update>
 <Update label="2025-12-05" tags={["self-hosted"]}>
 ## langsmith-0.12.28
 
-- Internal improvements and maintenance updates
+- Added mTLS (mutual TLS) support for PostgreSQL connections to enhance security for database communication.
+- Added mTLS support for ClickHouse clients.
+- Fixed Agent Builder onboarding and side navigation visibility when disabled in self-hosted deployments.
 
 **Download the Helm chart:** [`langsmith-0.12.28.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.28/langsmith-0.12.28.tgz)
 </Update>
 <Update label="2025-12-04" tags={["self-hosted"]}>
 ## langsmith-0.12.27
 
-- Internal improvements and maintenance updates
+- Added mTLS (mutual TLS) support for Redis connections to enhance security.
+- Added support for empty trigger server configuration in self-hosted deployments.
+- Improved incident banner styling and content.
 
 **Download the Helm chart:** [`langsmith-0.12.27.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.27/langsmith-0.12.27.tgz)
 </Update>
@@ -590,14 +1089,16 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2025-12-01" tags={["self-hosted"]}>
 ## langsmith-0.12.25
 
-- Internal improvements and maintenance updates
+- Enabled Agent Builder UI feature flag for self-hosted deployments.
+- Added Redis Cluster support for improved scalability and high availability.
 
 **Download the Helm chart:** [`langsmith-0.12.25.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.25/langsmith-0.12.25.tgz)
 </Update>
 <Update label="2025-11-27" tags={["self-hosted"]}>
 ## langsmith-0.12.24
 
-- Internal improvements and maintenance updates
+- Added dequeue timeouts to all SAQ (Simple Async Queue) queues to improve reliability.
+- Performance improvements and bug fixes.
 
 **Download the Helm chart:** [`langsmith-0.12.24.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.24/langsmith-0.12.24.tgz)
 </Update>
@@ -611,28 +1112,28 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2025-11-26" tags={["self-hosted"]}>
 ## langsmith-0.12.22
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.12.21. Refer to the [langsmith-0.12.21](#langsmith-01221) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.22.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.22/langsmith-0.12.22.tgz)
 </Update>
 <Update label="2025-11-26" tags={["self-hosted"]}>
 ## langsmith-0.12.21
 
-- Internal improvements and maintenance updates
+- Added explicit `revisionHistoryLimit` configuration for operator deployment template.
 
 **Download the Helm chart:** [`langsmith-0.12.21.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.21/langsmith-0.12.21.tgz)
 </Update>
 <Update label="2025-11-24" tags={["self-hosted"]}>
 ## langsmith-0.12.20
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.12.18. Refer to the [langsmith-0.12.18](#langsmith-01218) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.20.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.20/langsmith-0.12.20.tgz)
 </Update>
 <Update label="2025-11-24" tags={["self-hosted"]}>
 ## langsmith-0.12.19
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.12.18. Refer to the [langsmith-0.12.18](#langsmith-01218) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.19.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.19/langsmith-0.12.19.tgz)
 </Update>
@@ -674,7 +1175,7 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2025-11-13" tags={["self-hosted"]}>
 ## langsmith-0.12.13
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.12.12. Refer to the [langsmith-0.12.12](#langsmith-01212) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.13.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.13/langsmith-0.12.13.tgz)
 </Update>

--- a/src/langsmith/self-hosted-changelog.mdx
+++ b/src/langsmith/self-hosted-changelog.mdx
@@ -18,6 +18,7 @@ rss: true
 - This release packages the same LangSmith application version as langsmith-0.8.30. Refer to the [langsmith-0.8.30](#langsmith-0830) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.8.31.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.8.31/langsmith-0.8.31.tgz)
+{/* langsmith-release-image: 0.8.31 0.8.92 */}
 </Update>
 
 <Update label="2026-05-18" tags={["self-hosted"]}>
@@ -41,6 +42,7 @@ rss: true
 - Enhanced message processing with SubAgentDetails, facilitating better context capture and management.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.14.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.14/langsmith-0.15.0-rc.14.tgz)
+{/* langsmith-release-image: 0.15.0-rc.14 0.15.7-d6de5e64598efb40bc8a3ba25730f8807309e15a */}
 </Update>
 <Update label="2026-05-14" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.13
@@ -48,6 +50,7 @@ rss: true
 - This release packages the same LangSmith application version as langsmith-0.15.0-rc.12. Refer to the [langsmith-0.15.0-rc.12](#langsmith-0150-rc12) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.13.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.13/langsmith-0.15.0-rc.13.tgz)
+{/* langsmith-release-image: 0.15.0-rc.13 0.15.3-4a1b22708d0a402b664df96c75c6ffa261a2546a */}
 </Update>
 <Update label="2026-05-14" tags={["self-hosted"]}>
 ## langsmith-0.14.6
@@ -56,6 +59,7 @@ rss: true
 - Fixed security vulnerabilities: CVE-2026-40192, CVE-2026-40347, CVE-2026-41205, CVE-2026-42561
 
 **Download the Helm chart:** [`langsmith-0.14.6.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.6/langsmith-0.14.6.tgz)
+{/* langsmith-release-image: 0.14.6 0.14.9 */}
 </Update>
 <Update label="2026-05-13" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.12
@@ -80,6 +84,7 @@ rss: true
 These updates focus on improving user experience, performance, security, and feature set for self-hosted deployments.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.12.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.12/langsmith-0.15.0-rc.12.tgz)
+{/* langsmith-release-image: 0.15.0-rc.12 0.15.3-4a1b22708d0a402b664df96c75c6ffa261a2546a */}
 </Update>
 <Update label="2026-05-11" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.10
@@ -87,6 +92,7 @@ These updates focus on improving user experience, performance, security, and fea
 - This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.10.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.10/langsmith-0.15.0-rc.10.tgz)
+{/* langsmith-release-image: 0.15.0-rc.10 0.15.2-0dd2b56c14e44fbf384d9bb0bf094f2ca896c914 */}
 </Update>
 <Update label="2026-05-09" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.9
@@ -94,6 +100,7 @@ These updates focus on improving user experience, performance, security, and fea
 - This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.9.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.9/langsmith-0.15.0-rc.9.tgz)
+{/* langsmith-release-image: 0.15.0-rc.9 0.15.2-0dd2b56c14e44fbf384d9bb0bf094f2ca896c914 */}
 </Update>
 <Update label="2026-05-08" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.8
@@ -101,6 +108,7 @@ These updates focus on improving user experience, performance, security, and fea
 - This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.8.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.8/langsmith-0.15.0-rc.8.tgz)
+{/* langsmith-release-image: 0.15.0-rc.8 0.15.2-0dd2b56c14e44fbf384d9bb0bf094f2ca896c914 */}
 </Update>
 <Update label="2026-05-08" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.7
@@ -108,6 +116,7 @@ These updates focus on improving user experience, performance, security, and fea
 - This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.7.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.7/langsmith-0.15.0-rc.7.tgz)
+{/* langsmith-release-image: 0.15.0-rc.7 0.15.2-0dd2b56c14e44fbf384d9bb0bf094f2ca896c914 */}
 </Update>
 <Update label="2026-05-06" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.6
@@ -115,6 +124,7 @@ These updates focus on improving user experience, performance, security, and fea
 - This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.6.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.6/langsmith-0.15.0-rc.6.tgz)
+{/* langsmith-release-image: 0.15.0-rc.6 0.15.2-0dd2b56c14e44fbf384d9bb0bf094f2ca896c914 */}
 </Update>
 <Update label="2026-05-05" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.5
@@ -122,6 +132,7 @@ These updates focus on improving user experience, performance, security, and fea
 - This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.5.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.5/langsmith-0.15.0-rc.5.tgz)
+{/* langsmith-release-image: 0.15.0-rc.5 0.15.2-0dd2b56c14e44fbf384d9bb0bf094f2ca896c914 */}
 </Update>
 <Update label="2026-05-04" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.4
@@ -139,6 +150,7 @@ These updates focus on improving user experience, performance, security, and fea
 - Hidden minimal reasoning effort option for GPT-5.x models in the playground
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.4.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.4/langsmith-0.15.0-rc.4.tgz)
+{/* langsmith-release-image: 0.15.0-rc.4 0.15.2-0dd2b56c14e44fbf384d9bb0bf094f2ca896c914 */}
 </Update>
 <Update label="2026-05-01" tags={["self-hosted"]}>
 ## langsmith-0.14.5
@@ -146,6 +158,7 @@ These updates focus on improving user experience, performance, security, and fea
 - Fixed the agent-builder failure to start on v14 self-hosted 0.14.6 due to the `langgraph-api 0.8.3` base image bundling `LangSmith 0.7.37`, which removed `SandboxTemplate`, by pinning `LangSmith<0.7.34` to downgrade to a compatible version.
 
 **Download the Helm chart:** [`langsmith-0.14.5.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.5/langsmith-0.14.5.tgz)
+{/* langsmith-release-image: 0.14.5 0.14.7 */}
 </Update>
 <Update label="2026-04-30" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.3
@@ -153,6 +166,7 @@ These updates focus on improving user experience, performance, security, and fea
 - This release packages the same LangSmith application version as langsmith-0.15.0-rc.1. Refer to the [langsmith-0.15.0-rc.1](#langsmith-0150-rc1) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.3.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.3/langsmith-0.15.0-rc.3.tgz)
+{/* langsmith-release-image: 0.15.0-rc.3 0.15.1-bc7b710bcfb878cb28e908ad748ad8717431a51a */}
 </Update>
 <Update label="2026-04-29" tags={["self-hosted"]}>
 ## langsmith-0.14.3
@@ -161,6 +175,7 @@ These updates focus on improving user experience, performance, security, and fea
 - Reduced Microsoft Graph permission requirements for Microsoft 365 docs and Teams private-message tools.
 
 **Download the Helm chart:** [`langsmith-0.14.3.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.3/langsmith-0.14.3.tgz)
+{/* langsmith-release-image: 0.14.3 0.14.5 */}
 </Update>
 <Update label="2026-04-24" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.2
@@ -168,6 +183,7 @@ These updates focus on improving user experience, performance, security, and fea
 - This release packages the same LangSmith application version as langsmith-0.15.0-rc.1. Refer to the [langsmith-0.15.0-rc.1](#langsmith-0150-rc1) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.2.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.2/langsmith-0.15.0-rc.2.tgz)
+{/* langsmith-release-image: 0.15.0-rc.2 0.15.1-bc7b710bcfb878cb28e908ad748ad8717431a51a */}
 </Update>
 <Update label="2026-04-24" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.1
@@ -210,6 +226,7 @@ These updates focus on improving user experience, performance, security, and fea
 - Fixed default tracing project selection to Fleet to prevent inconsistencies.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.1.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.1/langsmith-0.15.0-rc.1.tgz)
+{/* langsmith-release-image: 0.15.0-rc.1 0.15.1-bc7b710bcfb878cb28e908ad748ad8717431a51a */}
 </Update>
 <Update label="2026-04-20" tags={["self-hosted"]}>
 ## langsmith-0.14.2
@@ -217,6 +234,7 @@ These updates focus on improving user experience, performance, security, and fea
 - This release packages the same LangSmith application version as langsmith-0.14.0. Refer to the [langsmith-0.14.0](#langsmith-0140) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.14.2.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.2/langsmith-0.14.2.tgz)
+{/* langsmith-release-image: 0.14.2 0.14.3 */}
 </Update>
 <Update label="2026-04-20" tags={["self-hosted"]}>
 ## langsmith-0.14.1
@@ -224,6 +242,7 @@ These updates focus on improving user experience, performance, security, and fea
 - This release packages the same LangSmith application version as langsmith-0.14.0. Refer to the [langsmith-0.14.0](#langsmith-0140) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.14.1.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.1/langsmith-0.14.1.tgz)
+{/* langsmith-release-image: 0.14.1 0.14.3 */}
 </Update>
 <Update label="2026-04-20" tags={["self-hosted"]}>
 ## langsmith-0.14.0
@@ -265,6 +284,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - **Granular usage reporting** — granular billable usage APIs that allow you to retrieve detailed trace usage data broken down by workspace, project, user, or API key.
 
 **Download the Helm chart:** [`langsmith-0.14.0.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.0/langsmith-0.14.0.tgz)
+{/* langsmith-release-image: 0.14.0 0.14.3 */}
 </Update>
 <Update label="2026-04-17" tags={["self-hosted"]}>
 ## langsmith-0.13.43
@@ -272,6 +292,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - This release packages the same LangSmith application version as langsmith-0.13.42. Refer to the [langsmith-0.13.42](#langsmith-01342) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.43.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.43/langsmith-0.13.43.tgz)
+{/* langsmith-release-image: 0.13.43 0.13.44 */}
 </Update>
 <Update label="2026-04-14" tags={["self-hosted"]}>
 ## langsmith-0.13.42
@@ -279,6 +300,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Fixed issue in metadata filtering to recognize json.Number as a primitive type, improving data ingestion accuracy.
 
 **Download the Helm chart:** [`langsmith-0.13.42.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.42/langsmith-0.13.42.tgz)
+{/* langsmith-release-image: 0.13.42 0.13.44 */}
 </Update>
 <Update label="2026-04-14" tags={["self-hosted"]}>
 ## langsmith-0.13.41
@@ -286,6 +308,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Internal improvements and maintenance updates
 
 **Download the Helm chart:** [`langsmith-0.13.41.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.41/langsmith-0.13.41.tgz)
+{/* langsmith-release-image: 0.13.41 0.13.43 */}
 </Update>
 <Update label="2026-04-09" tags={["self-hosted"]}>
 ## langsmith-0.13.40
@@ -297,6 +320,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Improved PostgreSQL IAM integration for better database management in self-hosted instances.
 
 **Download the Helm chart:** [`langsmith-0.13.40.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.40/langsmith-0.13.40.tgz)
+{/* langsmith-release-image: 0.13.40 0.13.41 */}
 </Update>
 <Update label="2026-04-07" tags={["self-hosted"]}>
 ## langsmith-0.13.39
@@ -343,6 +367,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Improved MCP proxy authorization and URL safety checks for agent runtime requests.
 
 **Download the Helm chart:** [`langsmith-0.13.39.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.39/langsmith-0.13.39.tgz)
+{/* langsmith-release-image: 0.13.39 0.13.40-7ed913b583e68d2684b0d7af1c72b5b2ad054639 */}
 </Update>
 <Update label="2026-04-03" tags={["self-hosted"]}>
 ## langsmith-0.13.38
@@ -364,6 +389,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Fixed layout shift in agent chat caused by the copy button unmounting during streaming.
 
 **Download the Helm chart:** [`langsmith-0.13.38.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.38/langsmith-0.13.38.tgz)
+{/* langsmith-release-image: 0.13.38 0.13.38-4359ae1c6829e7f2fb885191f12897d950bcb71e */}
 </Update>
 <Update label="2026-04-01" tags={["self-hosted"]}>
 ## langsmith-0.13.37
@@ -376,6 +402,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Fixed a bug with OpenAI tools rendering.
 
 **Download the Helm chart:** [`langsmith-0.13.37.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.37/langsmith-0.13.37.tgz)
+{/* langsmith-release-image: 0.13.37 0.13.37-3314407e0d73f796df84d6d0d2249e1efa16fbee */}
 </Update>
 <Update label="2026-03-30" tags={["self-hosted"]}>
 ## langsmith-0.13.36
@@ -383,6 +410,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-01332) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.36.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.36/langsmith-0.13.36.tgz)
+{/* langsmith-release-image: 0.13.36 0.13.35-7f6d0b900ea9cd45220782e793c6860d7abed822 */}
 </Update>
 <Update label="2026-03-27" tags={["self-hosted"]}>
 ## langsmith-0.13.35
@@ -390,6 +418,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-01332) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.35.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.35/langsmith-0.13.35.tgz)
+{/* langsmith-release-image: 0.13.35 0.13.35-7f6d0b900ea9cd45220782e793c6860d7abed822 */}
 </Update>
 <Update label="2026-03-27" tags={["self-hosted"]}>
 ## langsmith-0.13.34
@@ -397,6 +426,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-01332) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.34.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.34/langsmith-0.13.34.tgz)
+{/* langsmith-release-image: 0.13.34 0.13.35-7f6d0b900ea9cd45220782e793c6860d7abed822 */}
 </Update>
 <Update label="2026-03-27" tags={["self-hosted"]}>
 ## langsmith-0.13.33
@@ -404,6 +434,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-01332) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.33.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.33/langsmith-0.13.33.tgz)
+{/* langsmith-release-image: 0.13.33 0.13.35-7f6d0b900ea9cd45220782e793c6860d7abed822 */}
 </Update>
 <Update label="2026-03-27" tags={["self-hosted"]}>
 ## langsmith-0.13.32
@@ -443,6 +474,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Fetched full run data in new experiment detail pane.
 
 **Download the Helm chart:** [`langsmith-0.13.32.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.32/langsmith-0.13.32.tgz)
+{/* langsmith-release-image: 0.13.32 0.13.35-7f6d0b900ea9cd45220782e793c6860d7abed822 */}
 </Update>
 <Update label="2026-03-23" tags={["self-hosted"]}>
 ## langsmith-0.13.31
@@ -450,6 +482,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - This release packages the same LangSmith application version as langsmith-0.13.28. Refer to the [langsmith-0.13.28](#langsmith-01328) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.31.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.31/langsmith-0.13.31.tgz)
+{/* langsmith-release-image: 0.13.31 0.13.31-25d6895016f70da39a652bf2a8a088d5347cfeb9 */}
 </Update>
 <Update label="2026-03-23" tags={["self-hosted"]}>
 ## langsmith-0.13.30
@@ -457,6 +490,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - This release packages the same LangSmith application version as langsmith-0.13.28. Refer to the [langsmith-0.13.28](#langsmith-01328) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.30.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.30/langsmith-0.13.30.tgz)
+{/* langsmith-release-image: 0.13.30 0.13.31-25d6895016f70da39a652bf2a8a088d5347cfeb9 */}
 </Update>
 <Update label="2026-03-21" tags={["self-hosted"]}>
 ## langsmith-0.13.29
@@ -464,6 +498,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - This release packages the same LangSmith application version as langsmith-0.13.28. Refer to the [langsmith-0.13.28](#langsmith-01328) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.29.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.29/langsmith-0.13.29.tgz)
+{/* langsmith-release-image: 0.13.29 0.13.31-25d6895016f70da39a652bf2a8a088d5347cfeb9 */}
 </Update>
 <Update label="2026-03-21" tags={["self-hosted"]}>
 ## langsmith-0.13.28
@@ -499,6 +534,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Introduced support for specifying environment variables from secret references for improved configuration management.
 
 **Download the Helm chart:** [`langsmith-0.13.28.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.28/langsmith-0.13.28.tgz)
+{/* langsmith-release-image: 0.13.28 0.13.31-25d6895016f70da39a652bf2a8a088d5347cfeb9 */}
 </Update>
 <Update label="2026-03-18" tags={["self-hosted"]}>
 ## langsmith-0.13.27
@@ -512,6 +548,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Added prompt environments support.
 
 **Download the Helm chart:** [`langsmith-0.13.27.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.27/langsmith-0.13.27.tgz)
+{/* langsmith-release-image: 0.13.27 0.13.28-27251604f6050b18943ac32020fab85f716ff4df */}
 </Update>
 <Update label="2026-03-13" tags={["self-hosted"]}>
 ## langsmith-0.13.26
@@ -532,6 +569,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Added ABAC authorization middleware.
 
 **Download the Helm chart:** [`langsmith-0.13.26.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.26/langsmith-0.13.26.tgz)
+{/* langsmith-release-image: 0.13.26 0.13.27-88ce214af9cd3650c88004f9ad81e72f5d2c819a */}
 </Update>
 <Update label="2026-03-12" tags={["self-hosted"]}>
 ## langsmith-0.13.25
@@ -539,6 +577,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - This release packages the same LangSmith application version as langsmith-0.13.24. Refer to the [langsmith-0.13.24](#langsmith-01324) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.25.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.25/langsmith-0.13.25.tgz)
+{/* langsmith-release-image: 0.13.25 0.13.24-2ab8af1b0ecad3820d3938be644d83e6a78835e9 */}
 </Update>
 <Update label="2026-03-10" tags={["self-hosted"]}>
 ## langsmith-0.13.24
@@ -563,6 +602,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Added ABAC runs delete endpoint.
 
 **Download the Helm chart:** [`langsmith-0.13.24.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.24/langsmith-0.13.24.tgz)
+{/* langsmith-release-image: 0.13.24 0.13.24-2ab8af1b0ecad3820d3938be644d83e6a78835e9 */}
 </Update>
 <Update label="2026-03-07" tags={["self-hosted"]}>
 ## langsmith-0.13.23
@@ -575,6 +615,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Fixed Playground functionality in self-hosted environments.
 
 **Download the Helm chart:** [`langsmith-0.13.23.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.23/langsmith-0.13.23.tgz)
+{/* langsmith-release-image: 0.13.23 0.13.23-bedf8cf99dd9af6e545f5245b0aeed6b338f09f2 */}
 </Update>
 <Update label="2026-03-06" tags={["self-hosted"]}>
 ## langsmith-0.13.21
@@ -582,6 +623,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - This release packages the same LangSmith application version as langsmith-0.13.20. Refer to the [langsmith-0.13.20](#langsmith-01320) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.21.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.21/langsmith-0.13.21.tgz)
+{/* langsmith-release-image: 0.13.21 0.13.21-62853708b9669274abaddeffacfb2aeea616120f */}
 </Update>
 <Update label="2026-03-06" tags={["self-hosted"]}>
 ## langsmith-0.13.20
@@ -611,6 +653,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Added a feature to group experiments by prompt for streamlined data management.
 
 **Download the Helm chart:** [`langsmith-0.13.20.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.20/langsmith-0.13.20.tgz)
+{/* langsmith-release-image: 0.13.20 0.13.21-62853708b9669274abaddeffacfb2aeea616120f */}
 </Update>
 <Update label="2026-03-06" tags={["self-hosted"]}>
 ## langsmith-0.13.19
@@ -618,6 +661,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - This release packages the same LangSmith application version as langsmith-0.13.18. Refer to the [langsmith-0.13.18](#langsmith-01318) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.19.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.19/langsmith-0.13.19.tgz)
+{/* langsmith-release-image: 0.13.19 0.13.20-4a89d00b2ff6c55991ead2929f8bf0acd5c7a85b */}
 </Update>
 <Update label="2026-03-05" tags={["self-hosted"]}>
 ## langsmith-0.13.18
@@ -644,6 +688,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Added functionality to bind Slack agents dynamically, enhancing the integration experience.
 
 **Download the Helm chart:** [`langsmith-0.13.18.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.18/langsmith-0.13.18.tgz)
+{/* langsmith-release-image: 0.13.18 0.13.20-4a89d00b2ff6c55991ead2929f8bf0acd5c7a85b */}
 </Update>
 <Update label="2026-03-03" tags={["self-hosted"]}>
 ## langsmith-0.13.17
@@ -675,6 +720,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Added support for [custom separators in SCIM group names](/langsmith/user-management#configure-custom-separator).
 
 **Download the Helm chart:** [`langsmith-0.13.17.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.17/langsmith-0.13.17.tgz)
+{/* langsmith-release-image: 0.13.17 0.13.18-aed2fb010d6d6a4a73dc2305aabafc0684091ec5 */}
 </Update>
 <Update label="2026-02-26" tags={["self-hosted"]}>
 ## langsmith-0.13.16
@@ -682,6 +728,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - This release packages the same LangSmith application version as langsmith-0.13.15. Refer to the [langsmith-0.13.15](#langsmith-01315) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.16.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.16/langsmith-0.13.16.tgz)
+{/* langsmith-release-image: 0.13.16 0.13.16-a68bd778f5123fe302ed2b2838b2bff0f6e82b5b */}
 </Update>
 <Update label="2026-02-26" tags={["self-hosted"]}>
 ## langsmith-0.13.15
@@ -708,6 +755,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Improved keyboard shortcuts in the inbox feature of the Agent Builder UI.
 
 **Download the Helm chart:** [`langsmith-0.13.15.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.15/langsmith-0.13.15.tgz)
+{/* langsmith-release-image: 0.13.15 0.13.16-a68bd778f5123fe302ed2b2838b2bff0f6e82b5b */}
 </Update>
 <Update label="2026-02-24" tags={["self-hosted"]}>
 ## langsmith-0.13.14
@@ -732,6 +780,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Added UIs for managing and editing model API key names in the playground.
 
 **Download the Helm chart:** [`langsmith-0.13.14.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.14/langsmith-0.13.14.tgz)
+{/* langsmith-release-image: 0.13.14 0.13.15-e059ae344d55e040bb7c87df3fc16aaab6d6f9ac */}
 </Update>
 <Update label="2026-02-14" tags={["self-hosted"]}>
 ## langsmith-0.13.13
@@ -750,6 +799,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Added spinner to loading triggers skeleton for better loading indication.
 
 **Download the Helm chart:** [`langsmith-0.13.13.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.13/langsmith-0.13.13.tgz)
+{/* langsmith-release-image: 0.13.13 0.13.14-2ed26ea85b0ff71037df88ab587fb47d0fdd106b */}
 </Update>
 <Update label="2026-02-12" tags={["self-hosted"]}>
 ## langsmith-0.13.12
@@ -774,6 +824,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Enable new Granular Usage tab for reporting billable usage by workspace, project, user, and API key (enable with `DEFAULT_ORG_FEATURE_ENABLE_GRANULAR_USAGE_REPORTING=true` and `GRANULAR_USAGE_TABLE_ENABLED=true` environment variables in `commonEnv`)
 
 **Download the Helm chart:** [`langsmith-0.13.12.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.12/langsmith-0.13.12.tgz)
+{/* langsmith-release-image: 0.13.12 0.13.11-f55bf497782e1d13e9f6fc9d8325906e0024c49d */}
 </Update>
 <Update label="2026-02-12" tags={["self-hosted"]}>
 ## langsmith-0.13.11
@@ -795,6 +846,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Integrated changes to support custom model configs temporarily.
 
 **Download the Helm chart:** [`langsmith-0.13.11.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.11/langsmith-0.13.11.tgz)
+{/* langsmith-release-image: 0.13.11 0.13.10-0115b4d5095876591bb9cfdc9bc2d5f3aecdf4e3 */}
 </Update>
 <Update label="2026-02-10" tags={["self-hosted"]}>
 ## langsmith-0.13.10
@@ -802,6 +854,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - This release packages the same LangSmith application version as langsmith-0.13.9. Refer to the [langsmith-0.13.9](#langsmith-0139) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.10.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.10/langsmith-0.13.10.tgz)
+{/* langsmith-release-image: 0.13.10 0.13.9-d0c6453c5301e4f2d40bbb2d93106479ed1f6daa */}
 </Update>
 <Update label="2026-02-09" tags={["self-hosted"]}>
 ## langsmith-0.13.9
@@ -829,6 +882,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Added a 15-second timeout to the OAuth HTTP client for improved connection reliability.
 
 **Download the Helm chart:** [`langsmith-0.13.9.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.9/langsmith-0.13.9.tgz)
+{/* langsmith-release-image: 0.13.9 0.13.9-d0c6453c5301e4f2d40bbb2d93106479ed1f6daa */}
 </Update>
 <Update label="2026-02-06" tags={["self-hosted"]}>
 ## langsmith-0.13.7
@@ -836,6 +890,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - This release packages the same LangSmith application version as langsmith-0.13.6. Refer to the [langsmith-0.13.6](#langsmith-0136) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.7.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.7/langsmith-0.13.7.tgz)
+{/* langsmith-release-image: 0.13.7 0.13.7-2398b372e4c1544f0970d796874afaf8372161ee */}
 </Update>
 <Update label="2026-02-05" tags={["self-hosted"]}>
 ## langsmith-0.13.6
@@ -854,6 +909,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Enhanced large field uploads to S3 for single run POST/PATCH endpoints.
 
 **Download the Helm chart:** [`langsmith-0.13.6.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.6/langsmith-0.13.6.tgz)
+{/* langsmith-release-image: 0.13.6 0.13.7-2398b372e4c1544f0970d796874afaf8372161ee */}
 </Update>
 <Update label="2026-02-05" tags={["self-hosted"]}>
 ## langsmith-0.13.5
@@ -877,6 +933,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Enhanced tracing URLs allowed by adding them to the Datadog RUM config.
 
 **Download the Helm chart:** [`langsmith-0.13.5.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.5/langsmith-0.13.5.tgz)
+{/* langsmith-release-image: 0.13.5 0.13.6-29e5da7450495599f5ce57cd8cde994817596910 */}
 </Update>
 <Update label="2026-02-04" tags={["self-hosted"]}>
 ## langsmith-0.13.4
@@ -907,6 +964,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 These changes improve user interaction, enhance system performance, and expand support for custom models and infrastructure, benefiting self-hosted deployments.
 
 **Download the Helm chart:** [`langsmith-0.13.4.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.4/langsmith-0.13.4.tgz)
+{/* langsmith-release-image: 0.13.4 0.13.5-35e6309abc1e6ebf33f05e794f9950d6ea4dde62 */}
 </Update>
 <Update label="2026-01-26" tags={["self-hosted"]}>
 ## langsmith-0.13.3
@@ -932,6 +990,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Improved date/time selection UI by allowing bold "Last time" values for DateTimeRangePicker component.
 
 **Download the Helm chart:** [`langsmith-0.13.3.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.3/langsmith-0.13.3.tgz)
+{/* langsmith-release-image: 0.13.3 0.13.4-680826fad888b367b4fe596ffaf0e5d2149deae3 */}
 </Update>
 <Update label="2026-01-21" tags={["self-hosted"]}>
 ## langsmith-0.13.2
@@ -947,6 +1006,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Increased line-height on XS Text variant to prevent clipping issues in the frontend.
 
 **Download the Helm chart:** [`langsmith-0.13.2.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.2/langsmith-0.13.2.tgz)
+{/* langsmith-release-image: 0.13.2 0.13.3-d095866874cf9521b255f6d43dcc81497466c734 */}
 </Update>
 <Update label="2026-01-16" tags={["self-hosted"]}>
 ## langsmith-0.13.1
@@ -954,6 +1014,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - This release packages the same LangSmith application version as langsmith-0.13.0. Refer to the [langsmith-0.13.0](#langsmith-0130) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.1.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.1/langsmith-0.13.1.tgz)
+{/* langsmith-release-image: 0.13.1 0.13.1-69f6835dd37394eea1f5087287ae0e1ab3c7d183 */}
 </Update>
 <Update label="2026-01-16" tags={["self-hosted"]}>
 ## langsmith-0.13.0
@@ -966,6 +1027,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Fixed trace drawer skeleton not appearing immediately
 
 **Download the Helm chart:** [`langsmith-0.13.0.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.0/langsmith-0.13.0.tgz)
+{/* langsmith-release-image: 0.13.0 0.13.1-69f6835dd37394eea1f5087287ae0e1ab3c7d183 */}
 </Update>
 <Update label="2026-01-12" tags={["self-hosted"]}>
 ## langsmith-0.12.37
@@ -973,6 +1035,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - This release packages the same LangSmith application version as langsmith-0.12.36. Refer to the [langsmith-0.12.36](#langsmith-01236) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.37.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.37/langsmith-0.12.37.tgz)
+{/* langsmith-release-image: 0.12.37 0.12.76-5ca59e94d09e0911efacb79b06ded4a97c4d6e91 */}
 </Update>
 <Update label="2026-01-09" tags={["self-hosted"]}>
 ## langsmith-0.12.36
@@ -987,6 +1050,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Increased maximum automation rules per workspace to 200
 
 **Download the Helm chart:** [`langsmith-0.12.36.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.36/langsmith-0.12.36.tgz)
+{/* langsmith-release-image: 0.12.36 0.12.76-5ca59e94d09e0911efacb79b06ded4a97c4d6e91 */}
 </Update>
 <Update label="2026-01-08" tags={["self-hosted"]}>
 ## langsmith-0.12.35
@@ -1000,6 +1064,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Fixed race condition in OAuth authentication requests
 
 **Download the Helm chart:** [`langsmith-0.12.35.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.35/langsmith-0.12.35.tgz)
+{/* langsmith-release-image: 0.12.35 0.12.75-683d01f652578ff2194de4498b8a4cf70183b71d */}
 </Update>
 <Update label="2025-12-26" tags={["self-hosted"]}>
 ## langsmith-0.12.34
@@ -1019,6 +1084,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Made SCIM group name matching case-insensitive
 
 **Download the Helm chart:** [`langsmith-0.12.34.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.34/langsmith-0.12.34.tgz)
+{/* langsmith-release-image: 0.12.34 0.12.73-354d2af50f45ae3a123eae6ed538fa046913b43f */}
 </Update>
 <Update label="2025-12-20" tags={["self-hosted"]}>
 ## langsmith-0.12.33
@@ -1028,6 +1094,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Added self-serve audit logs for administrative actions (Private Preview)
 
 **Download the Helm chart:** [`langsmith-0.12.33.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.33/langsmith-0.12.33.tgz)
+{/* langsmith-release-image: 0.12.33 0.12.72-b5405ce6d2d43a0b2dc2609e573ac08989de6f5d */}
 </Update>
 <Update label="2025-12-12" tags={["self-hosted"]}>
 ## langsmith-0.12.32
@@ -1037,6 +1104,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Added support for setting memory limits on executor pods.
 
 **Download the Helm chart:** [`langsmith-0.12.32.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.32/langsmith-0.12.32.tgz)
+{/* langsmith-release-image: 0.12.32 0.12.70-ffd583f46b6808c02284b9063745d9bb8d787e64 */}
 </Update>
 <Update label="2025-12-11" tags={["self-hosted"]}>
 ## langsmith-0.12.31
@@ -1046,6 +1114,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Fixed issues with streaming datasets endpoint.
 
 **Download the Helm chart:** [`langsmith-0.12.31.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.31/langsmith-0.12.31.tgz)
+{/* langsmith-release-image: 0.12.31 0.12.69-5564f97c9c64b4657862cd1f8f1bd626941f0c39 */}
 </Update>
 <Update label="2025-12-09" tags={["self-hosted"]}>
 ## langsmith-0.12.30
@@ -1053,6 +1122,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - This release packages the same LangSmith application version as langsmith-0.12.29. Refer to the [langsmith-0.12.29](#langsmith-01229) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.30.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.30/langsmith-0.12.30.tgz)
+{/* langsmith-release-image: 0.12.30 0.12.68-4036298d6ea110f8ede0b6104e01d8fc50cd95a1 */}
 </Update>
 <Update label="2025-12-08" tags={["self-hosted"]}>
 ## langsmith-0.12.29
@@ -1060,6 +1130,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Added mTLS (mutual TLS) support for ClickHouse connections to enhance security for database communication.
 
 **Download the Helm chart:** [`langsmith-0.12.29.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.29/langsmith-0.12.29.tgz)
+{/* langsmith-release-image: 0.12.29 0.12.68-4036298d6ea110f8ede0b6104e01d8fc50cd95a1 */}
 </Update>
 <Update label="2025-12-05" tags={["self-hosted"]}>
 ## langsmith-0.12.28
@@ -1069,6 +1140,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Fixed Agent Builder onboarding and side navigation visibility when disabled in self-hosted deployments.
 
 **Download the Helm chart:** [`langsmith-0.12.28.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.28/langsmith-0.12.28.tgz)
+{/* langsmith-release-image: 0.12.28 0.12.67-121ec27c2de094684873ea2ff6fb11af8f30b956 */}
 </Update>
 <Update label="2025-12-04" tags={["self-hosted"]}>
 ## langsmith-0.12.27
@@ -1078,6 +1150,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Improved incident banner styling and content.
 
 **Download the Helm chart:** [`langsmith-0.12.27.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.27/langsmith-0.12.27.tgz)
+{/* langsmith-release-image: 0.12.27 0.12.66-7d27a5b91d0a4df9341a97ada0eee1cd440f31ea */}
 </Update>
 <Update label="2025-12-02" tags={["self-hosted"]}>
 ## langsmith-0.8.30
@@ -1085,6 +1158,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Internal improvements and maintenance updates
 
 **Download the Helm chart:** [`langsmith-0.8.30.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.8.30/langsmith-0.8.30.tgz)
+{/* langsmith-release-image: 0.8.30 0.8.92 */}
 </Update>
 <Update label="2025-12-01" tags={["self-hosted"]}>
 ## langsmith-0.12.25
@@ -1093,6 +1167,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Added Redis Cluster support for improved scalability and high availability.
 
 **Download the Helm chart:** [`langsmith-0.12.25.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.25/langsmith-0.12.25.tgz)
+{/* langsmith-release-image: 0.12.25 0.12.64-bd72fb0a24339b17682ad90a5572e5a554faafbc */}
 </Update>
 <Update label="2025-11-27" tags={["self-hosted"]}>
 ## langsmith-0.12.24
@@ -1101,6 +1176,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Performance improvements and bug fixes.
 
 **Download the Helm chart:** [`langsmith-0.12.24.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.24/langsmith-0.12.24.tgz)
+{/* langsmith-release-image: 0.12.24 0.12.63 */}
 </Update>
 <Update label="2025-11-26" tags={["self-hosted"]}>
 ## langsmith-0.12.23
@@ -1108,6 +1184,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Internal improvements and maintenance updates
 
 **Download the Helm chart:** [`langsmith-0.12.23.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.23/langsmith-0.12.23.tgz)
+{/* langsmith-release-image: 0.12.23 0.12.62 */}
 </Update>
 <Update label="2025-11-26" tags={["self-hosted"]}>
 ## langsmith-0.12.22
@@ -1115,6 +1192,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - This release packages the same LangSmith application version as langsmith-0.12.21. Refer to the [langsmith-0.12.21](#langsmith-01221) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.22.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.22/langsmith-0.12.22.tgz)
+{/* langsmith-release-image: 0.12.22 0.12.61 */}
 </Update>
 <Update label="2025-11-26" tags={["self-hosted"]}>
 ## langsmith-0.12.21
@@ -1122,6 +1200,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Added explicit `revisionHistoryLimit` configuration for operator deployment template.
 
 **Download the Helm chart:** [`langsmith-0.12.21.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.21/langsmith-0.12.21.tgz)
+{/* langsmith-release-image: 0.12.21 0.12.61 */}
 </Update>
 <Update label="2025-11-24" tags={["self-hosted"]}>
 ## langsmith-0.12.20
@@ -1129,6 +1208,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - This release packages the same LangSmith application version as langsmith-0.12.18. Refer to the [langsmith-0.12.18](#langsmith-01218) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.20.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.20/langsmith-0.12.20.tgz)
+{/* langsmith-release-image: 0.12.20 0.12.57 */}
 </Update>
 <Update label="2025-11-24" tags={["self-hosted"]}>
 ## langsmith-0.12.19
@@ -1136,6 +1216,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - This release packages the same LangSmith application version as langsmith-0.12.18. Refer to the [langsmith-0.12.18](#langsmith-01218) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.19.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.19/langsmith-0.12.19.tgz)
+{/* langsmith-release-image: 0.12.19 0.12.57 */}
 </Update>
 <Update label="2025-11-20" tags={["self-hosted"]}>
 ## langsmith-0.12.18
@@ -1143,6 +1224,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Internal improvements and maintenance updates
 
 **Download the Helm chart:** [`langsmith-0.12.18.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.18/langsmith-0.12.18.tgz)
+{/* langsmith-release-image: 0.12.18 0.12.57 */}
 </Update>
 <Update label="2025-11-19" tags={["self-hosted"]}>
 ## langsmith-0.12.17
@@ -1150,6 +1232,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Internal improvements and maintenance updates
 
 **Download the Helm chart:** [`langsmith-0.12.17.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.17/langsmith-0.12.17.tgz)
+{/* langsmith-release-image: 0.12.17 0.12.51 */}
 </Update>
 <Update label="2025-11-19" tags={["self-hosted"]}>
 ## langsmith-0.12.16
@@ -1157,6 +1240,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Internal improvements and maintenance updates
 
 **Download the Helm chart:** [`langsmith-0.12.16.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.16/langsmith-0.12.16.tgz)
+{/* langsmith-release-image: 0.12.16 0.12.50 */}
 </Update>
 <Update label="2025-11-17" tags={["self-hosted"]}>
 ## langsmith-0.12.15
@@ -1164,6 +1248,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Internal improvements and maintenance updates
 
 **Download the Helm chart:** [`langsmith-0.12.15.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.15/langsmith-0.12.15.tgz)
+{/* langsmith-release-image: 0.12.15 0.12.48 */}
 </Update>
 <Update label="2025-11-17" tags={["self-hosted"]}>
 ## langsmith-0.12.14
@@ -1171,6 +1256,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - Internal improvements and maintenance updates
 
 **Download the Helm chart:** [`langsmith-0.12.14.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.14/langsmith-0.12.14.tgz)
+{/* langsmith-release-image: 0.12.14 0.12.46 */}
 </Update>
 <Update label="2025-11-13" tags={["self-hosted"]}>
 ## langsmith-0.12.13
@@ -1178,6 +1264,7 @@ These changes improve user interaction, enhance system performance, and expand s
 - This release packages the same LangSmith application version as langsmith-0.12.12. Refer to the [langsmith-0.12.12](#langsmith-01212) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.13.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.13/langsmith-0.12.13.tgz)
+{/* langsmith-release-image: 0.12.13 0.12.42 */}
 </Update>
 <Update label="2025-11-13" tags={["self-hosted"]}>
 ## langsmith-0.12.12
@@ -1185,4 +1272,5 @@ These changes improve user interaction, enhance system performance, and expand s
 - Internal improvements and maintenance updates
 
 **Download the Helm chart:** [`langsmith-0.12.12.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.12/langsmith-0.12.12.tgz)
+{/* langsmith-release-image: 0.12.12 0.12.42 */}
 </Update>


### PR DESCRIPTION
## Summary

Backfills a `{/* langsmith-release-image: <version> <key> */}` MDX comment into every `<Update>` entry of the self-hosted changelog (88 entries). Each marker records the underlying LangSmith image a helm release packages — the image ref from its langchainplus release, or the appVersion string when no ref is published.

## Why

The `helm-changelog-bot` reads these markers (`git.parse_logged_release_keys`) to deduplicate future releases against entries **already in the changelog**: a new helm release that repackages an image an existing entry already shipped gets a cross-linked "refer to" note instead of duplicated or placeholder release notes.

The recovery/dedup changelog content already merged to `main` only carries markers for entries written *after* the bot change. This backfill extends that coverage to the pre-existing entries, so the bot dedupes against the full history.

The markers are MDX comments — invisible in the rendered page. Verified with `make lint_prose` (0 errors) and `make broken-links` (this file not flagged).

## AI disclosure

Prepared with assistance from Claude Code; see the `Co-Authored-By` trailer on the commit.
