### PR TITLE
update rubric docs

### DIFF
--- a/.deepagents/skills/docs-code-samples/SKILL.md
+++ b/.deepagents/skills/docs-code-samples/SKILL.md
@@ -56,7 +56,9 @@ src/
         └── ...
 ```
 
-**More than one snippet in one file**: A single code sample file can contain more than one named snippet using different `:snippet-start: snippet-name` and `:snippet-end:` pairs. Each snippet must have a unique name. This is useful for keeping related code samples together in one testable file.
+**Prefer one file per doc page or topic**: Collocate related snippets in a single code sample file whenever they belong to the same MDX page, tutorial flow, or feature (for example, setup plus invocation, or a do/don't pair). Use multiple `:snippet-start:` / `:snippet-end:` pairs in that file rather than splitting into several `.py` or `.ts` files. Reserve separate files for unrelated samples or when a page genuinely needs independent test entry points.
+
+**More than one snippet in one file**: A single code sample file can contain more than one named snippet using different `:snippet-start: snippet-name` and `:snippet-end:` pairs. Each snippet must have a unique name. Shared imports, helpers, and `:remove-start:` test harness code live once in the file; only the fenced regions between snippet tags appear in the generated MDX snippets.
 
 ## Step-by-step instructions
 
@@ -64,7 +66,7 @@ src/
 
 Place the file under `src/code-samples/` in the folder for the product: `langchain/`, `langgraph/`, `deepagents/`, or `langsmith/` (for example, `src/code-samples/langgraph/langgraph-sql-agent.py` for LangGraph docs).
 
-Use a descriptive filename, for example, `return-a-string.py`, `return-a-string.ts`, or `traceable-pipeline.java`.
+Use a descriptive filename, for example, `return-a-string.py`, `return-a-string.ts`, or `traceable-pipeline.java`. When a doc page needs several code blocks for the same feature, add them as multiple snippets in one file (for example, `rubric-configure.py` with `rubric-configure-py` and `rubric-invoke-py`) instead of creating `rubric-configure.py` and `rubric-invoke.py`.
 
 ### 2. Add snippet delineators
 
@@ -236,6 +238,7 @@ To support additional languages, add config entries in that script.
 
 ## Guidelines
 
+- **Collocate related snippets** in one code sample file per doc page or feature when possible. Import each generated MDX snippet separately in the MDX file (for example, `<RubricConfigurePy />` then `<RubricInvokePy />` from the same source file).
 - Do not mock LangChain internals (for example `unittest.mock.patch` on `init_chat_model` helpers) so that imports resolve real chat model instances. Do not use fake chat models in docs code samples (for example `GenericFakeChatModel`, `FakeListChatModel`, or other `langchain_core` testing fakes). Wire a real chat model (for example `ChatOpenAI`) so snippets match what readers run; `make test-code-samples` requires a valid API key when the sample calls the model.
 - Do not change `pyproject.toml` when making code sample changes.
 - Always run `make test-code-samples FILES="path/to/your/file.py"` before `make code-snippets` to ensure new samples pass.

--- a/src/code-samples/deepagents/rubric-code-generation.py
+++ b/src/code-samples/deepagents/rubric-code-generation.py
@@ -1,0 +1,123 @@
+"""Deep Agents: code generation with RubricMiddleware and a test suite grader tool."""
+
+# :snippet-start: rubric-code-generation-middleware-py
+from deepagents import RubricMiddleware
+from langchain.tools import tool
+
+
+@tool
+def run_test_suite(code: str) -> dict:
+    """Run the find_duplicates test suite against Python source code."""
+    namespace: dict = {"__builtins__": __builtins__}
+    try:
+        exec(code, namespace)
+    except Exception as exc:
+        return {"ok": False, "failures": [f"Failed to execute code: {exc}"]}
+
+    find_duplicates = namespace.get("find_duplicates")
+    if find_duplicates is None:
+        return {"ok": False, "failures": ["Function find_duplicates is not defined"]}
+
+    tests = [
+        ("test_basic", [1, 2, 2, 3, 1], [2, 1]),
+        ("test_empty", [], []),
+        ("test_no_duplicates", [1, 2, 3], []),
+        ("test_unhashable", [[1], [1], 2], [[1]]),
+    ]
+    failures: list[str] = []
+    for name, args, expected in tests:
+        try:
+            actual = find_duplicates(args)
+            if actual != expected:
+                failures.append(f"{name}: expected {expected}, got {actual}")
+        except Exception as exc:
+            failures.append(f"{name}: {exc}")
+
+    return {"ok": not failures, "failures": failures}
+
+
+rubric_middleware = RubricMiddleware(
+    model="anthropic:claude-haiku-4-5",
+    system_prompt="You are a code reviewer grading generated code against a rubric.",
+    tools=[run_test_suite],
+    max_iterations=5,
+)
+# :snippet-end:
+
+# :snippet-start: rubric-code-generation-agent-py
+from deepagents import create_deep_agent
+from langgraph.checkpoint.memory import InMemorySaver
+
+agent = create_deep_agent(
+    model="anthropic:claude-sonnet-4-6",
+    system_prompt=(
+        "You are a careful Python engineer. Write correct, readable code. "
+        "Follow the user's instructions exactly."
+    ),
+    middleware=[rubric_middleware],
+    checkpointer=InMemorySaver(),
+)
+# :snippet-end:
+
+# :remove-start:
+import os
+
+if __name__ == "__main__":
+    bad_code = """
+def find_duplicates(lst):
+    seen = set()
+    dups = []
+    for x in lst:
+        if x in seen:
+            dups.append(x)
+        seen.add(x)
+    return dups
+"""
+    bad_result = run_test_suite.invoke({"code": bad_code})
+    assert not bad_result["ok"]
+    assert any("test_unhashable" in failure for failure in bad_result["failures"])
+
+    good_code = """
+def find_duplicates(lst):
+    seen = []
+    dups = []
+    for item in lst:
+        if any(item == existing for existing in seen):
+            if not any(item == dup for dup in dups):
+                dups.append(item)
+        else:
+            seen.append(item)
+    return dups
+"""
+    good_result = run_test_suite.invoke({"code": good_code})
+    assert good_result["ok"], good_result["failures"]
+    assert agent is not None
+    if not os.environ.get("ANTHROPIC_API_KEY"):
+        print("✓ rubric code generation sample completed")
+        raise SystemExit(0)
+# :remove-end:
+
+# :snippet-start: rubric-code-generation-invoke-py
+from langchain.messages import HumanMessage
+
+if __name__ == "__main__":
+    result = agent.invoke(
+        {
+            "messages": [
+                HumanMessage(
+                    content=(
+                        "Write a Python function `find_duplicates(lst)` that returns a list of "
+                        "all elements that appear more than once in the input list, in the order "
+                        "they first appear."
+                    )
+                )
+            ],
+            "rubric": (
+                "- All tests pass in run_test_suite\n"
+                "- The function is named `find_duplicates` and accepts a single list argument\n"
+            ),
+        },
+        config={"configurable": {"thread_id": "code-generation-session"}},
+    )
+    print(result["messages"][-1].text)
+# :snippet-end:

--- a/src/code-samples/deepagents/rubric-configure.py
+++ b/src/code-samples/deepagents/rubric-configure.py
@@ -35,9 +35,10 @@ result = agent.invoke(
 
 # :snippet-start: rubric-stream-py
 from langchain.messages import HumanMessage
+from langgraph.stream import CustomTransformer
 
 config = {"configurable": {"thread_id": "my-rubric-thread"}}
-for chunk in agent.stream(
+stream = agent.stream_events(
     {
         "messages": [HumanMessage("Write a haiku about spring.")],
         "rubric": (
@@ -47,12 +48,11 @@ for chunk in agent.stream(
         ),
     },
     config=config,
-    stream_mode="custom",
-    version="v2",
-):
-    if chunk.get("type") != "custom":
-        continue
-    event = chunk["data"]
+    version="v3",
+    transformers=[CustomTransformer],
+)
+
+for event in stream.custom:
     event_type = event.get("type")
     if event_type == "rubric_evaluation_start":
         print(
@@ -101,6 +101,6 @@ agent.invoke(
 # :remove-start:
 if __name__ == "__main__":
     assert agent is not None
-    assert hasattr(agent, "stream")
+    assert hasattr(agent, "stream_events")
     print("✓ rubric configure sample completed")
 # :remove-end:

--- a/src/code-samples/deepagents/rubric-configure.py
+++ b/src/code-samples/deepagents/rubric-configure.py
@@ -1,0 +1,106 @@
+"""Deep Agents: configure RubricMiddleware and invoke with a rubric."""
+
+# :snippet-start: rubric-configure-py
+from deepagents import RubricMiddleware, create_deep_agent
+from langgraph.checkpoint.memory import InMemorySaver
+
+agent = create_deep_agent(
+    model="anthropic:claude-haiku-4-5",
+    middleware=[
+        RubricMiddleware(
+            model="anthropic:claude-haiku-4-5",
+            max_iterations=3,
+        ),
+    ],
+    checkpointer=InMemorySaver(),
+)
+# :snippet-end:
+
+# :snippet-start: rubric-invoke-py
+from langchain.messages import HumanMessage
+
+config = {"configurable": {"thread_id": "my-rubric-thread"}}
+result = agent.invoke(
+    {
+        "messages": [HumanMessage("Write a haiku about spring.")],
+        "rubric": (
+            "- The poem has three lines\n"
+            "- Lines follow a 5-7-5 syllable pattern\n"
+            "- The theme is spring"
+        ),
+    },
+    config=config,
+)
+# :snippet-end:
+
+# :snippet-start: rubric-stream-py
+from langchain.messages import HumanMessage
+
+config = {"configurable": {"thread_id": "my-rubric-thread"}}
+for chunk in agent.stream(
+    {
+        "messages": [HumanMessage("Write a haiku about spring.")],
+        "rubric": (
+            "- The poem has three lines\n"
+            "- Lines follow a 5-7-5 syllable pattern\n"
+            "- The theme is spring"
+        ),
+    },
+    config=config,
+    stream_mode="custom",
+    version="v2",
+):
+    if chunk.get("type") != "custom":
+        continue
+    event = chunk["data"]
+    event_type = event.get("type")
+    if event_type == "rubric_evaluation_start":
+        print(
+            f"Grading iteration {event['iteration']} "
+            f"(run {event['grading_run_id']})"
+        )
+    elif event_type == "rubric_evaluation_end":
+        print(f"Verdict: {event['result']} — {event.get('explanation', '')}")
+# :snippet-end:
+
+# :snippet-start: rubric-on-evaluation-py
+from deepagents import RubricMiddleware, create_deep_agent
+from deepagents.middleware.rubric import RubricEvaluation
+from langchain.messages import HumanMessage
+from langgraph.checkpoint.memory import InMemorySaver
+
+
+def log_evaluation(ev: RubricEvaluation) -> None:
+    print(f"iteration {ev['iteration']}: {ev['result']} — {ev['explanation']}")
+
+
+agent = create_deep_agent(
+    model="anthropic:claude-haiku-4-5",
+    middleware=[
+        RubricMiddleware(
+            model="anthropic:claude-haiku-4-5",
+            on_evaluation=log_evaluation,
+        ),
+    ],
+    checkpointer=InMemorySaver(),
+)
+
+config = {"configurable": {"thread_id": "rubric-eval-session"}}
+agent.invoke(
+    {
+        "messages": [HumanMessage("Write a one-sentence summary of photosynthesis.")],
+        "rubric": (
+            "- The answer is one sentence\n"
+            "- The answer mentions light and chlorophyll"
+        ),
+    },
+    config=config,
+)
+# :snippet-end:
+
+# :remove-start:
+if __name__ == "__main__":
+    assert agent is not None
+    assert hasattr(agent, "stream")
+    print("✓ rubric configure sample completed")
+# :remove-end:

--- a/src/oss/deepagents/rubric.mdx
+++ b/src/oss/deepagents/rubric.mdx
@@ -1,6 +1,6 @@
 ---
 title: Grading rubrics
-description: Self-evaluating agents that iterate against a rubric until done
+description: LLM-as-a-judge grading for agents that iterate against a rubric until done
 tag: "Beta"
 ---
 
@@ -8,14 +8,19 @@ import RubricConfigurePy from '/snippets/code-samples/rubric-configure-py.mdx';
 import RubricInvokePy from '/snippets/code-samples/rubric-invoke-py.mdx';
 import RubricOnEvaluationPy from '/snippets/code-samples/rubric-on-evaluation-py.mdx';
 import RubricStreamPy from '/snippets/code-samples/rubric-stream-py.mdx';
+import RubricCodeGenerationMiddlewarePy from '/snippets/code-samples/rubric-code-generation-middleware-py.mdx';
+import RubricCodeGenerationAgentPy from '/snippets/code-samples/rubric-code-generation-agent-py.mdx';
+import RubricCodeGenerationInvokePy from '/snippets/code-samples/rubric-code-generation-invoke-py.mdx';
 
 <Note>
 `RubricMiddleware` requires `deepagents>=0.6.5`. It is in [**beta**](/oss/versioning); the API may change in the future.
 </Note>
 
-Some agent tasks have a clear definition of "done" that the model alone cannot reliably hit on the first try: a haiku in the right syllable pattern, a refactor with all tests passing, a report that hits every required section. `RubricMiddleware` lets you declare *what done looks like* as a rubric and have the agent **self-evaluate and iterate** until the rubric is satisfied (or a configured maximum iteration cap is hit).
+Some agent tasks have a clear definition of "done" that the working model alone cannot reliably hit on the first try: a haiku in the right syllable pattern, a refactor with all tests passing, a report that hits every required section. `RubricMiddleware` lets you declare *what done looks like* as a rubric and have the agent **self-evaluate and iterate**  until the rubric is satisfied (or a configured maximum iteration cap is hit).
 
-When the deep agent finishes reasoning and has an output, a separate **grader sub-agent** reviews the transcript against the rubric. If the grader returns `needs_revision`, its feedback is injected back into the conversation and the agent runs again. The loop terminates on `satisfied`, `max_iterations_reached`, `failed`, or `grader_error`.
+**LLM-as-a-judge** is a pattern where one language model evaluates another model's output against defined criteria. In [LangSmith evaluations](/langsmith/evaluation-concepts#llm-as-judge), LLM-as-a-judge evaluators score application outputs offline in batch. `RubricMiddleware` applies the same pattern at runtime: after the deep agent produces output, a dedicated grader model reviews the transcript against your rubric and drives revision until every criterion passes (or a configured iteration cap is hit).
+
+When the deep agent finishes reasoning, the LLM-as-a-judge grader sub-agent reviews the output and returns a verdict. If it returns `needs_revision`, per-criterion feedback is injected back into the conversation and the agent runs again. The loop terminates on `satisfied`, `max_iterations_reached`, `failed`, or `grader_error`.
 
 ```mermaid
 graph LR
