### PR TITLE
docs: Add Redis to Vector Store documentation

### DIFF
--- a/pipeline/preprocessors/link_map.py
+++ b/pipeline/preprocessors/link_map.py
@@ -200,6 +200,9 @@ LINK_MAPS: list[LinkMap] = [
             "ParallelEnrichment": "langchain-parallel/tasks/ParallelEnrichment",
             "ParallelMonitor": "langchain-parallel/monitors/ParallelMonitor",
             "SourcePolicy": "langchain-parallel/_types/SourcePolicy",
+            # langchain-redis
+            "langchain-redis": "langchain-redis/",
+            "RedisVectorStore": "langchain-redis/vectorstores/RedisVectorStore",
             # langchain-tavily
             "langchain-tavily": "langchain-tavily/",
             "TavilySearch": "langchain-tavily/tavily_search/TavilySearch",

--- a/src/oss/python/integrations/providers/redis.mdx
+++ b/src/oss/python/integrations/providers/redis.mdx
@@ -119,6 +119,16 @@ set_llm_cache(RedisSemanticCache(
 ))
 ```
 
+## Vector store
+
+Redis includes a vector store integration for low-latency retrieval, metadata filtering, MMR, and hybrid full-text and vector search.
+
+```python
+from langchain_redis import RedisVectorStore
+```
+
+For a detailed walkthrough, see the [Redis vector store integration guide](/oss/integrations/vectorstores/redis).
+
 ## Retriever
 
 The Redis vector store retriever wrapper generalizes the vectorstore class to perform

--- a/src/oss/python/integrations/vectorstores/index.mdx
+++ b/src/oss/python/integrations/vectorstores/index.mdx
@@ -716,6 +716,30 @@ vector_store = QdrantVectorStore(
 )
 ```
 </Accordion>
+<Accordion title="Redis">
+
+<CodeGroup>
+```bash pip
+pip install -qU langchain-redis
+```
+
+```bash uv
+uv add langchain-redis
+```
+</CodeGroup>
+```python
+import os
+from langchain_redis import RedisConfig, RedisVectorStore
+
+config = RedisConfig(
+    index_name="my_vectors",
+    redis_url=os.getenv("REDIS_URL", "redis://localhost:6379"),
+    distance_metric="COSINE"
+)
+
+vector_store = RedisVectorStore(embeddings=embeddings, config=config)
+```
+</Accordion>
 <Accordion title="Oracle AI Database">
 
 <CodeGroup>
@@ -812,6 +836,7 @@ vector_store = ValkeyVectorStore(
 | [`openGauss`](/oss/integrations/vectorstores/opengauss) | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ |
 | [`PineconeVectorStore`](/oss/integrations/vectorstores/pinecone) | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ❌ | ✅ |
 | [`QdrantVectorStore`](/oss/integrations/vectorstores/qdrant) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
+| [`RedisVectorStore`](/oss/integrations/vectorstores/redis) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
 | [`Weaviate`](/oss/integrations/vectorstores/weaviate) | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ |
 | [`SQLServer`](/oss/integrations/vectorstores/sqlserver) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
 | [`ValkeyVectorStore`](/oss/integrations/vectorstores/valkey) | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ |
@@ -858,6 +883,7 @@ vector_store = ValkeyVectorStore(
 <Card title="Pinecone" icon="link" href="/oss/integrations/vectorstores/pinecone" arrow="true" cta="View guide"/>
 <Card title="Pinecone (sparse)" icon="link" href="/oss/integrations/vectorstores/pinecone_sparse" arrow="true" cta="View guide"/>
 <Card title="Qdrant" icon="link" href="/oss/integrations/vectorstores/qdrant" arrow="true" cta="View guide"/>
+<Card title="Redis" icon="link" href="/oss/integrations/vectorstores/redis" arrow="true" cta="View guide"/>
 <Card title="SAP HANA Cloud Vector Engine" icon="link" href="/oss/integrations/vectorstores/sap_hanavector" arrow="true" cta="View guide"/>
 <Card title="SQLServer" icon="link" href="/oss/integrations/vectorstores/sqlserver" arrow="true" cta="View guide"/>
 <Card title="SurrealDB" icon="link" href="/oss/integrations/vectorstores/surrealdb" arrow="true" cta="View guide"/>

--- a/src/oss/python/integrations/vectorstores/redis.mdx
+++ b/src/oss/python/integrations/vectorstores/redis.mdx
@@ -1,0 +1,205 @@
+---
+title: "Redis integration"
+description: "Integrate with the Redis vector store using LangChain Python."
+---
+
+>[Redis](https://redis.io/docs/latest/) is an in-memory data platform with vector search, full-text search, and semantic caching capabilities, designed for real-time AI applications.
+
+This notebook shows how to use functionality related to the `RedisVectorStore`.
+
+## Setup
+
+To use the `RedisVectorStore` you first need to install the partner package, as well as the other packages used throughout this notebook.
+
+```python
+pip install -qU langchain-redis langchain-openai
+```
+
+You'll need a running Redis instance with Search & Query features enabled. You can start one locally with Docker:
+
+```bash
+docker run -d --name redis -p 6379:6379 -p 8001:8001 redis/redis-stack:latest
+```
+
+This also starts [RedisInsight](http://localhost:8001) — a browser-based GUI for inspecting your data and indexes.
+
+Or use [Redis Cloud](https://redis.io/cloud/) for a managed deployment.
+
+### Credentials
+
+Configure your Redis connection by setting the following environment variable:
+
+```bash
+export REDIS_URL="redis://localhost:6379"
+```
+
+For Redis with authentication:
+
+```bash
+export REDIS_URL="redis://username:password@localhost:6379"
+```
+
+For Redis Cloud, use the connection string from your database dashboard:
+
+```bash
+export REDIS_URL="redis://default:<password>@<host>:<port>"
+```
+
+This package also supports SSL/TLS (`rediss://`) and high-availability Redis Sentinel deployments (`redis+sentinel://`). See the [langchain-redis README](https://github.com/langchain-ai/langchain-redis/blob/main/libs/redis/README.md#redis-connection-options) for full connection options.
+
+Set your OpenAI API key:
+
+```bash
+export OPENAI_API_KEY="your-api-key-here"
+```
+
+<Tip>
+The `langchain-redis` package also provides `RedisChatMessageHistory` for conversation memory and `RedisSemanticCache` for LLM response caching — all backed by the same Redis instance as your vector store.
+</Tip>
+
+## Initialization
+
+```python
+import os
+from langchain_openai import OpenAIEmbeddings
+
+embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
+```
+
+```python
+from langchain_redis import RedisConfig, RedisVectorStore
+
+config = RedisConfig(
+    index_name="my_vectors",
+    redis_url=os.getenv("REDIS_URL", "redis://localhost:6379"),
+    distance_metric="COSINE",  # Options: COSINE, L2, IP
+    metadata_schema=[
+        {"name": "baz", "type": "tag"},
+        {"name": "foo", "type": "tag"},
+    ]
+)
+
+vector_store = RedisVectorStore(embeddings=embeddings, config=config)
+```
+
+<Note>
+The `metadata_schema` parameter tells Redis which metadata fields to index. Fields not listed here cannot be used in filters. Use `"tag"` for categorical string values and `"numeric"` for numbers.
+</Note>
+
+## Manage vector store
+
+### Add items to vector store
+
+```python
+texts = ["foo", "bar"]
+metadatas = [{"baz": "bar"}, {"foo": "baz"}]
+vector_store.add_texts(texts, metadatas=metadatas)
+```
+
+You can also add documents with custom keys:
+
+```python
+custom_keys = ["doc1", "doc2"]
+vector_store.add_texts(texts, metadatas=metadatas, keys=custom_keys)
+```
+
+Or use `add_documents` with LangChain `Document` objects:
+
+```python
+from langchain_core.documents import Document
+
+document_1 = Document(page_content="foo", metadata={"baz": "bar"})
+document_2 = Document(page_content="bar", metadata={"foo": "baz"})
+document_3 = Document(page_content="to be deleted")
+
+documents = [document_1, document_2, document_3]
+ids = ["1", "2", "3"]
+vector_store.add_documents(documents=documents, ids=ids)
+```
+
+### Delete items from vector store
+
+```python
+vector_store.delete(ids=["3"])
+```
+
+## Query vector store
+
+Once your vector store has been created and the relevant documents have been added you will most likely wish to query it during the running of your chain or agent.
+
+### Query directly
+
+Performing a simple similarity search can be done as follows:
+
+```python
+query = "foo"
+docs = vector_store.similarity_search(query, k=2)
+for doc in docs:
+    print(f"* {doc.page_content} [{doc.metadata}]")
+```
+
+#### Similarity search with score
+
+```python
+docs_and_scores = vector_store.similarity_search_with_score(query, k=2)
+for doc, score in docs_and_scores:
+    print(f"* [SIM={score:.3f}] {doc.page_content} [{doc.metadata}]")
+```
+
+#### Similarity search with filtering
+
+```python
+from redisvl.query.filter import Tag
+
+results = vector_store.similarity_search(
+    query="foo",
+    k=1,
+    filter=Tag("baz") == "bar"
+)
+for doc in results:
+    print(f"* {doc.page_content} [{doc.metadata}]")
+```
+
+#### Maximum marginal relevance search
+
+```python
+docs = vector_store.max_marginal_relevance_search(query, k=2, fetch_k=10)
+for doc in docs:
+    print(f"* {doc.page_content} [{doc.metadata}]")
+```
+
+#### Other search methods
+
+There are more search methods not listed in this notebook, to find all of them be sure to read the @[`API reference`][RedisVectorStore].
+
+<Tip>
+Redis supports hybrid search combining vector similarity with full-text search. See the @[`API reference`][RedisVectorStore] for `similarity_search` parameters including `return_all` and `distance_threshold`.
+</Tip>
+
+### Query by turning into retriever
+
+You can also transform the vector store into a retriever for easier usage in your chains.
+
+```python
+retriever = vector_store.as_retriever(
+    search_type="mmr",
+    search_kwargs={"k": 1, "fetch_k": 2, "lambda_mult": 0.5},
+)
+retriever.invoke("your query here")
+```
+
+## Usage for retrieval-augmented generation
+
+For guides on how to use this vector store for retrieval-augmented generation (RAG), see the following sections:
+
+- [Retrieval docs](/oss/langchain/retrieval)
+- [Build a RAG app with LangChain](/oss/langchain/rag)
+- [Agentic RAG](/oss/langgraph/agentic-rag)
+
+For a full RAG walkthrough using `langchain-redis`, see this [example notebook](https://github.com/redis-developer/redis-ai-resources/blob/main/python-recipes/RAG/02_langchain.ipynb)
+
+---
+
+## API reference
+
+For detailed documentation of `RedisVectorStore` features and configurations head to the @[`API reference`][RedisVectorStore].

--- a/src/oss/python/integrations/vectorstores/redis.mdx
+++ b/src/oss/python/integrations/vectorstores/redis.mdx
@@ -21,7 +21,7 @@ You'll need a running Redis instance with Search & Query features enabled. You c
 docker run -d --name redis -p 6379:6379 -p 8001:8001 redis/redis-stack:latest
 ```
 
-This also starts [RedisInsight](http://localhost:8001) — a browser-based GUI for inspecting your data and indexes.
+This also starts [RedisInsight](https://redis.io/insight/)— a browser-based GUI for inspecting your data and indexes.
 
 Or use [Redis Cloud](https://redis.io/cloud/) for a managed deployment.
 

--- a/src/oss/python/integrations/vectorstores/redis.mdx
+++ b/src/oss/python/integrations/vectorstores/redis.mdx
@@ -11,19 +11,23 @@ This notebook shows how to use functionality related to the `RedisVectorStore`.
 
 To use the `RedisVectorStore` you first need to install the partner package, as well as the other packages used throughout this notebook.
 
-```python
+```bash
 pip install -qU langchain-redis langchain-openai
 ```
 
-You'll need a running Redis instance with Search & Query features enabled. You can start one locally with Docker:
+You'll need a running Redis instance with Redis Search features enabled. We recommend Redis 8.4+. You can start one locally with Docker:
 
 ```bash
-docker run -d --name redis -p 6379:6379 -p 8001:8001 redis/redis-stack:latest
+docker run -d --name redis -p 6379:6379 redis:8.4
 ```
 
-This also starts [RedisInsight](https://redis.io/insight/)— a browser-based GUI for inspecting your data and indexes.
-
 Or use [Redis Cloud](https://redis.io/cloud/) for a managed deployment.
+
+(Optional) Download [RedisInsight](https://redis.io/insight/) — a browser-based GUI for inspecting your data and indexes.
+
+```bash
+docker run -d --name redisinsight -p 5540:5540 redis/redisinsight:latest
+```
 
 ### Credentials
 
@@ -54,7 +58,7 @@ export OPENAI_API_KEY="your-api-key-here"
 ```
 
 <Tip>
-The `langchain-redis` package also provides `RedisChatMessageHistory` for conversation memory and `RedisSemanticCache` for LLM response caching — all backed by the same Redis instance as your vector store.
+The `langchain-redis` package also provides `RedisChatMessageHistory` for conversation memory and `RedisSemanticCache` for LLM response caching — all backed by the same Redis instance as your vector store. See more [here](https://github.com/langchain-ai/langchain-redis/blob/main/libs/redis/README.md).
 </Tip>
 
 ## Initialization
@@ -196,7 +200,7 @@ For guides on how to use this vector store for retrieval-augmented generation (R
 - [Build a RAG app with LangChain](/oss/langchain/rag)
 - [Agentic RAG](/oss/langgraph/agentic-rag)
 
-For a full RAG walkthrough using `langchain-redis`, see this [example notebook](https://github.com/redis-developer/redis-ai-resources/blob/main/python-recipes/RAG/02_langchain.ipynb)
+For a full RAG walkthrough using `langchain-redis`, see this [example notebook](https://github.com/redis-developer/redis-ai-resources/blob/main/python-recipes/RAG/02_langchain.ipynb).
 
 ---
 

--- a/src/oss/python/integrations/vectorstores/redis.mdx
+++ b/src/oss/python/integrations/vectorstores/redis.mdx
@@ -58,7 +58,7 @@ export OPENAI_API_KEY="your-api-key-here"
 ```
 
 <Tip>
-The `langchain-redis` package also provides `RedisChatMessageHistory` for conversation memory and `RedisSemanticCache` for LLM response caching — all backed by the same Redis instance as your vector store. See more [here](https://github.com/langchain-ai/langchain-redis/blob/main/libs/redis/README.md).
+The [`langchain-redis`](https://github.com/langchain-ai/langchain-redis/blob/main/libs/redis/README.md) package also provides `RedisChatMessageHistory` for conversation memory and `RedisSemanticCache` for LLM response caching — all backed by the same Redis instance as your vector store.
 </Tip>
 
 ## Initialization


### PR DESCRIPTION
## Overview
Adds a new integration page for Redis (`langchain-redis`) to the vector store integrations section. This includes:
- New `redis.mdx` integration guide under `src/oss/python/integrations/vectorstores/`
- Redis added to the "Select vector store" accordion, capability table, and "All vector stores" card list in `index.mdx`
- `langchain-redis` and `RedisVectorStore` added to `pipeline/preprocessors/link_map.py` for autolink resolution


## Type of change

**Type:** New documentation page

## Related issues/PRs
- GitHub issue: Fixes #4226 .

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed


## Additional notes
`src/docs.json` has not been updated — leaving navigation placement to the maintainers' discretion.