### PR TITLE
docs: fix broken cross-links in self-hosted changelog

### DIFF
--- a/src/langsmith/self-hosted-changelog.mdx
+++ b/src/langsmith/self-hosted-changelog.mdx
@@ -15,7 +15,7 @@ rss: true
 <Update label="2026-05-21" tags={["self-hosted"]} rss={{ title: "2026-05-21 - self-hosted" }}>
 ## langsmith-0.15.0-rc.16
 
-- This release packages the same LangSmith application version as langsmith-0.15.0-rc.14. Refer to the [langsmith-0.15.0-rc.14](#langsmith-0150-rc14) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.14. Refer to the [langsmith-0.15.0-rc.14](#langsmith-0-15-0-rc-14) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.16.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.16/langsmith-0.15.0-rc.16.tgz)
 {/* langsmith-release-image: 0.15.0-rc.16 0.15.7-d6de5e64598efb40bc8a3ba25730f8807309e15a */}
@@ -24,7 +24,7 @@ rss: true
 <Update label="2026-05-20" tags={["self-hosted"]} rss={{ title: "2026-05-20 - self-hosted" }}>
 ## langsmith-0.15.0-rc.15
 
-- This release packages the same LangSmith application version as langsmith-0.15.0-rc.14. Refer to the [langsmith-0.15.0-rc.14](#langsmith-0150-rc14) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.14. Refer to the [langsmith-0.15.0-rc.14](#langsmith-0-15-0-rc-14) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.15.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.15/langsmith-0.15.0-rc.15.tgz)
 {/* langsmith-release-image: 0.15.0-rc.15 0.15.7-d6de5e64598efb40bc8a3ba25730f8807309e15a */}
@@ -33,7 +33,7 @@ rss: true
 <Update label="2026-05-20" tags={["self-hosted"]} rss={{ title: "2026-05-20 - self-hosted" }}>
 ## langsmith-0.8.31
 
-- This release packages the same LangSmith application version as langsmith-0.8.30. Refer to the [langsmith-0.8.30](#langsmith-0830) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.8.30. Refer to the [langsmith-0.8.30](#langsmith-0-8-30) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.8.31.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.8.31/langsmith-0.8.31.tgz)
 {/* langsmith-release-image: 0.8.31 0.8.92 */}
@@ -65,7 +65,7 @@ rss: true
 <Update label="2026-05-14" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.13
 
-- This release packages the same LangSmith application version as langsmith-0.15.0-rc.12. Refer to the [langsmith-0.15.0-rc.12](#langsmith-0150-rc12) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.12. Refer to the [langsmith-0.15.0-rc.12](#langsmith-0-15-0-rc-12) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.13.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.13/langsmith-0.15.0-rc.13.tgz)
 {/* langsmith-release-image: 0.15.0-rc.13 0.15.3-4a1b22708d0a402b664df96c75c6ffa261a2546a */}
@@ -107,7 +107,7 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2026-05-11" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.10
 
-- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0-15-0-rc-4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.10.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.10/langsmith-0.15.0-rc.10.tgz)
 {/* langsmith-release-image: 0.15.0-rc.10 0.15.2-0dd2b56c14e44fbf384d9bb0bf094f2ca896c914 */}
@@ -115,7 +115,7 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2026-05-09" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.9
 
-- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0-15-0-rc-4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.9.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.9/langsmith-0.15.0-rc.9.tgz)
 {/* langsmith-release-image: 0.15.0-rc.9 0.15.2-0dd2b56c14e44fbf384d9bb0bf094f2ca896c914 */}
@@ -123,7 +123,7 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2026-05-08" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.8
 
-- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0-15-0-rc-4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.8.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.8/langsmith-0.15.0-rc.8.tgz)
 {/* langsmith-release-image: 0.15.0-rc.8 0.15.2-0dd2b56c14e44fbf384d9bb0bf094f2ca896c914 */}
@@ -131,7 +131,7 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2026-05-08" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.7
 
-- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0-15-0-rc-4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.7.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.7/langsmith-0.15.0-rc.7.tgz)
 {/* langsmith-release-image: 0.15.0-rc.7 0.15.2-0dd2b56c14e44fbf384d9bb0bf094f2ca896c914 */}