@@ -51,64 +56,24 @@ Add `RubricMiddleware` to the `middleware` list when you call `create_deep_agent
 
 | Argument | Required | Default | Description |
 | --- | --- | --- | --- |
-| `model` | Yes | `None` | Chat model used by the grader sub-agent. Accepts a `"provider:model-id"` string or a `BaseChatModel` instance. |
+| `model` | Yes | `None` | Chat model used by the LLM-as-a-judge grader sub-agent. Accepts a `"provider:model-id"` string or a `BaseChatModel` instance. Often a smaller or cheaper model than the deep agent's working model. |
 | `system_prompt` | No | Built-in grader prompt | Custom grading instructions. Falls back to a default system prompt that teaches the grader the verdict format and what tools it has at its disposal. |
 | `tools` | No | `None` | Tools the grader may call to gather evidence (run tests, count tokens, read files) before producing a verdict. With none, the grader reasons from the transcript alone. |
 | `max_iterations` | No | `3` | Hard cap on grader iterations per rubric attempt. Maximum input value is 20. When the cap is reached without a `satisfied` verdict, the agent terminates with status `max_iterations_reached`. |
-| `on_evaluation` | No | `None` | Optional callback invoked with each `RubricEvaluation` after grading to be used with `invoke()`. Useful for evals, observability, or persisting iteration history. |
+| `on_evaluation` | No | `None` | Optional callback invoked with each `RubricEvaluation` after every grading iteration, whether you use `invoke()`, `stream()` or `stream_events()`. Useful for logging, custom metrics, eval datasets, or UI updates. |
 
 ## Pass rubric on invocation
 
-Pass a `rubric` string on invocation state to start the self-evaluation loop. Use `invoke()` for a single blocking call, or `stream(..., stream_mode="custom")` to receive grading events as they occur:
+Pass a `rubric` string on invocation state to start the self-evaluation loop. Use `invoke()` for a single blocking call, or [`stream_events(..., version="v3")`](/oss/langchain/event-streaming) with [`CustomTransformer`](/oss/langchain/event-streaming#custom-updates) to receive grading events on `stream.custom` as they occur:
 
 <Tabs>
     <Tab title="invoke()">
         <RubricInvokePy />
     </Tab>
-    <Tab title="stream()">
-        <RubricStreamPy />
-    </Tab>
-</Tabs>
-
-### Rubric verdicts
-
-When the deep agent finishes reasoning and has an output, a grader sub-agent reviews the output based on the rubric and produces one of the following verdicts:
-
-| Status | Meaning | Loops back? |
-| --- | --- | --- |
-| `satisfied` | Every criterion in the rubric passes. | No |
-| `needs_revision` | At least one criterion fails; grader feedback is injected and the agent runs again. | Yes |
-| `max_iterations_reached` | Grader still wants revisions, but `max_iterations` has been hit. | No |
-| `failed` | The grader judged the rubric malformed or impossible to evaluate against the transcript. | No |
-| `grader_error` | The grader sub-agent itself raised an exception (provider timeout, missing credentials, malformed structured response, etc.). | No |
-
-## Observe iteration progress
-
-How you observe grader iterations depends on whether you use `invoke()` or `stream(..., stream_mode="custom")`:
-
-<Tabs>
-    <Tab title="invoke()">
-        Pass `on_evaluation` when you want a synchronous, in-process hook after each grader pass. You can use it for logging, custom metrics, eval datasets, or UI updates.
-
-        <RubricOnEvaluationPy />
-
-        The middleware calls your function with a `RubricEvaluation` dictionary after each [grader pass](#grader-pass).
-        The `RubricEvaluation` dictionary contains:
-
-        | Field | Type | Description |
-        | --- | --- | --- |
-        | `grading_run_id` | `str` | Identifier shared by every evaluation in one rubric attempt. A new run starts when the caller supplies a different `rubric`, or when the same `rubric` is invoked again after a terminal verdict. |
-        | `iteration` | `int` | Zero-based index of the current grader pass within that run. |
-        | `result` | `str` | The grader verdict for this pass: `satisfied`, `needs_revision`, `failed`, or `grader_error`. |
-        | `explanation` | `str` | Free-form summary from the grader. On infrastructure failures, this includes the exception type and message. |
-        | `criteria` | `list` | Per-criterion verdicts. Each entry is either `{name, passed: true}` or `{name, passed: false, gap}` where `gap` is actionable feedback for a failing criterion. |
-    </Tab>
-    <Tab title="stream()">
-        Use `stream(..., stream_mode="custom")` when you want to receive grading events as they occur:
-
+    <Tab title="stream_events()">
         <RubricStreamPy />
 
-        Rubric grading emits the following custom events:
+        Rubric grading emits the following custom events on `stream.custom`:
 
         | Event | When fired | Payload fields |
         | --- | --- | --- |
@@ -116,6 +81,34 @@ How you observe grader iterations depends on whether you use `invoke()` or `stre
         | `rubric_evaluation_end` | After the grader returns or after a grader exception. | <ul><li>`type`: event name</li><li>`grading_run_id`: shared across all events within one rubric attempt</li><li>`iteration`: zero-based index of the current grader pass</li><li>`result`: terminal verdict for this pass</li><li>`explanation`: summary from the grader</li><li>`criteria`: per-criterion verdicts</li></ul> |
     </Tab>
 </Tabs>
