### PR TITLE
docs(langsmith): document sandbox egress and network access control

### DIFF
--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -1,7 +1,7 @@
 ---
 title: Sandbox auth proxy
 sidebarTitle: Auth proxy
-description: Inject credentials into outbound API requests from sandboxes without hardcoding secrets.
+description: Inject credentials into outbound requests and control which destinations a sandbox can reach.
 ---
 
 The auth proxy lets sandbox code call external APIs (OpenAI, Anthropic, GitHub, etc.) without hardcoding credentials. When configured on a sandbox, a proxy sidecar automatically injects authentication headers into matching outbound requests using your workspace secrets or write-only credentials you provide in the proxy config.
@@ -9,6 +9,105 @@ The auth proxy lets sandbox code call external APIs (OpenAI, Anthropic, GitHub, 
 <Warning>
 You must configure your secrets (e.g., `OPENAI_API_KEY`) in your LangSmith [workspace](/langsmith/administration-overview#workspaces) settings before creating a sandbox that references them.
 </Warning>
+
+## Egress and network access control
+
+The same `proxy_config` that injects credentials also controls which destinations a sandbox can reach.
+
+### Default egress posture
+
+By default (no `access_control` configured):
+
+- **HTTP and HTTPS (ports 80 and 443) to any host are allowed.** Outbound HTTP(S) is transparently routed through the proxy, where your `rules` and `callbacks` inject credentials.
+- **All other raw TCP is blocked.** Connections to non-HTTP ports—databases (`psql`/`dbt` on 5432), SSH (22), Redis (6379), and so on—are dropped unless you explicitly allow them.
+
+This means raw protocols are not blocked because the proxy "can't speak" them—they are blocked by default and opened per host and port via `access_control`.
+
+### Allow and deny lists
+
+Add an `access_control` object to `proxy_config` with **either** an `allow_list` **or** a `deny_list` (not both—the request is rejected if both are set):
+
+| Mode | Behavior |
+|------|----------|
+| `allow_list` | **Default-deny.** Only listed destinations are reachable—including HTTP/HTTPS. If you set an `allow_list`, you must also list every HTTP(S) host the sandbox needs. |
+| `deny_list` | **Default-allow for HTTP/HTTPS.** All HTTP(S) hosts remain reachable except those listed. A `deny_list` cannot open raw TCP ports. |
+
+<Note>
+Raw TCP egress (e.g. PostgreSQL on 5432) can **only** be enabled with an `allow_list` entry that specifies an explicit non-HTTP port (`host:PORT`). The default posture and `deny_list` mode only ever permit HTTP/HTTPS.
+</Note>
+
+### Pattern syntax
+
+Each `allow_list`/`deny_list` entry uses the following forms:
+
+| Pattern | Meaning |
+|---------|---------|
+| `host` | Bare host → ports **80 and 443 only** (HTTP/S). |
+| `host:PORT` | Host on exactly `PORT`. `:22` grants only 22, **not** additive with 80/443—list the host twice if you need both. |
+| `*.example.com` | Glob (RFC 1034-style). The apex (`example.com`) is **not** included. |
+| `~regex` | Opaque regex match; no port suffix parsing. |
+| `1.2.3.4` / `10.0.0.0/8` | Literal IP or CIDR. CIDRs **cannot** carry a port (HTTP/S only in allow mode; block all ports in deny mode). |
+| `[::1]:22` | IPv6 literal uses the bracketed form when specifying a port. |
+
+### Connecting to a database (raw TCP)
+
+To let sandbox code reach an external PostgreSQL database with `psql`, `dbt`, or any driver, allow-list the host on its port. Because `allow_list` is default-deny, also list any HTTP(S) hosts the sandbox needs:
+
+```bash
+curl -X POST "$LANGSMITH_ENDPOINT/v2/sandboxes/boxes" \
+  -H "x-api-key: $LANGSMITH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "db-sandbox",
+    "wait_for_ready": true,
+    "proxy_config": {
+      "access_control": {
+        "allow_list": [
+          "db.example.com:5432",
+          "api.openai.com"
+        ]
+      }
+    }
+  }'
+```
+
+The connection to `db.example.com:5432` is passed through at the TCP layer with no interception, so the PostgreSQL wire protocol—and TLS, host-key checking, and any other end-to-end protocol on top of it—works unchanged.
+
+### Configure via SDK
+
+<CodeGroup>
+
+```python Python
+from langsmith.sandbox import SandboxClient
+
+client = SandboxClient()
+
+client.create_sandbox(
+    name="db-sandbox",
+    proxy_config={
+        "access_control": {
+            "allow_list": ["db.example.com:5432", "api.openai.com"]
+        }
+    },
+)
+```
+
+```ts TypeScript
+import { SandboxClient } from "langsmith/sandbox";
+
+const client = new SandboxClient();
+
+await client.createSandbox({
+  name: "db-sandbox",
+  proxyConfig: {
+    accessControl: {
+      allowList: ["db.example.com:5432", "api.openai.com"],
+    },
+  },
+});
+```
+
+</CodeGroup>
 
 ## Configure auth proxy rules
 


### PR DESCRIPTION
## Overview

The sandbox auth proxy guide documented credential injection (`rules`, `callbacks`) but said nothing about the egress posture or the `access_control` allow/deny lists that actually govern which destinations a sandbox can reach. That gap led to the misconception that sandboxes are HTTP-only and cannot reach databases over raw TCP.

This adds an **Egress and network access control** section to the auth proxy page covering:

- **Default posture** — HTTP/HTTPS to any host is open; all other raw TCP is blocked by default. Raw protocols aren't blocked because the proxy "can't speak" them — they're blocked by default and opened per host/port.
- **`allow_list` vs `deny_list`** — mutual exclusivity, allow=default-deny (must also list HTTP hosts), deny=default-allow for HTTP/S only.
- **Raw TCP passthrough** — enabled *only* via an `allow_list` entry with an explicit `host:PORT`; the connection is passed through at the TCP layer with no interception, so the PostgreSQL wire protocol (and TLS, SSH host-key checking, etc.) works unchanged.
- **Pattern syntax** reference and a database (`psql`/`dbt`) example in curl + Python/TS SDK form.

Verified against the smith-go source (`proxy_types.go`, `rules/types.go`, `matcher.go`, `validation.go`, `dns/server.go`): field names, mutual-exclusivity error, pattern forms, and passthrough-eligibility logic all match.

## Type of change

**Type:** Update existing documentation

## Checklist
- [x] I have used **root relative** paths for internal links
- [ ] No navigation change needed (section added to an existing page)

## Additional notes

SDK examples follow the existing page's key convention (snake_case for Python, camelCase like `accessControl`/`allowList` for TypeScript). Worth confirming the TS SDK transforms the nested `access_control` keys the same way it does `proxyConfig`/`matchHosts` before merge.