### PR TITLE
docs(langsmith): document SBOM attestation verification for mirrored images

### DIFF
--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -233,6 +233,38 @@ To inspect the certificate's claims (workflow run, commit, runner), download the
 cosign download attestation docker.io/langchain/langsmith-backend:<tag>
 ```
 
-<Note>
-SPDX SBOM attestations are not yet attached to released images and will land in a future release. This section will be updated once SBOMs are published, including the `cosign verify-attestation --type spdx` command to retrieve them.
-</Note>
+### Verifying SBOM attestations
+
+Released images also carry signed SPDX software bill of materials (SBOM) attestations, one per architecture in the image index. The attestations are attached to the per-architecture child digests rather than to the multi-architecture tag, so `cosign verify-attestation` against a bare tag reports `no matching attestations`. Resolve the child digests first, then verify each one.
+
+List the per-architecture digests for a tag:
+
+```bash
+docker buildx imagetools inspect --raw docker.io/langchain/langsmith-backend:<tag> \
+  | jq -r '.manifests[] | select(.platform.os == "linux") | .digest + "  " + .platform.architecture'
+```
+
+Verify the SBOM attestation on one of those digests:
+
+```bash
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'https://github\.com/langchain-ai/langchainplus/\.github/workflows/release_self_hosted_on_version_bump\.yaml@refs/heads/v[0-9]+-stable' \
+  docker.io/langchain/langsmith-backend@<digest>
+```
+
+A successful verification gives the same guarantees as the image signature: the attestation was produced by the stable-branch release workflow, and its claims are logged in the [Rekor](https://docs.sigstore.dev/rekor/overview/) transparency log.
+
+To extract the SPDX document itself, decode the verified attestation payload:
+
+```bash
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'https://github\.com/langchain-ai/langchainplus/\.github/workflows/release_self_hosted_on_version_bump\.yaml@refs/heads/v[0-9]+-stable' \
+  docker.io/langchain/langsmith-backend@<digest> \
+  | jq -r '.payload' | base64 -d | jq '.predicate'
+```
+
+The decoded predicate is a standard SPDX 2.3 document listing every package in that image.


### PR DESCRIPTION
## Overview

Released self-hosted images now carry signed SPDX SBOM attestations, so the placeholder note in the image mirroring guide ("SBOM attestations are not yet attached…") is out of date.

This replaces that note with a **Verifying SBOM attestations** section that documents how to:

- Resolve the per-architecture child digests for a tag (attestations attach to the child digests, not the multi-arch tag — verifying a bare tag reports `no matching attestations`).
- Verify each attestation with `cosign verify-attestation --type spdxjson` against the stable-branch release workflow identity.
- Decode the verified predicate to the SPDX 2.3 document.

Follows on from #4196 (cosign image-signature verification).

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- Feature PR: #4196

## Checklist
- [x] I have used **root relative** paths for internal links
- [ ] No navigation change needed (section added to an existing page)