### PR TITLE
docs: backfill self-hosted rc.15 and rc.16

### DIFF
--- a/src/langsmith/self-hosted-changelog.mdx
+++ b/src/langsmith/self-hosted-changelog.mdx
@@ -12,6 +12,24 @@ rss: true
 [Self-hosted LangSmith](/langsmith/self-hosted) is an add-on to the Enterprise plan designed for our largest, most security-conscious customers. For more details, refer to [Pricing](https://www.langchain.com/pricing). [Contact our sales team](https://www.langchain.com/contact-sales) if you want to get a license key to trial LangSmith in your environment.
 
 
+<Update label="2026-05-21" tags={["self-hosted"]} rss={{ title: "2026-05-21 - self-hosted" }}>
+## langsmith-0.15.0-rc.16
+
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.14. Refer to the [langsmith-0.15.0-rc.14](#langsmith-0150-rc14) release notes below.
+
+**Download the Helm chart:** [`langsmith-0.15.0-rc.16.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.16/langsmith-0.15.0-rc.16.tgz)
+{/* langsmith-release-image: 0.15.0-rc.16 0.15.7-d6de5e64598efb40bc8a3ba25730f8807309e15a */}
+</Update>
+
+<Update label="2026-05-20" tags={["self-hosted"]} rss={{ title: "2026-05-20 - self-hosted" }}>
+## langsmith-0.15.0-rc.15
+
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.14. Refer to the [langsmith-0.15.0-rc.14](#langsmith-0150-rc14) release notes below.
+
+**Download the Helm chart:** [`langsmith-0.15.0-rc.15.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.15/langsmith-0.15.0-rc.15.tgz)
+{/* langsmith-release-image: 0.15.0-rc.15 0.15.7-d6de5e64598efb40bc8a3ba25730f8807309e15a */}
+</Update>
+
 <Update label="2026-05-20" tags={["self-hosted"]} rss={{ title: "2026-05-20 - self-hosted" }}>
 ## langsmith-0.8.31
 


### PR DESCRIPTION
## Summary
- add the missing `langsmith-0.15.0-rc.15` and `langsmith-0.15.0-rc.16` changelog entries above `langsmith-0.8.31`
- collapse both RC entries to the existing `langsmith-0.15.0-rc.14` notes because they package the same underlying application image
- persist the shared `langsmith-release-image` markers so future bot runs continue deduping correctly

## Test plan
- [x] ran the updated bot logic locally and verified it detected exactly `rc.16` and `rc.15` as missing releases
- [x] verified the generated logic deduped both releases to `langsmith-0.15.0-rc.14`
- [x] checked the final `src/langsmith/self-hosted-changelog.mdx` diff locally

Made with [Cursor](https://cursor.com)