### PR TITLE
fix(playground): this example is no longer used/working

### DIFF
--- a/src/playground.mdx
+++ b/src/playground.mdx
@@ -57,9 +57,6 @@ noindex: true
             <Card title="Markdown Messages" icon="file-description" href="https://ui-patterns.langchain.com/react/#/markdown-messages" target="_blank">
                 Rich Markdown rendering with syntax-highlighted code blocks inside chat bubbles.
             </Card>
-            <Card title="Message Branching" icon="git-branch" href="https://ui-patterns.langchain.com/react/#/message-branching" target="_blank">
-                Display multi-branch message threads with branch selectors inline in the chat history.
-            </Card>
             <Card title="Branching Chat" icon="message" href="https://ui-patterns.langchain.com/react/#/branching-chat" target="_blank">
                 Full chat interface with first-class branch navigation and history traversal.
             </Card>
@@ -111,9 +108,6 @@ noindex: true
             </Card>
             <Card title="Markdown Messages" icon="file-description" href="https://ui-patterns.langchain.com/vue/#/markdown-messages" target="_blank">
                 Rich Markdown rendering with syntax-highlighted code blocks inside chat bubbles.
-            </Card>
-            <Card title="Message Branching" icon="git-branch" href="https://ui-patterns.langchain.com/vue/#/message-branching" target="_blank">
-                Display multi-branch message threads with branch selectors inline in the chat history.
             </Card>
             <Card title="Branching Chat" icon="message" href="https://ui-patterns.langchain.com/vue/#/branching-chat" target="_blank">
                 Full chat interface with first-class branch navigation and history traversal.
@@ -167,9 +161,6 @@ noindex: true
             <Card title="Markdown Messages" icon="file-description" href="https://ui-patterns.langchain.com/svelte/#/markdown-messages" target="_blank">
                 Rich Markdown rendering with syntax-highlighted code blocks inside chat bubbles.
             </Card>
-            <Card title="Message Branching" icon="git-branch" href="https://ui-patterns.langchain.com/svelte/#/message-branching" target="_blank">
-                Display multi-branch message threads with branch selectors inline in the chat history.
-            </Card>
             <Card title="Branching Chat" icon="message" href="https://ui-patterns.langchain.com/svelte/#/branching-chat" target="_blank">
                 Full chat interface with first-class branch navigation and history traversal.
             </Card>
@@ -221,9 +212,6 @@ noindex: true
             </Card>
             <Card title="Markdown Messages" icon="file-description" href="https://ui-patterns.langchain.com/angular/#/markdown-messages" target="_blank">
                 Rich Markdown rendering with syntax-highlighted code blocks inside chat bubbles.
-            </Card>
-            <Card title="Message Branching" icon="git-branch" href="https://ui-patterns.langchain.com/angular/#/message-branching" target="_blank">
-                Display multi-branch message threads with branch selectors inline in the chat history.
             </Card>
             <Card title="Branching Chat" icon="message" href="https://ui-patterns.langchain.com/angular/#/branching-chat" target="_blank">
                 Full chat interface with first-class branch navigation and history traversal.


### PR DESCRIPTION
We can remove the link to this outdated example. The canonical example for this is "branching-chat".