### PR TITLE
docs(deepagents): fix incorrect system prompt claim for general-purpose subagent

### DIFF
--- a/src/oss/deepagents/subagents.mdx
+++ b/src/oss/deepagents/subagents.mdx
@@ -341,7 +341,7 @@ For full details on schema types and strategies (tool calling vs. provider-nativ
 
 In addition to any user-defined subagents, every deep agent has access to a `general-purpose` subagent at all times. This subagent:
 
-- Has the same system prompt as the main agent
+- Uses its own default system prompt (not the main agent's `system_prompt=`), with profile overlays applied. See [General-purpose subagent prompt](/oss/deepagents/customization#prompt-assembly) for details.
 - Has access to all the same tools
 - Uses the same model (unless overridden)
 - Inherits skills from the main agent (when skills are configured)

--- a/src/oss/deepagents/subagents.mdx
+++ b/src/oss/deepagents/subagents.mdx
@@ -341,7 +341,7 @@ For full details on schema types and strategies (tool calling vs. provider-nativ
 
 In addition to any user-defined subagents, every deep agent has access to a `general-purpose` subagent at all times. This subagent:
 
-- Uses its own default system prompt (not the main agent's `system_prompt=`), with profile overlays applied. See [General-purpose subagent prompt](/oss/deepagents/customization#prompt-assembly) for details.
+- Uses its own [default system prompt with profile overlays applied](/oss/deepagents/customization#prompt-assembly)
 - Has access to all the same tools
 - Uses the same model (unless overridden)
 - Inherits skills from the main agent (when skills are configured)


### PR DESCRIPTION
Closes #4200

## Overview

The **Subagents** page (`src/oss/deepagents/subagents.mdx`) claimed the general-purpose subagent "has the same system prompt as the main agent." This is incorrect—the GP subagent uses its own default prompt (`DEFAULT_SUBAGENT_PROMPT` in `middleware/subagents.py`) with profile overlays applied, not the caller's `system_prompt=` argument passed to `create_deep_agent`.

The [Customization page's "General-purpose subagent prompt" accordion](https://docs.langchain.com/oss/python/deepagents/customization#prompt-assembly) already documents this correctly. This PR updates the subagents page to align with it.

## Type of change

**Type:** Fix existing documentation

## What changed

Replaced:

> Has the same system prompt as the main agent

With:

> Uses its own default system prompt (not the main agent's `system_prompt=`), with profile overlays applied. See General-purpose subagent prompt for details.

## Checklist

- [x] I have read the contributing guidelines, including the language policy
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
- [x] AI agent was used to assist with this change