@@ -139,7 +139,7 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2026-05-06" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.6
 
-- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0-15-0-rc-4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.6.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.6/langsmith-0.15.0-rc.6.tgz)
 {/* langsmith-release-image: 0.15.0-rc.6 0.15.2-0dd2b56c14e44fbf384d9bb0bf094f2ca896c914 */}
@@ -147,7 +147,7 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2026-05-05" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.5
 
-- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0150-rc4) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.4. Refer to the [langsmith-0.15.0-rc.4](#langsmith-0-15-0-rc-4) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.5.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.5/langsmith-0.15.0-rc.5.tgz)
 {/* langsmith-release-image: 0.15.0-rc.5 0.15.2-0dd2b56c14e44fbf384d9bb0bf094f2ca896c914 */}
@@ -181,7 +181,7 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2026-04-30" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.3
 
-- This release packages the same LangSmith application version as langsmith-0.15.0-rc.1. Refer to the [langsmith-0.15.0-rc.1](#langsmith-0150-rc1) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.1. Refer to the [langsmith-0.15.0-rc.1](#langsmith-0-15-0-rc-1) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.3.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.3/langsmith-0.15.0-rc.3.tgz)
 {/* langsmith-release-image: 0.15.0-rc.3 0.15.1-bc7b710bcfb878cb28e908ad748ad8717431a51a */}
@@ -198,7 +198,7 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2026-04-24" tags={["self-hosted"]}>
 ## langsmith-0.15.0-rc.2
 
-- This release packages the same LangSmith application version as langsmith-0.15.0-rc.1. Refer to the [langsmith-0.15.0-rc.1](#langsmith-0150-rc1) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.15.0-rc.1. Refer to the [langsmith-0.15.0-rc.1](#langsmith-0-15-0-rc-1) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.0-rc.2.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.0-rc.2/langsmith-0.15.0-rc.2.tgz)
 {/* langsmith-release-image: 0.15.0-rc.2 0.15.1-bc7b710bcfb878cb28e908ad748ad8717431a51a */}
@@ -249,7 +249,7 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2026-04-20" tags={["self-hosted"]}>
 ## langsmith-0.14.2
 
-- This release packages the same LangSmith application version as langsmith-0.14.0. Refer to the [langsmith-0.14.0](#langsmith-0140) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.14.0. Refer to the [langsmith-0.14.0](#langsmith-0-14-0) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.14.2.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.2/langsmith-0.14.2.tgz)
 {/* langsmith-release-image: 0.14.2 0.14.3 */}
@@ -257,7 +257,7 @@ These updates focus on improving user experience, performance, security, and fea
 <Update label="2026-04-20" tags={["self-hosted"]}>
 ## langsmith-0.14.1
 
-- This release packages the same LangSmith application version as langsmith-0.14.0. Refer to the [langsmith-0.14.0](#langsmith-0140) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.14.0. Refer to the [langsmith-0.14.0](#langsmith-0-14-0) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.14.1.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.14.1/langsmith-0.14.1.tgz)
 {/* langsmith-release-image: 0.14.1 0.14.3 */}
@@ -307,7 +307,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 <Update label="2026-04-17" tags={["self-hosted"]}>
 ## langsmith-0.13.43
 
-- This release packages the same LangSmith application version as langsmith-0.13.42. Refer to the [langsmith-0.13.42](#langsmith-01342) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.42. Refer to the [langsmith-0.13.42](#langsmith-0-13-42) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.43.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.43/langsmith-0.13.43.tgz)
 {/* langsmith-release-image: 0.13.43 0.13.44 */}
@@ -425,7 +425,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 <Update label="2026-03-30" tags={["self-hosted"]}>
 ## langsmith-0.13.36
 
-- This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-01332) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-0-13-32) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.36.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.36/langsmith-0.13.36.tgz)
 {/* langsmith-release-image: 0.13.36 0.13.35-7f6d0b900ea9cd45220782e793c6860d7abed822 */}
@@ -433,7 +433,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 <Update label="2026-03-27" tags={["self-hosted"]}>
 ## langsmith-0.13.35
 
-- This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-01332) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-0-13-32) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.35.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.35/langsmith-0.13.35.tgz)
 {/* langsmith-release-image: 0.13.35 0.13.35-7f6d0b900ea9cd45220782e793c6860d7abed822 */}
