### PR TITLE
docs(deepagents): use metadata.entrypoint for interpreter skills

### DIFF
--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -367,7 +367,7 @@ Every tool you expose through PTC is an outside capability that interpreter code
 | Top-level `await` | Yes | Use promises in interpreter code |
 | `console.log` capture | Yes | Disable with `capture_console=False` |
 | Agent tools | No | Add a PTC allowlist |
-| Interpreter skill modules | No | Add a `module` entry and configure `skills_backend` or `skillsBackend` |
+| Interpreter skill modules | No | Add a `metadata.entrypoint` entry and configure `skills_backend` or `skillsBackend` |
 | Filesystem access | No | Add the [built-in filesystem tools](/oss/deepagents/harness#virtual-filesystem-access) via the PTC allowlist |
 | Network access | No | Expose a specific network tool through PTC |
 | Wall-clock or datetime access | No | Expose an explicit time tool if needed |
@@ -380,7 +380,7 @@ Every tool you expose through PTC is an outside capability that interpreter code
 | Top-level `await` | Yes | Use promises in interpreter code |
 | `console.log` capture | Yes | Disable with `captureConsole: false` |
 | Agent tools | No | Add a PTC allowlist |
-| Interpreter skill modules | No | Add a `module` entry and configure `skills_backend` or `skillsBackend` |
+| Interpreter skill modules | No | Add a `metadata.entrypoint` entry and configure `skills_backend` or `skillsBackend` |
 | Filesystem access | No | Add the [built-in filesystem tools](/oss/deepagents/harness#virtual-filesystem-access) via the PTC allowlist |
 | Network access | No | Expose a specific network tool through PTC |
 | Wall-clock or datetime access | No | Expose an explicit time tool if needed |

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -73,7 +73,8 @@ The following example shows a skill that gives instructions on how to provide re
 ---
 name: langgraph-docs
 description: Use this skill for requests related to LangGraph in order to fetch relevant documentation to provide accurate, up-to-date guidance.
-module: index.ts
+metadata:
+  entrypoint: scripts/index.ts
 ---
 
 # langgraph-docs
@@ -136,10 +137,10 @@ pageUrls;
 ```
 ````
 
-The referenced helper code would be placed in `index.ts`:
+The referenced helper code would be placed in `scripts/index.ts`:
 
 ```typescript
-// index.ts
+// scripts/index.ts
 export function resolveLlmsUrl(url: string) {
   return url.endsWith(".md") ? url.slice(0, -3) : url;
 }
@@ -175,8 +176,8 @@ compatibility: Requires internet access for fetching documentation URLs
 metadata:
   author: langchain
   version: "1.0"
+  entrypoint: scripts/index.ts
 allowed-tools: fetch_url
-module: index.ts
 ---
 
 # langgraph-docs
@@ -411,8 +412,8 @@ Use interpreter skills for code that should be:
 To make a skill importable:
 
 <Steps titleSize="h4">
-    <Step title="Add a module entry">
-        Add a `module` key to the skill's `SKILL.md` frontmatter. The value is a JavaScript or TypeScript file path relative to the skill directory.
+    <Step title="Add a metadata entrypoint">
+        Add a `metadata.entrypoint` key to the skill's `SKILL.md` frontmatter. The value is a JavaScript or TypeScript file path relative to the skill directory.
     </Step>
     <Step title="Configure skills normally">
         Pass the skill source path with the `skills` argument when creating the agent.
@@ -431,14 +432,16 @@ Minimal skill layout:
 skills/
 `-- order-helpers/
     |-- SKILL.md
-    `-- index.ts
+    `-- scripts/
+        `-- index.ts
 ```
 
 ````md
 ---
 name: order-helpers
 description: Helper functions for normalizing and grouping order records.
-module: index.ts
+metadata:
+  entrypoint: scripts/index.ts
 ---
 
 # order-helpers
@@ -454,7 +457,7 @@ groupByStatus(...);
 ````
 
 ```typescript
-// skills/order-helpers/index.ts
+// skills/order-helpers/scripts/index.ts
 interface Order {
   id: string;
   status: string;
@@ -504,7 +507,7 @@ const agent = createDeepAgent({
 ```
 :::
 
-The agent can now import the module from interpreter code:
+The agent can now import the helper from interpreter code:
 
 ```javascript
 const { groupByStatus } = await import("@/skills/order-helpers");


### PR DESCRIPTION
## Summary

Updates the Deep Agents interpreter-skills documentation to match the upstream frontmatter change from `module` to `metadata.entrypoint` (langchain-ai/deepagents#3551). This removes outdated examples and instructions so docs align with the current skill metadata contract and importable skill layout.

## Changes

### Deep Agents docs (`src/oss/deepagents`)

- Updated interpreter capability tables in `interpreters.mdx` to instruct users to use `metadata.entrypoint` instead of `module`.
- Updated `skills.mdx` frontmatter examples from top-level `module` to nested `metadata.entrypoint`.
- Aligned associated example paths and explanatory text to the `scripts/index.ts` entrypoint layout referenced by the updated metadata.
