### PR TITLE
feat: add deploy feature information

### DIFF
--- a/src/langsmith/self-hosted-mission-control.mdx
+++ b/src/langsmith/self-hosted-mission-control.mdx
@@ -250,7 +250,7 @@ Use this path when installer scripts are not allowed. These steps use normal `ku
   </Step>
   <Step title="Install with Helm">
     ```bash
-    helm upgrade --install mission-control langchain/langsmith-mission-control \
+    helm upgrade --install mission-control langchain/mission-control \
       --namespace langsmith \
       --create-namespace \
       --values values.yaml \
@@ -347,7 +347,7 @@ kubectl delete secret -n langsmith \
 
 The Helm chart creates a `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` named `mission-control`. Most permissions are read-only. Write verbs are narrow and controlled by feature flags.
 
-Install or upgrade requires the ability to create cluster-scoped RBAC (`ClusterRole` and `ClusterRoleBinding`), usually `cluster-admin` or a custom equivalent. The broadest runtime permission set is only used when `config.features.deploy: true`; that flag is `false` by default.
+Install or upgrade requires the ability to create cluster-scoped RBAC (`ClusterRole` and `ClusterRoleBinding`), usually `cluster-admin` or a custom equivalent. The broadest runtime permission set is only used when `config.features.deploy: true`; that flag is enabled by default — set it to `false` for read-only installs.
 
 #### Always-present read-only permissions
 
@@ -370,7 +370,8 @@ Install or upgrade requires the ability to create cluster-scoped RBAC (`ClusterR
 | `config.features.alerts` | secrets (`mission-control-alerts-*`) | create, update, delete |
 | `config.features.fixIssue` | pods | delete |
 | `config.features.adopt` | secrets, configmaps, serviceaccounts, deployments, statefulsets | patch |
-| `config.auth.enabled` | secrets (`mission-control-auth`, setup-token), backend deployment | create, update, delete, patch |
+| `config.auth.enabled` | secrets (`mission-control-auth`, setup-token), backend statefulset | create, update, delete, patch |
+| `config.features.valuesOverride` | secrets (`mission-control-values-overrides`) | create, update, delete |
 | `config.features.deploy` | workloads, networking, RBAC, CRDs, Helm release secrets | create, update, patch, delete |
 
 Set feature flags to `false` in `values.yaml` to remove the corresponding write verbs. With all feature flags disabled, Mission Control is effectively read-only except for authentication setup permissions when `config.auth.enabled: true`.

--- a/src/langsmith/self-hosted-mission-control.mdx
+++ b/src/langsmith/self-hosted-mission-control.mdx
@@ -347,7 +347,7 @@ kubectl delete secret -n langsmith \
 
 The Helm chart creates a `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` named `mission-control`. Most permissions are read-only. Write verbs are narrow and controlled by feature flags.
 
-Install or upgrade requires the ability to create cluster-scoped RBAC (`ClusterRole` and `ClusterRoleBinding`), usually `cluster-admin` or a custom equivalent. The broadest runtime permission set is only used when `config.features.deploy: true`; that flag is enabled by default  set it to `false` for read-only installs.
+Install or upgrade requires the ability to create cluster-scoped RBAC (`ClusterRole` and `ClusterRoleBinding`), usually `cluster-admin` or a custom equivalent. The broadest runtime permission set is only used when `config.features.deploy: true`; that flag is enabled by default, set it to `false` for read-only installs.
 
 #### Always-present read-only permissions
 

--- a/src/langsmith/self-hosted-mission-control.mdx
+++ b/src/langsmith/self-hosted-mission-control.mdx
@@ -347,7 +347,7 @@ kubectl delete secret -n langsmith \
 
 The Helm chart creates a `ServiceAccount`, `ClusterRole`, and `ClusterRoleBinding` named `mission-control`. Most permissions are read-only. Write verbs are narrow and controlled by feature flags.
 
-Install or upgrade requires the ability to create cluster-scoped RBAC (`ClusterRole` and `ClusterRoleBinding`), usually `cluster-admin` or a custom equivalent. The broadest runtime permission set is only used when `config.features.deploy: true`; that flag is enabled by default — set it to `false` for read-only installs.
+Install or upgrade requires the ability to create cluster-scoped RBAC (`ClusterRole` and `ClusterRoleBinding`), usually `cluster-admin` or a custom equivalent. The broadest runtime permission set is only used when `config.features.deploy: true`; that flag is enabled by default  set it to `false` for read-only installs.
 
 #### Always-present read-only permissions
 


### PR DESCRIPTION
**Overview**
Fix four inaccuracies in the self-hosted Mission Control documentation: wrong Helm chart name, incorrect default value for the deploy feature flag, wrong workload type for the auth backend, and a missing valuesOverride row in the permissions reference table.

**Type of change**
Type: Fix typo/bug/link/formatting

**Checklist**
- [x] I have read thecontributing guidelines including the language 
- [x] I have tested my changes locally using docs dev
- [x] All code examples have been tested and work correctly
- [x] I have used root relative paths for internal links
- [x] I have updated navigation in src/docs.json if needed

**Additional notes**
Four corrections to self-hosted-mission-control.mdx:
- Helm chart name langchain/langsmith-mission-control to langchain/mission-control
- Deploy flag default clarified that config.features.deploy is enabled by default; previous wording incorrectly stated it was false by default
- Auth backend workload type backend deployment to backend statefulset
- Missing permissions row added config.features.values Override entry (secrets mission-control-values-overrides, verbs: create, update, delete) to the feature-gated permissions table