### PR TITLE
docs: use camelCase middleware factory names in agents.mdx JS examples

### DIFF
--- a/src/oss/langchain/agents.mdx
+++ b/src/oss/langchain/agents.mdx
@@ -406,7 +406,7 @@ agent = create_agent(
 :::
 :::js
 ```typescript
-import { createAgent, TodoListMiddleware } from "langchain";
+import { createAgent, todoListMiddleware } from "langchain";
 import { FilesystemMiddleware, SubAgentMiddleware, StateBackend } from "deepagents";
 
 const researcher = { name: "researcher", description: "Searches and returns a structured summary.", tools: [search] };
@@ -416,7 +416,7 @@ const agent = createAgent({
   tools: [search],
   middleware: [
     new FilesystemMiddleware({ backend: new StateBackend() }),
-    new TodoListMiddleware(),
+    todoListMiddleware(),
     new SubAgentMiddleware({ backend: new StateBackend(), subagents: [researcher] }),
   ],
 });
@@ -445,12 +445,12 @@ agent = create_agent(
 :::
 :::js
 ```typescript
-import { createAgent, ModelRetryMiddleware, ToolRetryMiddleware } from "langchain";
+import { createAgent, modelRetryMiddleware, toolRetryMiddleware } from "langchain";
 
 const agent = createAgent({
   model: "anthropic:claude-sonnet-4-6",
   tools: [search],
-  middleware: [new ModelRetryMiddleware({ maxRetries: 3 }), new ToolRetryMiddleware({ maxRetries: 2 })],
+  middleware: [modelRetryMiddleware({ maxRetries: 3 }), toolRetryMiddleware({ maxRetries: 2 })],
 });
 ```
 :::
@@ -474,12 +474,12 @@ agent = create_agent(
 :::
 :::js
 ```typescript
-import { createAgent, PIIMiddleware } from "langchain";
+import { createAgent, piiMiddleware } from "langchain";
 
 const agent = createAgent({
   model: "anthropic:claude-sonnet-4-6",
   tools: [search],
-  middleware: [new PIIMiddleware()],
+  middleware: [piiMiddleware("email")],
 });
 ```
 :::
@@ -503,12 +503,12 @@ agent = create_agent(
 :::
 :::js
 ```typescript
-import { createAgent, HumanInTheLoopMiddleware } from "langchain";
+import { createAgent, humanInTheLoopMiddleware } from "langchain";
 
 const agent = createAgent({
   model: "anthropic:claude-sonnet-4-6",
   tools: [search],
-  middleware: [new HumanInTheLoopMiddleware({ interruptOn: { writeFile: true } })],
+  middleware: [humanInTheLoopMiddleware({ interruptOn: { writeFile: true } })],
 });
 ```
 :::


### PR DESCRIPTION
The JavaScript middleware examples in the agents guide use the Python class names (`new TodoListMiddleware()`, `new ModelRetryMiddleware()`, etc.), but the `langchain` package exports these as camelCase factory functions, so the snippets fail to compile (`'langchain' has no exported member named 'TodoListMiddleware'`). This switches them to the factory functions, matching the package and the `middleware/built-in.mdx` examples.

`piiMiddleware` takes a PII type argument in JS (unlike the Python `PIIMiddleware()`), so that one becomes `piiMiddleware("email")`. The `deepagents` middleware (`FilesystemMiddleware`, `SubAgentMiddleware`) are genuinely classes and are left as-is. Verified each fixed snippet compiles against langchain 1.4.4.