### PR TITLE
docs: allow editing service key roles without rotation

### DIFF
--- a/src/langsmith/audit-logs.mdx
+++ b/src/langsmith/audit-logs.mdx
@@ -95,7 +95,7 @@ To forward audit log events to an external SIEM or logging platform, you can run
 
 | Category | Operations (`api.operation`) |
 |----------|-----------|
-| **API keys & credentials** | `create_api_key`, `delete_api_key`, `create_personal_access_token`, `delete_personal_access_token`, `create_service_key`, `delete_service_key`, `create_service_account`, `delete_service_account`, `list_org_personal_access_tokens`, `list_org_service_keys` |
+| **API keys & credentials** | `create_api_key`, `delete_api_key`, `create_personal_access_token`, `delete_personal_access_token`, `create_service_key`, `delete_service_key`, `update_service_key`, `create_service_account`, `delete_service_account`, `list_org_personal_access_tokens`, `list_org_service_keys` |
 | **Roles** | `create_role`, `update_role`, `delete_role` |
 | **Organizations** | `create_organization`, `create_provisioned_saas_org`, `create_tenant`, `invite_provisioned_org_member`, `claim_pending_organization_invite`, `delete_pending_organization_invite` |
 | **Organization members** | `invite_user_to_org`, `invite_users_to_org_batch`, `update_org_member`, `delete_org_member`, `delete_org_pending_member`, `add_basic_auth_users_to_org`, `update_basic_auth_user` |

--- a/src/langsmith/create-account-api-key.mdx
+++ b/src/langsmith/create-account-api-key.mdx
@@ -38,6 +38,10 @@ To log traces and run evaluations with LangSmith, create an API key to authentic
   To delete an API key, navigate to the [Settings page](https://smith.langchain.com/settings), find the key in the **API Keys** section, and select the trash icon <Icon icon="trash" iconType="solid"/> in the **Actions** column.
 </Tip>
 
+<Tip>
+  [Enterprise](/langsmith/pricing-plans) organization admins can edit the [role](/langsmith/administration-overview#workspace-roles-rbac) on an existing service key without rotating the key. On the [Settings page](https://smith.langchain.com/settings) **API Keys** section, switch to the **Service** tab and click any service key row to open the edit dialog. Update the workspace role (and, for organization-scoped keys, the org role) and click **Save** — the key string itself is unchanged.
+</Tip>
+
 ## Configure the SDK
 
 Install the SDK for your language:

--- a/src/langsmith/create-account-api-key.mdx
+++ b/src/langsmith/create-account-api-key.mdx
@@ -39,7 +39,7 @@ To log traces and run evaluations with LangSmith, create an API key to authentic
 </Tip>
 
 <Tip>
-  [Enterprise](/langsmith/pricing-plans) organization admins can edit the [role](/langsmith/administration-overview#workspace-roles-rbac) on an existing service key without rotating the key. On the [Settings page](https://smith.langchain.com/settings) **API Keys** section, switch to the **Service** tab and click any service key row to open the edit dialog. Update the workspace role (and, for organization-scoped keys, the org role) and click **Save** — the key string itself is unchanged.
+  [Enterprise](/langsmith/pricing-plans) organization admins can edit the [role](/langsmith/administration-overview#workspace-roles-rbac) on an existing service key without rotating the key. On the [Settings page](https://smith.langchain.com/settings) **API Keys** section, switch to the **Service** tab and click any service key row to open the edit dialog. Update the workspace role (and, for organization-scoped keys, the org role) and click **Save**—the key string itself is unchanged.
 </Tip>
 
 ## Configure the SDK

--- a/src/langsmith/manage-organization-by-api.mdx
+++ b/src/langsmith/manage-organization-by-api.mdx
@@ -68,6 +68,7 @@ These params should be omitted: `read_only` (deprecated), `password` and `full_n
 ## API keys
 
 * [Create a service key](/langsmith/smith-api/api-key/generate-api-key)
+* [Update a service key role](/langsmith/smith-api/orgs/update-org-service-key)
 * [Delete a service key](/langsmith/smith-api/api-key/delete-api-key)
 
 ## Security settings

--- a/src/langsmith/organization-workspace-operations.mdx
+++ b/src/langsmith/organization-workspace-operations.mdx
@@ -140,6 +140,7 @@ Attribute-based access control (ABAC) policies for fine-grained permissions.
 | List org-scoped service keys | ✓ | ✓ | ✓ | ✓ | `organization:read` |
 | Create org-scoped service key (workspace-scoped)* | ✓ | ✓ | ⚠ | ✗ | `organization:pats:create` |
 | Create org-scoped service key (org-wide)* | ✓ | ✗ | ✗ | ✗ | `organization:pats:create` + `organization:manage` |
+| Update service key role | ✓ | ✗ | ✗ | ✗ | `organization:manage` |
 | List personal access tokens (PATs) | ✓ | ✓ | ✓ | ✗ | `organization:read` |
 | Create personal access token (PAT) | ✓ | ✓ | ✓ | ✗ | `organization:pats:create` |
 | Delete personal access token (PAT) | ✓ | ✓ | ✓ | ✗ | `organization:read` |


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
