### PR TITLE
docs(langsmith): add cosign verification to mirroring images guide

### DIFF
--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -190,3 +190,45 @@ operator:
 Replace `(your-registry)` with your registry URL. The template variables (`${service_name}`, `${namespace}`, `${max_connections}`, `${storage_gi}`) are replaced by the operator at runtime and must be kept as-is.
 
 Once configured, you will need to update your LangSmith installation. You can follow our upgrade guide here: [Upgrading LangSmith](/langsmith/self-host-upgrades). If your upgrade is successful, your LangSmith instance should now be using the mirrored images from your Docker registry.
+
+## Verifying image signatures
+
+Stable-channel LangSmith images on `docker.io/langchain/*` are signed at release time using keyless [Sigstore/Cosign](https://docs.sigstore.dev/cosign/overview/) from the release workflow. The signing identity is bound to a specific GitHub Actions workflow, run, and commit, so the signature attests not just that the image is authentic but that it was produced by the stable-branch release pipeline running in `langchain-ai/langchainplus`. You can verify a signature before pulling or mirroring an image, and again after mirroring to confirm the digest you mirrored matches what we signed.
+
+Install `cosign` ([installation guide](https://docs.sigstore.dev/cosign/system_config/installation/)), then verify any tag:
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'https://github\.com/langchain-ai/langchainplus/\.github/workflows/release_self_hosted_on_version_bump\.yaml@refs/heads/v[0-9]+-stable' \
+  docker.io/langchain/langsmith-backend:<tag>
+```
+
+A successful verification confirms:
+
+- The cosign claims on the signature are valid.
+- The certificate chains to the Sigstore root and is logged in the [Rekor](https://docs.sigstore.dev/rekor/overview/) transparency log.
+- The signing certificate was issued to the stable-branch release workflow via GitHub Actions OIDC.
+
+The same command works against any of the released images by substituting the repository (`langsmith-frontend`, `langsmith-go-backend`, `agent-builder-deep-agent`, `langsmith-clio`, `langsmith-polly`, `agent-builder-tool-server`, `agent-builder-trigger-server`, `hosted-langserve-backend`, `langsmith-playground`, `langsmith-ace-backend`, plus their `*-fips` variants).
+
+### Pinning to a specific release
+
+For stricter verification — for example, pinning to a single stable branch or a specific commit — drop the regex and supply the exact certificate identity. Each signature's certificate also carries the workflow run ID and commit SHA as Subject Alternative Name extensions, so you can constrain to a specific release:
+
+```bash
+cosign verify \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity 'https://github.com/langchain-ai/langchainplus/.github/workflows/release_self_hosted_on_version_bump.yaml@refs/heads/v15-stable' \
+  docker.io/langchain/langsmith-backend:0.15.9
+```
+
+To inspect the certificate's claims (workflow run, commit, runner), download the attestation and decode the embedded certificate:
+
+```bash
+cosign download attestation docker.io/langchain/langsmith-backend:<tag>
+```
+
+<Note>
+SPDX SBOM attestations are not yet attached to released images and will land in a future release. This section will be updated once SBOMs are published, including the `cosign verify-attestation --type spdx` command to retrieve them.
+</Note>

--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -193,6 +193,10 @@ Once configured, you will need to update your LangSmith installation. You can fo
 
 ## Verifying image signatures
 
+<Note>
+Image signatures are available **starting with v15** (LangSmith app version `0.15.x` and later). Earlier releases on the `v14-stable` and older channels are not signed and cannot be verified with the steps below.
+</Note>
+
 Stable-channel LangSmith images on `docker.io/langchain/*` are signed at release time using keyless [Sigstore/Cosign](https://docs.sigstore.dev/cosign/overview/) from the release workflow. The signing identity is bound to a specific GitHub Actions workflow, run, and commit, so the signature attests not just that the image is authentic but that it was produced by the stable-branch release pipeline running in `langchain-ai/langchainplus`. You can verify a signature before pulling or mirroring an image, and again after mirroring to confirm the digest you mirrored matches what we signed.
 
 Install `cosign` ([installation guide](https://docs.sigstore.dev/cosign/system_config/installation/)), then verify any tag:


### PR DESCRIPTION
Adds a "Verifying image signatures" section to the existing self-hosted mirroring-images doc covering:

- That stable-channel images on \`docker.io/langchain/*\` are signed via keyless Sigstore/Cosign from the release workflow.
- The full \`cosign verify\` command (with both the regex form and a strict per-release identity form).
- The list of repositories the same command applies to.
- A note that SPDX SBOM attestations are not yet attached and will be added in a follow-up.

Signatures were spot-checked on \`langsmith-backend:0.15.9\`, \`langsmith-frontend:0.15.9\`, \`agent-builder-deep-agent:0.15.9\`, and \`langsmith-backend:0.15.8\`; all pass with the documented identity binding.

## Test plan

- [ ] Render the page locally; the new section appears under existing mirroring instructions.
- [ ] Copy the \`cosign verify\` command verbatim; it succeeds against \`docker.io/langchain/langsmith-backend:0.15.9\`.