### PR TITLE
Add note to docs about Gemini model capabilities

### DIFF
--- a/src/langsmith/evaluate-with-attachments.mdx
+++ b/src/langsmith/evaluate-with-attachments.mdx
@@ -4,14 +4,14 @@ sidebarTitle: Run an evaluation with multimodal content
 description: Learn how to create dataset examples with file attachments and use them in prompts and evaluators when running LangSmith evaluations with multimodal content.
 ---
 
-LangSmith lets you create dataset examples with file attachments—like images, audio files, or documents—and use them in your prompts and evaluators when running evaluations with multimodal content.
+LangSmith lets you create dataset examples with file attachments, like images, audio files, or documents, and use them in your prompts and evaluators when running evaluations with multimodal content.
 
 While you can include multimodal data in your examples by base64 encoding it, this approach is inefficient—the encoded data takes up more space than the original binary files, resulting in slower transfers to and from LangSmith. Using attachments instead provides two key benefits:
 
 - Faster upload and download speeds due to more efficient binary file transfers.
 - Enhanced visualization of different file types in the LangSmith UI.
 
-This guide covers how to create examples with attachments, build multimodal prompts and evaluators that use those attachments, and run evaluations with multimodal content—select the [**UI**](#ui) or [**SDK**](#sdk) following tabs to get started.
+This guide covers how to create examples with attachments, build multimodal prompts and evaluators that use those attachments, and run evaluations with multimodal content. Select either the [**UI**](#ui) or [**SDK**](#sdk) tab to get started.
 
 **Choose your preferred method:**
 
@@ -43,7 +43,7 @@ The LangSmith UI allows you to include attachments in your prompts when evaluati
 First, click the file icon in the message where you want to add multimodal content. Next, add a template variable for the attachment(s) you want to include for each example.
 
 - If you want to include a specific attachment, you can use the suggested variable name, such as `{{attachment.file_name}}`, this will map the file with `file_name` in the attachment list to pass it to the evaluator
-- If you want to include all attachments, use the `{{attachments}`}` variable.
+- If you want to include all attachments, use the `{{attachments}}` variable.
 
 ![Adding multimodal variable](/langsmith/images/adding-multimodal-variable.gif)
 
@@ -51,12 +51,16 @@ First, click the file icon in the message where you want to add multimodal conte
 
 You can create evaluators that use multimodal content from your dataset examples.
 
+<Note>
+Evaluators must use a model that supports both the input modality and structured output. For audio attachments, this is currently only Gemini. Image and PDF attachments work with any vision-capable model that returns structured output.
+</Note>
+
 Since your dataset already has examples with attachments (added in step 1), you can reference them directly in your evaluator. To do so:
 
 1. Select **+ Evaluator** from the dataset page.
 1. In the **Template variables** editor, add a variable for the attachment(s) to include:
    - If you want to include a specific attachment, you can use the suggested variable name, such as `{{attachment.file_name}}`, this will map the file with `file_name` in the attachment list to pass it to the evaluator.
-    - If you want to include all attachments, use the `{{attachments}`}` variable.
+    - If you want to include all attachments, use the `{{attachments}}` variable.
 
     <img
         className="block dark:hidden"


### PR DESCRIPTION
Modified evaluate-with-attachments.mdx, added note that Gemini is the only model that supports audio attachments and structured output, replaced em dashes, and fixed code formatting.

Fixes DOC-1141