### PR TITLE
docs: standardize Deep Agents beta labels

### DIFF
--- a/src/oss/deepagents/event-streaming.mdx
+++ b/src/oss/deepagents/event-streaming.mdx
@@ -1,6 +1,7 @@
 ---
 title: Event streaming
 description: Stream subagents, messages, tool calls, and final output from Deep Agents.
+tag: "Beta"
 ---
 
 This page covers streaming concerns specific to Deep Agents—most importantly, streaming from delegated subagents via `stream.subagents`. For general agent streaming (`stream.messages`, `stream.values`, tool calls, custom updates), see [LangChain Event Streaming](/oss/langchain/event-streaming).

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -1,7 +1,7 @@
 ---
 title: Interpreters
 description: Run lightweight code inside Deep Agents to compose tools, orchestrate subagents, and transform structured data
-tag: "Experimental"
+tag: "Beta"
 ---
 
 Interpreters give agents a programmable workspace where they can explore data, coordinate tool calls, and keep intermediate work out of the model context. The agent writes code to express its intent, then an **in-memory** runtime executes that code and returns the relevant results.
@@ -9,7 +9,7 @@ Interpreters give agents a programmable workspace where they can explore data, c
 Where [sandboxes](/oss/deepagents/sandboxes) are a code-first way for acting on an environment (such as running commands, installing dependencies, and editing files), interpreters are a code-first way for acting inside the agent loop: composing tools, preserving state, and deciding what information should return to the model.
 
 <Warning>
-    Interpreters are experimental. APIs and lifecycle behavior may change between releases.
+    Interpreters are in [**beta**](/oss/versioning). APIs and lifecycle behavior may change between releases.
 </Warning>
 
 :::python


### PR DESCRIPTION
## Description
Standardizes Deep Agents docs labels on beta by updating the Interpreters page and adding a beta tag to Event streaming.

## Self-Hosted Release Note
none

## Test Plan
- [x] Ran Vale prose lint on the changed Deep Agents docs pages.

Made by [Open SWE](https://openswe.vercel.app)