@@ -441,7 +441,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 <Update label="2026-03-27" tags={["self-hosted"]}>
 ## langsmith-0.13.34
 
-- This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-01332) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-0-13-32) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.34.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.34/langsmith-0.13.34.tgz)
 {/* langsmith-release-image: 0.13.34 0.13.35-7f6d0b900ea9cd45220782e793c6860d7abed822 */}
@@ -449,7 +449,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 <Update label="2026-03-27" tags={["self-hosted"]}>
 ## langsmith-0.13.33
 
-- This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-01332) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.32. Refer to the [langsmith-0.13.32](#langsmith-0-13-32) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.33.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.33/langsmith-0.13.33.tgz)
 {/* langsmith-release-image: 0.13.33 0.13.35-7f6d0b900ea9cd45220782e793c6860d7abed822 */}
@@ -497,7 +497,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 <Update label="2026-03-23" tags={["self-hosted"]}>
 ## langsmith-0.13.31
 
-- This release packages the same LangSmith application version as langsmith-0.13.28. Refer to the [langsmith-0.13.28](#langsmith-01328) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.28. Refer to the [langsmith-0.13.28](#langsmith-0-13-28) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.31.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.31/langsmith-0.13.31.tgz)
 {/* langsmith-release-image: 0.13.31 0.13.31-25d6895016f70da39a652bf2a8a088d5347cfeb9 */}
@@ -505,7 +505,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 <Update label="2026-03-23" tags={["self-hosted"]}>
 ## langsmith-0.13.30
 
-- This release packages the same LangSmith application version as langsmith-0.13.28. Refer to the [langsmith-0.13.28](#langsmith-01328) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.28. Refer to the [langsmith-0.13.28](#langsmith-0-13-28) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.30.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.30/langsmith-0.13.30.tgz)
 {/* langsmith-release-image: 0.13.30 0.13.31-25d6895016f70da39a652bf2a8a088d5347cfeb9 */}
@@ -513,7 +513,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 <Update label="2026-03-21" tags={["self-hosted"]}>
 ## langsmith-0.13.29
 
-- This release packages the same LangSmith application version as langsmith-0.13.28. Refer to the [langsmith-0.13.28](#langsmith-01328) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.28. Refer to the [langsmith-0.13.28](#langsmith-0-13-28) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.29.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.29/langsmith-0.13.29.tgz)
 {/* langsmith-release-image: 0.13.29 0.13.31-25d6895016f70da39a652bf2a8a088d5347cfeb9 */}
@@ -592,7 +592,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 <Update label="2026-03-12" tags={["self-hosted"]}>
 ## langsmith-0.13.25
 
-- This release packages the same LangSmith application version as langsmith-0.13.24. Refer to the [langsmith-0.13.24](#langsmith-01324) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.24. Refer to the [langsmith-0.13.24](#langsmith-0-13-24) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.25.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.25/langsmith-0.13.25.tgz)
 {/* langsmith-release-image: 0.13.25 0.13.24-2ab8af1b0ecad3820d3938be644d83e6a78835e9 */}
@@ -638,7 +638,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 <Update label="2026-03-06" tags={["self-hosted"]}>
 ## langsmith-0.13.21
 
-- This release packages the same LangSmith application version as langsmith-0.13.20. Refer to the [langsmith-0.13.20](#langsmith-01320) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.20. Refer to the [langsmith-0.13.20](#langsmith-0-13-20) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.21.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.21/langsmith-0.13.21.tgz)
 {/* langsmith-release-image: 0.13.21 0.13.21-62853708b9669274abaddeffacfb2aeea616120f */}
@@ -676,7 +676,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 <Update label="2026-03-06" tags={["self-hosted"]}>
 ## langsmith-0.13.19
 
-- This release packages the same LangSmith application version as langsmith-0.13.18. Refer to the [langsmith-0.13.18](#langsmith-01318) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.18. Refer to the [langsmith-0.13.18](#langsmith-0-13-18) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.19.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.19/langsmith-0.13.19.tgz)
 {/* langsmith-release-image: 0.13.19 0.13.20-4a89d00b2ff6c55991ead2929f8bf0acd5c7a85b */}
@@ -743,7 +743,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 <Update label="2026-02-26" tags={["self-hosted"]}>
 ## langsmith-0.13.16
 
-- This release packages the same LangSmith application version as langsmith-0.13.15. Refer to the [langsmith-0.13.15](#langsmith-01315) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.15. Refer to the [langsmith-0.13.15](#langsmith-0-13-15) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.16.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.16/langsmith-0.13.16.tgz)
 {/* langsmith-release-image: 0.13.16 0.13.16-a68bd778f5123fe302ed2b2838b2bff0f6e82b5b */}
@@ -869,7 +869,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 <Update label="2026-02-10" tags={["self-hosted"]}>
 ## langsmith-0.13.10
 
-- This release packages the same LangSmith application version as langsmith-0.13.9. Refer to the [langsmith-0.13.9](#langsmith-0139) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.9. Refer to the [langsmith-0.13.9](#langsmith-0-13-9) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.10.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.10/langsmith-0.13.10.tgz)
 {/* langsmith-release-image: 0.13.10 0.13.9-d0c6453c5301e4f2d40bbb2d93106479ed1f6daa */}
@@ -905,7 +905,7 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 <Update label="2026-02-06" tags={["self-hosted"]}>
 ## langsmith-0.13.7
 
-- This release packages the same LangSmith application version as langsmith-0.13.6. Refer to the [langsmith-0.13.6](#langsmith-0136) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.6. Refer to the [langsmith-0.13.6](#langsmith-0-13-6) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.7.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.7/langsmith-0.13.7.tgz)
 {/* langsmith-release-image: 0.13.7 0.13.7-2398b372e4c1544f0970d796874afaf8372161ee */}
@@ -1029,7 +1029,7 @@ These changes improve user interaction, enhance system performance, and expand s
 <Update label="2026-01-16" tags={["self-hosted"]}>
 ## langsmith-0.13.1
 
-- This release packages the same LangSmith application version as langsmith-0.13.0. Refer to the [langsmith-0.13.0](#langsmith-0130) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.13.0. Refer to the [langsmith-0.13.0](#langsmith-0-13-0) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.13.1.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.1/langsmith-0.13.1.tgz)
 {/* langsmith-release-image: 0.13.1 0.13.1-69f6835dd37394eea1f5087287ae0e1ab3c7d183 */}
@@ -1050,7 +1050,7 @@ These changes improve user interaction, enhance system performance, and expand s
 <Update label="2026-01-12" tags={["self-hosted"]}>
 ## langsmith-0.12.37
 
-- This release packages the same LangSmith application version as langsmith-0.12.36. Refer to the [langsmith-0.12.36](#langsmith-01236) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.12.36. Refer to the [langsmith-0.12.36](#langsmith-0-12-36) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.37.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.37/langsmith-0.12.37.tgz)
 {/* langsmith-release-image: 0.12.37 0.12.76-5ca59e94d09e0911efacb79b06ded4a97c4d6e91 */}
@@ -1137,7 +1137,7 @@ These changes improve user interaction, enhance system performance, and expand s
 <Update label="2025-12-09" tags={["self-hosted"]}>
 ## langsmith-0.12.30
 
-- This release packages the same LangSmith application version as langsmith-0.12.29. Refer to the [langsmith-0.12.29](#langsmith-01229) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.12.29. Refer to the [langsmith-0.12.29](#langsmith-0-12-29) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.30.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.30/langsmith-0.12.30.tgz)
 {/* langsmith-release-image: 0.12.30 0.12.68-4036298d6ea110f8ede0b6104e01d8fc50cd95a1 */}
@@ -1207,7 +1207,7 @@ These changes improve user interaction, enhance system performance, and expand s
 <Update label="2025-11-26" tags={["self-hosted"]}>
 ## langsmith-0.12.22
 
-- This release packages the same LangSmith application version as langsmith-0.12.21. Refer to the [langsmith-0.12.21](#langsmith-01221) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.12.21. Refer to the [langsmith-0.12.21](#langsmith-0-12-21) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.22.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.22/langsmith-0.12.22.tgz)
 {/* langsmith-release-image: 0.12.22 0.12.61 */}
@@ -1223,7 +1223,7 @@ These changes improve user interaction, enhance system performance, and expand s
 <Update label="2025-11-24" tags={["self-hosted"]}>
 ## langsmith-0.12.20
 
-- This release packages the same LangSmith application version as langsmith-0.12.18. Refer to the [langsmith-0.12.18](#langsmith-01218) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.12.18. Refer to the [langsmith-0.12.18](#langsmith-0-12-18) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.20.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.20/langsmith-0.12.20.tgz)
 {/* langsmith-release-image: 0.12.20 0.12.57 */}
@@ -1231,7 +1231,7 @@ These changes improve user interaction, enhance system performance, and expand s
 <Update label="2025-11-24" tags={["self-hosted"]}>
 ## langsmith-0.12.19
 
-- This release packages the same LangSmith application version as langsmith-0.12.18. Refer to the [langsmith-0.12.18](#langsmith-01218) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.12.18. Refer to the [langsmith-0.12.18](#langsmith-0-12-18) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.19.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.19/langsmith-0.12.19.tgz)
 {/* langsmith-release-image: 0.12.19 0.12.57 */}
@@ -1279,7 +1279,7 @@ These changes improve user interaction, enhance system performance, and expand s
 <Update label="2025-11-13" tags={["self-hosted"]}>
 ## langsmith-0.12.13
 
-- This release packages the same LangSmith application version as langsmith-0.12.12. Refer to the [langsmith-0.12.12](#langsmith-01212) release notes below.
+- This release packages the same LangSmith application version as langsmith-0.12.12. Refer to the [langsmith-0.12.12](#langsmith-0-12-12) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.12.13.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.12.13/langsmith-0.12.13.tgz)
 {/* langsmith-release-image: 0.12.13 0.12.42 */}


### PR DESCRIPTION
## Summary

- The self-hosted changelog used dot-stripped slugs (e.g. `#langsmith-0150-rc14`, `#langsmith-01342`) for its in-page cross-references between RC/patch releases and the underlying notes, but Mintlify generates heading anchors by replacing each dot with a hyphen (e.g. `#langsmith-0-15-0-rc-14`, `#langsmith-0-13-42`).
- As a result, all 35 "Refer to the …" cross-links in `src/langsmith/self-hosted-changelog.mdx` were broken — clicking them stayed on the same page without scrolling.
- This PR rewrites every internal anchor target to match the actual Mintlify-generated IDs. No content or ordering changes.

## Test plan

- [ ] Open the deploy preview for `langsmith/self-hosted-changelog` and click each "Refer to the [langsmith-x.y.z](#…) release notes" link to confirm it jumps to the correct release heading.
- [ ] Spot-check `langsmith-0.15.0-rc.16` → `langsmith-0.15.0-rc.14`, `langsmith-0.8.31` → `langsmith-0.8.30`, and `langsmith-0.13.1` → `langsmith-0.13.0`.
- [ ] `make lint_prose FILES="src/langsmith/self-hosted-changelog.mdx"` passes (already verified locally — 0 errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