+
+### Rubric verdicts
+
+When the deep agent finishes reasoning and has an output, the LLM-as-a-judge grader sub-agent reviews the output against the rubric and produces one of the following verdicts:
+
+| Status | Meaning | Loops back? |
+| --- | --- | --- |
+| `satisfied` | Every criterion in the rubric passes. | No |
+| `needs_revision` | At least one criterion fails; grader feedback is injected and the agent runs again. | Yes |
+| `max_iterations_reached` | Grader still wants revisions, but `max_iterations` has been hit. | No |
+| `failed` | The grader judged the rubric malformed or impossible to evaluate against the transcript. | No |
+| `grader_error` | The LLM-as-a-judge grader sub-agent itself raised an exception (provider timeout, missing credentials, malformed structured response, etc.). | No |
+
+## Observe iteration progress
+
+`on_evaluation` is a callback that fires after each grading iteration with the grader's verdict, whether you call `invoke()` or `stream_events()`. If you are not reading rubric events from `stream.custom` (with `CustomTransformer`) or [tracing the run with LangSmith](/langsmith/tracing), it is the main way to inspect what happened during grading.
+
+<RubricOnEvaluationPy />
+
+The middleware calls your function with a `RubricEvaluation` dictionary after each [grader pass](#grader-pass-events). The `RubricEvaluation` dictionary contains:
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `grading_run_id` | `str` | Identifier shared by every evaluation in one rubric attempt. A new run starts when the caller supplies a different `rubric`, or when the same `rubric` is invoked again after a terminal verdict. |
+| `iteration` | `int` | Zero-based index of the current grader pass within that run. |
+| `result` | `str` | The grader verdict for this pass: `satisfied`, `needs_revision`, `failed`, or `grader_error`. |
+| `explanation` | `str` | Free-form summary from the grader. On infrastructure failures, this includes the exception type and message. |
+| `criteria` | `list` | Per-criterion verdicts. Each entry is either `{name, passed: true}` or `{name, passed: false, gap}` where `gap` is actionable feedback for a failing criterion. |
 
 ### Grader pass events
 
@@ -125,139 +118,42 @@ How you observe grader iterations depends on whether you use `invoke()` or `stre
 | **Grader exceptions** | Fires with `result: "grader_error"`, an explanation derived from the exception, and an empty `criteria` list. |
 | **Errors in your callback** | Exceptions are logged and suppressed. The grading loop continues. Do not use `on_evaluation` to enforce control flow (for example, raising to stop the agent). |
 
-## Read accumulated history from state
-
-The RubricMiddleware appends each evaluation to `_rubric_evaluations` on the agent state. These fields are private (omitted from the public input/output schema) but you can retrieve them on a [checkpointed](/oss/langgraph/persistence#checkpoints) thread:
-
-```python
-state = agent.get_state(config).values
-status = state.get("_rubric_status")           # terminal status for the run
-history = state.get("_rubric_evaluations", [])  # list[RubricEvaluation]
-```
-
-The following example accumulates evaluations in a list, logs failing criteria, and checks the terminal status after `invoke`:
-
-```python expandable wrap
-from deepagents import RubricMiddleware, create_deep_agent
-from deepagents.middleware.rubric import RubricEvaluation
-from langchain.messages import HumanMessage
-from langgraph.checkpoint.memory import InMemorySaver
-
-
-def make_evaluation_logger(history: list[RubricEvaluation]):
-    """Return an on_evaluation callback that appends each grader pass."""
-
-    def log_evaluation(ev: RubricEvaluation) -> None:
-        history.append(ev)
-        print(
-            f"[{ev['grading_run_id']}] iteration {ev['iteration']}: {ev['result']}"
-        )
-        if ev["result"] == "needs_revision":
-            for criterion in ev["criteria"]:
-                if not criterion.get("passed"):
-                    print(f"  - {criterion['name']}: {criterion.get('gap', '')}")
-
-    return log_evaluation
-
-
-eval_history: list[RubricEvaluation] = []
-agent = create_deep_agent(
-    model="anthropic:claude-haiku-4-5",
-    middleware=[
-        RubricMiddleware(
-            model="anthropic:claude-haiku-4-5",
-            on_evaluation=make_evaluation_logger(eval_history),
-        ),
-    ],
-    checkpointer=InMemorySaver(),
-)
-
-config = {"configurable": {"thread_id": "rubric-eval-session"}}
-agent.invoke(
-    {
-        "messages": [HumanMessage("Write a one-sentence summary of photosynthesis.")],
-        "rubric": (
-            "- The answer is one sentence\n"
-            "- The answer mentions light and chlorophyll"
-        ),
-    },
-    config=config,
-)
-
-final_status = agent.get_state(config).values.get("_rubric_status")
-print(final_status, len(eval_history), "grader passes recorded")
-```
-
 ## Persist rubrics across invocations
 
-A single `agent.invoke()` or `agent.stream()` call runs the rubric loop to completion and finishes with a terminal verdict: `satisfied`, `failed`, or `max_iterations_reached`.
+A single `agent.invoke()` or `agent.stream_events()` call runs the rubric loop to completion and finishes with a terminal verdict: `satisfied`, `failed`, or `max_iterations_reached`.
 
-To carry rubrics over to follow up invocations, attach a [checkpointer](/oss/langgraph/persistence#checkpoints) and pass the same `thread_id` alongside the invocation. In these cases, the same `rubric` persists across future `invoke()` or `stream()` calls until you pass a new one in.
+To carry rubrics over to follow up invocations, attach a [checkpointer](/oss/langgraph/persistence#checkpoints) and pass the same `thread_id` alongside the invocation. In these cases, the same `rubric` persists across future `invoke()` or `stream_events()` calls until you pass a new one in.
 
-Interrupts (`KeyboardInterrupt`, `asyncio.CancelledError`) propagate out of `agent.invoke()` and `agent.stream()` uncaught. On a checkpointed thread, the next call with the same rubric resumes the in-flight grading run.
+Interrupts (`KeyboardInterrupt`, `asyncio.CancelledError`) propagate out of `agent.invoke()` and `agent.stream_events()` uncaught. On a checkpointed thread, the next call with the same rubric resumes the in-flight grading run.
 
-## Example: grade a lipogram with a custom tool and prompt
+## Example: generate vetted Python code
 
-The following example builds a deep agent that writes a short paragraph about the ocean without using the letter "e". The rubric asks for zero instances of "e", at least two vivid sensory details, and a 3-4 sentence length.
+The following example builds a deep agent that writes a `find_duplicates` function. It defines `RubricMiddleware` once, attaches it to the agent, then passes a `rubric` string at invoke time.
 
-```python expandable wrap
-from deepagents import RubricMiddleware, create_deep_agent
-from langchain.messages import HumanMessage
-from langchain.tools import tool
-from langgraph.checkpoint.memory import InMemorySaver
+Rather than asking the grader to reason abstractly about correctness, the example gives it a `run_test_suite` tool to verify behavior directly. The grader calls this tool for additional information before producing a verdict, and falls back to reasoning from the transcript when no tools are provided.
 
+<Steps>
+<Step title="Define RubricMiddleware">
 
-@tool
-def check_lipogram(text: str, forbidden: str = "e") -> dict:
-    """Check whether `text` contains the forbidden letter (case-insensitive)."""
-    forbidden_lower = forbidden.lower()
-    violating_words = sorted({w for w in text.split() if forbidden_lower in w.lower()})
-    hit_count = sum(1 for c in text.lower() if c == forbidden_lower)
-    return {
-        "forbidden": forbidden,
-        "hit_count": hit_count,
-        "violating_words": violating_words,
-        "ok": hit_count == 0,
-    }
+This middleware adds an LLM-as-a-judge grader loop on top of the base agent. Configure the grader model, optional custom prompt, tools for evidence gathering, and a maximum iteration cap.
 
+<RubricCodeGenerationMiddlewarePy />
 
-LIPOGRAM_GRADER_PROMPT = "You are an editor grading short paragraphs against a rubric."
+</Step>
+<Step title="Pass it to a deep agent">
 
-agent = create_deep_agent(
-    model="anthropic:claude-haiku-4-5",
-    middleware=[
-        RubricMiddleware(
-            model="anthropic:claude-haiku-4-5",
-            system_prompt=LIPOGRAM_GRADER_PROMPT,
-            tools=[check_lipogram],
-            max_iterations=5,
-            on_evaluation=lambda ev: print(ev["result"], ev["explanation"]),
-        ),
-    ],
-    checkpointer=InMemorySaver(),
-)
+The agent's `system_prompt` tells it how to do the work, while the rubric tells the grader how to judge the work.
 
-config = {"configurable": {"thread_id": "lipogram-session"}}
-result = agent.invoke(
-    {
-        "messages": [
-            HumanMessage(
-                "Write a short paragraph (3-4 sentences) about the ocean without using the letter 'e'."
-            )
-        ],
-        "rubric": (
-            "- The paragraph contains zero instances of the letter 'e'\n"
-            "- The paragraph is about the ocean and includes at least two vivid sensory details"
-            " (sight, sound, smell, touch, or taste).\n"
-            "- The paragraph is 3-4 sentences long."
-        ),
-    },
-    config=config,
-)
+<RubricCodeGenerationAgentPy />
 
-print(result["messages"][-1].content)   # the final paragraph
-```
+</Step>
+<Step title="Invoke with a human message and rubric">
 
-The `rubric` field on input state is the trigger. Each grader iteration is delivered to `on_evaluation` as a `RubricEvaluation` dictionary containing the verdict, explanation, and per-criterion gaps.
+At invocation time, provide the user request in `messages` and a newline-delimited checklist in `rubric` that the grader must mark satisfied. When no `rubric` is supplied on input state, the middleware does not run.
 
-When no `rubric` is supplied on input state, the middleware does not run.
+<RubricCodeGenerationInvokePy />
+
+</Step>
+</Steps>
+
+After the agent produces output, the grader takes over and checks the output for each criterion: for example, that `test_unhashable` fails with a `TypeError` when the input contains unhashable types. If there are any issues the grader provides this feedback and the agent then revises its implementation and returns it to the grader.

--- a/src/oss/deepagents/rubric.mdx
+++ b/src/oss/deepagents/rubric.mdx
@@ -4,8 +4,13 @@ description: Self-evaluating agents that iterate against a rubric until done
 tag: "Beta"
 ---
 
+import RubricConfigurePy from '/snippets/code-samples/rubric-configure-py.mdx';
+import RubricInvokePy from '/snippets/code-samples/rubric-invoke-py.mdx';
+import RubricOnEvaluationPy from '/snippets/code-samples/rubric-on-evaluation-py.mdx';
+import RubricStreamPy from '/snippets/code-samples/rubric-stream-py.mdx';
+
 <Note>
-`RubricMiddleware` is in [**beta**](/oss/versioning). The API may change in the future.
+`RubricMiddleware` requires `deepagents>=0.6.5`. It is in [**beta**](/oss/versioning); the API may change in the future.
 </Note>
 
 Some agent tasks have a clear definition of "done" that the model alone cannot reliably hit on the first try: a haiku in the right syllable pattern, a refactor with all tests passing, a report that hits every required section. `RubricMiddleware` lets you declare *what done looks like* as a rubric and have the agent **self-evaluate and iterate** until the rubric is satisfied (or a configured maximum iteration cap is hit).
@@ -38,9 +43,36 @@ graph LR
     class Done,MaxOut alert
 ```
 
-## Rubric verdicts
+## Configure the middleware
 
-Every grader pass produces one of five verdicts:
+Add `RubricMiddleware` to the `middleware` list when you call `create_deep_agent`:
+
+<RubricConfigurePy />
+
+| Argument | Required | Default | Description |
+| --- | --- | --- | --- |
+| `model` | Yes | `None` | Chat model used by the grader sub-agent. Accepts a `"provider:model-id"` string or a `BaseChatModel` instance. |
+| `system_prompt` | No | Built-in grader prompt | Custom grading instructions. Falls back to a default system prompt that teaches the grader the verdict format and what tools it has at its disposal. |
+| `tools` | No | `None` | Tools the grader may call to gather evidence (run tests, count tokens, read files) before producing a verdict. With none, the grader reasons from the transcript alone. |
+| `max_iterations` | No | `3` | Hard cap on grader iterations per rubric attempt. Maximum input value is 20. When the cap is reached without a `satisfied` verdict, the agent terminates with status `max_iterations_reached`. |
+| `on_evaluation` | No | `None` | Optional callback invoked with each `RubricEvaluation` after grading to be used with `invoke()`. Useful for evals, observability, or persisting iteration history. |
+
+## Pass rubric on invocation
+
+Pass a `rubric` string on invocation state to start the self-evaluation loop. Use `invoke()` for a single blocking call, or `stream(..., stream_mode="custom")` to receive grading events as they occur:
+
+<Tabs>
+    <Tab title="invoke()">
+        <RubricInvokePy />
+    </Tab>
+    <Tab title="stream()">
+        <RubricStreamPy />
+    </Tab>
+</Tabs>
+
+### Rubric verdicts
+
+When the deep agent finishes reasoning and has an output, a grader sub-agent reviews the output based on the rubric and produces one of the following verdicts:
 
 | Status | Meaning | Loops back? |
 | --- | --- | --- |
@@ -50,34 +82,119 @@ Every grader pass produces one of five verdicts:
 | `failed` | The grader judged the rubric malformed or impossible to evaluate against the transcript. | No |
 | `grader_error` | The grader sub-agent itself raised an exception (provider timeout, missing credentials, malformed structured response, etc.). | No |
 
-## Configure the middleware
-
-| Argument | Required | Default | Description |
-| --- | --- | --- | --- |
-| `model` | Yes | `None` | Chat model used by the grader sub-agent. Accepts a `"provider:model-id"` string or a `BaseChatModel` instance. |
-| `system_prompt` | No | Built-in grader prompt | Custom grading instructions. Falls back to a default system prompt that teaches the grader the verdict format and what tools it has at its disposal. |
-| `tools` | No | `None` | Tools the grader may call to gather evidence (run tests, count tokens, read files) before producing a verdict. With none, the grader reasons from the transcript alone. |
-| `max_iterations` | No | `3` | Hard cap on grader iterations per rubric attempt. Maximum input value is 20. When the cap is reached without a `satisfied` verdict, the agent terminates with status `max_iterations_reached`. |
-| `on_evaluation` | No | `None` | Optional callback invoked with each `RubricEvaluation` after grading. Useful for evals, observability, or persisting iteration history. |
-
 ## Observe iteration progress
 
-Run the agent with `agent.stream(..., stream_mode="custom")` instead of `agent.invoke(...)` to receive each grader event as it fires.
+How you observe grader iterations depends on whether you use `invoke()` or `stream(..., stream_mode="custom")`:
 
-| Event | When fired | Payload fields |
-| --- | --- | --- |
-| `rubric_evaluation_start` | Before the grader runs. | `type` — event name<br/>`grading_run_id` — shared across all events within one rubric attempt<br/>`iteration` — zero-based index of the current grading run |
-| `rubric_evaluation_end` | After the grader returns or after a grader exception. | `type` — event name<br/>`grading_run_id` — shared across all events within one rubric attempt<br/>`iteration` — zero-based index of the current grader pass<br/>`result` — terminal verdict for this pass<br/>`explanation` — summary from the grader<br/>`criteria` — per-criterion verdicts |
+<Tabs>
+    <Tab title="invoke()">
+        Pass `on_evaluation` when you want a synchronous, in-process hook after each grader pass. You can use it for logging, custom metrics, eval datasets, or UI updates.
 
-The same `RubricEvaluation` payload is also delivered synchronously to the `on_evaluation` callback after each grader pass, and the full history is reachable through `agent.get_state(config).values` on a checkpointed thread.
+        <RubricOnEvaluationPy />
+
+        The middleware calls your function with a `RubricEvaluation` dictionary after each [grader pass](#grader-pass).
+        The `RubricEvaluation` dictionary contains:
+
+        | Field | Type | Description |
+        | --- | --- | --- |
+        | `grading_run_id` | `str` | Identifier shared by every evaluation in one rubric attempt. A new run starts when the caller supplies a different `rubric`, or when the same `rubric` is invoked again after a terminal verdict. |
+        | `iteration` | `int` | Zero-based index of the current grader pass within that run. |
+        | `result` | `str` | The grader verdict for this pass: `satisfied`, `needs_revision`, `failed`, or `grader_error`. |
+        | `explanation` | `str` | Free-form summary from the grader. On infrastructure failures, this includes the exception type and message. |
+        | `criteria` | `list` | Per-criterion verdicts. Each entry is either `{name, passed: true}` or `{name, passed: false, gap}` where `gap` is actionable feedback for a failing criterion. |
+    </Tab>
+    <Tab title="stream()">
+        Use `stream(..., stream_mode="custom")` when you want to receive grading events as they occur:
+
+        <RubricStreamPy />
+
+        Rubric grading emits the following custom events:
+
+        | Event | When fired | Payload fields |
+        | --- | --- | --- |
+        | `rubric_evaluation_start` | Before the grader runs. | <ul><li>`type`: event name</li><li>`grading_run_id`: shared across all events within one rubric attempt</li><li>`iteration`: zero-based index of the current grading run</li></ul> |
+        | `rubric_evaluation_end` | After the grader returns or after a grader exception. | <ul><li>`type`: event name</li><li>`grading_run_id`: shared across all events within one rubric attempt</li><li>`iteration`: zero-based index of the current grader pass</li><li>`result`: terminal verdict for this pass</li><li>`explanation`: summary from the grader</li><li>`criteria`: per-criterion verdicts</li></ul> |
+    </Tab>
+</Tabs>
+
+### Grader pass events
+
+| Event | Description |
+| ----- | ------------- |
+| **Successful grading** | Fires once per pass, including intermediate `needs_revision` verdicts and the final `satisfied` or `failed` verdict. <br /><br /> When the grader returns `needs_revision` but `max_iterations` has been reached, the callback still receives `result: "needs_revision"` (the grader's verdict). The run's terminal status is `max_iterations_reached` on private state `_rubric_status`, not on the evaluation record. Inspect `_rubric_status` after `invoke` completes, or read the last entry in `_rubric_evaluations` together with `_rubric_iterations`, to branch on cap exhaustion. |
+| **Grader exceptions** | Fires with `result: "grader_error"`, an explanation derived from the exception, and an empty `criteria` list. |
+| **Errors in your callback** | Exceptions are logged and suppressed. The grading loop continues. Do not use `on_evaluation` to enforce control flow (for example, raising to stop the agent). |
+
+## Read accumulated history from state
+
+The RubricMiddleware appends each evaluation to `_rubric_evaluations` on the agent state. These fields are private (omitted from the public input/output schema) but you can retrieve them on a [checkpointed](/oss/langgraph/persistence#checkpoints) thread:
+
+```python
+state = agent.get_state(config).values
+status = state.get("_rubric_status")           # terminal status for the run
+history = state.get("_rubric_evaluations", [])  # list[RubricEvaluation]
+```
+
+The following example accumulates evaluations in a list, logs failing criteria, and checks the terminal status after `invoke`:
+
+```python expandable wrap
+from deepagents import RubricMiddleware, create_deep_agent
+from deepagents.middleware.rubric import RubricEvaluation
+from langchain.messages import HumanMessage
+from langgraph.checkpoint.memory import InMemorySaver
+
+
+def make_evaluation_logger(history: list[RubricEvaluation]):
+    """Return an on_evaluation callback that appends each grader pass."""
+
+    def log_evaluation(ev: RubricEvaluation) -> None:
+        history.append(ev)
+        print(
+            f"[{ev['grading_run_id']}] iteration {ev['iteration']}: {ev['result']}"
+        )
+        if ev["result"] == "needs_revision":
+            for criterion in ev["criteria"]:
+                if not criterion.get("passed"):
+                    print(f"  - {criterion['name']}: {criterion.get('gap', '')}")
+
+    return log_evaluation
+
+
+eval_history: list[RubricEvaluation] = []
+agent = create_deep_agent(
+    model="anthropic:claude-haiku-4-5",
+    middleware=[
+        RubricMiddleware(
+            model="anthropic:claude-haiku-4-5",
+            on_evaluation=make_evaluation_logger(eval_history),
+        ),
+    ],
+    checkpointer=InMemorySaver(),
+)
+
+config = {"configurable": {"thread_id": "rubric-eval-session"}}
+agent.invoke(
+    {
+        "messages": [HumanMessage("Write a one-sentence summary of photosynthesis.")],
+        "rubric": (
+            "- The answer is one sentence\n"
+            "- The answer mentions light and chlorophyll"
+        ),
+    },
+    config=config,
+)
+
+final_status = agent.get_state(config).values.get("_rubric_status")
+print(final_status, len(eval_history), "grader passes recorded")
+```
 
 ## Persist rubrics across invocations
 
-A single `agent.invoke()` call runs the rubric loop to completion and returns with a terminal verdict: `satisfied`, `failed`, or `max_iterations_reached`.
+A single `agent.invoke()` or `agent.stream()` call runs the rubric loop to completion and finishes with a terminal verdict: `satisfied`, `failed`, or `max_iterations_reached`.
 
-To carry rubrics over to follow up invocations, attach a [checkpointer](/oss/langgraph/persistence#checkpoints) and pass the same `thread_id` alongside the invocation. In these cases, the same `rubric` persists across future `invoke` calls until the user passes a new one in.
+To carry rubrics over to follow up invocations, attach a [checkpointer](/oss/langgraph/persistence#checkpoints) and pass the same `thread_id` alongside the invocation. In these cases, the same `rubric` persists across future `invoke()` or `stream()` calls until you pass a new one in.
 
-Interrupts (`KeyboardInterrupt`, `asyncio.CancelledError`) propagate out of `agent.invoke()` uncaught. On a checkpointed thread, the next invocation with the same rubric resumes the in-flight grading run.
+Interrupts (`KeyboardInterrupt`, `asyncio.CancelledError`) propagate out of `agent.invoke()` and `agent.stream()` uncaught. On a checkpointed thread, the next call with the same rubric resumes the in-flight grading run.
 
 ## Example: grade a lipogram with a custom tool and prompt
 

--- a/src/oss/deepagents/rubric.mdx
+++ b/src/oss/deepagents/rubric.mdx
@@ -96,7 +96,7 @@ When the deep agent finishes reasoning and has an output, the LLM-as-a-judge gra
 
 ## Observe iteration progress
 
-`on_evaluation` is a callback that fires after each grading iteration with the grader's verdict, whether you call `invoke()` or `stream_events()`. If you are not reading rubric events from `stream.custom` (with `CustomTransformer`) or [tracing the run with LangSmith](/langsmith/tracing), it is the main way to inspect what happened during grading.
+`on_evaluation` is a callback that fires after each grading iteration with the grader's verdict, whether you call `invoke()` or `stream_events()`. If you are not reading rubric events from `stream.custom` (with `CustomTransformer`) or [tracing the run with LangSmith](/langsmith/trace-with-langgraph), it is the main way to inspect what happened during grading.
 
 <RubricOnEvaluationPy />
 

--- a/src/snippets/code-samples/rubric-code-generation-agent-py.mdx
+++ b/src/snippets/code-samples/rubric-code-generation-agent-py.mdx
@@ -1,0 +1,106 @@
+<CodeGroup>
+    ```python Google
+    from deepagents import create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    agent = create_deep_agent(
+        model="google_genai:gemini-3.5-flash",
+        system_prompt=(
+            "You are a careful Python engineer. Write correct, readable code. "
+            "Follow the user's instructions exactly."
+        ),
+        middleware=[rubric_middleware],
+        checkpointer=InMemorySaver(),
+    )
+    ```
+
+    ```python OpenAI
+    from deepagents import create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    agent = create_deep_agent(
+        model="openai:gpt-5.4",
+        system_prompt=(
+            "You are a careful Python engineer. Write correct, readable code. "
+            "Follow the user's instructions exactly."
+        ),
+        middleware=[rubric_middleware],
+        checkpointer=InMemorySaver(),
+    )
+    ```
+
+    ```python Anthropic
+    from deepagents import create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    agent = create_deep_agent(
+        model="anthropic:claude-sonnet-4-6",
+        system_prompt=(
+            "You are a careful Python engineer. Write correct, readable code. "
+            "Follow the user's instructions exactly."
+        ),
+        middleware=[rubric_middleware],
+        checkpointer=InMemorySaver(),
+    )
+    ```
+
+    ```python OpenRouter
+    from deepagents import create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    agent = create_deep_agent(
+        model="openrouter:anthropic/claude-sonnet-4-6",
+        system_prompt=(
+            "You are a careful Python engineer. Write correct, readable code. "
+            "Follow the user's instructions exactly."
+        ),
+        middleware=[rubric_middleware],
+        checkpointer=InMemorySaver(),
+    )
+    ```
+
+    ```python Fireworks
+    from deepagents import create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    agent = create_deep_agent(
+        model="fireworks:accounts/fireworks/models/qwen3p5-397b-a17b",
+        system_prompt=(
+            "You are a careful Python engineer. Write correct, readable code. "
+            "Follow the user's instructions exactly."
+        ),
+        middleware=[rubric_middleware],
+        checkpointer=InMemorySaver(),
+    )
+    ```
+
+    ```python Baseten
+    from deepagents import create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    agent = create_deep_agent(
+        model="baseten:zai-org/GLM-5",
+        system_prompt=(
+            "You are a careful Python engineer. Write correct, readable code. "
+            "Follow the user's instructions exactly."
+        ),
+        middleware=[rubric_middleware],
+        checkpointer=InMemorySaver(),
+    )
+    ```
+
+    ```python Ollama
+    from deepagents import create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    agent = create_deep_agent(
+        model="ollama:devstral-2",
+        system_prompt=(
+            "You are a careful Python engineer. Write correct, readable code. "
+            "Follow the user's instructions exactly."
+        ),
+        middleware=[rubric_middleware],
+        checkpointer=InMemorySaver(),
+    )
+    ```
+</CodeGroup>

--- a/src/snippets/code-samples/rubric-code-generation-invoke-py.mdx
+++ b/src/snippets/code-samples/rubric-code-generation-invoke-py.mdx
@@ -1,0 +1,24 @@
+```python
+from langchain.messages import HumanMessage
+
+if __name__ == "__main__":
+    result = agent.invoke(
+        {
+            "messages": [
+                HumanMessage(
+                    content=(
+                        "Write a Python function `find_duplicates(lst)` that returns a list of "
+                        "all elements that appear more than once in the input list, in the order "
+                        "they first appear."
+                    )
+                )
+            ],
+            "rubric": (
+                "- All tests pass in run_test_suite\n"
+                "- The function is named `find_duplicates` and accepts a single list argument\n"
+            ),
+        },
+        config={"configurable": {"thread_id": "code-generation-session"}},
+    )
+    print(result["messages"][-1].text)
+```

--- a/src/snippets/code-samples/rubric-code-generation-middleware-py.mdx
+++ b/src/snippets/code-samples/rubric-code-generation-middleware-py.mdx
@@ -1,0 +1,309 @@
+<CodeGroup>
+    ```python Google
+    from deepagents import RubricMiddleware
+    from langchain.tools import tool
+    
+    
+    @tool
+    def run_test_suite(code: str) -> dict:
+        """Run the find_duplicates test suite against Python source code."""
+        namespace: dict = {"__builtins__": __builtins__}
+        try:
+            exec(code, namespace)
+        except Exception as exc:
+            return {"ok": False, "failures": [f"Failed to execute code: {exc}"]}
+    
+        find_duplicates = namespace.get("find_duplicates")
+        if find_duplicates is None:
+            return {"ok": False, "failures": ["Function find_duplicates is not defined"]}
+    
+        tests = [
+            ("test_basic", [1, 2, 2, 3, 1], [2, 1]),
+            ("test_empty", [], []),
+            ("test_no_duplicates", [1, 2, 3], []),
+            ("test_unhashable", [[1], [1], 2], [[1]]),
+        ]
+        failures: list[str] = []
+        for name, args, expected in tests:
+            try:
+                actual = find_duplicates(args)
+                if actual != expected:
+                    failures.append(f"{name}: expected {expected}, got {actual}")
+            except Exception as exc:
+                failures.append(f"{name}: {exc}")
+    
+        return {"ok": not failures, "failures": failures}
+    
+    
+    rubric_middleware = RubricMiddleware(
+        model="google_genai:gemini-3.5-flash",
+        system_prompt="You are a code reviewer grading generated code against a rubric.",
+        tools=[run_test_suite],
+        max_iterations=5,
+    )
+    ```
+
+    ```python OpenAI
+    from deepagents import RubricMiddleware
+    from langchain.tools import tool
+    
+    
+    @tool
+    def run_test_suite(code: str) -> dict:
+        """Run the find_duplicates test suite against Python source code."""
+        namespace: dict = {"__builtins__": __builtins__}
+        try:
+            exec(code, namespace)
+        except Exception as exc:
+            return {"ok": False, "failures": [f"Failed to execute code: {exc}"]}
+    
+        find_duplicates = namespace.get("find_duplicates")
+        if find_duplicates is None:
+            return {"ok": False, "failures": ["Function find_duplicates is not defined"]}
+    
+        tests = [
+            ("test_basic", [1, 2, 2, 3, 1], [2, 1]),
+            ("test_empty", [], []),
+            ("test_no_duplicates", [1, 2, 3], []),
+            ("test_unhashable", [[1], [1], 2], [[1]]),
+        ]
+        failures: list[str] = []
+        for name, args, expected in tests:
+            try:
+                actual = find_duplicates(args)
+                if actual != expected:
+                    failures.append(f"{name}: expected {expected}, got {actual}")
+            except Exception as exc:
+                failures.append(f"{name}: {exc}")
+    
+        return {"ok": not failures, "failures": failures}
+    
+    
+    rubric_middleware = RubricMiddleware(
+        model="openai:gpt-5.4",
+        system_prompt="You are a code reviewer grading generated code against a rubric.",
+        tools=[run_test_suite],
+        max_iterations=5,
+    )
+    ```
+
+    ```python Anthropic
+    from deepagents import RubricMiddleware
+    from langchain.tools import tool
+    
+    
+    @tool
+    def run_test_suite(code: str) -> dict:
+        """Run the find_duplicates test suite against Python source code."""
+        namespace: dict = {"__builtins__": __builtins__}
+        try:
+            exec(code, namespace)
+        except Exception as exc:
+            return {"ok": False, "failures": [f"Failed to execute code: {exc}"]}
+    
+        find_duplicates = namespace.get("find_duplicates")
+        if find_duplicates is None:
+            return {"ok": False, "failures": ["Function find_duplicates is not defined"]}
+    
+        tests = [
+            ("test_basic", [1, 2, 2, 3, 1], [2, 1]),
+            ("test_empty", [], []),
+            ("test_no_duplicates", [1, 2, 3], []),
+            ("test_unhashable", [[1], [1], 2], [[1]]),
+        ]
+        failures: list[str] = []
+        for name, args, expected in tests:
+            try:
+                actual = find_duplicates(args)
+                if actual != expected:
+                    failures.append(f"{name}: expected {expected}, got {actual}")
+            except Exception as exc:
+                failures.append(f"{name}: {exc}")
+    
+        return {"ok": not failures, "failures": failures}
+    
+    
+    rubric_middleware = RubricMiddleware(
+        model="anthropic:claude-sonnet-4-6",
+        system_prompt="You are a code reviewer grading generated code against a rubric.",
+        tools=[run_test_suite],
+        max_iterations=5,
+    )
+    ```
+
+    ```python OpenRouter
+    from deepagents import RubricMiddleware
+    from langchain.tools import tool
+    
+    
+    @tool
+    def run_test_suite(code: str) -> dict:
+        """Run the find_duplicates test suite against Python source code."""
+        namespace: dict = {"__builtins__": __builtins__}
+        try:
+            exec(code, namespace)
+        except Exception as exc:
+            return {"ok": False, "failures": [f"Failed to execute code: {exc}"]}
+    
+        find_duplicates = namespace.get("find_duplicates")
+        if find_duplicates is None:
+            return {"ok": False, "failures": ["Function find_duplicates is not defined"]}
+    
+        tests = [
+            ("test_basic", [1, 2, 2, 3, 1], [2, 1]),
+            ("test_empty", [], []),
+            ("test_no_duplicates", [1, 2, 3], []),
+            ("test_unhashable", [[1], [1], 2], [[1]]),
+        ]
+        failures: list[str] = []
+        for name, args, expected in tests:
+            try:
+                actual = find_duplicates(args)
+                if actual != expected:
+                    failures.append(f"{name}: expected {expected}, got {actual}")
+            except Exception as exc:
+                failures.append(f"{name}: {exc}")
+    
+        return {"ok": not failures, "failures": failures}
+    
+    
+    rubric_middleware = RubricMiddleware(
+        model="openrouter:anthropic/claude-sonnet-4-6",
+        system_prompt="You are a code reviewer grading generated code against a rubric.",
+        tools=[run_test_suite],
+        max_iterations=5,
+    )
+    ```
+
+    ```python Fireworks
+    from deepagents import RubricMiddleware
+    from langchain.tools import tool
+    
+    
+    @tool
+    def run_test_suite(code: str) -> dict:
+        """Run the find_duplicates test suite against Python source code."""
+        namespace: dict = {"__builtins__": __builtins__}
+        try:
+            exec(code, namespace)
+        except Exception as exc:
+            return {"ok": False, "failures": [f"Failed to execute code: {exc}"]}
+    
+        find_duplicates = namespace.get("find_duplicates")
+        if find_duplicates is None:
+            return {"ok": False, "failures": ["Function find_duplicates is not defined"]}
+    
+        tests = [
+            ("test_basic", [1, 2, 2, 3, 1], [2, 1]),
+            ("test_empty", [], []),
+            ("test_no_duplicates", [1, 2, 3], []),
+            ("test_unhashable", [[1], [1], 2], [[1]]),
+        ]
+        failures: list[str] = []
+        for name, args, expected in tests:
+            try:
+                actual = find_duplicates(args)
+                if actual != expected:
+                    failures.append(f"{name}: expected {expected}, got {actual}")
+            except Exception as exc:
+                failures.append(f"{name}: {exc}")
+    
+        return {"ok": not failures, "failures": failures}
+    
+    
+    rubric_middleware = RubricMiddleware(
+        model="fireworks:accounts/fireworks/models/qwen3p5-397b-a17b",
+        system_prompt="You are a code reviewer grading generated code against a rubric.",
+        tools=[run_test_suite],
+        max_iterations=5,
+    )
+    ```
+
+    ```python Baseten
+    from deepagents import RubricMiddleware
+    from langchain.tools import tool
+    
+    
+    @tool
+    def run_test_suite(code: str) -> dict:
+        """Run the find_duplicates test suite against Python source code."""
+        namespace: dict = {"__builtins__": __builtins__}
+        try:
+            exec(code, namespace)
+        except Exception as exc:
+            return {"ok": False, "failures": [f"Failed to execute code: {exc}"]}
+    
+        find_duplicates = namespace.get("find_duplicates")
+        if find_duplicates is None:
+            return {"ok": False, "failures": ["Function find_duplicates is not defined"]}
+    
+        tests = [
+            ("test_basic", [1, 2, 2, 3, 1], [2, 1]),
+            ("test_empty", [], []),
+            ("test_no_duplicates", [1, 2, 3], []),
+            ("test_unhashable", [[1], [1], 2], [[1]]),
+        ]
+        failures: list[str] = []
+        for name, args, expected in tests:
+            try:
+                actual = find_duplicates(args)
+                if actual != expected:
+                    failures.append(f"{name}: expected {expected}, got {actual}")
+            except Exception as exc:
+                failures.append(f"{name}: {exc}")
+    
+        return {"ok": not failures, "failures": failures}
+    
+    
+    rubric_middleware = RubricMiddleware(
+        model="baseten:zai-org/GLM-5",
+        system_prompt="You are a code reviewer grading generated code against a rubric.",
+        tools=[run_test_suite],
+        max_iterations=5,
+    )
+    ```
+
+    ```python Ollama
+    from deepagents import RubricMiddleware
+    from langchain.tools import tool
+    
+    
+    @tool
+    def run_test_suite(code: str) -> dict:
+        """Run the find_duplicates test suite against Python source code."""
+        namespace: dict = {"__builtins__": __builtins__}
+        try:
+            exec(code, namespace)
+        except Exception as exc:
+            return {"ok": False, "failures": [f"Failed to execute code: {exc}"]}
+    
+        find_duplicates = namespace.get("find_duplicates")
+        if find_duplicates is None:
+            return {"ok": False, "failures": ["Function find_duplicates is not defined"]}
+    
+        tests = [
+            ("test_basic", [1, 2, 2, 3, 1], [2, 1]),
+            ("test_empty", [], []),
+            ("test_no_duplicates", [1, 2, 3], []),
+            ("test_unhashable", [[1], [1], 2], [[1]]),
+        ]
+        failures: list[str] = []
+        for name, args, expected in tests:
+            try:
+                actual = find_duplicates(args)
+                if actual != expected:
+                    failures.append(f"{name}: expected {expected}, got {actual}")
+            except Exception as exc:
+                failures.append(f"{name}: {exc}")
+    
+        return {"ok": not failures, "failures": failures}
+    
+    
+    rubric_middleware = RubricMiddleware(
+        model="ollama:devstral-2",
+        system_prompt="You are a code reviewer grading generated code against a rubric.",
+        tools=[run_test_suite],
+        max_iterations=5,
+    )
+    ```
+</CodeGroup>

--- a/src/snippets/code-samples/rubric-configure-py.mdx
+++ b/src/snippets/code-samples/rubric-configure-py.mdx
@@ -1,0 +1,113 @@
+<CodeGroup>
+    ```python Google
+    from deepagents import RubricMiddleware, create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    agent = create_deep_agent(
+        model="google_genai:gemini-3.5-flash",
+        middleware=[
+            RubricMiddleware(
+                model="anthropic:claude-haiku-4-5",
+                max_iterations=3,
+            ),
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    ```
+
+    ```python OpenAI
+    from deepagents import RubricMiddleware, create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    agent = create_deep_agent(
+        model="openai:gpt-5.4",
+        middleware=[
+            RubricMiddleware(
+                model="anthropic:claude-haiku-4-5",
+                max_iterations=3,
+            ),
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    ```
+
+    ```python Anthropic
+    from deepagents import RubricMiddleware, create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    agent = create_deep_agent(
+        model="anthropic:claude-sonnet-4-6",
+        middleware=[
+            RubricMiddleware(
+                model="anthropic:claude-haiku-4-5",
+                max_iterations=3,
+            ),
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    ```
+
+    ```python OpenRouter
+    from deepagents import RubricMiddleware, create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    agent = create_deep_agent(
+        model="openrouter:anthropic/claude-sonnet-4-6",
+        middleware=[
+            RubricMiddleware(
+                model="anthropic:claude-haiku-4-5",
+                max_iterations=3,
+            ),
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    ```
+
+    ```python Fireworks
+    from deepagents import RubricMiddleware, create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    agent = create_deep_agent(
+        model="fireworks:accounts/fireworks/models/qwen3p5-397b-a17b",
+        middleware=[
+            RubricMiddleware(
+                model="anthropic:claude-haiku-4-5",
+                max_iterations=3,
+            ),
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    ```
+
+    ```python Baseten
+    from deepagents import RubricMiddleware, create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    agent = create_deep_agent(
+        model="baseten:zai-org/GLM-5",
+        middleware=[
+            RubricMiddleware(
+                model="anthropic:claude-haiku-4-5",
+                max_iterations=3,
+            ),
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    ```
+
+    ```python Ollama
+    from deepagents import RubricMiddleware, create_deep_agent
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    agent = create_deep_agent(
+        model="ollama:devstral-2",
+        middleware=[
+            RubricMiddleware(
+                model="anthropic:claude-haiku-4-5",
+                max_iterations=3,
+            ),
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    ```
+</CodeGroup>

--- a/src/snippets/code-samples/rubric-invoke-py.mdx
+++ b/src/snippets/code-samples/rubric-invoke-py.mdx
@@ -1,0 +1,16 @@
+```python
+from langchain.messages import HumanMessage
+
+config = {"configurable": {"thread_id": "my-rubric-thread"}}
+result = agent.invoke(
+    {
+        "messages": [HumanMessage("Write a haiku about spring.")],
+        "rubric": (
+            "- The poem has three lines\n"
+            "- Lines follow a 5-7-5 syllable pattern\n"
+            "- The theme is spring"
+        ),
+    },
+    config=config,
+)
+```

--- a/src/snippets/code-samples/rubric-on-evaluation-py.mdx
+++ b/src/snippets/code-samples/rubric-on-evaluation-py.mdx
@@ -1,0 +1,246 @@
+<CodeGroup>
+    ```python Google
+    from deepagents import RubricMiddleware, create_deep_agent
+    from deepagents.middleware.rubric import RubricEvaluation
+    from langchain.messages import HumanMessage
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    
+    def log_evaluation(ev: RubricEvaluation) -> None:
+        print(f"iteration {ev['iteration']}: {ev['result']} — {ev['explanation']}")
+    
+    
+    agent = create_deep_agent(
+        model="google_genai:gemini-3.5-flash",
+        middleware=[
+            RubricMiddleware(
+                model="anthropic:claude-haiku-4-5",
+                on_evaluation=log_evaluation,
+            ),
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    
+    config = {"configurable": {"thread_id": "rubric-eval-session"}}
+    agent.invoke(
+        {
+            "messages": [HumanMessage("Write a one-sentence summary of photosynthesis.")],
+            "rubric": (
+                "- The answer is one sentence\n"
+                "- The answer mentions light and chlorophyll"
+            ),
+        },
+        config=config,
+    )
+    ```
+
+    ```python OpenAI
+    from deepagents import RubricMiddleware, create_deep_agent
+    from deepagents.middleware.rubric import RubricEvaluation
+    from langchain.messages import HumanMessage
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    
+    def log_evaluation(ev: RubricEvaluation) -> None:
+        print(f"iteration {ev['iteration']}: {ev['result']} — {ev['explanation']}")
+    
+    
+    agent = create_deep_agent(
+        model="openai:gpt-5.4",
+        middleware=[
+            RubricMiddleware(
+                model="anthropic:claude-haiku-4-5",
+                on_evaluation=log_evaluation,
+            ),
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    
+    config = {"configurable": {"thread_id": "rubric-eval-session"}}
+    agent.invoke(
+        {
+            "messages": [HumanMessage("Write a one-sentence summary of photosynthesis.")],
+            "rubric": (
+                "- The answer is one sentence\n"
+                "- The answer mentions light and chlorophyll"
+            ),
+        },
+        config=config,
+    )
+    ```
+
+    ```python Anthropic
+    from deepagents import RubricMiddleware, create_deep_agent
+    from deepagents.middleware.rubric import RubricEvaluation
+    from langchain.messages import HumanMessage
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    
+    def log_evaluation(ev: RubricEvaluation) -> None:
+        print(f"iteration {ev['iteration']}: {ev['result']} — {ev['explanation']}")
+    
+    
+    agent = create_deep_agent(
+        model="anthropic:claude-sonnet-4-6",
+        middleware=[
+            RubricMiddleware(
+                model="anthropic:claude-haiku-4-5",
+                on_evaluation=log_evaluation,
+            ),
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    
+    config = {"configurable": {"thread_id": "rubric-eval-session"}}
+    agent.invoke(
+        {
+            "messages": [HumanMessage("Write a one-sentence summary of photosynthesis.")],
+            "rubric": (
+                "- The answer is one sentence\n"
+                "- The answer mentions light and chlorophyll"
+            ),
+        },
+        config=config,
+    )
+    ```
+
+    ```python OpenRouter
+    from deepagents import RubricMiddleware, create_deep_agent
+    from deepagents.middleware.rubric import RubricEvaluation
+    from langchain.messages import HumanMessage
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    
+    def log_evaluation(ev: RubricEvaluation) -> None:
+        print(f"iteration {ev['iteration']}: {ev['result']} — {ev['explanation']}")
+    
+    
+    agent = create_deep_agent(
+        model="openrouter:anthropic/claude-sonnet-4-6",
+        middleware=[
+            RubricMiddleware(
+                model="anthropic:claude-haiku-4-5",
+                on_evaluation=log_evaluation,
+            ),
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    
+    config = {"configurable": {"thread_id": "rubric-eval-session"}}
+    agent.invoke(
+        {
+            "messages": [HumanMessage("Write a one-sentence summary of photosynthesis.")],
+            "rubric": (
+                "- The answer is one sentence\n"
+                "- The answer mentions light and chlorophyll"
+            ),
+        },
+        config=config,
+    )
+    ```
+
+    ```python Fireworks
+    from deepagents import RubricMiddleware, create_deep_agent
+    from deepagents.middleware.rubric import RubricEvaluation
+    from langchain.messages import HumanMessage
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    
+    def log_evaluation(ev: RubricEvaluation) -> None:
+        print(f"iteration {ev['iteration']}: {ev['result']} — {ev['explanation']}")
+    
+    
+    agent = create_deep_agent(
+        model="fireworks:accounts/fireworks/models/qwen3p5-397b-a17b",
+        middleware=[
+            RubricMiddleware(
+                model="anthropic:claude-haiku-4-5",
+                on_evaluation=log_evaluation,
+            ),
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    
+    config = {"configurable": {"thread_id": "rubric-eval-session"}}
+    agent.invoke(
+        {
+            "messages": [HumanMessage("Write a one-sentence summary of photosynthesis.")],
+            "rubric": (
+                "- The answer is one sentence\n"
+                "- The answer mentions light and chlorophyll"
+            ),
+        },
+        config=config,
+    )
+    ```
+
+    ```python Baseten
+    from deepagents import RubricMiddleware, create_deep_agent
+    from deepagents.middleware.rubric import RubricEvaluation
+    from langchain.messages import HumanMessage
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    
+    def log_evaluation(ev: RubricEvaluation) -> None:
+        print(f"iteration {ev['iteration']}: {ev['result']} — {ev['explanation']}")
+    
+    
+    agent = create_deep_agent(
+        model="baseten:zai-org/GLM-5",
+        middleware=[
+            RubricMiddleware(
+                model="anthropic:claude-haiku-4-5",
+                on_evaluation=log_evaluation,
+            ),
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    
+    config = {"configurable": {"thread_id": "rubric-eval-session"}}
+    agent.invoke(
+        {
+            "messages": [HumanMessage("Write a one-sentence summary of photosynthesis.")],
+            "rubric": (
+                "- The answer is one sentence\n"
+                "- The answer mentions light and chlorophyll"
+            ),
+        },
+        config=config,
+    )
+    ```
+
+    ```python Ollama
+    from deepagents import RubricMiddleware, create_deep_agent
+    from deepagents.middleware.rubric import RubricEvaluation
+    from langchain.messages import HumanMessage
+    from langgraph.checkpoint.memory import InMemorySaver
+    
+    
+    def log_evaluation(ev: RubricEvaluation) -> None:
+        print(f"iteration {ev['iteration']}: {ev['result']} — {ev['explanation']}")
+    
+    
+    agent = create_deep_agent(
+        model="ollama:devstral-2",
+        middleware=[
+            RubricMiddleware(
+                model="anthropic:claude-haiku-4-5",
+                on_evaluation=log_evaluation,
+            ),
+        ],
+        checkpointer=InMemorySaver(),
+    )
+    
+    config = {"configurable": {"thread_id": "rubric-eval-session"}}
+    agent.invoke(
+        {
+            "messages": [HumanMessage("Write a one-sentence summary of photosynthesis.")],
+            "rubric": (
+                "- The answer is one sentence\n"
+                "- The answer mentions light and chlorophyll"
+            ),
+        },
+        config=config,
+    )
+    ```
+</CodeGroup>

--- a/src/snippets/code-samples/rubric-stream-py.mdx
+++ b/src/snippets/code-samples/rubric-stream-py.mdx
@@ -1,8 +1,9 @@
 ```python
 from langchain.messages import HumanMessage
+from langgraph.stream import CustomTransformer
 
 config = {"configurable": {"thread_id": "my-rubric-thread"}}
-for chunk in agent.stream(
+stream = agent.stream_events(
     {
         "messages": [HumanMessage("Write a haiku about spring.")],
         "rubric": (
@@ -12,12 +13,11 @@ for chunk in agent.stream(
         ),
     },
     config=config,
-    stream_mode="custom",
-    version="v2",
-):
-    if chunk.get("type") != "custom":
-        continue
-    event = chunk["data"]
+    version="v3",
+    transformers=[CustomTransformer],
+)
+
+for event in stream.custom:
     event_type = event.get("type")
     if event_type == "rubric_evaluation_start":
         print(

--- a/src/snippets/code-samples/rubric-stream-py.mdx
+++ b/src/snippets/code-samples/rubric-stream-py.mdx
@@ -1,0 +1,29 @@
+```python
+from langchain.messages import HumanMessage
+
+config = {"configurable": {"thread_id": "my-rubric-thread"}}
+for chunk in agent.stream(
+    {
+        "messages": [HumanMessage("Write a haiku about spring.")],
+        "rubric": (
+            "- The poem has three lines\n"
+            "- Lines follow a 5-7-5 syllable pattern\n"
+            "- The theme is spring"
+        ),
+    },
+    config=config,
+    stream_mode="custom",
+    version="v2",
+):
+    if chunk.get("type") != "custom":
+        continue
+    event = chunk["data"]
+    event_type = event.get("type")
+    if event_type == "rubric_evaluation_start":
+        print(
+            f"Grading iteration {event['iteration']} "
+            f"(run {event['grading_run_id']})"
+        )
+    elif event_type == "rubric_evaluation_end":
+        print(f"Verdict: {event['result']} — {event.get('explanation', '')}")
+```


### PR DESCRIPTION
Reorganizes rubric docs to place `invoke()` and `stream()` into separate tabs to clarify on_evaluation. Probably best to look at the preview link (see comment)