### PR TITLE
add warning for community integration of document loaders

### DIFF
--- a/src/oss/javascript/integrations/document_loaders/index.mdx
+++ b/src/oss/javascript/integrations/document_loaders/index.mdx
@@ -10,6 +10,10 @@ This ensures that data can be handled consistently regardless of the source.
 
 All document loaders implement the @[BaseLoader] interface.
 
+<Warning>
+Community document loaders are user-contributed and unverified. LangChain does not review or endorse these integrations; use them at your own risk.
+</Warning>
+
 ## Interface
 
 Each document loader may define its own parameters, but they share a common API:

--- a/src/oss/python/integrations/document_loaders/index.mdx
+++ b/src/oss/python/integrations/document_loaders/index.mdx
@@ -9,7 +9,9 @@ Document loaders provide a **standard interface** for reading data from differen
 This ensures that data can be handled consistently regardless of the source.
 
 All document loaders implement the @[`BaseLoader`] interface.
-
+<Warning>
+Community document loaders are user-contributed and unverified. LangChain does not review or endorse these integrations; use them at your own risk.
+</Warning>
 ## Interface
 
 Each document loader may define its own parameters, but they share a common API:

--- a/src/oss/python/integrations/document_loaders/index.mdx
+++ b/src/oss/python/integrations/document_loaders/index.mdx
@@ -9,9 +9,11 @@ Document loaders provide a **standard interface** for reading data from differen
 This ensures that data can be handled consistently regardless of the source.
 
 All document loaders implement the @[`BaseLoader`] interface.
+
 <Warning>
 Community document loaders are user-contributed and unverified. LangChain does not review or endorse these integrations; use them at your own risk.
 </Warning>
+
 ## Interface
 
 Each document loader may define its own parameters, but they share a common API:


### PR DESCRIPTION
## Overview
Just noticed that some users used community document loaders and complained a little bit. Add warning to reduce such complaints

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue: #3883 
- Feature PR:



## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
