### PR TITLE
Add Tuning Engines OpenAI-compatible endpoint example

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -223,6 +223,12 @@ python:
     tool_calling: true
     structured_output: true
     multimodal: false
+  - name: Tuning Engines
+    docs_url: https://www.tuningengines.com/
+    stream: true
+    tool_calling: true
+    structured_output: true
+    multimodal: false
   - name: Apertis
     pypi: langchain-apertis
     docs_url: https://docs.apertis.ai/api/sdks/langchain/
@@ -1896,6 +1902,12 @@ javascript:
     multimodal: true
   - name: Auxen
     docs_url: https://auxen.ai
+    stream: true
+    tool_calling: true
+    structured_output: true
+    multimodal: false
+  - name: Tuning Engines
+    docs_url: https://www.tuningengines.com/
     stream: true
     tool_calling: true
     structured_output: true

--- a/src/oss/concepts/providers-and-models.mdx
+++ b/src/oss/concepts/providers-and-models.mdx
@@ -235,36 +235,6 @@ const model = new ChatOpenAI({
 ```
 :::
 
-For example, a team using Tuning Engines as a governed OpenAI-compatible
-endpoint can keep the LangChain/LangGraph application code on `ChatOpenAI`
-while Tuning Engines handles tenant keys, model access, policy checks, audit
-logs, traces, and usage/cost accounting behind the endpoint.
-
-:::python
-```python
-import os
-from langchain_openai import ChatOpenAI
-
-model = ChatOpenAI(
-    base_url="https://api.tuningengines.com/v1",
-    api_key=os.environ["TUNING_ENGINES_API_KEY"],
-    model="gpt-4o",
-)
-```
-:::
-
-:::js
-```typescript
-import { ChatOpenAI } from "@langchain/openai";
-
-const model = new ChatOpenAI({
-    configuration: { baseURL: "https://api.tuningengines.com/v1" },
-    apiKey: process.env.TUNING_ENGINES_API_KEY,
-    model: "gpt-4o",
-});
-```
-:::
-
 <Warning>
     `ChatOpenAI` targets [official OpenAI API specifications](https://github.com/openai/openai-openapi) only. Non-standard response fields from third-party providers are not extracted or preserved. Use a dedicated provider package or router when you need access to non-standard features.
 </Warning>

--- a/src/oss/concepts/providers-and-models.mdx
+++ b/src/oss/concepts/providers-and-models.mdx
@@ -235,6 +235,36 @@ const model = new ChatOpenAI({
 ```
 :::
 
+For example, a team using Tuning Engines as a governed OpenAI-compatible
+endpoint can keep the LangChain/LangGraph application code on `ChatOpenAI`
+while Tuning Engines handles tenant keys, model access, policy checks, audit
+logs, traces, and usage/cost accounting behind the endpoint.
+
+:::python
+```python
+import os
+from langchain_openai import ChatOpenAI
+
+model = ChatOpenAI(
+    base_url="https://api.tuningengines.com/v1",
+    api_key=os.environ["TUNING_ENGINES_API_KEY"],
+    model="gpt-4o",
+)
+```
+:::
+
+:::js
+```typescript
+import { ChatOpenAI } from "@langchain/openai";
+
+const model = new ChatOpenAI({
+    configuration: { baseURL: "https://api.tuningengines.com/v1" },
+    apiKey: process.env.TUNING_ENGINES_API_KEY,
+    model: "gpt-4o",
+});
+```
+:::
+
 <Warning>
     `ChatOpenAI` targets [official OpenAI API specifications](https://github.com/openai/openai-openapi) only. Non-standard response fields from third-party providers are not extracted or preserved. Use a dedicated provider package or router when you need access to non-standard features.
 </Warning>

--- a/src/oss/javascript/integrations/chat/index.mdx
+++ b/src/oss/javascript/integrations/chat/index.mdx
@@ -215,6 +215,8 @@ Certain model providers offer endpoints that are compatible with OpenAI's (legac
 
 [Auxen](https://auxen.ai) hosts dedicated per-customer LLM endpoints with an OpenAI-compatible Chat Completions API. Use `ChatOpenAI` with a custom base URL and per-instance API key.
 
+[Tuning Engines](https://www.tuningengines.com/) provides a governed OpenAI-compatible Chat Completions API. Use `ChatOpenAI` with `baseURL` `https://api.tuningengines.com/v1` and a Tuning Engines inference key.
+
 ## All chat models
 
 <ChatDownloads />

--- a/src/oss/javascript/integrations/providers/all_providers.mdx
+++ b/src/oss/javascript/integrations/providers/all_providers.mdx
@@ -242,6 +242,13 @@ Connect LangGraph agents to front ends and observability platforms.
     Open-weight chat and multimodal models with image and video input over SCX's OpenAI-compatible API.
   </Card>
 
+  <Card
+    title="Tuning Engines"
+    href="https://www.tuningengines.com/"
+    icon="link"
+  >
+    Governed OpenAI-compatible endpoint for model access, policy checks, and usage accounting.
+  </Card>
 
   <Card
     title="xAI"

--- a/src/oss/python/integrations/chat/index.mdx
+++ b/src/oss/python/integrations/chat/index.mdx
@@ -53,6 +53,8 @@ Certain model providers offer endpoints that are compatible with OpenAI's [Chat 
 
 [AI Power Grid](https://aipowergrid.io/) routes OpenAI-compatible Chat Completions to community-operated model workers. Use `ChatOpenAI` with `base_url` `https://api.aipowergrid.io/v1` and an account-scoped API key.
 
+[Tuning Engines](https://www.tuningengines.com/) provides a governed OpenAI-compatible Chat Completions API. Use `ChatOpenAI` with `base_url` `https://api.tuningengines.com/v1` and a Tuning Engines inference key.
+
 ## All chat models
 
 <ChatDownloads />

--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -3067,6 +3067,14 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
+        title="Tuning Engines"
+        href="https://www.tuningengines.com/"
+        icon="link"
+    >
+        Governed OpenAI-compatible endpoint for model access, policy checks, and usage accounting.
+    </Card>
+
+    <Card
         title="TypeDB"
         href="https://typedb.com/docs"
         icon="link"

--- a/src/snippets/oss/javascript-chat-downloads.mdx
+++ b/src/snippets/oss/javascript-chat-downloads.mdx
@@ -32,5 +32,6 @@
 | [`Auxen`](https://auxen.ai) | <span data-sort-value="2">✅</span> | <span data-sort-value="2">✅</span> | <span data-sort-value="2">✅</span> | <span data-sort-value="1">❌</span> | <span data-sort-value="-1">N/A</span> |
 | [`FakeListChatModel`](/oss/integrations/chat/fake) | <span data-sort-value="0"></span> | <span data-sort-value="0"></span> | <span data-sort-value="0"></span> | <span data-sort-value="0"></span> | <span data-sort-value="-1">N/A</span> |
 | [`FuturMix`](https://futurmix.ai/) | <span data-sort-value="2">✅</span> | <span data-sort-value="2">✅</span> | <span data-sort-value="2">✅</span> | <span data-sort-value="2">✅</span> | <span data-sort-value="-1">N/A</span> |
+| [`Tuning Engines`](https://www.tuningengines.com/) | <span data-sort-value="2">✅</span> | <span data-sort-value="2">✅</span> | <span data-sort-value="2">✅</span> | <span data-sort-value="1">❌</span> | <span data-sort-value="-1">N/A</span> |
 
 </div>

--- a/src/snippets/oss/python-chat-downloads.mdx
+++ b/src/snippets/oss/python-chat-downloads.mdx
@@ -83,5 +83,6 @@
 | [`Snowflake Cortex REST API`](https://docs.snowflake.com/en/user-guide/snowflake-cortex/cortex-rest-api) | <span data-sort-value="2">✅</span> | <span data-sort-value="2">✅</span> | <span data-sort-value="2">✅</span> | <span data-sort-value="1">❌</span> | <span data-sort-value="-1">N/A</span> |
 | [`Synthorai`](https://synthorai.io/docs/) | <span data-sort-value="0"></span> | <span data-sort-value="0"></span> | <span data-sort-value="0"></span> | <span data-sort-value="0"></span> | <span data-sort-value="-1">N/A</span> |
 | [`TokenMix`](https://tokenmix.ai/docs) | <span data-sort-value="2">✅</span> | <span data-sort-value="2">✅</span> | <span data-sort-value="2">✅</span> | <span data-sort-value="1">❌</span> | <span data-sort-value="-1">N/A</span> |
+| [`Tuning Engines`](https://www.tuningengines.com/) | <span data-sort-value="2">✅</span> | <span data-sort-value="2">✅</span> | <span data-sort-value="2">✅</span> | <span data-sort-value="1">❌</span> | <span data-sort-value="-1">N/A</span> |
 
 </div>


### PR DESCRIPTION
## Why

LangChain already documents `ChatOpenAI` with custom `base_url` for OpenAI-compatible endpoints. Tuning Engines fits that path without requiring a new provider package: teams keep their LangChain or LangGraph code on `ChatOpenAI`, while Tuning Engines provides a governed endpoint for model access, tenant keys, policy checks, audit logs, traces, and usage/cost accounting.

This is useful for teams that want LangChain/LangGraph to own chains, agents, graph state, and orchestration, while a separate control plane governs the model endpoint used by those apps.

## What changed

- Adds a small Python and TypeScript example under the existing "OpenAI-compatible endpoints" section.
- Uses placeholder env var `TUNING_ENGINES_API_KEY`; no secrets or internal provider details are included.
- Does not add a new package, provider abstraction, or vendor-specific API surface.

## Validation

- Docs-only MDX change.
- Checked the modified page locally.
