### PR TITLE
feat(oss): add Advanced section to deepagents customization guide

### DIFF
--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -573,6 +573,30 @@ For more information and examples, see [response format](/oss/langchain/structur
 
 `create_deep_agent` is a thin wrapper around [`create_agent`][langchain.agents.create_agent] — under the hood it assembles a middleware stack and calls `create_agent` with it. For fully custom agents, you can use `create_agent` directly and compose exactly the middleware you need.
 
+The table below shows all available middleware by category. The sections that follow build a complete example layer by layer.
+
+| Category | Middleware | What it adds | Default in `create_deep_agent` |
+|---|---|---|---|
+| **Execution environment** | @[`FilesystemMiddleware`] | Virtual filesystem, file tools, large-result offloading | ✓ |
+| | @[`CodeInterpreterMiddleware`] | Persistent JS REPL via QuickJS (`langchain_quickjs`) | |
+| | @[`ShellToolMiddleware`] | Stateful shell tool that persists across turns | |
+| **Context management** | @[`SummarizationMiddleware`] | Compresses history and offloads large tool results | ✓ |
+| | @[`SummarizationToolMiddleware`] | Agent-triggered summarization between tasks | |
+| | @[`MemoryMiddleware`] | Injects `AGENTS.md` files every turn | when `memory=` set |
+| | @[`SkillsMiddleware`] | Progressive skill disclosure | when `skills=` set |
+| | @[`AnthropicPromptCachingMiddleware`] | Reduces redundant token processing | ✓ (Anthropic) |
+| | @[`LLMToolSelectorMiddleware`] | Dynamic LLM-based tool filtering | |
+| **Planning & delegation** | @[`TodoListMiddleware`] | Todo list tracking across turns | ✓ |
+| | @[`SubAgentMiddleware`] | Sync subagent spawning via `task` tool | ✓ |
+| | @[`AsyncSubAgentMiddleware`] | Background non-blocking subagents | |
+| **Fault tolerance** | @[`ModelRetryMiddleware`] | Retry on model call failure | |
+| | @[`ToolRetryMiddleware`] | Retry failed tool calls | |
+| | @[`ModelFallbackMiddleware`] | Fall back to an alternate model | |
+| | @[`ModelCallLimitMiddleware`] | Cap total model calls per session | |
+| | @[`ToolCallLimitMiddleware`] | Cap total tool calls per session | |
+| **Guardrails** | @[`PIIMiddleware`] | Detect and redact PII from tool results | |
+| **Steering** | @[`HumanInTheLoopMiddleware`] | Pause for human approval before tool calls | when `interrupt_on=` set |
+
 The most minimal agent is just a model calling tools in a loop:
 
 ```python
@@ -588,7 +612,7 @@ From here, each section below adds one capability layer, building toward a compl
 
 ### Execution environment
 
-@[`FilesystemMiddleware`] gives the agent a virtual filesystem: it can read, write, and edit files, and automatically offloads large tool results out of the context window to keep it from filling up.
+@[`FilesystemMiddleware`] gives the agent a virtual filesystem: it can read, write, and edit files, and automatically offloads large tool results out of the context window. For code execution, @[`CodeInterpreterMiddleware`] adds a persistent JavaScript REPL via QuickJS, and @[`ShellToolMiddleware`] provides a stateful shell that persists across turns. To run code in a fully isolated environment, swap `StateBackend` for a [`SandboxBackend`](/oss/deepagents/sandboxes).
 
 ```python
 from langchain.agents import create_agent
@@ -606,45 +630,43 @@ agent = create_agent(
 )
 ```
 
-Swap `StateBackend` for a [`SandboxBackend`](/oss/deepagents/sandboxes) to give the agent an isolated environment with shell execution.
-
 ### Context management
 
-@[`MemoryMiddleware`] injects `AGENTS.md` context on every turn. @[`SkillsMiddleware`] progressively loads skill files only when the agent determines they are relevant — keeping the initial context window lean.
+@[`SummarizationMiddleware`] compresses message history and offloads large tool results when the context window fills up. @[`MemoryMiddleware`] injects `AGENTS.md` context on every turn. @[`SkillsMiddleware`] progressively loads skill files only when the agent determines they are relevant, keeping the initial context window lean.
 
 ```python
 from langchain.agents import create_agent
 from deepagents.backends import StateBackend
-from deepagents.middleware import FilesystemMiddleware, MemoryMiddleware, SkillsMiddleware
+from deepagents.middleware import FilesystemMiddleware, MemoryMiddleware, SkillsMiddleware, SummarizationMiddleware
 
 backend = StateBackend()
+model = "anthropic:claude-sonnet-4-6"
 
 agent = create_agent(
-    model="anthropic:claude-sonnet-4-6",
+    model=model,
     tools=[search],
     middleware=[
         FilesystemMiddleware(backend=backend),
+        SummarizationMiddleware(model=model, backend=backend),
         MemoryMiddleware(backend=backend, sources=["./AGENTS.md"]),
         SkillsMiddleware(backend=backend, sources=["./skills/"]),
     ],
 )
 ```
 
-<Note>
-`create_deep_agent` also includes @[`SummarizationMiddleware`] by default, which compresses message history when the context window grows long. Add it explicitly from `langchain.agents.middleware` if your custom agent handles long sessions.
-</Note>
-
 ### Planning and delegation
 
-@[`SubAgentMiddleware`] adds a `task` tool that spawns subagents for isolated subtasks. Each subagent runs in its own fresh context window, so complex multi-step work does not exhaust the main agent's context.
+@[`TodoListMiddleware`] tracks tasks across turns. @[`SubAgentMiddleware`] adds a `task` tool that spawns subagents for isolated subtasks — each subagent runs in its own fresh context window, so complex multi-step work does not exhaust the main agent's context.
 
 ```python
 from langchain.agents import create_agent
+from langchain.agents.middleware import TodoListMiddleware
 from deepagents import SubAgent
 from deepagents.backends import StateBackend
-from deepagents.middleware import FilesystemMiddleware, MemoryMiddleware, SkillsMiddleware, SubAgentMiddleware
+from deepagents.middleware import FilesystemMiddleware, MemoryMiddleware, SkillsMiddleware, SubAgentMiddleware, SummarizationMiddleware
 
 backend = StateBackend()
+model = "anthropic:claude-sonnet-4-6"
 
 researcher: SubAgent = {
     "name": "researcher",
@@ -654,12 +676,14 @@ researcher: SubAgent = {
 }
 
 agent = create_agent(
-    model="anthropic:claude-sonnet-4-6",
+    model=model,
     tools=[search],
     middleware=[
         FilesystemMiddleware(backend=backend),
+        SummarizationMiddleware(model=model, backend=backend),
         MemoryMiddleware(backend=backend, sources=["./AGENTS.md"]),
         SkillsMiddleware(backend=backend, sources=["./skills/"]),
+        TodoListMiddleware(),
         SubAgentMiddleware(backend=backend, subagents=[researcher]),
     ],
 )
@@ -673,13 +697,14 @@ For background (non-blocking) subagents that run in parallel, see @[`AsyncSubAge
 
 ```python
 from langchain.agents import create_agent
-from langchain.agents.middleware import HumanInTheLoopMiddleware
+from langchain.agents.middleware import HumanInTheLoopMiddleware, TodoListMiddleware
 from langgraph.checkpoint.memory import MemorySaver
 from deepagents import SubAgent
 from deepagents.backends import StateBackend
-from deepagents.middleware import FilesystemMiddleware, MemoryMiddleware, SkillsMiddleware, SubAgentMiddleware
+from deepagents.middleware import FilesystemMiddleware, MemoryMiddleware, SkillsMiddleware, SubAgentMiddleware, SummarizationMiddleware
 
 backend = StateBackend()
+model = "anthropic:claude-sonnet-4-6"
 
 researcher: SubAgent = {
     "name": "researcher",
@@ -689,14 +714,16 @@ researcher: SubAgent = {
 }
 
 agent = create_agent(
-    model="anthropic:claude-sonnet-4-6",
+    model=model,
     tools=[search],
     middleware=[
-        FilesystemMiddleware(backend=backend),                                   # execution environment
-        MemoryMiddleware(backend=backend, sources=["./AGENTS.md"]),              # context management
-        SkillsMiddleware(backend=backend, sources=["./skills/"]),                # context management
-        SubAgentMiddleware(backend=backend, subagents=[researcher]),             # planning & delegation
-        HumanInTheLoopMiddleware(interrupt_on={"write_file": True}),            # steering
+        FilesystemMiddleware(backend=backend),                                       # execution environment
+        SummarizationMiddleware(model=model, backend=backend),                       # context management
+        MemoryMiddleware(backend=backend, sources=["./AGENTS.md"]),                  # context management
+        SkillsMiddleware(backend=backend, sources=["./skills/"]),                    # context management
+        TodoListMiddleware(),                                                         # planning & delegation
+        SubAgentMiddleware(backend=backend, subagents=[researcher]),                 # planning & delegation
+        HumanInTheLoopMiddleware(interrupt_on={"write_file": True}),                # steering
     ],
     checkpointer=MemorySaver(),
 )

--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -69,6 +69,7 @@ import CustomizationStructuredOutputJs from '/snippets/code-samples/customizatio
 - [Memory](#memory)
 :::python
 - [Profiles](#profiles)
+- [Advanced](#advanced)
 :::
 
 :::python
@@ -565,3 +566,143 @@ When the model generates the structured data, it's captured, validated, and retu
 :::
 
 For more information and examples, see [response format](/oss/langchain/structured-output#response-format).
+
+:::python
+
+## Advanced
+
+`create_deep_agent` is a thin wrapper around [`create_agent`][langchain.agents.create_agent] — under the hood it assembles a middleware stack and calls `create_agent` with it. For fully custom agents, you can use `create_agent` directly and compose exactly the middleware you need.
+
+The most minimal agent is just a model calling tools in a loop:
+
+```python
+from langchain.agents import create_agent
+
+agent = create_agent(
+    model="anthropic:claude-sonnet-4-6",
+    tools=[search],
+)
+```
+
+From here, each section below adds one capability layer, building toward a complete research assistant. Add only the layers your use case needs.
+
+### Execution environment
+
+@[`FilesystemMiddleware`] gives the agent a virtual filesystem: it can read, write, and edit files, and automatically offloads large tool results out of the context window to keep it from filling up.
+
+```python
+from langchain.agents import create_agent
+from deepagents.backends import StateBackend
+from deepagents.middleware import FilesystemMiddleware
+
+backend = StateBackend()
+
+agent = create_agent(
+    model="anthropic:claude-sonnet-4-6",
+    tools=[search],
+    middleware=[
+        FilesystemMiddleware(backend=backend),
+    ],
+)
+```
+
+Swap `StateBackend` for a [`SandboxBackend`](/oss/deepagents/sandboxes) to give the agent an isolated environment with shell execution.
+
+### Context management
+
+@[`MemoryMiddleware`] injects `AGENTS.md` context on every turn. @[`SkillsMiddleware`] progressively loads skill files only when the agent determines they are relevant — keeping the initial context window lean.
+
+```python
+from langchain.agents import create_agent
+from deepagents.backends import StateBackend
+from deepagents.middleware import FilesystemMiddleware, MemoryMiddleware, SkillsMiddleware
+
+backend = StateBackend()
+
+agent = create_agent(
+    model="anthropic:claude-sonnet-4-6",
+    tools=[search],
+    middleware=[
+        FilesystemMiddleware(backend=backend),
+        MemoryMiddleware(backend=backend, sources=["./AGENTS.md"]),
+        SkillsMiddleware(backend=backend, sources=["./skills/"]),
+    ],
+)
+```
+
+<Note>
+`create_deep_agent` also includes @[`SummarizationMiddleware`] by default, which compresses message history when the context window grows long. Add it explicitly from `langchain.agents.middleware` if your custom agent handles long sessions.
+</Note>
+
+### Planning and delegation
+
+@[`SubAgentMiddleware`] adds a `task` tool that spawns subagents for isolated subtasks. Each subagent runs in its own fresh context window, so complex multi-step work does not exhaust the main agent's context.
+
+```python
+from langchain.agents import create_agent
+from deepagents import SubAgent
+from deepagents.backends import StateBackend
+from deepagents.middleware import FilesystemMiddleware, MemoryMiddleware, SkillsMiddleware, SubAgentMiddleware
+
+backend = StateBackend()
+
+researcher: SubAgent = {
+    "name": "researcher",
+    "description": "Deep-dives into a topic and returns a structured summary.",
+    "system_prompt": "You are a research specialist. Search thoroughly and cite your sources.",
+    "tools": [search],
+}
+
+agent = create_agent(
+    model="anthropic:claude-sonnet-4-6",
+    tools=[search],
+    middleware=[
+        FilesystemMiddleware(backend=backend),
+        MemoryMiddleware(backend=backend, sources=["./AGENTS.md"]),
+        SkillsMiddleware(backend=backend, sources=["./skills/"]),
+        SubAgentMiddleware(backend=backend, subagents=[researcher]),
+    ],
+)
+```
+
+For background (non-blocking) subagents that run in parallel, see @[`AsyncSubAgentMiddleware`] and [async subagents](/oss/deepagents/async-subagents).
+
+### Steering
+
+@[`HumanInTheLoopMiddleware`] pauses before specified tool calls so a human can review and approve. A checkpointer is required to preserve the agent's state while waiting.
+
+```python
+from langchain.agents import create_agent
+from langchain.agents.middleware import HumanInTheLoopMiddleware
+from langgraph.checkpoint.memory import MemorySaver
+from deepagents import SubAgent
+from deepagents.backends import StateBackend
+from deepagents.middleware import FilesystemMiddleware, MemoryMiddleware, SkillsMiddleware, SubAgentMiddleware
+
+backend = StateBackend()
+
+researcher: SubAgent = {
+    "name": "researcher",
+    "description": "Deep-dives into a topic and returns a structured summary.",
+    "system_prompt": "You are a research specialist. Search thoroughly and cite your sources.",
+    "tools": [search],
+}
+
+agent = create_agent(
+    model="anthropic:claude-sonnet-4-6",
+    tools=[search],
+    middleware=[
+        FilesystemMiddleware(backend=backend),                                   # execution environment
+        MemoryMiddleware(backend=backend, sources=["./AGENTS.md"]),              # context management
+        SkillsMiddleware(backend=backend, sources=["./skills/"]),                # context management
+        SubAgentMiddleware(backend=backend, subagents=[researcher]),             # planning & delegation
+        HumanInTheLoopMiddleware(interrupt_on={"write_file": True}),            # steering
+    ],
+    checkpointer=MemorySaver(),
+)
+```
+
+This fully assembled agent is equivalent to calling `create_deep_agent` with `memory=`, `skills=`, `subagents=`, and `interrupt_on=` — which is exactly what `create_deep_agent` does under the hood.
+
+:::
+


### PR DESCRIPTION
## Summary

- Adds a new `## Advanced` section to `customization.mdx` that frames `create_deep_agent` as a thin wrapper around `create_agent` + deepagents middleware
- Shows how to compose a custom agent layer by layer using the four key components from the Interrupt 2026 deep agents talk:
  - **Execution environment** — `FilesystemMiddleware` (+ `SandboxBackend`)
  - **Context management** — `MemoryMiddleware`, `SkillsMiddleware`, note on `SummarizationMiddleware`
  - **Planning & delegation** — `SubAgentMiddleware`
  - **Steering** — `HumanInTheLoopMiddleware`
- Single running example (research assistant) built up across all four sections, ending with the fully assembled agent
- Adds `[Advanced](#advanced)` to the page TOC
- Python-only; JS parity is a follow-up

## Test plan

- [ ] Verify MDX renders correctly in Mintlify preview
- [ ] Check all `@[...]` cross-reference links resolve
- [ ] Confirm code examples import paths are correct against deepagents source
- [ ] Verify `:::python` block hides section for JS variant