### PR TITLE
docs: restore LangSmith N-2 support policy

### DIFF
--- a/src/langsmith/release-versions.mdx
+++ b/src/langsmith/release-versions.mdx
@@ -10,23 +10,23 @@ Self-hosted LangSmith ships on two release channels: a stable channel that custo
 
 ### Stable
 
-The current generally available major version. This is the channel we recommend for production. Stable receives weekly patch releases containing critical bug fixes and security patches only. No new features, data migrations, or infrastructure changes land on stable between major versions.
+The current generally available major version. LangSmith recommends this channel for production. Stable receives weekly patch releases containing critical bug fixes and security patches only. No new features, data migrations, or infrastructure changes land on stable between major versions.
 
 At any given time, the latest major version (N) is the preview channel and the previous major version (N-1) is stable.
 
 ### Preview
 
-The development build of the next major version. Preview includes new features and fixes as they merge into LangSmith SaaS, giving you an early look at what the next major version will contain. Preview builds may include data migrations, but never add or remove services or introduce breaking changes.
+The development build of the next major version. Preview includes new features and fixes as they merge into LangSmith SaaS, so you can evaluate the next major version before it becomes stable. Preview builds may include data migrations, but never add or remove services or introduce breaking changes.
 
-Preview is intended for evaluation in test and staging environments. We don't recommend running preview in production.
+Preview is intended for evaluation in test and staging environments. LangSmith does not recommend running preview in production.
 
 ## Release cadence
 
 | Channel | Cadence |
 |---------|---------|
 | Preview | Published mirroring the LangSmith SaaS release cadence |
-| Stable — new major (`v0.X.0`) | Approximately every 6 weeks (two per quarter) |
-| Stable — patch (`v0.X.Y`) | Weekly (typically Friday), skipped if no changes. Ad-hoc releases issued for critical customer issues. |
+| Stable: new major (`v0.X.0`) | Approximately every 6 weeks (two per quarter) |
+| Stable: patch (`v0.X.Y`) | Weekly (typically Friday), skipped if no changes. Ad-hoc releases issued for critical customer issues. |
 
 ## What ships in each channel
 
@@ -45,16 +45,24 @@ Service additions, service removals, and breaking changes only land in a new maj
 
 Self-hosted LangSmith uses the following scheme:
 
-- `v0.X.0` — Major version (stable GA release)
-- `v0.X.Y` — Stable patch release (critical fixes only)
-- `v0.X.0-rcN` — Preview build (release candidate) for the next major version, where `N` is an incrementing build number
+- `v0.X.0`: Major version (stable GA release)
+- `v0.X.Y`: Stable patch release (critical fixes only)
+- `v0.X.0-rcN`: Preview build (release candidate) for the next major version, where `N` is an incrementing build number
+
+## Version support
+
+LangSmith supports the current stable major version and the two previous stable major versions. When `N` represents the current stable major version:
+
+- `N` receives active support, including critical bug fixes, security patches, and new patch releases.
+- `N-1` and `N-2` receive critical support, including critical bug fixes and security patches.
+- Versions older than `N-2` are end of life and do not receive new patch releases, bug fixes, or security updates.
 
 ## Recommendations
 
 - **Run stable in production.** Preview is for evaluation only and may contain unreleased features still under validation.
 - **Use preview in test or staging.** Running preview in a non-production environment is the best way to catch issues early and prepare for the next major upgrade.
 - **Plan for major upgrades.** Data migrations, service additions or removals, and breaking changes only land in new major versions. Review the [self-hosted changelog](/langsmith/self-hosted-changelog) before upgrading and plan for any required data or infrastructure changes.
-- **Stay on a supported version.** We recommend upgrading to each new major version soon after it's released to pick up architectural improvements on our recommended cadence.
+- **Stay on a supported version.** LangSmith recommends upgrading to each new major version soon after it is released to pick up architectural improvements on the recommended cadence.
 
 ## Current version
 


### PR DESCRIPTION
## Description
Restore the LangSmith self-hosted release support policy so customers can see that the current stable major and two previous stable majors are supported.

## Release Note
Clarifies LangSmith self-hosted version support policy.

## Test Plan
- [ ] Confirm the release policy page clearly documents N-2 support.

Made by [Open SWE](https://openswe.vercel.app)