### PR TITLE
chore(deepagent): add streaming as core capability

### DIFF
--- a/src/oss/deepagents/overview.mdx
+++ b/src/oss/deepagents/overview.mdx
@@ -256,6 +256,9 @@ Use the **Deep Agents SDK** to build agents that handle complex, multi-step task
 <Card title="Subagent spawning" icon="users-group">
     A built-in `task` tool spawns general-purpose or specialized [subagents](/oss/deepagents/subagents) for context isolation on subtasks. For long-running or parallel work, [async subagents](/oss/deepagents/async-subagents) run in the background with progress checks, follow-ups, and cancellation.
 </Card>
+<Card title="Streaming" icon="broadcast">
+    [Event streaming](/oss/deepagents/event-streaming) exposes agent runs as typed projections for messages, tool calls, values, and output. Deep Agents add `stream.subagents` so each delegated task gets its own handle with independent message, tool-call, and nested subagent streams.
+</Card>
 <Card title="Long-term memory" icon="database">
     Persist memory across threads and conversations using LangGraph's [Memory Store](/oss/langgraph/persistence#memory-store).
 </Card>


### PR DESCRIPTION
Allowing to stream individual subagents efficiently seems to me like a great core capability to point out. 