### PR TITLE
fix(langsmith): indent self-hosted feedback

### DIFF
--- a/src/langsmith/agent-server-scale.mdx
+++ b/src/langsmith/agent-server-scale.mdx
@@ -99,7 +99,7 @@ queue:
 
 This will allow the API server to offload the queue management to the queue workers, significantly reducing the load on the API server and allowing it to focus on handling requests.
 
-#### Support a number of jobs equal to expected throughput
+##### Support a number of jobs equal to expected throughput
 
 The more runs you execute in parallel, the more jobs you will need to handle the load. There are two main parameters to scale the available jobs:
 


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

This section is a subsection of Self Hosted but currently sits a section above and so shows up in the side scroll bar. Indenting it so that doesn't happen.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
