### PR TITLE
Update data-analysis.mdx

### DIFF
--- a/src/oss/deepagents/data-analysis.mdx
+++ b/src/oss/deepagents/data-analysis.mdx
@@ -213,7 +213,7 @@ backend.upload_files([("/home/daytona/data/sales_data.csv", csv_bytes)])
 
 ## Implement custom tools
 
-Data analysis tasks might produce artefacts, like reports or plots.
+Data analysis tasks might produce artifacts, like reports or plots.
 The following simple [tool](/oss/langchain/tools) downloads them with `backend.download_files` and then uploads them using the Slack SDK.
 We could also ask our agent to list the relevant file paths instead of uploading them, so interested parties can obtain them separately as needed.
 


### PR DESCRIPTION
docs: fix typo in documentation

## Overview

Updated the data analysis documentation to fix a typo by changing "artefacts" to "artifacts" for consistency with the project's language conventions.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs

* GitHub issue: N/A
* Feature PR: N/A

<!-- For LangChain employees, if applicable: -->

* Linear issue: N/A
* Slack thread: N/A

## Checklist

* [x] I have read the [[contributing guidelines](https://chatgpt.com/c/README.md)](README.md), including the [[language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
* [ ] I have tested my changes locally using `docs dev`
* [x] All code examples have been tested and work correctly
* [x] I have used **root relative** paths for internal links
* [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes

This PR only updates a documentation typo and does not introduce any functional changes.
