### PR TITLE
docs: update Engine configuration guidance

### DIFF
--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -51,7 +51,7 @@ Organization Admins can set an org-wide monthly spend limit for the number of La
 
 To set a limit, open **Settings**, select **Engine enablement** under **Engine**, then enter a value under **Monthly LCU spend limit**. You can enter the limit in LCU or USD. The values stay in sync at a rate of 1 LCU = $1.50.
 
-Leave the limit blank to allow unlimited Engine spend. To stop Engine entirely, use the **Enable Engine** toggle above the spend limit setting.
+Leave the limit blank to allow unlimited Engine spend. To stop Engine entirely, use the **Enable Engine** toggle above the spend limit setting. Once Engine is running, you can see your monthly LCU spend on Engine per workspace on the Engine enablement page.
 
 ### Set up Engine for a tracing project
 
@@ -170,7 +170,6 @@ Within a tracing project, click the **Engine settings** gear icon on the **Engin
 
 - **Agent Overview**: Edit your agent overview document to keep LangSmith Engine's understanding of your project accurate as your application evolves.
 - **Priorities**: Areas the LangSmith Engine should pay extra attention to when scanning traces. Changes take effect on the next scan.
-- **Current month spend**: Total cost of LangSmith Engine runs for this project in the current calendar month. Organization Admins can see the current month's spend for each workspace from the Engine enablement settings page.
 - **Code repository**: Update the connected GitHub repository or subfolder.
 - **Webhooks**: Configure webhooks to be notified when new issues are found at different priority levels. See [Engine webhook events](/langsmith/engine-webhooks) for the event payload reference.
 - **Pause Engine**: The LangSmith Engine scans your traces every 6 hours by default. Click **Pause** to suspend scanning or **Resume** to resume scanning.

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -166,12 +166,12 @@ langsmith project issues list --project <project-name>
 LangSmith Engine uses **LangChain-managed inference** exclusively. Bring Your Own Key (BYOK) is not supported; you cannot supply your own provider API keys for Engine.
 </Note>
 
-Click the **Engine settings** gear icon on the **Engine** tab to open the **Edit Engine Settings** panel. From here you can configure:
+Within a tracing project, click the **Engine settings** gear icon on the **Engine** tab to open the **Edit Engine Settings** panel. From here you can configure:
 
 - **Agent Overview**: Edit your agent overview document to keep LangSmith Engine's understanding of your project accurate as your application evolves.
-- **Scan schedule**: The LangSmith Engine scans your traces every 6 hours by default. Click **Pause** to suspend scanning or **Resume** to resume scanning.
 - **Priorities**: Areas the LangSmith Engine should pay extra attention to when scanning traces. Changes take effect on the next scan.
 - **Current month spend**: Total cost of LangSmith Engine runs for this project in the current calendar month. Organization Admins can see the current month's spend for each workspace from the Engine enablement settings page.
 - **Code repository**: Update the connected GitHub repository or subfolder.
 - **Webhooks**: Configure webhooks to be notified when new issues are found at different priority levels. See [Engine webhook events](/langsmith/engine-webhooks) for the event payload reference.
+- **Pause Engine**: The LangSmith Engine scans your traces every 6 hours by default. Click **Pause** to suspend scanning or **Resume** to resume scanning.
 - **Delete all issues**: This action cannot be undone. All issues and settings will be permanently removed.

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -169,9 +169,9 @@ LangSmith Engine uses **LangChain-managed inference** exclusively. Bring Your Ow
 Click the **Engine settings** gear icon on the **Engine** tab to open the **Edit Engine Settings** panel. From here you can configure:
 
 - **Agent Overview**: Edit your agent overview document to keep LangSmith Engine's understanding of your project accurate as your application evolves.
-- **Scan schedule**: The LangSmith Engine scans your traces every 6 hours by default. Click **Edit** to change the frequency or **Pause** to suspend scanning or **Resume** to resume scanning.
+- **Scan schedule**: The LangSmith Engine scans your traces every 6 hours by default. Click **Pause** to suspend scanning or **Resume** to resume scanning.
 - **Priorities**: Areas the LangSmith Engine should pay extra attention to when scanning traces. Changes take effect on the next scan.
-- **Current month spend**: Total cost of LangSmith Engine runs for this project in the current calendar month.
+- **Current month spend**: Total cost of LangSmith Engine runs for this project in the current calendar month. Organization Admins can see the current month's spend for each workspace from the Engine enablement settings page.
 - **Code repository**: Update the connected GitHub repository or subfolder.
 - **Webhooks**: Configure webhooks to be notified when new issues are found at different priority levels. See [Engine webhook events](/langsmith/engine-webhooks) for the event payload reference.
 - **Delete all issues**: This action cannot be undone. All issues and settings will be permanently removed.


### PR DESCRIPTION
## Description
Updates the LangSmith Engine docs to move workspace spend visibility into monthly spend limit guidance and keep the tracing project settings list focused on available project controls.

## Release Note
Clarified where to view LangSmith Engine monthly LCU spend per workspace.

## Test Plan
- [x] Confirm the Configure the LangSmith Engine and monthly spend limit sections reflect the current UI.

_Opened collaboratively by Bagatur (@baskaryan) and open-swe._
