### PR TITLE
Remove all beta call outs for engine since GA

### DIFF
--- a/src/index.mdx
+++ b/src/index.mdx
@@ -25,7 +25,7 @@ mode: "custom"
                 See exactly how your agent thinks and acts with detailed tracing and aggregate trend metrics.
             </Card>
             <Card
-                title="Engine (Beta)"
+                title="Engine"
                 href="/langsmith/engine"
                 icon="engine"
                 cta="Learn more"

--- a/src/langsmith/engine-webhooks.mdx
+++ b/src/langsmith/engine-webhooks.mdx
@@ -2,10 +2,7 @@
 title: LangSmith Engine webhook events
 sidebarTitle: Engine webhook events
 description: Reference for the webhook events the LangSmith Engine sends when it creates issues or links new traces to existing issues.
-tag: Beta
 ---
-
-<Note>[LangSmith Engine](/langsmith/engine) is in **Beta** and under active development. To provide feedback or use this feature, reach out to the [LangChain team](https://forum.langchain.com/c/help/langsmith/).</Note>
 
 Forward LangSmith-detected agent issues into your incident-management, paging, or chat tools. [LangSmith Engine](/langsmith/engine) sends a webhook event to your endpoint when it opens a new issue, or when it links a new trace to an issue it has already opened.
 

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -2,10 +2,7 @@
 title: Find and fix your agent's failures with LangSmith Engine
 sidebarTitle: Engine
 description: Automatically detect and resolve recurring issues in your tracing project using the LangSmith Engine.
-tag: Beta
 ---
-
-<Note>Engine is in **Beta** and under active development. To provide feedback or use this feature, reach out to the [LangChain team](https://forum.langchain.com/c/help/langsmith/).</Note>
 
 The LangSmith Engine turns your traces into a continuous improvement workflow. It surfaces recurring issues, diagnoses their root cause, and guides you through fixing them and preventing them from coming back.
 


### PR DESCRIPTION
Modified index.mdx, engine.mdx, engine-webhooks.mdx, removed Beta callout and tag.

Fixes DOC-1185