### PR TITLE
docs: correct Engine LCU name

### DIFF
--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -47,7 +47,7 @@ Once Engine is enabled, any team member in your organization can set it up for t
 
 ### Set a monthly spend limit
 
-Organization Admins can set an org-wide monthly spend limit for the number of LangChain Credit Units (LCUs) their organization can spend on Engine each month. When the organization reaches the monthly limit, LangSmith pauses new Engine runs until the limit is raised or the next monthly billing period begins.
+Organization Admins can set an org-wide monthly spend limit for the number of LangChain Compute Units (LCUs) their organization can spend on Engine each month. When the organization reaches the monthly limit, LangSmith pauses new Engine runs until the limit is raised or the next monthly billing period begins.
 
 To set a limit, open **Settings**, select **Engine enablement** under **Engine**, then enter a value under **Monthly LCU spend limit**. You can enter the limit in LCU or USD. The values stay in sync at a rate of 1 LCU = $1.50.
 


### PR DESCRIPTION
## Description
Corrects the Engine page to expand LCUs as LangChain Compute Units instead of LangChain Credit Units.

## Release Note
Corrected the LangSmith Engine LCU terminology.

## Test Plan
- [x] Confirm the Engine page uses LangChain Compute Units.

Made by [Open SWE](https://openswe.vercel.app)