### PR TITLE
docs(mda): typo fix on tavily search tool

### DIFF
--- a/src/langsmith/deploy-managed-deep-agent.mdx
+++ b/src/langsmith/deploy-managed-deep-agent.mdx
@@ -83,14 +83,14 @@ For the API request, pass the agent instructions and tool configuration directly
 {
   "tools": [
     {
-      "name": "tavily-search",
+      "name": "tavily_search",
       "mcp_server_url": "https://mcp.tavily.com/mcp/",
       "mcp_server_name": "tavily",
-      "display_name": "tavily-search"
+      "display_name": "tavily_search"
     }
   ],
   "interrupt_config": {
-    "https://mcp.tavily.com/mcp/::tavily-search::tavily": false
+    "https://mcp.tavily.com/mcp/::tavily_search::tavily": false
   }
 }
 ```
@@ -316,14 +316,14 @@ Each entry in `tools[].mcp_server_url` must match a server you registered in [Co
             "tools": {
                 "tools": [
                     {
-                        "name": "tavily-search",
+                        "name": "tavily_search",
                         "mcp_server_url": "https://mcp.tavily.com/mcp/",
                         "mcp_server_name": "tavily",
-                        "display_name": "tavily-search",
+                        "display_name": "tavily_search",
                     },
                 ],
                 "interrupt_config": {
-                    "https://mcp.tavily.com/mcp/::tavily-search::tavily": False,
+                    "https://mcp.tavily.com/mcp/::tavily_search::tavily": False,
                 },
             },
         },
@@ -353,14 +353,14 @@ Each entry in `tools[].mcp_server_url` must match a server you registered in [Co
         tools: {
           tools: [
             {
-              name: "tavily-search",
+              name: "tavily_search",
               mcp_server_url: "https://mcp.tavily.com/mcp/",
               mcp_server_name: "tavily",
-              display_name: "tavily-search",
+              display_name: "tavily_search",
             },
           ],
           interrupt_config: {
-            "https://mcp.tavily.com/mcp/::tavily-search::tavily": false,
+            "https://mcp.tavily.com/mcp/::tavily_search::tavily": false,
           },
         },
       }),
@@ -388,14 +388,14 @@ Each entry in `tools[].mcp_server_url` must match a server you registered in [Co
         "tools": {
           "tools": [
             {
-              "name": "tavily-search",
+              "name": "tavily_search",
               "mcp_server_url": "https://mcp.tavily.com/mcp/",
               "mcp_server_name": "tavily",
-              "display_name": "tavily-search"
+              "display_name": "tavily_search"
             }
           ],
           "interrupt_config": {
-            "https://mcp.tavily.com/mcp/::tavily-search::tavily": false
+            "https://mcp.tavily.com/mcp/::tavily_search::tavily": false
           }
         }
       }'
@@ -614,7 +614,7 @@ The run is traced in LangSmith. Open the trace to inspect messages, tool calls, 
 
 Use `PATCH /v1/deepagents/agents/{agent_id}` when you need to update instructions, runtime settings, or tool configuration.
 
-The example below extends the agent created above by adding `tavily-extract` (Tavily's structured-extraction tool) alongside the existing `tavily-search` tool. It also flips `tavily-extract` to require human approval before each call by setting that tool's `interrupt_config` value to `true`. Because PATCH replaces `tools` wholesale, pass the full new tool set, not just the additions.
+The example below extends the agent created above by adding `tavily-extract` (Tavily's structured-extraction tool) alongside the existing `tavily_search` tool. It also flips `tavily-extract` to require human approval before each call by setting that tool's `interrupt_config` value to `true`. Because PATCH replaces `tools` wholesale, pass the full new tool set, not just the additions.
 
 <Tabs>
   <Tab title="Python (httpx)">
@@ -632,10 +632,10 @@ The example below extends the agent created above by adding `tavily-extract` (Ta
             "tools": {
                 "tools": [
                     {
-                        "name": "tavily-search",
+                        "name": "tavily_search",
                         "mcp_server_url": "https://mcp.tavily.com/mcp/",
                         "mcp_server_name": "tavily",
-                        "display_name": "tavily-search",
+                        "display_name": "tavily_search",
                     },
                     {
                         "name": "tavily-extract",
@@ -645,7 +645,7 @@ The example below extends the agent created above by adding `tavily-extract` (Ta
                     },
                 ],
                 "interrupt_config": {
-                    "https://mcp.tavily.com/mcp/::tavily-search::tavily": False,
+                    "https://mcp.tavily.com/mcp/::tavily_search::tavily": False,
                     "https://mcp.tavily.com/mcp/::tavily-extract::tavily": True,
                 },
             },
@@ -668,10 +668,10 @@ The example below extends the agent created above by adding `tavily-extract` (Ta
         tools: {
           tools: [
             {
-              name: "tavily-search",
+              name: "tavily_search",
               mcp_server_url: "https://mcp.tavily.com/mcp/",
               mcp_server_name: "tavily",
-              display_name: "tavily-search",
+              display_name: "tavily_search",
             },
             {
               name: "tavily-extract",
@@ -681,7 +681,7 @@ The example below extends the agent created above by adding `tavily-extract` (Ta
             },
           ],
           interrupt_config: {
-            "https://mcp.tavily.com/mcp/::tavily-search::tavily": false,
+            "https://mcp.tavily.com/mcp/::tavily_search::tavily": false,
             "https://mcp.tavily.com/mcp/::tavily-extract::tavily": true,
           },
         },
@@ -707,10 +707,10 @@ The example below extends the agent created above by adding `tavily-extract` (Ta
         "tools": {
           "tools": [
             {
-              "name": "tavily-search",
+              "name": "tavily_search",
               "mcp_server_url": "https://mcp.tavily.com/mcp/",
               "mcp_server_name": "tavily",
-              "display_name": "tavily-search"
+              "display_name": "tavily_search"
             },
             {
               "name": "tavily-extract",
@@ -720,7 +720,7 @@ The example below extends the agent created above by adding `tavily-extract` (Ta
             }
           ],
           "interrupt_config": {
-            "https://mcp.tavily.com/mcp/::tavily-search::tavily": false,
+            "https://mcp.tavily.com/mcp/::tavily_search::tavily": false,
             "https://mcp.tavily.com/mcp/::tavily-extract::tavily": true
           }
         }


### PR DESCRIPTION
## Overview
Fixing a small typo in tavily search tool! 

## Type of change

**Type:** Fix typo/bug/link/formatting

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

