### PR TITLE
docs(oss): overhaul deepagents skills documentation

### DIFF
--- a/src/langsmith/skills.mdx
+++ b/src/langsmith/skills.mdx
@@ -8,7 +8,7 @@ description: Use Agent Skills to work with LangSmith traces, datasets, and evalu
 Agent Skills are reusable, on‑demand capabilities that bundle instructions plus optional helper scripts. This page summarizes the LangSmith‑oriented skills you can add to a compatible coding agent to query traces, generate datasets, and define evaluators. To work with the same LangSmith data directly from the terminal, use the [LangSmith CLI](/langsmith/langsmith-cli).
 
 <Note>
-These skills follow the Agent Skills specification and are maintained in the [`langsmith-skills` GitHub repository](https://github.com/langchain-ai/langsmith-skills). You can copy the `SKILL.md` and any referenced `scripts/` into your agent’s skills directory. The installers below only install the LangSmith skills (trace, dataset, evaluator).
+These skills follow the Agent Skills specification and are maintained in the [`langsmith-skills` GitHub repository](https://github.com/langchain-ai/langsmith-skills). You can copy the `SKILL.md` and any referenced `scripts/` into your agent's skills directory. The installers below only install the LangSmith skills (trace, dataset, evaluator).
 </Note>
 
 ## Quick install

--- a/src/langsmith/skills.mdx
+++ b/src/langsmith/skills.mdx
@@ -8,7 +8,7 @@ description: Use Agent Skills to work with LangSmith traces, datasets, and evalu
 Agent Skills are reusable, on‑demand capabilities that bundle instructions plus optional helper scripts. This page summarizes the LangSmith‑oriented skills you can add to a compatible coding agent to query traces, generate datasets, and define evaluators. To work with the same LangSmith data directly from the terminal, use the [LangSmith CLI](/langsmith/langsmith-cli).
 
 <Note>
-These skills follow the Agent Skills specification and are maintained in the [`langsmith-skills` GitHub repository](https://github.com/langchain-ai/langsmith-skills). You can copy the `SKILL.md` and any referenced `scripts/` into your agent's skills directory. The installers below only install the LangSmith skills (trace, dataset, evaluator).
+These skills follow the Agent Skills specification and are maintained in the [`langsmith-skills` GitHub repository](https://github.com/langchain-ai/langsmith-skills). You can copy the `SKILL.md` and any referenced `scripts/` into your agent’s skills directory. The installers below only install the LangSmith skills (trace, dataset, evaluator).
 </Note>
 
 ## Quick install

--- a/src/oss/deepagents/code/memory-and-skills.mdx
+++ b/src/oss/deepagents/code/memory-and-skills.mdx
@@ -8,7 +8,9 @@ There are two primary ways to customize an agent in Deep Agents Code:
 
 - **[Memory](#memory)**: `AGENTS.md` files and auto-saved memories that persist across sessions. Use memory for general coding style, preferences, and learned conventions.
 
-- **[Skills](#skills)**: Global and project-specific context, conventions, guidelines, or instructions. Use skills for context that applies when performing specific tasks.
+- **[Skills](#skills)**: Reusable directories of domain expertise that the agent discovers and reads only when relevant. Use skills for task-specific context that benefits from on-demand loading.
+
+In practice, skills and memory sit on a spectrum. For more on when to use each, see [Skills, memory, and tools](/oss/deepagents/skills#skills-memory-and-tools).
 
 Use `/remember` to explicitly prompt the agent to update its memory and skills from the current conversation.
 
@@ -89,9 +91,8 @@ Use a project `AGENTS.md` (`.deepagents/AGENTS.md` in project root) for:
 
 ## Skills
 
-Skills are reusable agent capabilities that provide specialized workflows and domain knowledge.
-You can use [skills](/oss/deepagents/skills) to provide your deep agent with new capabilities and expertise.
-Deep agent skills follow the [Agent Skills standard](https://agentskills.io/).
+Skills package domain expertise—workflows, best practices, scripts, and reference docs—into reusable directories that the agent discovers and reads only when relevant.
+Deep agent skills follow the [Agent Skills specification](https://agentskills.io/). For more on how skills work and how to write effective ones, see [Skills](/oss/deepagents/skills).
 
 At startup, Deep Agents Code reads the name and description from each `SKILL.md` file's frontmatter. When a task matches a skill's description, the agent reads the skill file and follows its instructions. Discovery runs again on `/reload`.
 

--- a/src/oss/deepagents/code/memory-and-skills.mdx
+++ b/src/oss/deepagents/code/memory-and-skills.mdx
@@ -8,7 +8,7 @@ There are two primary ways to customize an agent in Deep Agents Code:
 
 - **[Memory](#memory)**: `AGENTS.md` files and auto-saved memories that persist across sessions. Use memory for general coding style, preferences, and learned conventions.
 
-- **[Skills](#skills)**: Reusable directories of domain expertise that the agent discovers and reads only when relevant. Use skills for task-specific context that benefits from on-demand loading.
+- **[Skills](#skills)**: Reusable, on-demand capabilities that the agent discovers and reads only when relevant. Use skills for task-specific context such as workflows, best practices, and reference docs.
 
 In practice, skills and memory sit on a spectrum. For more on when to use each, see [Skills, memory, and tools](/oss/deepagents/skills#skills-memory-and-tools).
 
@@ -91,7 +91,7 @@ Use a project `AGENTS.md` (`.deepagents/AGENTS.md` in project root) for:
 
 ## Skills
 
-Skills package domain expertise—workflows, best practices, scripts, and reference docs—into reusable directories that the agent discovers and reads only when relevant.
+Skills package domain expertise, such as workflows, best practices, scripts, and reference docs, into reusable directories that the agent discovers and reads only when relevant.
 Deep agent skills follow the [Agent Skills specification](https://agentskills.io/). For more on how skills work and how to write effective ones, see [Skills](/oss/deepagents/skills).
 
 At startup, Deep Agents Code reads the name and description from each `SKILL.md` file's frontmatter. When a task matches a skill's description, the agent reads the skill file and follows its instructions. Discovery runs again on `/reload`.

--- a/src/oss/deepagents/code/memory-and-skills.mdx
+++ b/src/oss/deepagents/code/memory-and-skills.mdx
@@ -122,7 +122,7 @@ At startup, Deep Agents Code reads the name and description from each `SKILL.md`
         Open the generated `SKILL.md` and edit the file to include your instructions.
     </Step>
     <Step title="Add optional resources">
-        Optionally add additional scripts or other resources to the `test-skill` folder. For more information, see [Examples](/oss/deepagents/skills#examples).
+        Optionally add additional scripts or other resources to the `test-skill` folder. For more information, see [What are skills](/oss/deepagents/skills#what-are-skills).
     </Step>
 </Steps>
 

--- a/src/oss/deepagents/code/memory-and-skills.mdx
+++ b/src/oss/deepagents/code/memory-and-skills.mdx
@@ -121,7 +121,7 @@ At startup, Deep Agents Code reads the name and description from each `SKILL.md`
         Open the generated `SKILL.md` and edit the file to include your instructions.
     </Step>
     <Step title="Add optional resources">
-        Optionally add additional scripts or other resources to the `test-skill` folder. For more information, see [Examples](/oss/deepagents/skills#example).
+        Optionally add additional scripts or other resources to the `test-skill` folder. For more information, see [Examples](/oss/deepagents/skills#examples).
     </Step>
 </Steps>
 

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -62,7 +62,7 @@ QuickJS is the execution boundary for interpreter code. Explicit bridges, such a
 | One or two simple external calls | Normal tool calling |
 | A small program that loops, branches, retries, or aggregates results | Interpreter |
 | Many selected tool calls that should run from code | Interpreter with programmatic tool calling |
-| Reusable helpers used across threads | Interpreter with [interpreter skills](/oss/deepagents/skills#use-interpreter-skills) |
+| Reusable helpers used across threads | Interpreter with [interpreter skills](/oss/deepagents/skills#interpreter-skills) |
 | Shell commands, package installs, tests, or full OS filesystem access | [Sandboxes](/oss/deepagents/sandboxes) |
 
 ## Add an interpreter to an agent
@@ -310,7 +310,7 @@ releaseSummary;
 
 Interpreter skills are [skills](/oss/deepagents/skills) that expose code modules to an interpreter. When configured with interpreter middleware, the agent can import these modules from code and use them for deterministic helper logic.
 
-Interpreter skills are useful when the agent needs reusable helpers for structured data workflows, such as sorting, grouping, scoring, parsing, validating, or aggregating data. For setup details, see [Interpreter skills](/oss/deepagents/skills#use-interpreter-skills).
+Interpreter skills are useful when the agent needs reusable helpers for structured data workflows, such as sorting, grouping, scoring, parsing, validating, or aggregating data. For setup details, see [Interpreter skills](/oss/deepagents/skills#interpreter-skills).
 
 :::python
 ## Snapshots and time travel

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -206,6 +206,8 @@ Instructions for the agent go here. See the [basic skill example](#basic-skill) 
 
 ## Usage
 
+### Getting started
+
 Pass a list of skill directory paths when creating your agent. The backend you choose determines how skill files are stored and loaded:
 
 :::python
@@ -263,54 +265,6 @@ Pass a list of skill directory paths when creating your agent. The backend you c
         Then pass that ordered list as `skills` when creating your agent.
     </Accordion>
 </Note>
-
-## Build effective skills
-
-### Authoring best practices
-
-**Write specific descriptions.** During [discovery](#how-skills-work), the `description` field is the only information the agent sees for each skill. A good description tells the agent both what the skill does and when to activate it, with specific keywords the agent can match against:
-
-```yaml
-# Good: specific about what and when
-description: >-
-  Extract text and tables from PDF files, fill PDF forms, and merge
-  multiple PDFs. Use when working with PDF documents or when the user
-  mentions PDFs, forms, or document extraction.
-
-# Poor: too vague for reliable matching
-description: Helps with PDFs.
-```
-
-When you have multiple skills in related domains, differentiate their descriptions clearly. Overlapping descriptions cause the agent to activate the wrong skill or hesitate between options. If two skills serve similar purposes, consolidate them into one.
-
-**Keep instructions focused.** The Agent Skills specification recommends keeping your `SKILL.md` under 500 lines. When instructions grow longer, move detailed reference material into separate files and reference them from the main `SKILL.md`:
-
-```plaintext
-skills/
-└── data-pipeline/
-    ├── SKILL.md
-    └── references/
-        ├── schema-reference.md
-        └── error-codes.md
-```
-
-The agent loads reference files only when the instructions call for them, keeping each layer of progressive disclosure appropriately sized. Keep file references one level deep from `SKILL.md` and avoid deeply nested reference chains, which force the agent through multiple reads to reach the information it needs.
-
-**Structure instructions for the agent.** Write your `SKILL.md` body as clear instructions the agent can follow:
-
-- **Step-by-step procedures** for multi-step workflows
-- **Decision criteria** for choosing between approaches
-- **Examples of expected inputs and outputs** so the agent knows what success looks like
-- **Edge cases** the agent should handle or flag to the user
-
-**Manage skill count.** Fewer well-scoped skills outperform many overlapping ones. As the number of skills with similar descriptions grows, the agent's ability to select the right one degrades. If you find yourself with many related skills, consider:
-
-- Consolidating related capabilities into a single skill with sections for each sub-task
-- Using reference files to keep the main `SKILL.md` concise while covering multiple sub-tasks
-
-<Tip>
-    Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check that your `SKILL.md` frontmatter follows the Agent Skills specification naming and format conventions.
-</Tip>
 
 ### Source precedence
 
@@ -387,6 +341,170 @@ const agent = await createDeepAgent({
 :::
 
 For more information on subagent configuration and skills inheritance, see [Subagents](/oss/deepagents/subagents).
+
+### Dynamic skills per run
+
+To serve different skills to different users, route `/skills/` to a @[StoreBackend] with a namespace factory. Pre-seed each namespace with the appropriate skills, and the middleware automatically resolves to the correct set at runtime:
+
+:::python
+```python
+from deepagents import create_deep_agent
+from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
+
+agent = create_deep_agent(
+    model="anthropic:claude-sonnet-4-6",
+    skills=["/skills/"],
+    backend=CompositeBackend(
+        default=StateBackend(),
+        routes={
+            "/skills/": StoreBackend(
+                namespace=lambda rt: (
+                    rt.server_info.assistant_id,
+                    rt.server_info.user.identity,
+                ),
+            ),
+        },
+    ),
+)
+```
+:::
+
+:::js
+```typescript
+import {
+  createDeepAgent,
+  CompositeBackend,
+  StateBackend,
+  StoreBackend,
+} from "deepagents";
+
+const agent = await createDeepAgent({
+  model: "anthropic:claude-sonnet-4-6",
+  skills: ["/skills/"],
+  backend: new CompositeBackend({
+    default: new StateBackend(),
+    routes: {
+      "/skills/": new StoreBackend({
+        namespace: (ctx) => [
+          ctx.assistantId ?? "default",
+          ctx.config?.configurable?.user_id ?? "anonymous",
+        ],
+      }),
+    },
+  }),
+});
+```
+:::
+
+Each user's namespace contains only their skills. This pattern is useful for multi-tenant applications, role-based skill access, and per-customer configurations.
+
+Seed each namespace with the skills that user should have access to:
+
+:::python
+```python
+from deepagents.backends.utils import create_file_data
+from langgraph.store.memory import InMemoryStore
+
+store = InMemoryStore()
+
+# Seed skills for user "alice"
+store.put(
+    ("my-agent", "alice"),
+    "/data-analysis/SKILL.md",
+    create_file_data(data_analysis_skill_content),
+)
+
+store.put(
+    ("my-agent", "alice"),
+    "/report-builder/SKILL.md",
+    create_file_data(report_builder_skill_content),
+)
+
+# Seed different skills for user "bob"
+store.put(
+    ("my-agent", "bob"),
+    "/code-review/SKILL.md",
+    create_file_data(code_review_skill_content),
+)
+```
+:::
+
+:::js
+```typescript
+import { createFileData } from "deepagents";
+import { InMemoryStore } from "@langchain/langgraph";
+
+const store = new InMemoryStore();
+
+// Seed skills for user "alice"
+await store.put(
+  ["my-agent", "alice"],
+  "/data-analysis/SKILL.md",
+  createFileData(dataAnalysisSkillContent),
+);
+
+await store.put(
+  ["my-agent", "alice"],
+  "/report-builder/SKILL.md",
+  createFileData(reportBuilderSkillContent),
+);
+
+// Seed different skills for user "bob"
+await store.put(
+  ["my-agent", "bob"],
+  "/code-review/SKILL.md",
+  createFileData(codeReviewSkillContent),
+);
+```
+:::
+
+When Alice invokes the agent, the namespace resolves to `("my-agent", "alice")` and the agent discovers only `data-analysis` and `report-builder`. Bob sees only `code-review`.
+
+## Writing effective skills
+
+**Write specific descriptions.** During [discovery](#how-skills-work), the `description` field is the only information the agent sees for each skill. A good description tells the agent both what the skill does and when to activate it, with specific keywords the agent can match against:
+
+```yaml
+# Good: specific about what and when
+description: >-
+  Extract text and tables from PDF files, fill PDF forms, and merge
+  multiple PDFs. Use when working with PDF documents or when the user
+  mentions PDFs, forms, or document extraction.
+
+# Poor: too vague for reliable matching
+description: Helps with PDFs.
+```
+
+When you have multiple skills in related domains, differentiate their descriptions clearly. Overlapping descriptions cause the agent to activate the wrong skill or hesitate between options. If two skills serve similar purposes, consolidate them into one.
+
+**Keep instructions focused.** The Agent Skills specification recommends keeping your `SKILL.md` under 500 lines. When instructions grow longer, move detailed reference material into separate files and reference them from the main `SKILL.md`:
+
+```plaintext
+skills/
+└── data-pipeline/
+    ├── SKILL.md
+    └── references/
+        ├── schema-reference.md
+        └── error-codes.md
+```
+
+The agent loads reference files only when the instructions call for them, keeping each layer of progressive disclosure appropriately sized. Keep file references one level deep from `SKILL.md` and avoid deeply nested reference chains, which force the agent through multiple reads to reach the information it needs.
+
+**Structure instructions for the agent.** Write your `SKILL.md` body as clear instructions the agent can follow:
+
+- **Step-by-step procedures** for multi-step workflows
+- **Decision criteria** for choosing between approaches
+- **Examples of expected inputs and outputs** so the agent knows what success looks like
+- **Edge cases** the agent should handle or flag to the user
+
+**Manage skill count.** Fewer well-scoped skills outperform many overlapping ones. As the number of skills with similar descriptions grows, the agent's ability to select the right one degrades. If you find yourself with many related skills, consider:
+
+- Consolidating related capabilities into a single skill with sections for each sub-task
+- Using reference files to keep the main `SKILL.md` concise while covering multiple sub-tasks
+
+<Tip>
+    Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check that your `SKILL.md` frontmatter follows the Agent Skills specification naming and format conventions.
+</Tip>
 
 ## Execute code with skills
 

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -517,23 +517,22 @@ Skills support code execution in two ways:
 
 Skills can include scripts alongside the `SKILL.md` file, such as a Python file that performs a search or data transformation. The agent can _read_ these scripts from any backend, but to _execute_ them, the agent needs access to a shell, which only [sandbox backends](/oss/deepagents/sandboxes) provide.
 
-When you use a @[CompositeBackend] that routes skills to a @[StoreBackend] for persistence while using a sandbox as the default backend, skill files live in the store rather than in the sandbox where code runs. For sandboxes to use the scripts, you must use [custom middleware](/oss/langchain/middleware/custom) to upload skill scripts into the sandbox before the agent starts:
+[Sandbox backends](/oss/deepagents/sandboxes) run in isolated containers. Skill files stored outside the sandbox are not available inside it, which means the agent cannot execute skill scripts or access skill resources unless they are transferred in first. Use [custom middleware](/oss/langchain/middleware/custom) to handle this transfer:
+
+- **`before_agent`**: Read skill files from the backend and upload them into the sandbox so the agent can execute scripts from the start.
+- **`after_agent`**: Download any updated or newly created skill files from the sandbox and write them back to the backend so changes persist across runs.
 
 :::python
 
 <SkillsSandboxPy />
 
-The middleware's `before_agent` hook runs before each agent invocation, reading skill files from that shared namespace and uploading them into the sandbox filesystem. Once synced, the agent can execute scripts with the `execute` tool just like any other file in the sandbox.
-
 :::
 
 :::js
 <SkillsSandboxJs />
-
-The middleware's `beforeAgent` hook runs before each agent invocation, reading skill files from that shared namespace and uploading them into the sandbox filesystem. Once synced, the agent can execute scripts with the `execute` tool just like any other file in the sandbox.
 :::
 
-For a more complete example that also syncs [memories](/oss/deepagents/memory) bidirectionally, see [syncing skills and memories with custom middleware](/oss/deepagents/going-to-production#example-syncing-skills-and-memories-with-custom-middleware).
+For a complete example that seeds both skills and memories before execution and syncs both back afterward, see [syncing skills and memories with custom middleware](/oss/deepagents/going-to-production#example-syncing-skills-and-memories-with-custom-middleware).
 
 ### Interpreter skills
 

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -10,7 +10,9 @@ import SkillsSandboxJs from '/snippets/code-samples/skills-sandbox-js.mdx';
 import BackendReadonlySkillsPy from '/snippets/code-samples/backend-readonly-skills-py.mdx';
 import BackendReadonlySkillsJs from '/snippets/code-samples/backend-readonly-skills-js.mdx';
 
-Skills are reusable agent capabilities that provide specialized workflows and domain knowledge.
+As agents take on more complex tasks, the context they need grows with them. Loading all instructions into the system prompt wastes tokens on information irrelevant to the current task, and providing the same guidance manually across sessions does not scale.
+
+Skills solve this by packaging domain expertise—workflows, best practices, scripts, reference docs, and templates—into reusable directories that the agent discovers and reads only when relevant.
 
 :::js
 <Note>
@@ -18,174 +20,62 @@ Skills require `deepagents>=1.7.0`.
 </Note>
 :::
 
-You can use [Agent Skills](https://agentskills.io/) to provide your deep agent with new capabilities and expertise. For ready-to-use skills that improve your agent's performance on LangChain ecosystem tasks, see the [LangChain Skills](https://github.com/langchain-ai/langchain-skills) repository.
-
-Deep agent skills follow the [Agent Skills specification](https://agentskills.io/specification) and add additional capability for interpreter skills, which makes it possible to provide skills with importable functions that an interpreter can call.
+Deep agent skills follow the [Agent Skills specification](https://agentskills.io/specification). For ready-to-use skills that improve your agent's performance on LangChain ecosystem tasks, see the [LangChain Skills](https://github.com/langchain-ai/langchain-skills) repository.
 
 ## What are skills
 
-Skills are a directory of folders, where each folder has one or more files that contain context the agent can use:
+Each skill is a directory containing a `SKILL.md` file: a markdown file with YAML frontmatter (`name` and `description`) followed by instructions the agent follows when the skill is activated. A skill directory can also include supporting files:
 
-- A `SKILL.md` file containing instructions and metadata about the skill
-- Additional scripts (optional)
-- Additional reference info, such as docs (optional)
-- Additional assets, such as templates and other resources (optional)
+- **`SKILL.md`** (required): Metadata and instructions for the agent
+- **`scripts/`** (optional): Executable code the agent can run
+- **`references/`** (optional): Additional documentation or technical details
+- **`assets/`** (optional): Templates, schemas, or other resources
 
 <Note>
-    Any additional assets (scripts, docs, templates, or other resources) must be referenced in the `SKILL.md` file with information on what the file contains and how to use it so the agent can decide when to use them.
+    Reference any supporting files in your `SKILL.md` with a description of what each file contains and when to use it. The agent discovers these files through the references in the skill instructions.
 </Note>
 
 ## How skills work
 
-When you create a deep agent, you can pass in a list of directories containing skills. As the agent starts, it reads through the frontmatter of each `SKILL.md` file.
+Skills use *progressive disclosure*: the agent loads skill information in layers, pulling in more detail only when the task calls for it.
 
-When the agent receives a prompt, the agent checks if it can use any skills while fulfilling the prompt. If it finds a matching prompt, it then reviews the rest of the skill files. This pattern of only reviewing the skill information when needed is called *progressive disclosure*.
+In Deep Agents, `SkillsMiddleware` handles this in three stages:
 
-## Example
+1. **Discovery**: At agent start, the middleware scans the configured skill paths, parses each `SKILL.md` frontmatter, and injects skill names and descriptions into the system prompt.
+2. **Read**: When the agent determines a skill matches the current task, it reads the full `SKILL.md` content via `read_file`. There is no dedicated activation mechanism.
+3. **Execute**: The agent follows the skill's instructions and reads any supporting files (scripts, references, assets) as needed.
 
-You might have a skills folder that contains a skill to use a docs site in a certain way, as well as another skill to search the arXiv preprint repository of research papers:
+The [Agent Skills specification](https://agentskills.io/specification) recommends ~100 tokens for frontmatter and under 5,000 tokens for the `SKILL.md` body. Following these guidelines matters because every skill's frontmatter is added to the system prompt at discovery, while the full body is only read when activated. Keeping both layers small means you can load many skills without crowding the context window.
 
-:::python
+<Tip>
+    Write clear, specific descriptions in your `SKILL.md` frontmatter. The agent decides whether to activate a skill based on the description alone. Include specific keywords and use cases so the agent can match accurately.
+</Tip>
+
+## Examples
+
+### Basic skill
+
+A minimal skill is a directory with a single `SKILL.md` file:
+
 ```plaintext
-    skills/
-    ├── langgraph-docs
-    │   └── SKILL.md
-    └── arxiv_search
-        ├── SKILL.md
-        └── arxiv_search.py # code for searching arXiv
+skills/
+└── langgraph-docs/
+    └── SKILL.md
 ```
-:::
 
-:::js
-```plaintext
-    skills/
-    ├── langgraph-docs
-    │   └── SKILL.md
-    └── arxiv_search
-        ├── SKILL.md
-        └── arxiv_search.ts # code for searching arXiv
-```
-:::
-
-The `SKILL.md` file always follows the same pattern, starting with metadata in the frontmatter and followed by the instructions for the skill.
-
-The following example shows a skill that gives instructions on how to provide relevant langgraph docs when prompted:
+The `SKILL.md` starts with YAML frontmatter followed by markdown instructions:
 
 ````md
 ---
 name: langgraph-docs
 description: Use this skill for requests related to LangGraph in order to fetch relevant documentation to provide accurate, up-to-date guidance.
-module: index.ts
 ---
 
 # langgraph-docs
 
 ## Overview
 
-This skill explains how to access LangGraph Python documentation to help answer questions and guide implementation.
-
-## Instructions
-
-### 1. Fetch the Documentation Index
-
-Use the fetch_url tool to read the following URL:
-https://docs.langchain.com/llms.txt
-
-This provides a structured list of all available documentation with descriptions.
-
-### 2. Select Relevant Documentation
-
-Based on the question, identify 2-4 most relevant documentation URLs from the index. Prioritize:
-
-- Specific how-to guides for implementation questions
-- Core concept pages for understanding questions
-- Tutorials for end-to-end examples
-- Reference docs for API details
-
-### 3. Fetch Selected Documentation
-
-Use the fetch_url tool to read the selected documentation URLs.
-
-### 4. Provide accurate guidance
-
-After reading the documentation, answer the user's question using the relevant LangGraph docs you fetched.
-
-In your response:
-
-- Give a direct answer first.
-- Include the minimum necessary context and any key steps or API names.
-- Avoid quoting long passages. Paraphrase and link instead.
-
-### 5. Provide the regular links for the used references
-
-At the end of your response, include a **References** section listing the page URLs you used.
-
-`llms.txt` uses Markdown link targets that typically end in `.md`. Use the helper from this skill module to resolve those into the actual page URLs before listing them as references.
-
-```typescript
-const { resolveLlmsUrl } = await import("@/skills/langgraph-docs");
-
-// llms.txt uses Markdown link targets that typically end in `.md`.
-// Convert those into the actual page URLs before fetching.
-const llmsUrls = [
-  "https://docs.langchain.com/oss/langgraph/concepts.md",
-  "https://docs.langchain.com/oss/langgraph/concepts.md",
-  "https://docs.langchain.com/oss/langgraph/tutorials.md",
-];
-
-const pageUrls = [...new Set(llmsUrls.map(resolveLlmsUrl))];
-pageUrls;
-```
-````
-
-The referenced helper code would be placed in `index.ts`:
-
-```typescript
-// index.ts
-export function resolveLlmsUrl(url: string) {
-  return url.endsWith(".md") ? url.slice(0, -3) : url;
-}
-```
-
-:::python
-For more example skills, see [Deep Agents example skills](https://github.com/langchain-ai/deepagents/tree/main/libs/cli/examples/skills).
-:::
-
-:::js
-For more example skills, see [Deep Agents example skills](https://github.com/langchain-ai/deepagentsjs/tree/main/examples/skills).
-:::
-
-<Warning>
-    **Important**
-
-    Refer to the full [Agent Skills Specification](https://agentskills.io/specification) for information on constraints and best practices when authoring skill files. Notably:
-
-    * The `description` field is truncated to 1024 characters if it exceeds that length.
-    * In Deep Agents, `SKILL.md` files must be under 10 MB. Files exceeding this limit are skipped during skill loading.
-</Warning>
-
-### Full example
-
-The following example shows a `SKILL.md` file using all available frontmatter fields:
-
-````md expandable
----
-name: langgraph-docs
-description: Use this skill for requests related to LangGraph in order to fetch relevant documentation to provide accurate, up-to-date guidance.
-license: MIT
-compatibility: Requires internet access for fetching documentation URLs
-metadata:
-  author: langchain
-  version: "1.0"
-allowed-tools: fetch_url
-module: index.ts
----
-
-# langgraph-docs
-
-## Overview
-
-This skill explains how to access LangGraph Python documentation to help answer questions and guide implementation.
+This skill explains how to access LangGraph documentation to help answer questions and guide implementation.
 
 ## Instructions
 
@@ -205,41 +95,168 @@ Based on the question, identify 2-4 most relevant documentation URLs from the in
 - Tutorials for end-to-end examples
 - Reference docs for API details
 
-### 3. Fetch selected documentation
+### 3. Fetch and synthesize
 
-Use the fetch_url tool to read the selected documentation URLs.
-
-### 4. Provide accurate guidance
-
-After reading the documentation, answer the user's question using the relevant LangGraph docs you fetched.
-
-In your response:
-
-- Give a direct answer first.
-- Include the minimum necessary context and any key steps or API names.
-- Avoid quoting long passages. Paraphrase and link instead.
-
-### 5. Provide the regular links for the used references
-
-At the end of your response, include a **References** section listing the page URLs you used.
-
-`llms.txt` uses Markdown link targets that typically end in `.md`. Use the helper from this skill module to resolve those into the actual page URLs before listing them as references.
-
-```typescript
-const { resolveLlmsUrl } = await import("@/skills/langgraph-docs");
-
-// llms.txt uses Markdown link targets that typically end in `.md`.
-// Convert those into the actual page URLs before fetching.
-const llmsUrls = [
-  "https://docs.langchain.com/oss/langgraph/concepts.md",
-  "https://docs.langchain.com/oss/langgraph/concepts.md",
-  "https://docs.langchain.com/oss/langgraph/tutorials.md",
-];
-
-const pageUrls = [...new Set(llmsUrls.map(resolveLlmsUrl))];
-pageUrls;
-```
+Use the fetch_url tool to read the selected documentation URLs, then answer the user's question. Give a direct answer first, include the minimum necessary context, and link to the source pages rather than quoting long passages.
 ````
+
+### Skill with scripts
+
+Skills can include executable code alongside the instructions. Reference scripts in your `SKILL.md` so the agent knows they exist and when to run them:
+
+:::python
+```plaintext
+skills/
+└── arxiv-search/
+    ├── SKILL.md
+    └── scripts/
+        └── search.py
+```
+:::
+
+:::js
+```plaintext
+skills/
+└── arxiv-search/
+    ├── SKILL.md
+    └── scripts/
+        └── search.ts
+```
+:::
+
+:::python
+````md
+---
+name: arxiv-search
+description: Search the arXiv preprint repository for research papers. Use when the user asks about academic papers, recent research, or scientific literature.
+---
+
+# arxiv-search
+
+Search arXiv for papers matching the user's query.
+
+## Instructions
+
+1. Run `scripts/search.py` with the user's query as an argument.
+2. Parse the results and present them with title, authors, abstract summary, and link.
+3. If the user asks for more detail on a specific paper, fetch the full abstract.
+````
+:::
+
+:::js
+````md
+---
+name: arxiv-search
+description: Search the arXiv preprint repository for research papers. Use when the user asks about academic papers, recent research, or scientific literature.
+---
+
+# arxiv-search
+
+Search arXiv for papers matching the user's query.
+
+## Instructions
+
+1. Run `scripts/search.ts` with the user's query as an argument.
+2. Parse the results and present them with title, authors, abstract summary, and link.
+3. If the user asks for more detail on a specific paper, fetch the full abstract.
+````
+:::
+
+:::python
+For more example skills, see [Deep Agents example skills](https://github.com/langchain-ai/deepagents/tree/main/libs/cli/examples/skills).
+:::
+
+:::js
+For more example skills, see [Deep Agents example skills](https://github.com/langchain-ai/deepagentsjs/tree/main/examples/skills).
+:::
+
+### All frontmatter fields
+
+The [Agent Skills specification](https://agentskills.io/specification) defines the following frontmatter fields:
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Lowercase alphanumeric with hyphens, 1-64 characters. Must match the parent directory name. |
+| `description` | Yes | What the skill does and when to use it. Max 1,024 characters. |
+| `license` | No | License name or reference to a bundled license file. |
+| `compatibility` | No | Environment requirements (system packages, network access). Max 500 characters. |
+| `metadata` | No | Arbitrary key-value pairs for additional properties. |
+| `allowed-tools` | No | Space-separated list of pre-approved tools the skill can use. Experimental. |
+
+````md expandable
+---
+name: langgraph-docs
+description: Use this skill for requests related to LangGraph in order to fetch relevant documentation to provide accurate, up-to-date guidance.
+license: MIT
+compatibility: Requires internet access for fetching documentation URLs
+metadata:
+  author: langchain
+  version: "1.0"
+allowed-tools: fetch_url
+---
+
+# langgraph-docs
+
+Instructions for the agent go here. See the [basic skill example](#basic-skill) for a complete example of skill instructions.
+````
+
+<Warning>
+    Refer to the full [Agent Skills specification](https://agentskills.io/specification) for detailed constraints and validation rules. In Deep Agents, `SKILL.md` files must be under 10 MB. Files exceeding this limit are skipped during skill loading.
+</Warning>
+
+## Write effective skills
+
+### Write specific descriptions
+
+During [discovery](#how-skills-work), the `description` field is the only information the agent sees for each skill. A good description tells the agent both what the skill does and when to activate it, with specific keywords the agent can match against:
+
+```yaml
+# Good: specific about what and when
+description: >-
+  Extract text and tables from PDF files, fill PDF forms, and merge
+  multiple PDFs. Use when working with PDF documents or when the user
+  mentions PDFs, forms, or document extraction.
+
+# Poor: too vague for reliable matching
+description: Helps with PDFs.
+```
+
+When you have multiple skills in related domains, differentiate their descriptions clearly. Overlapping descriptions cause the agent to activate the wrong skill or hesitate between options. If two skills serve similar purposes, consolidate them into one.
+
+### Keep instructions focused
+
+The Agent Skills specification recommends keeping your `SKILL.md` under 500 lines. When instructions grow longer, move detailed reference material into separate files and reference them from the main `SKILL.md`:
+
+```plaintext
+skills/
+└── data-pipeline/
+    ├── SKILL.md
+    └── references/
+        ├── schema-reference.md
+        └── error-codes.md
+```
+
+The agent loads reference files only when the instructions call for them, keeping each layer of progressive disclosure appropriately sized. Keep file references one level deep from `SKILL.md` and avoid deeply nested reference chains, which force the agent through multiple reads to reach the information it needs.
+
+### Structure instructions for the agent
+
+Write your `SKILL.md` body as clear instructions the agent can follow:
+
+- **Step-by-step procedures** for multi-step workflows
+- **Decision criteria** for choosing between approaches
+- **Examples of expected inputs and outputs** so the agent knows what success looks like
+- **Edge cases** the agent should handle or flag to the user
+
+### Manage skill count
+
+Fewer well-scoped skills outperform many overlapping ones. As the number of skills with similar descriptions grows, the agent's ability to select the right one degrades. If you find yourself with many related skills, consider:
+
+- Consolidating related capabilities into a single skill with sections for each sub-task
+- Using reference files to keep the main `SKILL.md` concise while covering multiple sub-tasks
+
+<Tip>
+    Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check that your `SKILL.md` frontmatter follows the Agent Skills specification naming and format conventions.
+</Tip>
 
 ## Usage
 
@@ -376,18 +393,6 @@ const agent = await createDeepAgent({
 :::
 
 For more information on subagent configuration and skills inheritance, see [Subagents](/oss/deepagents/subagents).
-
-## What the agent sees
-
-When skills are configured, a "Skills System" section is injected into the agent's system prompt. The agent uses this information to follow a three-step process:
-
-1. **Match**—When a user prompt arrives, the agent checks whether any skill's description matches the task.
-2. **Read**—If a skill applies, the agent reads the full `SKILL.md` file using the path shown in its skills list.
-3. **Execute**—The agent follows the skill's instructions and accesses any supporting files (scripts, templates, reference docs) as needed.
-
-<Tip>
-    Write clear, specific descriptions in your `SKILL.md` frontmatter. The agent decides whether to use a skill based on the description alone—detailed descriptions lead to better skill matching.
-</Tip>
 
 ## Execute code with skills
 
@@ -556,25 +561,27 @@ Seed the store under the same namespace with keys like `/company-policies/SKILL.
 
 Use this for enterprise knowledge bases, approved tool instructions, or shared skill packs where the agent should benefit from centrally managed context but should not rewrite the source of truth. If you want agents to save their own learnings, route a separate path such as `/memories/` to another backend with write permissions enabled. See [Backends](/oss/deepagents/backends) for routing and store setup.
 
-## Skills vs. memory
+## Skills, memory, and tools
 
-Skills and [memory](/oss/deepagents/customization#memory) (`AGENTS.md` files) serve different purposes:
+Skills, [memory](/oss/deepagents/memory) (`AGENTS.md` files), and tools all provide context or capabilities to the agent. The following table summarizes when to reach for each:
 
-| | Skills | Memory |
-|---|--------|--------|
-| **Purpose** | On-demand capabilities discovered through progressive disclosure | Persistent context always loaded at startup |
-| **Loading** | Read only when the agent determines relevance | Always injected into system prompt |
-| **Format** | `SKILL.md` in named directories | `AGENTS.md` files |
-| **Layering** | User → project (last wins) | User → project (combined) |
-| **Use when** | Instructions are task-specific and potentially large | Context is always relevant (project conventions, preferences) |
+| | Skills | Memory | Tools |
+|---|--------|--------|-------|
+| **Purpose** | On-demand capabilities discovered through progressive disclosure | Persistent context always loaded at startup | Programmatic actions the agent can call |
+| **Loading** | Read only when the agent determines relevance | Always injected into system prompt | Available every turn |
+| **Format** | `SKILL.md` in named directories | `AGENTS.md` files | Functions bound to the agent |
+| **Layering** | User, then project (last wins) | User, then project (combined) | Defined at agent creation |
+| **Use when** | Instructions are task-specific and potentially large | Context is always relevant (project conventions, preferences) | The agent needs a programmatic action, or does not have access to the file system |
 
-## When to use skills and tools
+These are guidelines, not hard boundaries. In practice, skills and memory sit on a spectrum. An agent can update its own skills as it works, capturing new procedures and refining instructions over time. In this way, skills can function as a form of progressive-disclosure memory: context the agent builds up and retrieves on demand rather than loading on every prompt.
 
-These are a few general guidelines for using tools and skills:
+### Control skill updates
 
-- Use skills when there is a lot of context to reduce the number of tokens in the system prompt.
-- Use skills to bundle capabilities together into larger actions and provide additional context beyond single tool descriptions.
-- Use tools if the agent does not have access to the file system.
+By default, agents can write to skill files if the backend permits it. Use these mechanisms to control that behavior:
+
+- **Read-only skills**: Use [filesystem permissions](/oss/deepagents/permissions) to deny write operations under skill paths. See [read-only skills from a store](#read-only-skills-from-a-store) for a production pattern.
+- **Scoped permissions**: Allow writes to user-scoped skill paths while keeping workspace or shared skills read-only, so agents can personalize their own skills without modifying shared ones.
+- **Human-in-the-loop**: Use [`interrupt_on`](/oss/deepagents/human-in-the-loop) to require approval before the agent executes write operations, adding a review step without fully blocking writes.
 
 <Tip>
 Trace how your agent discovers and executes skills with [LangSmith](https://smith.langchain.com). Follow the [observability quickstart](/langsmith/observability-quickstart) to get set up.

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -12,7 +12,7 @@ import BackendReadonlySkillsJs from '/snippets/code-samples/backend-readonly-ski
 
 As agents take on more complex tasks, the context they need grows with them. Loading all instructions into the system prompt wastes tokens on information irrelevant to the current task, and providing the same guidance manually across sessions does not scale.
 
-Skills solve this by packaging domain expertise—workflows, best practices, scripts, reference docs, and templates—into reusable directories that the agent discovers and reads only when relevant.
+Skills solve this by packaging domain expertise, such as workflows, best practices, scripts, reference docs, and templates, into reusable directories. The agent gets a summary of the contents on startup and discovers and reads the contained files only when relevant.
 
 :::js
 <Note>
@@ -24,38 +24,7 @@ Deep agent skills follow the [Agent Skills specification](https://agentskills.io
 
 ## What are skills
 
-Each skill is a directory containing a `SKILL.md` file: a markdown file with YAML frontmatter (`name` and `description`) followed by instructions the agent follows when the skill is activated. A skill directory can also include supporting files:
-
-- **`SKILL.md`** (required): Metadata and instructions for the agent
-- **`scripts/`** (optional): Executable code the agent can run
-- **`references/`** (optional): Additional documentation or technical details
-- **`assets/`** (optional): Templates, schemas, or other resources
-
-<Note>
-    Reference any supporting files in your `SKILL.md` with a description of what each file contains and when to use it. The agent discovers these files through the references in the skill instructions.
-</Note>
-
-## How skills work
-
-Skills use *progressive disclosure*: the agent loads skill information in layers, pulling in more detail only when the task calls for it.
-
-In Deep Agents, `SkillsMiddleware` handles this in three stages:
-
-1. **Discovery**: At agent start, the middleware scans the configured skill paths, parses each `SKILL.md` frontmatter, and injects skill names and descriptions into the system prompt.
-2. **Read**: When the agent determines a skill matches the current task, it reads the full `SKILL.md` content via `read_file`. There is no dedicated activation mechanism.
-3. **Execute**: The agent follows the skill's instructions and reads any supporting files (scripts, references, assets) as needed.
-
-The [Agent Skills specification](https://agentskills.io/specification) recommends ~100 tokens for frontmatter and under 5,000 tokens for the `SKILL.md` body. Following these guidelines matters because every skill's frontmatter is added to the system prompt at discovery, while the full body is only read when activated. Keeping both layers small means you can load many skills without crowding the context window.
-
-<Tip>
-    Write clear, specific descriptions in your `SKILL.md` frontmatter. The agent decides whether to activate a skill based on the description alone. Include specific keywords and use cases so the agent can match accurately.
-</Tip>
-
-## Examples
-
-### Basic skill
-
-A minimal skill is a directory with a single `SKILL.md` file:
+Each skill is a directory containing a `SKILL.md` file: a markdown file with YAML frontmatter (`name` and `description`) followed by instructions the agent follows when the skill is activated. A skill directory can also include supporting files such as scripts, reference docs, and templates.
 
 ```plaintext
 skills/
@@ -100,9 +69,365 @@ Based on the question, identify 2-4 most relevant documentation URLs from the in
 Use the fetch_url tool to read the selected documentation URLs, then answer the user's question. Give a direct answer first, include the minimum necessary context, and link to the source pages rather than quoting long passages.
 ````
 
-### Skill with scripts
+<Note>
+    Reference any supporting files in your `SKILL.md` with a description of what each file contains and when to use it. The agent discovers these files through the references in the skill instructions.
+</Note>
 
-Skills can include executable code alongside the instructions. Reference scripts in your `SKILL.md` so the agent knows they exist and when to run them:
+Skills use *progressive disclosure*: the agent loads skill information in layers, pulling in more detail only when the task calls for it.
+
+```mermaid
+%%{init: {'theme': 'base', 'themeVariables': {'lineColor': '#40668D', 'primaryColor': '#E5F4FF', 'primaryTextColor': '#030710', 'primaryBorderColor': '#006DDD'}}}%%
+flowchart TB
+    subgraph L1[" Metadata "]
+        M["name + description\nLoaded at startup for all skills"]
+    end
+
+    L1 -- "Agent determines skill is relevant" --> L2
+
+    subgraph L2[" Instructions "]
+        I["Full SKILL.md body\nRead when the skill is activated"]
+    end
+
+    L2 -- "Instructions reference supporting files" --> L3
+
+    subgraph L3[" Resources "]
+        R["scripts/, references/, assets/\nLoaded only when referenced"]
+    end
+
+    classDef trigger fill:#F6FFDB,stroke:#6E8900,stroke-width:2px,color:#2E3900
+    classDef process fill:#E5F4FF,stroke:#006DDD,stroke-width:2px,color:#030710
+    classDef neutral fill:#F2FAFF,stroke:#40668D,stroke-width:2px,color:#2F4B68
+
+    class L1 trigger
+    class L2 process
+    class L3 neutral
+```
+
+In Deep Agents, `SkillsMiddleware` handles this in three stages:
+
+1. **Discovery**: At agent start, the middleware scans the configured skill paths, parses each `SKILL.md` frontmatter, and injects skill names and descriptions into the system prompt.
+2. **Read**: When the agent determines a skill matches the current task, it reads the full `SKILL.md` content via `read_file`. There is no dedicated activation mechanism.
+3. **Execute**: The agent follows the skill's instructions and reads any supporting files (scripts, references, assets) as needed.
+
+The [Agent Skills specification](https://agentskills.io/specification) recommends keeping frontmatter concise and the `SKILL.md` body under 5,000 tokens. Following these guidelines matters because every skill's frontmatter is added to the system prompt at discovery, while the full body is only read when activated. Keeping both layers small means you can load many skills without crowding the context window.
+
+<Tip>
+    Write clear, specific descriptions in your `SKILL.md` frontmatter. The agent decides whether to activate a skill based on the description alone. Include specific keywords and use cases so the agent can match accurately.
+</Tip>
+
+## Get started
+
+Create a skill directory with a `SKILL.md` file, then pass the path when creating your agent:
+
+:::python
+```python
+from deepagents import create_deep_agent
+from deepagents.backends.filesystem import FilesystemBackend
+
+backend = FilesystemBackend(root_dir="./my-project")
+
+agent = create_deep_agent(
+    model="anthropic:claude-sonnet-4-6",
+    backend=backend,
+    skills=["./my-project/skills/"],
+)
+
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "What is LangGraph?"}]},
+    config={"configurable": {"thread_id": "1"}},
+)
+```
+:::
+
+:::js
+```typescript
+import { createDeepAgent, FilesystemBackend } from "deepagents";
+
+const backend = new FilesystemBackend({ rootDir: process.cwd() });
+
+const agent = await createDeepAgent({
+  model: "anthropic:claude-sonnet-4-6",
+  backend,
+  skills: ["/skills/"],
+});
+
+const result = await agent.invoke(
+  { messages: [{ role: "user", content: "What is LangGraph?" }] },
+  { configurable: { thread_id: "1" } },
+);
+```
+:::
+
+This example uses `FilesystemBackend` to load skills from disk. For other storage options, including loading skills from remote sources, see [Backends and remote skill loading](#backends-and-remote-skill-loading).
+
+## Write effective skills
+
+The [Agent Skills specification](https://agentskills.io/specification) includes guidance on structuring skills for reliable discovery and activation. The recommendations below build on that foundation with practical patterns for Deep Agents.
+
+**Write specific descriptions.** During [discovery](#what-are-skills), the `description` field is the only information the agent sees for each skill. A good description tells the agent both what the skill does and when to activate it, with specific keywords the agent can match against:
+
+```yaml
+# Good: specific about what and when
+description: >-
+  Extract text and tables from PDF files, fill PDF forms, and merge
+  multiple PDFs. Use when working with PDF documents or when the user
+  mentions PDFs, forms, or document extraction.
+
+# Poor: too vague for reliable matching
+description: Helps with PDFs.
+```
+
+When you have multiple skills in related domains, differentiate their descriptions clearly. Overlapping descriptions cause the agent to activate the wrong skill or hesitate between options. If two skills serve similar purposes, consolidate them into one.
+
+**Keep instructions focused.** The Agent Skills specification recommends keeping your `SKILL.md` under 500 lines. When instructions grow longer, move detailed reference material into separate files and reference them from the main `SKILL.md`:
+
+```plaintext
+skills/
+└── data-pipeline/
+    ├── SKILL.md
+    └── references/
+        ├── schema-reference.md
+        └── error-codes.md
+```
+
+The agent loads reference files only when the instructions call for them, keeping each layer of progressive disclosure appropriately sized. Keep file references one level deep from `SKILL.md` and avoid deeply nested reference chains, which force the agent through multiple reads to reach the information it needs.
+
+**Structure instructions for the agent.** Write your `SKILL.md` body as clear instructions the agent can follow:
+
+- **Step-by-step procedures** for multi-step workflows
+- **Decision criteria** for choosing between approaches
+- **Examples of expected inputs and outputs** so the agent knows what success looks like
+- **Edge cases** the agent should handle or flag to the user
+
+**Manage skill count.** Fewer well-scoped skills outperform many overlapping ones. As the number of skills with similar descriptions grows, the agent's ability to select the right one degrades. If you find yourself with many related skills, consider:
+
+- Consolidating related capabilities into a single skill with sections for each sub-task
+- Using reference files to keep the main `SKILL.md` concise while covering multiple sub-tasks
+
+<Tip>
+    Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check that your `SKILL.md` frontmatter follows the Agent Skills specification naming and format conventions.
+</Tip>
+
+## Backends and remote skill loading
+
+The [Get started](#get-started) example uses `FilesystemBackend`, which loads skills from disk. Deep Agents supports other backends depending on how you want to store and manage skill files:
+
+:::python
+<SkillsUsageTabsPy />
+:::
+
+:::js
+<SkillsUsageTabsJs />
+:::
+
+<ParamField body="skills" type="list[str]" optional>
+    List of skill source paths.
+
+    Paths must be specified using forward slashes and are relative to the backend's root.
+
+    - If omitted, no skills are loaded.
+    - When using `StateBackend` (default), provide skill files with `invoke(files={...})`. Use `create_file_data()` from `deepagents.backends.utils` to format file contents; raw strings are not supported.
+    - With `FilesystemBackend`, skills are loaded from disk relative to the backend's `root_dir`.
+
+    Later sources override earlier ones for skills with the same name (last one wins).
+</ParamField>
+
+<Note>
+    When multiple skill sources contain a skill with the same name, the skill from the source listed later in the `skills` array takes precedence (last one wins). This lets you layer skills from different origins, such as base skills overridden by project-specific versions.
+</Note>
+
+## Load skills at runtime
+
+When you have a large collection of skills but only a subset is relevant for a given run, select which skills to load based on runtime context such as user role, tenant, or request type. There are two main approaches:
+
+### Dynamic skill lists
+
+The simplest approach is to construct the `skills` array before creating the agent. Choose which skill paths to include based on whatever runtime context you have:
+
+:::python
+```python
+from deepagents import create_deep_agent
+
+SKILLS_BY_ROLE = {
+    "engineering": ["/skills/code-review/", "/skills/testing/", "/skills/deployment/"],
+    "data": ["/skills/sql-analysis/", "/skills/visualization/", "/skills/data-pipeline/"],
+    "support": ["/skills/ticket-triage/", "/skills/runbook/"],
+}
+
+def create_agent_for_user(user_role: str):
+    return create_deep_agent(
+        model="anthropic:claude-sonnet-4-6",
+        skills=SKILLS_BY_ROLE.get(user_role, []),
+    )
+```
+:::
+
+:::js
+```typescript
+import { createDeepAgent } from "deepagents";
+
+const SKILLS_BY_ROLE: Record<string, string[]> = {
+  engineering: ["/skills/code-review/", "/skills/testing/", "/skills/deployment/"],
+  data: ["/skills/sql-analysis/", "/skills/visualization/", "/skills/data-pipeline/"],
+  support: ["/skills/ticket-triage/", "/skills/runbook/"],
+};
+
+function createAgentForUser(userRole: string) {
+  return createDeepAgent({
+    model: "anthropic:claude-sonnet-4-6",
+    skills: SKILLS_BY_ROLE[userRole] ?? [],
+  });
+}
+```
+:::
+
+This works well when skills live on disk or in a shared backend and you just need to control which ones the agent sees. The skills themselves are not duplicated — you maintain one copy and vary the paths passed to each run.
+
+### Namespaced skills
+
+For multi-tenant applications where each user's skill set is managed independently, route `/skills/` to a @[StoreBackend] with a namespace factory. Populate each namespace with only the skills that user should have access to, and the middleware resolves to the correct set at runtime:
+
+:::python
+```python
+from deepagents import create_deep_agent
+from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
+
+agent = create_deep_agent(
+    model="anthropic:claude-sonnet-4-6",
+    skills=["/skills/"],
+    backend=CompositeBackend(
+        default=StateBackend(),
+        routes={
+            "/skills/": StoreBackend(
+                namespace=lambda rt: (
+                    rt.server_info.assistant_id,
+                    rt.server_info.user.identity,
+                ),
+            ),
+        },
+    ),
+)
+```
+:::
+
+:::js
+```typescript
+import {
+  createDeepAgent,
+  CompositeBackend,
+  StateBackend,
+  StoreBackend,
+} from "deepagents";
+
+const agent = await createDeepAgent({
+  model: "anthropic:claude-sonnet-4-6",
+  skills: ["/skills/"],
+  backend: new CompositeBackend({
+    default: new StateBackend(),
+    routes: {
+      "/skills/": new StoreBackend({
+        namespace: (ctx) => [
+          ctx.assistantId ?? "default",
+          ctx.config?.configurable?.user_id ?? "anonymous",
+        ],
+      }),
+    },
+  }),
+});
+```
+:::
+
+This pattern is useful when different users or tenants need fully independent skill libraries that can be updated separately. For a managed solution that handles skill access, sharing, and workspace-level visibility out of the box, see [Fleet skills](/langsmith/fleet/skills).
+
+## Skills for subagents
+
+When you use [subagents](/oss/deepagents/subagents), you can configure which skills each type has access to:
+
+- **General-purpose subagent**: Automatically inherits skills from the main agent when you pass `skills` to `create_deep_agent`. No additional configuration is needed.
+- **Custom subagents**: Do not inherit the main agent's skills. Add a `skills` parameter to each subagent definition with that subagent's skill source paths.
+
+Skill state is fully isolated: the main agent's skills are not visible to subagents, and subagent skills are not visible to the main agent.
+
+:::python
+```python
+from deepagents import create_deep_agent
+
+research_subagent = {
+    "name": "researcher",
+    "description": "Research assistant with specialized skills",
+    "system_prompt": "You are a researcher.",
+    "tools": [web_search],
+    "skills": ["/skills/research/", "/skills/web-search/"],  # Subagent-specific skills
+}
+
+agent = create_deep_agent(
+    model="google_genai:gemini-3.5-flash",
+    skills=["/skills/main/"],  # Main agent and GP subagent get these
+    subagents=[research_subagent],  # Researcher gets only its own skills
+)
+```
+:::
+
+:::js
+```typescript
+const researchSubagent = {
+  name: "researcher",
+  description: "Research assistant with specialized skills",
+  systemPrompt: "You are a researcher.",
+  tools: [webSearch],
+  skills: ["/skills/research/", "/skills/web-search/"],  // Subagent-specific skills
+};
+
+const agent = await createDeepAgent({
+  model: "google_genai:gemini-3.5-flash",
+  skills: ["/skills/main/"],  // Main agent and GP subagent get these
+  subagents: [researchSubagent],  // Researcher gets only its own skills
+});
+```
+:::
+
+For more information on subagent configuration and skills inheritance, see [Subagents](/oss/deepagents/subagents).
+
+## Skill permissions
+
+By default, agents can write to skill files if the backend permits it. Use these mechanisms to control that behavior:
+
+- **Read-only skills**: Use [filesystem permissions](/oss/deepagents/permissions) to deny write operations under skill paths.
+- **Scoped permissions**: Allow writes to user-scoped skill paths while keeping workspace or shared skills read-only, so agents can personalize their own skills without modifying shared ones.
+- **Human-in-the-loop**: Use [`interrupt_on`](/oss/deepagents/human-in-the-loop) to require approval before the agent executes write operations, adding a review step without fully blocking writes.
+
+### Read-only skills
+
+A common production pattern is to give agents access to a curated skills library without allowing them to change it. Route `/skills/` to a shared `StoreBackend`, pass that route in `skills`, and deny write operations under `/skills/**` with [filesystem permissions](/oss/deepagents/permissions). The agent can discover and read skills, while only your application code or an admin workflow updates the store.
+
+:::python
+
+<BackendReadonlySkillsPy />
+
+:::
+
+:::js
+
+<BackendReadonlySkillsJs />
+
+:::
+
+Seed the store under the same namespace with keys like `/company-policies/SKILL.md` and values that include `content` and `encoding` fields. The `/skills/` route prefix is stripped before records are read from the store.
+
+Use this for enterprise knowledge bases, approved tool instructions, or shared skill packs where the agent should benefit from centrally managed context but should not rewrite the source of truth. If you want agents to save their own learnings, route a separate path such as `/memories/` to another backend with write permissions enabled. See [Backends](/oss/deepagents/backends) for routing and store setup.
+
+## Execute code with skills
+
+Without code execution, skills are passive: the agent reads instructions and follows them using its available tools. Code execution turns skills into active capabilities. A skill can ship a tested script that calls an API, transforms data, validates output, or runs a pipeline — and the agent executes it deterministically rather than regenerating the logic from instructions each time. This is especially valuable for workflows that require exact behavior (data transformations, API integrations, compliance checks) or that depend on libraries the agent cannot use through tool calls alone.
+
+Skills support code execution in two ways:
+
+- [Sandbox scripts](#sandbox-scripts) when the agent needs to install dependencies, run tests, call CLIs, or work with an operating-system filesystem.
+- [Interpreter skills](#interpreter-skills) when the agent needs reusable, importable helpers available from interpreter code.
+
+### Sandbox scripts
+
+Skills can include scripts alongside the `SKILL.md` file. Reference scripts in your `SKILL.md` so the agent knows they exist and when to run them:
 
 :::python
 ```plaintext
@@ -162,360 +487,7 @@ Search arXiv for papers matching the user's query.
 ````
 :::
 
-:::python
-For more example skills, see [Deep Agents example skills](https://github.com/langchain-ai/deepagents/tree/main/libs/cli/examples/skills).
-:::
-
-:::js
-For more example skills, see [Deep Agents example skills](https://github.com/langchain-ai/deepagentsjs/tree/main/examples/skills).
-:::
-
-### All frontmatter fields
-
-The [Agent Skills specification](https://agentskills.io/specification) defines the following frontmatter fields:
-
-| Field | Required | Description |
-|-------|----------|-------------|
-| `name` | Yes | Lowercase alphanumeric with hyphens, 1-64 characters. Must match the parent directory name. |
-| `description` | Yes | What the skill does and when to use it. Max 1,024 characters. |
-| `license` | No | License name or reference to a bundled license file. |
-| `compatibility` | No | Environment requirements (system packages, network access). Max 500 characters. |
-| `metadata` | No | Arbitrary key-value pairs for additional properties. |
-| `allowed-tools` | No | Space-separated list of pre-approved tools the skill can use. Experimental. |
-
-````md expandable
----
-name: langgraph-docs
-description: Use this skill for requests related to LangGraph in order to fetch relevant documentation to provide accurate, up-to-date guidance.
-license: MIT
-compatibility: Requires internet access for fetching documentation URLs
-metadata:
-  author: langchain
-  version: "1.0"
-allowed-tools: fetch_url
----
-
-# langgraph-docs
-
-Instructions for the agent go here. See the [basic skill example](#basic-skill) for a complete example of skill instructions.
-````
-
-<Warning>
-    Refer to the full [Agent Skills specification](https://agentskills.io/specification) for detailed constraints and validation rules. In Deep Agents, `SKILL.md` files must be under 10 MB. Files exceeding this limit are skipped during skill loading.
-</Warning>
-
-## Usage
-
-### Getting started
-
-Pass a list of skill directory paths when creating your agent. The backend you choose determines how skill files are stored and loaded:
-
-:::python
-<SkillsUsageTabsPy />
-
-<ParamField body="skills" type="list[str]" optional>
-    List of skill source paths.
-
-    Paths must be specified using forward slashes and are relative to the backend's root.
-
-    - If omitted, no skills are loaded.
-    - When using `StateBackend` (default), provide skill files with `invoke(files={...})`. Use `create_file_data()` from `deepagents.backends.utils` to format file contents; raw strings are not supported.
-    - With `FilesystemBackend`, skills are loaded from disk relative to the backend's `root_dir`.
-
-    Later sources override earlier ones for skills with the same name (last one wins).
-</ParamField>
-
-:::
-
-:::js
-<SkillsUsageTabsJs />
-
-<ParamField body="skills" type="list[str]" optional>
-    List of skill source paths.
-
-    Paths must be specified using forward slashes and are relative to the backend's root.
-
-    - If omitted, no skills are loaded.
-    - When using `StateBackend` (default), provide skill files with `invoke(files={...})`.
-    - With `FilesystemBackend`, skills are loaded from disk relative to the backend's `root_dir`.
-
-    Later sources override earlier ones for skills with the same name (last one wins).
-</ParamField>
-:::
-
-<Note>
-    The SDK only loads the sources you pass in `skills`. It does not automatically scan CLI directories such as `~/.deepagents/...` or `~/.agents/...`.
-
-    For CLI storage conventions, see [App data](/oss/deepagents/data-locations).
-
-    <Accordion
-        title="Emulating CLI source order in SDK"
-    >
-        If you want CLI-style layering in SDK code, pass all desired sources explicitly in lowest-to-highest precedence order:
-
-        ```text
-        [
-        "<user-home>/.deepagents/{agent}/skills/",
-        "<user-home>/.agents/skills/",
-        "<project-root>/.deepagents/skills/",
-        "<project-root>/.agents/skills/",
-        ]
-        ```
-
-        Then pass that ordered list as `skills` when creating your agent.
-    </Accordion>
-</Note>
-
-### Source precedence
-
-When multiple skill sources contain a skill with the same name, the skill from the source listed later in the `skills` array takes precedence (last one wins). This lets you layer skills from different origins.
-
-:::python
-```python
-# If both sources contain a skill named "web-search",
-# the one from "/skills/project/" wins (loaded last).
-agent = create_deep_agent(
-    model="google_genai:gemini-3.5-flash",
-    skills=["/skills/user/", "/skills/project/"],
-    ...
-)
-```
-:::
-
-:::js
-```typescript
-// If both sources contain a skill named "web-search",
-// the one from "/skills/project/" wins (loaded last).
-const agent = await createDeepAgent({
-  skills: ["/skills/user/", "/skills/project/"],
-  ...
-});
-```
-:::
-
-### Skills for subagents
-
-When you use [subagents](/oss/deepagents/subagents), you can configure which skills each type has access to:
-
-- **General-purpose subagent**: Automatically inherits skills from the main agent when you pass `skills` to `create_deep_agent`. No additional configuration is needed.
-- **Custom subagents**: Do not inherit the main agent's skills. Add a `skills` parameter to each subagent definition with that subagent's skill source paths.
-
-Skill state is fully isolated: the main agent's skills are not visible to subagents, and subagent skills are not visible to the main agent.
-
-:::python
-```python
-from deepagents import create_deep_agent
-
-research_subagent = {
-    "name": "researcher",
-    "description": "Research assistant with specialized skills",
-    "system_prompt": "You are a researcher.",
-    "tools": [web_search],
-    "skills": ["/skills/research/", "/skills/web-search/"],  # Subagent-specific skills
-}
-
-agent = create_deep_agent(
-    model="google_genai:gemini-3.5-flash",
-    skills=["/skills/main/"],  # Main agent and GP subagent get these
-    subagents=[research_subagent],  # Researcher gets only its own skills
-)
-```
-:::
-
-:::js
-```typescript
-const researchSubagent = {
-  name: "researcher",
-  description: "Research assistant with specialized skills",
-  systemPrompt: "You are a researcher.",
-  tools: [webSearch],
-  skills: ["/skills/research/", "/skills/web-search/"],  // Subagent-specific skills
-};
-
-const agent = await createDeepAgent({
-  model: "google_genai:gemini-3.5-flash",
-  skills: ["/skills/main/"],  // Main agent and GP subagent get these
-  subagents: [researchSubagent],  // Researcher gets only its own skills
-});
-```
-:::
-
-For more information on subagent configuration and skills inheritance, see [Subagents](/oss/deepagents/subagents).
-
-### Dynamic skills per run
-
-To serve different skills to different users, route `/skills/` to a @[StoreBackend] with a namespace factory. Pre-seed each namespace with the appropriate skills, and the middleware automatically resolves to the correct set at runtime:
-
-:::python
-```python
-from deepagents import create_deep_agent
-from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
-
-agent = create_deep_agent(
-    model="anthropic:claude-sonnet-4-6",
-    skills=["/skills/"],
-    backend=CompositeBackend(
-        default=StateBackend(),
-        routes={
-            "/skills/": StoreBackend(
-                namespace=lambda rt: (
-                    rt.server_info.assistant_id,
-                    rt.server_info.user.identity,
-                ),
-            ),
-        },
-    ),
-)
-```
-:::
-
-:::js
-```typescript
-import {
-  createDeepAgent,
-  CompositeBackend,
-  StateBackend,
-  StoreBackend,
-} from "deepagents";
-
-const agent = await createDeepAgent({
-  model: "anthropic:claude-sonnet-4-6",
-  skills: ["/skills/"],
-  backend: new CompositeBackend({
-    default: new StateBackend(),
-    routes: {
-      "/skills/": new StoreBackend({
-        namespace: (ctx) => [
-          ctx.assistantId ?? "default",
-          ctx.config?.configurable?.user_id ?? "anonymous",
-        ],
-      }),
-    },
-  }),
-});
-```
-:::
-
-Each user's namespace contains only their skills. This pattern is useful for multi-tenant applications, role-based skill access, and per-customer configurations.
-
-Seed each namespace with the skills that user should have access to:
-
-:::python
-```python
-from deepagents.backends.utils import create_file_data
-from langgraph.store.memory import InMemoryStore
-
-store = InMemoryStore()
-
-# Seed skills for user "alice"
-store.put(
-    ("my-agent", "alice"),
-    "/data-analysis/SKILL.md",
-    create_file_data(data_analysis_skill_content),
-)
-
-store.put(
-    ("my-agent", "alice"),
-    "/report-builder/SKILL.md",
-    create_file_data(report_builder_skill_content),
-)
-
-# Seed different skills for user "bob"
-store.put(
-    ("my-agent", "bob"),
-    "/code-review/SKILL.md",
-    create_file_data(code_review_skill_content),
-)
-```
-:::
-
-:::js
-```typescript
-import { createFileData } from "deepagents";
-import { InMemoryStore } from "@langchain/langgraph";
-
-const store = new InMemoryStore();
-
-// Seed skills for user "alice"
-await store.put(
-  ["my-agent", "alice"],
-  "/data-analysis/SKILL.md",
-  createFileData(dataAnalysisSkillContent),
-);
-
-await store.put(
-  ["my-agent", "alice"],
-  "/report-builder/SKILL.md",
-  createFileData(reportBuilderSkillContent),
-);
-
-// Seed different skills for user "bob"
-await store.put(
-  ["my-agent", "bob"],
-  "/code-review/SKILL.md",
-  createFileData(codeReviewSkillContent),
-);
-```
-:::
-
-When Alice invokes the agent, the namespace resolves to `("my-agent", "alice")` and the agent discovers only `data-analysis` and `report-builder`. Bob sees only `code-review`.
-
-## Writing effective skills
-
-**Write specific descriptions.** During [discovery](#how-skills-work), the `description` field is the only information the agent sees for each skill. A good description tells the agent both what the skill does and when to activate it, with specific keywords the agent can match against:
-
-```yaml
-# Good: specific about what and when
-description: >-
-  Extract text and tables from PDF files, fill PDF forms, and merge
-  multiple PDFs. Use when working with PDF documents or when the user
-  mentions PDFs, forms, or document extraction.
-
-# Poor: too vague for reliable matching
-description: Helps with PDFs.
-```
-
-When you have multiple skills in related domains, differentiate their descriptions clearly. Overlapping descriptions cause the agent to activate the wrong skill or hesitate between options. If two skills serve similar purposes, consolidate them into one.
-
-**Keep instructions focused.** The Agent Skills specification recommends keeping your `SKILL.md` under 500 lines. When instructions grow longer, move detailed reference material into separate files and reference them from the main `SKILL.md`:
-
-```plaintext
-skills/
-└── data-pipeline/
-    ├── SKILL.md
-    └── references/
-        ├── schema-reference.md
-        └── error-codes.md
-```
-
-The agent loads reference files only when the instructions call for them, keeping each layer of progressive disclosure appropriately sized. Keep file references one level deep from `SKILL.md` and avoid deeply nested reference chains, which force the agent through multiple reads to reach the information it needs.
-
-**Structure instructions for the agent.** Write your `SKILL.md` body as clear instructions the agent can follow:
-
-- **Step-by-step procedures** for multi-step workflows
-- **Decision criteria** for choosing between approaches
-- **Examples of expected inputs and outputs** so the agent knows what success looks like
-- **Edge cases** the agent should handle or flag to the user
-
-**Manage skill count.** Fewer well-scoped skills outperform many overlapping ones. As the number of skills with similar descriptions grows, the agent's ability to select the right one degrades. If you find yourself with many related skills, consider:
-
-- Consolidating related capabilities into a single skill with sections for each sub-task
-- Using reference files to keep the main `SKILL.md` concise while covering multiple sub-tasks
-
-<Tip>
-    Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check that your `SKILL.md` frontmatter follows the Agent Skills specification naming and format conventions.
-</Tip>
-
-## Execute code with skills
-
-Skills support code execution in two ways:
-
-- [Sandbox scripts](#sandbox-scripts) when the agent needs to install dependencies, run tests, call CLIs, or work with an operating-system filesystem.
-- [Interpreter skills](#interpreter-skills) when the agent needs reusable, importable helpers available from interpreter code.
-
-### Sandbox scripts
-
-Skills can include scripts alongside the `SKILL.md` file, such as a Python file that performs a search or data transformation. The agent can _read_ these scripts from any backend, but to _execute_ them, the agent needs access to a shell, which only [sandbox backends](/oss/deepagents/sandboxes) provide.
+The agent can _read_ scripts from any backend, but to _execute_ them, the agent needs access to a shell, which only [sandbox backends](/oss/deepagents/sandboxes) provide.
 
 [Sandbox backends](/oss/deepagents/sandboxes) run in isolated containers. Skill files stored outside the sandbox are not available inside it, which means the agent cannot execute skill scripts or access skill resources unless they are transferred in first. Use [custom middleware](/oss/langchain/middleware/custom) to handle this transfer:
 
@@ -653,47 +625,63 @@ const grouped = groupByStatus(orders);
 grouped;
 ```
 
-## Skills, memory, and tools
+## Reference
+
+### Skills, memory, and tools
 
 Skills, [memory](/oss/deepagents/memory) (`AGENTS.md` files), and tools all provide context or capabilities to the agent. The following table summarizes when to reach for each:
 
 | | Skills | Memory | Tools |
 |---|--------|--------|-------|
-| **Purpose** | On-demand capabilities discovered through progressive disclosure | Persistent context always loaded at startup | Programmatic actions the agent can call |
-| **Loading** | Read only when the agent determines relevance | Always injected into system prompt | Available every turn |
+| **Purpose** | On-demand capabilities discovered through progressive disclosure | Persistent context loaded at startup | Programmatic actions the agent can call |
+| **Loading** | Read only when the agent determines relevance | Loaded at agent start | Available every turn |
 | **Format** | `SKILL.md` in named directories | `AGENTS.md` files | Functions bound to the agent |
 | **Layering** | User, then project (last wins) | User, then project (combined) | Defined at agent creation |
 | **Use when** | Instructions are task-specific and potentially large | Context is always relevant (project conventions, preferences) | The agent needs a programmatic action, or does not have access to the file system |
 
 These are guidelines, not hard boundaries. In practice, skills and memory sit on a spectrum. An agent can update its own skills as it works, capturing new procedures and refining instructions over time. In this way, skills can function as a form of progressive-disclosure memory: context the agent builds up and retrieves on demand rather than loading on every prompt.
 
-## Skill permissions
+### Frontmatter fields
 
-By default, agents can write to skill files if the backend permits it. Use these mechanisms to control that behavior:
+The [Agent Skills specification](https://agentskills.io/specification) defines the following frontmatter fields:
 
-- **Read-only skills**: Use [filesystem permissions](/oss/deepagents/permissions) to deny write operations under skill paths.
-- **Scoped permissions**: Allow writes to user-scoped skill paths while keeping workspace or shared skills read-only, so agents can personalize their own skills without modifying shared ones.
-- **Human-in-the-loop**: Use [`interrupt_on`](/oss/deepagents/human-in-the-loop) to require approval before the agent executes write operations, adding a review step without fully blocking writes.
+| Field | Required | Description |
+|-------|----------|-------------|
+| `name` | Yes | Lowercase alphanumeric with hyphens, 1-64 characters. Must match the parent directory name. |
+| `description` | Yes | What the skill does and when to use it. Max 1,024 characters. |
+| `license` | No | License name or reference to a bundled license file. |
+| `compatibility` | No | Environment requirements (system packages, network access). Max 500 characters. |
+| `metadata` | No | Arbitrary key-value pairs for additional properties. |
+| `allowed-tools` | No | Space-separated list of pre-approved tools the skill can use. Experimental. |
 
-### Read-only skills
+````md expandable
+---
+name: langgraph-docs
+description: Use this skill for requests related to LangGraph in order to fetch relevant documentation to provide accurate, up-to-date guidance.
+license: MIT
+compatibility: Requires internet access for fetching documentation URLs
+metadata:
+  author: langchain
+  version: "1.0"
+allowed-tools: fetch_url
+---
 
-A common production pattern is to give agents access to a curated skills library without allowing them to change it. Route `/skills/` to a shared `StoreBackend`, pass that route in `skills`, and deny write operations under `/skills/**` with [filesystem permissions](/oss/deepagents/permissions). The agent can discover and read skills, while only your application code or an admin workflow updates the store.
+# langgraph-docs
+
+Instructions for the agent go here. See the [langgraph-docs example](#what-are-skills) for a complete example of skill instructions.
+````
+
+<Warning>
+    Refer to the full [Agent Skills specification](https://agentskills.io/specification) for detailed constraints and validation rules. In Deep Agents, `SKILL.md` files must be under 10 MB. Files exceeding this limit are skipped during skill loading.
+</Warning>
 
 :::python
-
-<BackendReadonlySkillsPy />
-
+For more example skills, see [Deep Agents example skills](https://github.com/langchain-ai/deepagents/tree/main/libs/cli/examples/skills).
 :::
 
 :::js
-
-<BackendReadonlySkillsJs />
-
+For more example skills, see [Deep Agents example skills](https://github.com/langchain-ai/deepagentsjs/tree/main/examples/skills).
 :::
-
-Seed the store under the same namespace with keys like `/company-policies/SKILL.md` and values that include `content` and `encoding` fields. The `/skills/` route prefix is stripped before records are read from the store.
-
-Use this for enterprise knowledge bases, approved tool instructions, or shared skill packs where the agent should benefit from centrally managed context but should not rewrite the source of truth. If you want agents to save their own learnings, route a separate path such as `/memories/` to another backend with write permissions enabled. See [Backends](/oss/deepagents/backends) for routing and store setup.
 
 <Tip>
 Trace how your agent discovers and executes skills with [LangSmith](https://smith.langchain.com). Follow the [observability quickstart](/langsmith/observability-quickstart) to get set up.

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -119,7 +119,7 @@ The [Agent Skills specification](https://agentskills.io/specification) recommend
     Write clear, specific descriptions in your `SKILL.md` frontmatter. The agent decides whether to activate a skill based on the description alone. Include specific keywords and use cases so the agent can match accurately.
 </Tip>
 
-## Get started
+## Usage
 
 Create a top level skills directory. Then create a directory inside that with a `SKILL.md` file for your first skill. Finally, pass the path to the top level skills directory when creating your agent:
 
@@ -163,6 +163,22 @@ const result = await agent.invoke(
 :::
 
 This example uses `FilesystemBackend` to load skills from disk. For other storage options, including loading skills from remote sources, see [Backends and remote skill loading](#backends-and-remote-skill-loading).
+
+<ParamField body="skills" type="list[str]" optional>
+    List of skill source paths.
+
+    Paths must be specified using forward slashes and are relative to the backend's root.
+
+    - If omitted, no skills are loaded.
+    - When using `StateBackend` (default), provide skill files with `invoke(files={...})`. Use `create_file_data()` from `deepagents.backends.utils` to format file contents; raw strings are not supported.
+    - With `FilesystemBackend`, skills are loaded from disk relative to the backend's `root_dir`.
+
+    Later sources override earlier ones for skills with the same name (last one wins).
+</ParamField>
+
+<Note>
+    When multiple skill sources contain a skill with the same name, the skill from the source listed later in the `skills` array takes precedence (last one wins). This lets you layer skills from different origins, such as base skills overridden by project-specific versions.
+</Note>
 
 ## Write effective skills
 
@@ -214,7 +230,7 @@ The agent loads reference files only when the instructions call for them, keepin
 
 ## Backends and remote skill loading
 
-The [Get started](#get-started) example uses `FilesystemBackend`, which loads skills from disk. Deep Agents supports other backends depending on how you want to store and manage skill files:
+The [Usage](#usage) example uses `FilesystemBackend`, which loads skills from disk. Deep Agents supports other backends depending on how you want to store and manage skill files:
 
 :::python
 <SkillsUsageTabsPy />
@@ -223,22 +239,6 @@ The [Get started](#get-started) example uses `FilesystemBackend`, which loads sk
 :::js
 <SkillsUsageTabsJs />
 :::
-
-<ParamField body="skills" type="list[str]" optional>
-    List of skill source paths.
-
-    Paths must be specified using forward slashes and are relative to the backend's root.
-
-    - If omitted, no skills are loaded.
-    - When using `StateBackend` (default), provide skill files with `invoke(files={...})`. Use `create_file_data()` from `deepagents.backends.utils` to format file contents; raw strings are not supported.
-    - With `FilesystemBackend`, skills are loaded from disk relative to the backend's `root_dir`.
-
-    Later sources override earlier ones for skills with the same name (last one wins).
-</ParamField>
-
-<Note>
-    When multiple skill sources contain a skill with the same name, the skill from the source listed later in the `skills` array takes precedence (last one wins). This lets you layer skills from different origins, such as base skills overridden by project-specific versions.
-</Note>
 
 ## Load skills at runtime
 

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -230,7 +230,11 @@ The agent loads reference files only when the instructions call for them, keepin
 
 ## Backends and remote skill loading
 
-The [Usage](#usage) example uses `FilesystemBackend`, which loads skills from disk. Deep Agents supports other backends depending on how you want to store and manage skill files:
+Deep Agents supports different backends depending on how you want to store and manage skill files:
+
+- `StateBackend`: Stores files in LangGraph agent state for the current thread.
+- `StoreBackend`: Stores files in a LangGraph store for durable, cross-thread storage.
+- `FilesystemBackend`: Reads and writes skill files from disk under a configurable `root_dir`.
 
 :::python
 <SkillsUsageTabsPy />

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -425,9 +425,6 @@ For a more complete example that also syncs [memories](/oss/deepagents/memory) b
 
 ### Use interpreter skills
 
-<Note>
-    Interpreter skills use a `module` frontmatter field that is a Deep Agents extension, not part of the [Agent Skills specification](https://agentskills.io/specification).
-</Note>
 
 Interpreter skills expose code modules to an [interpreter](/oss/deepagents/interpreters). Regular skills give the agent instructions and context. Interpreter skills also give the agent importable functions it can call from interpreter code.
 
@@ -442,8 +439,8 @@ Use interpreter skills for code that should be:
 To make a skill importable:
 
 <Steps titleSize="h4">
-    <Step title="Add a module entry">
-        Add a `module` key to the skill's `SKILL.md` frontmatter. The value is a JavaScript or TypeScript file path relative to the skill directory.
+    <Step title="Add an entrypoint">
+        Add a `metadata.entrypoint` key to the skill's `SKILL.md` frontmatter. The value is a JavaScript or TypeScript file path relative to the skill directory.
     </Step>
     <Step title="Configure skills normally">
         Pass the skill source path with the `skills` argument when creating the agent.
@@ -462,14 +459,16 @@ Minimal skill layout:
 skills/
 `-- order-helpers/
     |-- SKILL.md
-    `-- index.ts
+    `-- scripts/
+        `-- index.ts
 ```
 
 ````md
 ---
 name: order-helpers
 description: Helper functions for normalizing and grouping order records.
-module: index.ts
+metadata:
+  entrypoint: scripts/index.ts
 ---
 
 # order-helpers
@@ -485,7 +484,7 @@ groupByStatus(...);
 ````
 
 ```typescript
-// skills/order-helpers/index.ts
+// skills/order-helpers/scripts/index.ts
 interface Order {
   id: string;
   status: string;

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -266,7 +266,7 @@ Pass a list of skill directory paths when creating your agent. The backend you c
 
 ## Build effective skills
 
-### Write effective skills
+### Authoring best practices
 
 **Write specific descriptions.** During [discovery](#how-skills-work), the `description` field is the only information the agent sees for each skill. A good description tells the agent both what the skill does and when to activate it, with specific keywords the agent can match against:
 

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -20,7 +20,11 @@ Skills require `deepagents>=1.7.0`.
 </Note>
 :::
 
-Deep agent skills follow the [Agent Skills specification](https://agentskills.io/specification). For ready-to-use skills that improve your agent's performance on LangChain ecosystem tasks, see the [LangChain Skills](https://github.com/langchain-ai/langchain-skills) repository.
+Deep agent skills follow the [Agent Skills specification](https://agentskills.io/specification).
+
+<Tip>
+For ready-to-use skills that improve your agent's performance on LangChain ecosystem tasks, see the [LangChain Skills](https://github.com/langchain-ai/langchain-skills) repository.
+</Tip>
 
 ## What are skills
 
@@ -117,7 +121,7 @@ The [Agent Skills specification](https://agentskills.io/specification) recommend
 
 ## Get started
 
-Create a skill directory with a `SKILL.md` file, then pass the path when creating your agent:
+Create a top level skills directory. Then create a directory inside that with a `SKILL.md` file for your first skill. Finally, pass the path to the top level skills directory when creating your agent:
 
 :::python
 ```python
@@ -162,7 +166,7 @@ This example uses `FilesystemBackend` to load skills from disk. For other storag
 
 ## Write effective skills
 
-The [Agent Skills specification](https://agentskills.io/specification) includes guidance on structuring skills for reliable discovery and activation. The recommendations below build on that foundation with practical patterns for Deep Agents.
+The [Agent Skills specification](https://agentskills.io/specification) includes guidance on structuring skills for reliable discovery and activation. The following recommendations build on that foundation with practical patterns for Deep Agents.
 
 **Write specific descriptions.** During [discovery](#what-are-skills), the `description` field is the only information the agent sees for each skill. A good description tells the agent both what the skill does and when to activate it, with specific keywords the agent can match against:
 

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -398,21 +398,46 @@ For more information on subagent configuration and skills inheritance, see [Suba
 
 Skills support code execution in two ways:
 
-- [Use interpreter skills](#use-interpreter-skills) when the agent needs reusable, importable helpers available from interpreter code.
 - [Execute skill scripts in a sandbox](#execute-skill-scripts-in-a-sandbox) when the agent needs to install dependencies, run tests, call CLIs, or work with an operating-system filesystem.
+- [Use interpreter skills](#use-interpreter-skills) when the agent needs reusable, importable helpers available from interpreter code.
+
+### Execute skill scripts in a sandbox
+
+Skills can include scripts alongside the `SKILL.md` file, such as a Python file that performs a search or data transformation. The agent can _read_ these scripts from any backend, but to _execute_ them, the agent needs access to a shell, which only [sandbox backends](/oss/deepagents/sandboxes) provide.
+
+When you use a @[CompositeBackend] that routes skills to a @[StoreBackend] for persistence while using a sandbox as the default backend, skill files live in the store rather than in the sandbox where code runs. For sandboxes to use the scripts, you must use [custom middleware](/oss/langchain/middleware/custom) to upload skill scripts into the sandbox before the agent starts:
+
+:::python
+
+<SkillsSandboxPy />
+
+The middleware's `before_agent` hook runs before each agent invocation, reading skill files from that shared namespace and uploading them into the sandbox filesystem. Once synced, the agent can execute scripts with the `execute` tool just like any other file in the sandbox.
+
+:::
+
+:::js
+<SkillsSandboxJs />
+
+The middleware's `beforeAgent` hook runs before each agent invocation, reading skill files from that shared namespace and uploading them into the sandbox filesystem. Once synced, the agent can execute scripts with the `execute` tool just like any other file in the sandbox.
+:::
+
+For a more complete example that also syncs [memories](/oss/deepagents/memory) bidirectionally, see [syncing skills and memories with custom middleware](/oss/deepagents/going-to-production#example-syncing-skills-and-memories-with-custom-middleware).
 
 ### Use interpreter skills
 
-Interpreter skills are skills that expose code modules to an [interpreter](/oss/deepagents/interpreters). Regular skills give the agent instructions and context. Interpreter skills also give the agent importable functions it can call from interpreter code.
+<Note>
+    Interpreter skills use a `module` frontmatter field that is a Deep Agents extension, not part of the [Agent Skills specification](https://agentskills.io/specification).
+</Note>
 
-This lets you package domain-specific logic once and make it available as a deterministic building block inside the agent's workspace. Instead of asking the model to re-create a parser, scorer, normalizer, validator, or aggregation routine from scratch, the agent can import a tested helper and compose it with tools, subagents, and runtime state.
+Interpreter skills expose code modules to an [interpreter](/oss/deepagents/interpreters). Regular skills give the agent instructions and context. Interpreter skills also give the agent importable functions it can call from interpreter code.
+
+This lets you package domain-specific logic once and make it available as a deterministic building block. Instead of asking the model to re-create a parser, validator, or aggregation routine from scratch, the agent can import a tested helper and compose it with tools, subagents, and runtime state.
 
 Use interpreter skills for code that should be:
 
-- **Reusable** across prompts, agents, or projects.
-- **Deterministic** enough that you want the same behavior every time.
-- **Too detailed** to keep in the model context as instructions.
-- **Useful inside larger workflows**, such as scoring search results, normalizing API responses, validating records, grouping rows, or converting data into a report-ready shape.
+- **Reusable** across prompts, agents, or projects
+- **Deterministic** enough that you want the same behavior every time
+- **Too detailed** to keep in the model context as instructions
 
 To make a skill importable:
 
@@ -518,28 +543,6 @@ const { groupByStatus } = await import("@/skills/order-helpers");
 const grouped = groupByStatus(orders);
 grouped;
 ```
-
-### Execute skill scripts in a sandbox
-
-Skills can include scripts alongside the `SKILL.md` file, such as, for example, a Python file that performs a search or data transformation. The agent can _read_ these scripts from any backend, but to _execute_ them, the agent needs access to a shell — which only [sandbox backends](/oss/deepagents/sandboxes) provide.
-
-When you use a @[CompositeBackend] that routes skills to a @[StoreBackend] for persistence while using a sandbox as the default backend, skill files live in the store rather than in the sandbox is where code runs. For sandboxes to be able to use the scripts, you must use [custom middleware](/oss/langchain/middleware/custom) to upload skill scripts into the sandbox before the agent starts:
-
-:::python
-
-<SkillsSandboxPy />
-
-The middleware's `before_agent` hook runs before each agent invocation, reading skill files from that shared namespace and uploading them into the sandbox filesystem. Once synced, the agent can execute scripts with the `execute` tool just like any other file in the sandbox.
-
-:::
-
-:::js
-<SkillsSandboxJs />
-
-The middleware's `beforeAgent` hook runs before each agent invocation, reading skill files from that shared namespace and uploading them into the sandbox filesystem. Once synced, the agent can execute scripts with the `execute` tool just like any other file in the sandbox.
-:::
-
-For a more complete example that also syncs [memories](/oss/deepagents/memory) bidirectionally, see [syncing skills and memories with custom middleware](/oss/deepagents/going-to-production#example-syncing-skills-and-memories-with-custom-middleware).
 
 ## Read-only skills from a store
 

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -204,63 +204,9 @@ Instructions for the agent go here. See the [basic skill example](#basic-skill) 
     Refer to the full [Agent Skills specification](https://agentskills.io/specification) for detailed constraints and validation rules. In Deep Agents, `SKILL.md` files must be under 10 MB. Files exceeding this limit are skipped during skill loading.
 </Warning>
 
-## Write effective skills
-
-### Write specific descriptions
-
-During [discovery](#how-skills-work), the `description` field is the only information the agent sees for each skill. A good description tells the agent both what the skill does and when to activate it, with specific keywords the agent can match against:
-
-```yaml
-# Good: specific about what and when
-description: >-
-  Extract text and tables from PDF files, fill PDF forms, and merge
-  multiple PDFs. Use when working with PDF documents or when the user
-  mentions PDFs, forms, or document extraction.
-
-# Poor: too vague for reliable matching
-description: Helps with PDFs.
-```
-
-When you have multiple skills in related domains, differentiate their descriptions clearly. Overlapping descriptions cause the agent to activate the wrong skill or hesitate between options. If two skills serve similar purposes, consolidate them into one.
-
-### Keep instructions focused
-
-The Agent Skills specification recommends keeping your `SKILL.md` under 500 lines. When instructions grow longer, move detailed reference material into separate files and reference them from the main `SKILL.md`:
-
-```plaintext
-skills/
-└── data-pipeline/
-    ├── SKILL.md
-    └── references/
-        ├── schema-reference.md
-        └── error-codes.md
-```
-
-The agent loads reference files only when the instructions call for them, keeping each layer of progressive disclosure appropriately sized. Keep file references one level deep from `SKILL.md` and avoid deeply nested reference chains, which force the agent through multiple reads to reach the information it needs.
-
-### Structure instructions for the agent
-
-Write your `SKILL.md` body as clear instructions the agent can follow:
-
-- **Step-by-step procedures** for multi-step workflows
-- **Decision criteria** for choosing between approaches
-- **Examples of expected inputs and outputs** so the agent knows what success looks like
-- **Edge cases** the agent should handle or flag to the user
-
-### Manage skill count
-
-Fewer well-scoped skills outperform many overlapping ones. As the number of skills with similar descriptions grows, the agent's ability to select the right one degrades. If you find yourself with many related skills, consider:
-
-- Consolidating related capabilities into a single skill with sections for each sub-task
-- Using reference files to keep the main `SKILL.md` concise while covering multiple sub-tasks
-
-<Tip>
-    Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check that your `SKILL.md` frontmatter follows the Agent Skills specification naming and format conventions.
-</Tip>
-
 ## Usage
 
-Pass the skills directory when creating your deep agent:
+Pass a list of skill directory paths when creating your agent. The backend you choose determines how skill files are stored and loaded:
 
 :::python
 <SkillsUsageTabsPy />
@@ -318,7 +264,55 @@ Pass the skills directory when creating your deep agent:
     </Accordion>
 </Note>
 
-## Source precedence
+## Build effective skills
+
+### Write effective skills
+
+**Write specific descriptions.** During [discovery](#how-skills-work), the `description` field is the only information the agent sees for each skill. A good description tells the agent both what the skill does and when to activate it, with specific keywords the agent can match against:
+
+```yaml
+# Good: specific about what and when
+description: >-
+  Extract text and tables from PDF files, fill PDF forms, and merge
+  multiple PDFs. Use when working with PDF documents or when the user
+  mentions PDFs, forms, or document extraction.
+
+# Poor: too vague for reliable matching
+description: Helps with PDFs.
+```
+
+When you have multiple skills in related domains, differentiate their descriptions clearly. Overlapping descriptions cause the agent to activate the wrong skill or hesitate between options. If two skills serve similar purposes, consolidate them into one.
+
+**Keep instructions focused.** The Agent Skills specification recommends keeping your `SKILL.md` under 500 lines. When instructions grow longer, move detailed reference material into separate files and reference them from the main `SKILL.md`:
+
+```plaintext
+skills/
+└── data-pipeline/
+    ├── SKILL.md
+    └── references/
+        ├── schema-reference.md
+        └── error-codes.md
+```
+
+The agent loads reference files only when the instructions call for them, keeping each layer of progressive disclosure appropriately sized. Keep file references one level deep from `SKILL.md` and avoid deeply nested reference chains, which force the agent through multiple reads to reach the information it needs.
+
+**Structure instructions for the agent.** Write your `SKILL.md` body as clear instructions the agent can follow:
+
+- **Step-by-step procedures** for multi-step workflows
+- **Decision criteria** for choosing between approaches
+- **Examples of expected inputs and outputs** so the agent knows what success looks like
+- **Edge cases** the agent should handle or flag to the user
+
+**Manage skill count.** Fewer well-scoped skills outperform many overlapping ones. As the number of skills with similar descriptions grows, the agent's ability to select the right one degrades. If you find yourself with many related skills, consider:
+
+- Consolidating related capabilities into a single skill with sections for each sub-task
+- Using reference files to keep the main `SKILL.md` concise while covering multiple sub-tasks
+
+<Tip>
+    Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check that your `SKILL.md` frontmatter follows the Agent Skills specification naming and format conventions.
+</Tip>
+
+### Source precedence
 
 When multiple skill sources contain a skill with the same name, the skill from the source listed later in the `skills` array takes precedence (last one wins). This lets you layer skills from different origins.
 
@@ -345,7 +339,7 @@ const agent = await createDeepAgent({
 ```
 :::
 
-## Skills for subagents
+### Skills for subagents
 
 When you use [subagents](/oss/deepagents/subagents), you can configure which skills each type has access to:
 
@@ -398,10 +392,10 @@ For more information on subagent configuration and skills inheritance, see [Suba
 
 Skills support code execution in two ways:
 
-- [Execute skill scripts in a sandbox](#execute-skill-scripts-in-a-sandbox) when the agent needs to install dependencies, run tests, call CLIs, or work with an operating-system filesystem.
-- [Use interpreter skills](#use-interpreter-skills) when the agent needs reusable, importable helpers available from interpreter code.
+- [Sandbox scripts](#sandbox-scripts) when the agent needs to install dependencies, run tests, call CLIs, or work with an operating-system filesystem.
+- [Interpreter skills](#interpreter-skills) when the agent needs reusable, importable helpers available from interpreter code.
 
-### Execute skill scripts in a sandbox
+### Sandbox scripts
 
 Skills can include scripts alongside the `SKILL.md` file, such as a Python file that performs a search or data transformation. The agent can _read_ these scripts from any backend, but to _execute_ them, the agent needs access to a shell, which only [sandbox backends](/oss/deepagents/sandboxes) provide.
 
@@ -423,8 +417,7 @@ The middleware's `beforeAgent` hook runs before each agent invocation, reading s
 
 For a more complete example that also syncs [memories](/oss/deepagents/memory) bidirectionally, see [syncing skills and memories with custom middleware](/oss/deepagents/going-to-production#example-syncing-skills-and-memories-with-custom-middleware).
 
-### Use interpreter skills
-
+### Interpreter skills
 
 Interpreter skills expose code modules to an [interpreter](/oss/deepagents/interpreters). Regular skills give the agent instructions and context. Interpreter skills also give the agent importable functions it can call from interpreter code.
 
@@ -543,7 +536,29 @@ const grouped = groupByStatus(orders);
 grouped;
 ```
 
-## Read-only skills from a store
+## Skills, memory, and tools
+
+Skills, [memory](/oss/deepagents/memory) (`AGENTS.md` files), and tools all provide context or capabilities to the agent. The following table summarizes when to reach for each:
+
+| | Skills | Memory | Tools |
+|---|--------|--------|-------|
+| **Purpose** | On-demand capabilities discovered through progressive disclosure | Persistent context always loaded at startup | Programmatic actions the agent can call |
+| **Loading** | Read only when the agent determines relevance | Always injected into system prompt | Available every turn |
+| **Format** | `SKILL.md` in named directories | `AGENTS.md` files | Functions bound to the agent |
+| **Layering** | User, then project (last wins) | User, then project (combined) | Defined at agent creation |
+| **Use when** | Instructions are task-specific and potentially large | Context is always relevant (project conventions, preferences) | The agent needs a programmatic action, or does not have access to the file system |
+
+These are guidelines, not hard boundaries. In practice, skills and memory sit on a spectrum. An agent can update its own skills as it works, capturing new procedures and refining instructions over time. In this way, skills can function as a form of progressive-disclosure memory: context the agent builds up and retrieves on demand rather than loading on every prompt.
+
+## Skill permissions
+
+By default, agents can write to skill files if the backend permits it. Use these mechanisms to control that behavior:
+
+- **Read-only skills**: Use [filesystem permissions](/oss/deepagents/permissions) to deny write operations under skill paths.
+- **Scoped permissions**: Allow writes to user-scoped skill paths while keeping workspace or shared skills read-only, so agents can personalize their own skills without modifying shared ones.
+- **Human-in-the-loop**: Use [`interrupt_on`](/oss/deepagents/human-in-the-loop) to require approval before the agent executes write operations, adding a review step without fully blocking writes.
+
+### Read-only skills
 
 A common production pattern is to give agents access to a curated skills library without allowing them to change it. Route `/skills/` to a shared `StoreBackend`, pass that route in `skills`, and deny write operations under `/skills/**` with [filesystem permissions](/oss/deepagents/permissions). The agent can discover and read skills, while only your application code or an admin workflow updates the store.
 
@@ -562,28 +577,6 @@ A common production pattern is to give agents access to a curated skills library
 Seed the store under the same namespace with keys like `/company-policies/SKILL.md` and values that include `content` and `encoding` fields. The `/skills/` route prefix is stripped before records are read from the store.
 
 Use this for enterprise knowledge bases, approved tool instructions, or shared skill packs where the agent should benefit from centrally managed context but should not rewrite the source of truth. If you want agents to save their own learnings, route a separate path such as `/memories/` to another backend with write permissions enabled. See [Backends](/oss/deepagents/backends) for routing and store setup.
-
-## Skills, memory, and tools
-
-Skills, [memory](/oss/deepagents/memory) (`AGENTS.md` files), and tools all provide context or capabilities to the agent. The following table summarizes when to reach for each:
-
-| | Skills | Memory | Tools |
-|---|--------|--------|-------|
-| **Purpose** | On-demand capabilities discovered through progressive disclosure | Persistent context always loaded at startup | Programmatic actions the agent can call |
-| **Loading** | Read only when the agent determines relevance | Always injected into system prompt | Available every turn |
-| **Format** | `SKILL.md` in named directories | `AGENTS.md` files | Functions bound to the agent |
-| **Layering** | User, then project (last wins) | User, then project (combined) | Defined at agent creation |
-| **Use when** | Instructions are task-specific and potentially large | Context is always relevant (project conventions, preferences) | The agent needs a programmatic action, or does not have access to the file system |
-
-These are guidelines, not hard boundaries. In practice, skills and memory sit on a spectrum. An agent can update its own skills as it works, capturing new procedures and refining instructions over time. In this way, skills can function as a form of progressive-disclosure memory: context the agent builds up and retrieves on demand rather than loading on every prompt.
-
-### Control skill updates
-
-By default, agents can write to skill files if the backend permits it. Use these mechanisms to control that behavior:
-
-- **Read-only skills**: Use [filesystem permissions](/oss/deepagents/permissions) to deny write operations under skill paths. See [read-only skills from a store](#read-only-skills-from-a-store) for a production pattern.
-- **Scoped permissions**: Allow writes to user-scoped skill paths while keeping workspace or shared skills read-only, so agents can personalize their own skills without modifying shared ones.
-- **Human-in-the-loop**: Use [`interrupt_on`](/oss/deepagents/human-in-the-loop) to require approval before the agent executes write operations, adding a review step without fully blocking writes.
 
 <Tip>
 Trace how your agent discovers and executes skills with [LangSmith](https://smith.langchain.com). Follow the [observability quickstart](/langsmith/observability-quickstart) to get set up.


### PR DESCRIPTION
## Overview
Rewrites the main Deep Agents skills page to improve clarity for newcomers and better align with the Agent Skills specification. Also addresses PR feedback and adds new content for dynamic skills and sandbox seeding.

  - Rewrote the intro to clearly articulate the problem skills solve: agents lack context, system prompts waste tokens, manual guidance across sessions does not scale
  - Overhauled "How skills work" with concrete discovery/read/execute stages showing how SkillsMiddleware actually handles progressive disclosure
  - Restructured examples to start with a minimal skill before progressing to scripts and advanced frontmatter
  - Added a "Writing effective skills" best practices section covering descriptions, sizing, instruction structure, and skill count management
  - Combined "Skills vs. memory" and "When to use skills and tools" into a single "Skills, memory, and tools" section with a comparison table, the skills-as-memory concept, and skill permissions
  - Reordered code execution section to lead with sandbox scripts, and aligned interpreter skills with the spec by replacing module with metadata.entrypoint
  - Added "Dynamic skills per run" section showing how to use StoreBackend namespace factories to serve different skills per user
  - Expanded sandbox scripts section with full seeding and syncing lifecycle (middleware before_agent/after_agent hooks)
  - Reorganized page structure: Usage now includes getting started, source precedence, skills for subagents, and dynamic skills per run as subsections
  - Updated CLI memory-and-skills page to reflect the updated skills-as-memory framing

## Type of change

**Type:** Update existing documentation

## Checklist

<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
