### PR TITLE
 docs: rework Deep Agents Code credentials, endpoints, and providers

### DIFF
--- a/pipeline/preprocessors/link_map.py
+++ b/pipeline/preprocessors/link_map.py
@@ -536,6 +536,9 @@ LINK_MAPS: list[LinkMap] = [
             "BaseChatModel.bindTools": "classes/_langchain_core.language_models_chat_models.BaseChatModel.html#bindTools",
             "BaseChatModel.with_structured_output": "classes/_langchain_core.language_models_chat_models.BaseChatModel.html#withStructuredOutput",
             "BaseChatModel.with_structured_output(include_raw)": "classes/_langchain_core.language_models_chat_models.BaseChatModel.html#withStructuredOutput",
+            # Deep Agents Code is Python-only; point its JS-scope build at the
+            # Python reference since there is no JS ModelProfile.
+            "ModelProfile": "https://reference.langchain.com/python/langchain-core/language_models/model_profile/ModelProfile",
             "BaseTool": "classes/_langchain_core.tools.StructuredTool.html",
             "ContentBlock": "langchain-core/messages/ContentBlock",
             "ChatOpenAI": "langchain-openai/ChatOpenAI",

--- a/pipeline/preprocessors/link_map.py
+++ b/pipeline/preprocessors/link_map.py
@@ -224,6 +224,7 @@ LINK_MAPS: list[LinkMap] = [
             "BaseChatModel.with_structured_output": "langchain-core/language_models/chat_models/BaseChatModel/with_structured_output",
             "BaseChatModel.with_structured_output(include_raw)": "langchain-core/language_models/chat_models/BaseChatModel/with_structured_output",
             "BaseChatModel.with_retry": "langchain_core/language_models/#langchain_core.language_models.BaseChatModel.with_retry",
+            "ModelProfile": "langchain-core/language_models/model_profile/ModelProfile",
             # ??
             "ChatPromptTemplate": "langchain-core/prompts/chat/ChatPromptTemplate",
             "GenericFakeChatModel": "langchain-core/language_models/fake_chat_models/GenericFakeChatModel",

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -434,7 +434,13 @@ With this config, switch to the model with `/model xyz:abc-xyz-1` or `--model xy
     Although optional, setting `max_input_tokens` to your model's context window is strongly encouraged. Without it, Deep Agents Code cannot show how full the context is, and auto-summarization falls back to a fixed trigger (around 170,000 tokens) instead of a fraction of your model's window. For a model with a smaller window, summarization may not run before you reach the model's hard limit, so requests start failing once the conversation grows.
 </Note>
 
-The provider package must be installed in the same Python environment as `deepagents-code`.
+Because Deep Agents Code imports the `class_path` class at startup, the package that defines it must be importable from the same environment that runs `dcode`. Built-in providers ship as [install extras](/oss/deepagents/code/providers#quickstart), but a custom or in-house package is not one. Install it into the `dcode` environment with the `--package` flag:
+
+```bash
+dcode --install my_package --package
+```
+
+In a session, run `/install my_package --package --force`. Both install the package alongside `dcode`. If the package is missing or cannot be imported, Deep Agents Code skips the provider and its models do not appear in `/model`.
 
 When you switch to `my_custom:my-model-v1` (via `/model` or `--model`), the model name (`my-model-v1`) is passed as the `model` kwarg:
 

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -21,7 +21,7 @@ Deep Agents Code stores its configuration in the `~/.deepagents/` directory. The
 
 ## Provider credentials
 
-Deep Agents Code needs an API key for each model provider you use. The recommended way to add one is the [`/auth`](#use-auth-recommended) credential manager. For non-interactive runs, set [environment variables](#environment-variables-ci-and-headless) instead.
+Deep Agents Code needs an API key for each model provider you use. The recommended way to add one is the [`/auth`](#use-%2Fauth-recommended) credential manager. For non-interactive runs, set [environment variables](#environment-variables-ci-and-headless) instead.
 
 If the same key is set in more than one place, see [Key resolution order](#key-resolution-order) for which one wins.
 

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -9,7 +9,7 @@ Deep Agents Code stores its configuration in the `~/.deepagents/` directory. The
 | File | Format | Purpose |
 |------|--------|---------|
 | `config.toml` | TOML | Model defaults, provider settings, constructor params, profile overrides, themes, update settings |
-| `.env` | Dotenv | Global API keys and secrets |
+| `.env` | Dotenv | Global API keys, secrets, and other environment variables |
 | `hooks.json` | JSON | External tool subscriptions to Deep Agents Code lifecycle events |
 | `.mcp.json` | JSON | Global MCP server definitions |
 
@@ -17,14 +17,13 @@ Deep Agents Code stores its configuration in the `~/.deepagents/` directory. The
     Files under `~/.deepagents/.state/` hold per-machine Deep Agents Code state and are managed automatically.
 </Note>
 
+---
+
 ## Provider credentials
 
-For every provider, Deep Agents Code checks two credential sources in order:
+Deep Agents Code needs an API key for each model provider you use. The recommended way to add one is the [`/auth`](#use-auth-recommended) credential manager. For non-interactive runs, set [environment variables](#environment-variables-ci-and-headless) instead.
 
-1. **Stored keys** — entered via `/auth` and persisted locally.
-2. **Environment variables** — `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, etc., plus the same names with a [`DEEPAGENTS_CODE_`](#deepagents_code_-prefix) prefix and any keys loaded from [`.env` files](#environment-variables).
-
-A stored key always wins over an env-var key for the same provider.
+If the same key is set in more than one place, see [Key resolution order](#key-resolution-order) for which one wins.
 
 ### Use `/auth` (recommended)
 
@@ -34,17 +33,23 @@ Open the credential manager from any session:
 /auth
 ```
 
-The manager lists every LLM provider Deep Agents Code knows about, marks the ones that already have a key, and lets you paste, rotate, or clear credentials inline. Each provider renders as one of:
+The manager lists the LLM providers available in your installation and marks the ones that already have a key set. Select a provider to add or replace its key, or remove one you have already stored. Keys you save here persist across sessions.
 
-| Label | Meaning |
-|-------|---------|
-| `✓ credentials set` | A stored or env-var key is available |
-| `! missing OPENAI_API_KEY` | The named env var is unset and no key is stored — pick the row to paste one |
-| `local provider` | No credentials needed (e.g., local Ollama) |
-| `implicit auth` | Credentials are implicit (e.g., Vertex AI Application Default Credentials) |
-| `custom auth` | A `class_path` provider managing its own auth (mTLS, JWT, custom headers) |
+<Accordion title="Provider row labels" icon="list-check">
+    Each row shows the provider name followed by where its key comes from:
 
-Press Enter on a row to paste a key, or use the row's delete affordance to clear an existing one. Saved keys are written atomically and persist across sessions and `/reload`.
+    | Label | Meaning |
+    |-------|---------|
+    | `[stored]` | A key saved in this manager via `/auth` |
+    | `[env: VARNAME]` | The key comes from environment variable `VARNAME` (the resolved name, such as `DEEPAGENTS_CODE_OPENAI_API_KEY` or `OPENAI_API_KEY`) |
+    | `[missing]` | No key is stored and the env var is unset; select the row to paste one |
+</Accordion>
+
+The `/auth` prompt also has an optional **base URL** field. Leave it blank to use the provider's default endpoint, or set a custom one to use with this key. The base URL is saved alongside the key. See [Endpoints, keys, and gateways](#endpoints-keys-and-gateways) for how endpoints resolve, including with gateways.
+
+<Warning>
+    A stored base URL is not a secret and may be logged; the key paired with it is never logged.
+</Warning>
 
 <Note>
     Keys are scoped to your user account on this machine — Deep Agents Code never transmits them anywhere except to the configured provider's API.
@@ -54,60 +59,41 @@ Press Enter on a row to paste a key, or use the row's delete affordance to clear
 
 ### Environment variables (CI and headless)
 
-For non-interactive runs, CI/CD pipelines, or anywhere a TUI isn't available, export the provider's env var or write it to `~/.deepagents/.env`:
+For non-interactive runs, CI/CD pipelines, or anywhere a TUI isn't available, export the provider's env var in your shell:
 
 ```bash
 export ANTHROPIC_API_KEY="sk-ant-..."
 export OPENAI_API_KEY="sk-..."
+
+# Prefix with DEEPAGENTS_CODE_ to scope a key to Deep Agents Code only,
+# leaving a shared key used by other CI steps untouched
+export DEEPAGENTS_CODE_OPENAI_API_KEY="sk-..."
 ```
 
-See [Environment variables](#environment-variables) below for loading order, the `DEEPAGENTS_CODE_` prefix, and per-project overrides.
+To keep keys in a file instead, define them in a [`.env` file](#environment-variables).
 
-## Environment variables
+### Key resolution order
 
-Deep Agents Code loads environment variables from dotenv files so you don't need to `export` API keys in your shell profile or duplicate `.env` files across projects.
+When a provider's key is set in more than one place, Deep Agents Code uses the first of these that is set:
 
-### Loading order and precedence
+1. **`DEEPAGENTS_CODE_`-prefixed env var** — for example `DEEPAGENTS_CODE_OPENAI_API_KEY` as an inline shell export. The [`DEEPAGENTS_CODE_` prefix](#deepagents_code_-prefix) is the explicit "use this key in Deep Agents Code" override.
+2. **App-stored key** — entered in the `/auth` credential manager.
+3. **Plain provider env var** — for example `OPENAI_API_KEY`, from your shell or `.env` files.
 
-Two `.env` files are loaded at startup:
-
-1. **Project `.env`** — the `.env` file in your current working directory (if present)
-2. **Global `~/.deepagents/.env`** — a single shared file that acts as a fallback for all projects
-
-The effective precedence is: **shell environment > project `.env` > global `.env`**. Values already set in the shell are never overwritten—including on `/reload`.
-
-### `DEEPAGENTS_CODE_` prefix
-
-All Deep Agents Code-specific environment variables use a `DEEPAGENTS_CODE_` prefix (e.g., `DEEPAGENTS_CODE_AUTO_UPDATE`, `DEEPAGENTS_CODE_DEBUG`). See the [environment variable reference](#environment-variable-reference) for the full list.
-
-The prefix also works as an override mechanism for any environment variable Deep Agents Code reads, including third-party credentials. Deep Agents Code checks `DEEPAGENTS_CODE_{NAME}` first, then falls back to `{NAME}`:
-
-```bash title="~/.deepagents/.env"
-# Override OPENAI_API_KEY only for Deep Agents Code, without affecting other tools
-DEEPAGENTS_CODE_OPENAI_API_KEY=sk-cli-only
-
-# Block a shell-exported key within Deep Agents Code by setting the prefixed var to empty
-DEEPAGENTS_CODE_ANTHROPIC_API_KEY=
-```
-
-On `/reload`, Deep Agents Code re-reads `.env` files and picks up prefixed values, so you can rotate keys without restarting.
-
-### Example
-
-Store API keys once in `~/.deepagents/.env`:
+An app-stored key wins over a plain env-var key for the same provider, but a `DEEPAGENTS_CODE_`-prefixed key wins over an app-stored key. The prefix is the way to override an already-stored key for a single run, without clearing it:
 
 ```bash
-ANTHROPIC_API_KEY=sk-ant-...
-OPENAI_API_KEY=sk-...
-LANGSMITH_API_KEY=lsv2_...
-TAVILY_API_KEY=tvly-...
+# With a key already stored via /auth, a plain env var does not override it.
+# dcode still uses the app-stored key for this run:
+OPENAI_API_KEY=sk-xxxx dcode -n "..."
 
-# If OPENAI_API_KEY is already exported in your shell for other tools,
-# use the prefix to give Deep Agents Code its own key without conflict
-DEEPAGENTS_CODE_OPENAI_API_KEY=sk-cli-only-...
+# The DEEPAGENTS_CODE_ prefix does override it, for this run only:
+DEEPAGENTS_CODE_OPENAI_API_KEY=sk-xxxx dcode -n "..."
 ```
 
-Then override per-project where needed by placing a `.env` in the project directory.
+This layering exists for the common case where your machine already exports a plain provider variable for some other purpose — a shared `OPENAI_API_KEY` used by other tools, scripts, or CI — that you do not want Deep Agents Code to reuse. An app-stored key or a `DEEPAGENTS_CODE_`-prefixed variable gives Deep Agents Code its own value while leaving the unprefixed one untouched for everything else, so the two never mix.
+
+Each provider's API key and its endpoint (`base_url`) resolve as a pair from the same source. See [Endpoints, keys, and gateways](#endpoints-keys-and-gateways).
 
 ### Enable web search with Tavily
 
@@ -141,9 +127,43 @@ The built-in `web_search` tool uses [Tavily](https://tavily.com). Deep Agents Co
 
 ---
 
+## Environment variables
+
+In addition to shell exports, Deep Agents Code reads environment variables from dotenv files, so you can keep API keys out of your shell profile and avoid duplicating `.env` files across projects.
+
+```bash title="~/.deepagents/.env"
+ANTHROPIC_API_KEY=sk-ant-...
+OPENAI_API_KEY=sk-...
+```
+
+### Loading order and precedence
+
+At startup, Deep Agents Code reads the nearest project `.env`, found by searching the directory you launch from and walking up through its parents (the first `.env` found wins), then `~/.deepagents/.env` as a global fallback for all projects. A project `.env` wins over the global one, and neither overrides a value already set in your shell. Running `/reload` re-reads both `.env` files so you can change keys without restarting, with shell values still taking precedence. This applies to every variable Deep Agents Code reads (for example, `TAVILY_API_KEY` or the `DEEPAGENTS_CODE_*` settings). Provider API keys have additional resolution rules; see [Provider credentials](#provider-credentials).
+
+### `DEEPAGENTS_CODE_` prefix
+
+All Deep Agents Code-specific environment variables use a `DEEPAGENTS_CODE_` prefix (e.g., `DEEPAGENTS_CODE_AUTO_UPDATE`, `DEEPAGENTS_CODE_DEBUG`). See the [environment variable reference](#environment-variable-reference) for the full list.
+
+The prefix also works as an override mechanism for any environment variable Deep Agents Code reads, including third-party credentials. Deep Agents Code checks `DEEPAGENTS_CODE_{NAME}` first, then falls back to `{NAME}`:
+
+```bash title="~/.deepagents/.env"
+# Give Deep Agents Code its own value, without affecting other tools
+DEEPAGENTS_CODE_OPENAI_API_KEY=sk-cli-only
+
+# Or set it empty so Deep Agents Code ignores a key exported in your shell
+DEEPAGENTS_CODE_ANTHROPIC_API_KEY=
+```
+
+---
+
 ## Config file
 
-`~/.deepagents/config.toml` lets you customize model providers, set defaults, and pass extra parameters to model constructors.
+`~/.deepagents/config.toml` lets you customize model providers, set defaults, and pass extra parameters to model constructors. This section covers:
+
+- **Defaults**: pin a [default model](#default-and-recent-model) or [agent](#default-and-recent-agent).
+- **Provider setup**: the [`[models.providers.<name>]` table](#provider-configuration), [constructor params](#model-constructor-params), [profile overrides](#profile-overrides-advanced), and [adding models to the `/model` switcher](#adding-models-to-the-interactive-switcher).
+- **Custom endpoints and providers**: [custom base URLs](#custom-base-url), [OpenAI- or Anthropic-compatible APIs](#compatible-apis), and [arbitrary providers](#arbitrary-providers).
+- **Endpoints and gateways**: how [API keys and base URLs resolve together](#endpoints-keys-and-gateways), including through a managed gateway.
 
 ### Default and recent model
 
@@ -190,19 +210,35 @@ temperature = 0.7
 Providers have the following configuration options:
 
 <ResponseField name="models" type="string[]" post={["optional"]}>
-    A list of model names to show in the interactive `/model` switcher for this provider. For providers that already ship with model profiles, any names you add here appear alongside the bundled ones, useful for newly released models that haven't been added to the package yet. For [arbitrary providers](#arbitrary-providers), this list is the only source of models in the switcher.
+    A list of model names to show in the interactive `/model` switcher for the provider defined as `<name>`. For providers that already ship with model profiles, any names you add here appear in addition to bundled ones (useful for newly released models that haven't been added to the package yet). For [arbitrary providers](#arbitrary-providers), this list is the only source of models in the switcher.
 
-    Models listed here **bypass** the profile-based [filtering criteria](/oss/deepagents/code/providers#which-models-appear-in-the-switcher) and always appear in the switcher. This makes it the recommended way to surface models that are excluded because their profile lacks `tool_calling` support or doesn't exist yet.
+    Models listed here **bypass** any applied profile-based [filtering criteria](/oss/deepagents/code/providers#which-models-appear-in-the-switcher), always appearing in the switcher. This makes it the recommended way to surface models that are excluded because their profile lacks `tool_calling` support or doesn't exist yet.
 
     This key is optional. You can always pass any model name directly to `/model` or `--model` regardless of whether it appears in the switcher; the provider validates the name at request time.
 </ResponseField>
 
 <ResponseField name="api_key_env" type="string" post={["optional"]}>
-    The **name** of the environment variable that holds the API key (e.g., `"OPENAI_API_KEY"`), not the key itself. Deep Agents Code reads the credential from this env var at startup to verify access before creating the model. Most chat model packages read from a default env var automatically. See the [Provider reference](/oss/deepagents/code/providers#provider-reference) table for which variable each provider checks.
+    The **name** of the environment variable that holds the API key (e.g., `"OPENAI_API_KEY"`). Deep Agents Code reads the credential from this env var at startup to verify access before creating the model.
+
+    Most chat model packages read from a default env var automatically. See the [Provider reference](/oss/deepagents/code/providers#provider-reference) table for which variable name each built-in provider checks. For a provider not in that table, set `api_key_env` to its variable name (see [Arbitrary providers](#arbitrary-providers)).
 </ResponseField>
 
 <ResponseField name="base_url" type="string" post={["optional"]}>
     Override the base URL used by the provider, if supported. Refer to your provider packages' [reference docs](https://reference.langchain.com/python/integrations/) for more info.
+
+    See [Compatible APIs](#compatible-apis) for pointing a built-in provider at a wire-compatible endpoint, or [Arbitrary providers](#arbitrary-providers) for one configured via `class_path`.
+</ResponseField>
+
+<ResponseField name="base_url_env" type="string" post={["optional"]}>
+    Name of the environment variable that holds this provider's base URL, parallel to `api_key_env`. Reach for this instead of `base_url` when the endpoint comes from the environment rather than a fixed value — for example a gateway URL that differs by machine or CI job — so it can change without editing `config.toml` and can take part in endpoint resolution and key/endpoint pairing (see [Endpoints, keys, and gateways](#endpoints-keys-and-gateways)). It also extends those to providers outside the [built-in set](/oss/deepagents/code/providers#provider-reference); see [Arbitrary providers](#arbitrary-providers).
+
+    If both are set, the static `base_url` wins:
+
+    ```toml
+    [models.providers.example]
+    base_url = "https://fixed.example/v1"   # used
+    base_url_env = "EXAMPLE_BASE_URL"        # ignored while base_url is set
+    ```
 </ResponseField>
 
 <ResponseField name="params" type="object" post={["optional"]}>
@@ -212,7 +248,7 @@ Providers have the following configuration options:
 </ResponseField>
 
 <ResponseField name="profile" type="object" post={["optional"]}>
-    (Advanced) Override fields in the model's runtime [profile](/oss/langchain/models#model-profiles) (e.g., `max_input_tokens`). Flat keys apply to every model from this provider. Model-keyed sub-tables (e.g., `[profile."claude-sonnet-4-5"]`) override individual values for that model only; the merge is shallow (model wins on conflict). These overrides are applied after the model is created, so they take effect for context-limit display, auto-summarization, and any other feature that reads the profile.
+    (Advanced) Override fields in the model's runtime [profile](/oss/langchain/models#model-profiles) (e.g., `max_input_tokens`). Flat keys apply to every model from this provider. Model-keyed sub-tables (e.g., `[profile."claude-sonnet-4-5"]`) override individual values for that model only; the merge is shallow (model wins on conflict). These overrides are applied after the model is created, so they take effect for context-limit display, auto-summarization, and any other feature that reads the profile. See [Profile overrides](#profile-overrides-advanced) for examples and the `--profile-override` flag.
 </ResponseField>
 
 <ResponseField name="class_path" type="string" post={["optional"]}>
@@ -220,22 +256,12 @@ Providers have the following configuration options:
 </ResponseField>
 
 <ResponseField name="enabled" type="boolean" default="true" post={["optional"]}>
-    Whether this provider appears in the `/model` selector. Set to `false` to hide a provider that was auto-discovered from an installed package (e.g., a transitive dependency you don't want cluttering the switcher). You can still use a disabled provider directly via `/model provider:model` or `--model`.
+    Whether this provider appears in the `/model` selector. Set to `false` to hide a provider that was auto-discovered from an installed package (e.g., a transitive dependency you don't want cluttering the model switcher). You can still use a disabled provider directly via `/model provider:model` or `--model`.
 </ResponseField>
 
 ### Model constructor params
 
-Any provider can use the `params` table to pass extra arguments to the model constructor:
-
-```toml
-[models.providers.ollama.params]
-temperature = 0
-num_ctx = 8192
-```
-
-#### Per-model overrides
-
-If a specific model needs different params, add a model-keyed sub-table under `params` to override individual values without duplicating the entire provider config:
+The [`params` field](#provider-configuration) forwards extra arguments to the model constructor. To give one model different values, add a model-keyed sub-table so you do not have to duplicate the whole provider config:
 
 ```toml
 [models.providers.ollama]
@@ -263,7 +289,7 @@ The merge is shallow: any key present in the model sub-table replaces the same k
 
 ### Profile overrides (Advanced)
 
-Override fields in the model's runtime profile to change how Deep Agents Code interprets model capabilities. The most common use case is lowering `max_input_tokens` to trigger auto-summarization earlier — useful for testing or for constraining context usage:
+Override fields in the model's runtime profile to change how Deep Agents Code interprets model capabilities. See @[`ModelProfile`] for the full list of overridable fields. The most common use case is lowering `max_input_tokens` to trigger auto-summarization earlier — useful for testing or for constraining context usage:
 
 ```toml
 # Apply to all models from this provider
@@ -284,23 +310,44 @@ max_input_tokens = 8192
 
 Profile overrides are merged into the model's profile after creation. Any feature that reads the profile — context-limit display in the status bar, auto-summarization thresholds, capability checks — will see the overridden values.
 
-#### CLI profile overrides with `--profile-override` (Advanced)
+<Accordion title="CLI profile overrides with --profile-override" icon="terminal">
+    To override model profile fields at runtime without editing the config file, pass a JSON object via `--profile-override`:
 
-To override model profile fields at runtime without editing the config file, pass a JSON object via `--profile-override`:
+    ```bash
+    dcode --profile-override '{"max_input_tokens": 4096}'
 
-```bash
-dcode --profile-override '{"max_input_tokens": 4096}'
+    # Combine with --model
+    dcode --model google_genai:gemini-3.5-flash --profile-override '{"max_input_tokens": 4096}'
 
-# Combine with --model
-dcode --model google_genai:gemini-3.5-flash --profile-override '{"max_input_tokens": 4096}'
+    # In non-interactive mode
+    dcode -n "Summarize this repo" --profile-override '{"max_input_tokens": 4096}'
+    ```
 
-# In non-interactive mode
-dcode -n "Summarize this repo" --profile-override '{"max_input_tokens": 4096}'
+    These are merged on top of config file profile overrides (CLI wins). The priority chain is: model default &lt; config.toml profile &lt; CLI `--profile-override`.
+
+    `--profile-override` values persist across mid-session `/model` hot-swaps — switching models re-applies the override to the new model.
+</Accordion>
+
+### Adding models to the interactive switcher
+
+Some providers (e.g. `langchain-ollama`) don't bundle model profile data (see [Provider reference](/oss/deepagents/code/providers#provider-reference) for full listing). When this is the case, the interactive `/model` switcher won't list models for that provider. You can fill in the gap by defining a `models` list in your config file for the provider:
+
+```toml
+[models.providers.ollama]
+models = ["gemma4", "qwen3.6", "granite4.1:3b"]
 ```
 
-These are merged on top of config file profile overrides (CLI wins). The priority chain is: model default &lt; config.toml profile &lt; CLI `--profile-override`.
+The `/model` switcher will now include an Ollama section with these models listed.
 
-`--profile-override` values persist across mid-session `/model` hot-swaps — switching models re-applies the override to the new model.
+This is entirely optional. You can always switch to any model by specifying its full name directly:
+
+```txt
+/model ollama:qwen3.6:27b
+```
+
+<Note>
+    When `langchain-ollama` is installed and the daemon is reachable, Deep Agents Code auto-discovers locally pulled models and merges them into the switcher—no `models` list required. Run `/reload` to refresh after pulling new models, or set `DEEPAGENTS_CODE_OLLAMA_DISCOVERY=0` to opt out.
+</Note>
 
 ### Custom base URL
 
@@ -344,30 +391,9 @@ models = ["my-model"]
     ```
 </Warning>
 
-### Adding models to the interactive switcher
-
-Some providers (e.g. `langchain-ollama`) don't bundle model profile data (see [Provider reference](/oss/deepagents/code/providers#provider-reference) for full listing). When this is the case, the interactive `/model` switcher won't list models for that provider. You can fill in the gap by defining a `models` list in your config file for the provider:
-
-```toml
-[models.providers.ollama]
-models = ["llama3", "mistral", "codellama"]
-```
-
-The `/model` switcher will now include an Ollama section with these models listed.
-
-This is entirely optional. You can always switch to any model by specifying its full name directly:
-
-```txt
-/model ollama:llama3
-```
-
-<Note>
-    When `langchain-ollama` is installed and the daemon is reachable, Deep Agents Code auto-discovers locally pulled models and merges them into the switcher—no `models` list required. Run `/reload` to refresh after pulling new models, or set `DEEPAGENTS_CODE_OLLAMA_DISCOVERY=0` to opt out.
-</Note>
-
 ### Arbitrary providers
 
-You can use any [LangChain `BaseChatModel`](https://reference.langchain.com/python/langchain_core/language_models/#langchain_core.language_models.BaseChatModel) subclass using `class_path`. Deep Agents Code imports and instantiates the class directly — no built-in provider package required.
+Deep Agents Code works with any tool calling LLM available as a [LangChain `BaseChatModel`](https://reference.langchain.com/python/langchain_core/language_models/#langchain_core.language_models.BaseChatModel). The [built-in providers](/oss/deepagents/code/providers#provider-reference) work out of the box; a less common or in-house model takes a little more setup. Point `class_path` at its `BaseChatModel` subclass and Deep Agents Code imports and instantiates the class directly.
 
 ```toml
 [models.providers.my_custom]
@@ -380,7 +406,9 @@ temperature = 0
 max_tokens = 4096
 ```
 
-`api_key_env` and `base_url` are optional. `class_path` providers are expected to handle their own authentication internally — useful when your model uses custom auth (JWT tokens, proprietary headers, mTLS, etc.) rather than a standard API key:
+`api_key_env` and `base_url` are optional. To read the endpoint from an environment variable instead of hardcoding `base_url`, use [`base_url_env`](#provider-configuration); it then resolves and pairs with the key the same way as for the built-in providers (see [Endpoints, keys, and gateways](#endpoints-keys-and-gateways)).
+
+`class_path` providers are expected to handle their own authentication internally — useful when your model uses custom auth (JWT tokens, proprietary headers, mTLS, etc.) rather than a standard API key:
 
 ```toml
 [models.providers.xyz]
@@ -403,15 +431,10 @@ With this config, switch to the model with `/model xyz:abc-xyz-1` or `--model xy
     max_input_tokens = 128000
     ```
 
-    Set `max_input_tokens` to what your model supports to enable accurate context length tracking and auto-summarization.
+    Although optional, setting `max_input_tokens` to your model's context window is strongly encouraged. Without it, Deep Agents Code cannot show how full the context is, and auto-summarization falls back to a fixed trigger (around 170,000 tokens) instead of a fraction of your model's window. For a model with a smaller window, summarization may not run before you reach the model's hard limit, so requests start failing once the conversation grows.
 </Note>
 
-The provider package must be installed in the same Python environment as `deepagents-code`:
-
-```bash
-# If deepagents-code was installed with uv tool:
-uv tool install deepagents-code --with my_package
-```
+The provider package must be installed in the same Python environment as `deepagents-code`.
 
 When you switch to `my_custom:my-model-v1` (via `/model` or `--model`), the model name (`my-model-v1`) is passed as the `model` kwarg:
 
@@ -425,9 +448,59 @@ MyChatModel(model="my-model-v1", base_url="...", api_key="...", temperature=0, m
 
 Your provider package may optionally provide model profiles at a `_PROFILES` dict in `<package>.data._profiles` in lieu of defining them under the `models` key. See LangChain [model profiles](https://github.com/langchain-ai/langchain/tree/master/libs/model-profiles) for more info.
 
+### Endpoints, keys, and gateways
+
+An API key and the endpoint it is sent to have to match: the endpoint has to accept that key, or the request will likely fail. Deep Agents Code resolves the key and endpoint together, so overriding one updates the other to match. For example, if you replace a gateway-provisioned key with your own, Deep Agents Code also drops the gateway endpoint, so your key goes to the provider directly instead of to a gateway that would reject it.
+
+#### How `base_url` resolves
+
+Deep Agents Code resolves a provider's endpoint in this order (first match wins):
+
+1. **`base_url` in `config.toml`** for the provider.
+2. **The `DEEPAGENTS_CODE_`-prefixed endpoint variable.**
+3. **The plain endpoint variable** in the environment (for example, `OPENAI_BASE_URL`).
+4. **The endpoint saved with a `/auth` credential.** This step applies the saved endpoint for a provider that has no endpoint variable—such as a provider you add without declaring [`base_url_env`](#provider-configuration). Steps 2-3 have no variable to read for these, so the saved endpoint is used directly here. For a provider that does have an endpoint variable, the saved endpoint already took effect at step 2 or 3 (it is written to that variable), so this step changes nothing. Either way, an endpoint entered in `/auth` applies.
+5. **The provider SDK's own default endpoint**, when none of the above is set.
+
+<Note>
+    Resolved endpoints are delivered to the model as the `base_url` constructor argument.
+</Note>
+
+As with API keys, the [`DEEPAGENTS_CODE_` prefix](#deepagents_code_-prefix) scopes the endpoint to Deep Agents Code without affecting other tools. For any other provider, declare the name with [`base_url_env`](#provider-configuration) and the endpoint resolves and pairs the same way:
+
+```toml
+[models.providers.myprovider]
+api_key_env = "MYPROVIDER_API_KEY"
+base_url_env = "MYPROVIDER_BASE_URL"
+models = ["my-model"]
+```
+
+A literal `base_url` wins over `base_url_env`, so set only the one you need:
+
+```toml
+[models.providers.myprovider]
+base_url = "https://fixed.example/v1"   # used
+base_url_env = "MYPROVIDER_BASE_URL"    # ignored while base_url is set
+```
+
+#### Overrides keep the pair together
+
+When you store a key with `/auth`, the endpoint you enter (or the provider's default, if left blank) is applied together with the key. Storing a key with a blank base URL also clears any endpoint already set in your environment (for example, a gateway `OPENAI_BASE_URL` your shell exports), so your key goes to the provider's default endpoint instead of to that gateway.
+
+```bash title="Scope both the key and the endpoint to Deep Agents Code"
+DEEPAGENTS_CODE_OPENAI_API_KEY=sk-cli-only
+DEEPAGENTS_CODE_OPENAI_BASE_URL=https://api.openai.com/v1
+```
+
+#### Managed gateways
+
+On a machine provisioned with a model gateway (for example, the LangSmith gateway), the gateway typically exports a gateway key and the matching endpoint variable (`OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL`, or `GOOGLE_GEMINI_BASE_URL`) together. Deep Agents Code uses that pair by default, so no configuration is needed.
+
+To use your own key instead, store it with `/auth` (leave the base URL blank for the provider default, or set it explicitly), or set the `DEEPAGENTS_CODE_` prefixed key and endpoint. Both override the gateway pair without leaving a mismatched endpoint behind.
+
 ---
 
-## Skills extra allowed directories
+## Skill directory allowlist
 
 By default, when Deep Agents Code loads skills it validates that a resolved skill file path stays inside one of the standard [skill directories](/oss/deepagents/code/data-locations#skills). This prevents symlinks inside skill directories from reading arbitrary files outside those roots.
 
@@ -602,6 +675,8 @@ Non-root installs are unaffected: all root-specific code paths short-circuit whe
 
 To pre-configure auto-update for managed installs, set `DEEPAGENTS_CODE_AUTO_UPDATE=1` in the user's shell profile or deploy a `config.toml` with `[update] auto_update = true` to `~/.deepagents/config.toml`. To suppress automatic updates and update checks entirely, set `DEEPAGENTS_CODE_NO_UPDATE_CHECK=1`.
 
+To route every user's model traffic through a managed gateway (provisioning a gateway key and base URL fleet-wide), see [Managed gateways](#managed-gateways).
+
 ---
 
 ## Environment variable reference
@@ -621,7 +696,7 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_EXTRA_SKILLS_DIRS" type="string" post={["optional"]}>
-    Colon-separated paths added to the [skill containment allowlist](#skills-extra-allowed-directories).
+    Colon-separated paths added to the [skill containment allowlist](#skill-directory-allowlist).
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_LANGSMITH_PROJECT" type="string" post={["optional"]}>

--- a/src/oss/deepagents/code/data-locations.mdx
+++ b/src/oss/deepagents/code/data-locations.mdx
@@ -75,7 +75,7 @@ Precedence order (lowest to highest):
 3. `.deepagents/skills/` — Project Deep Agents Code
 4. `.agents/skills/` — Project tool-agnostic *(highest)*
 
-When a skill is loaded, Deep Agents Code verifies that the resolved file path stays within one of these directories. Symlinks that resolve outside all skill roots are rejected. To allow symlink targets in additional directories, see [`[skills].extra_allowed_dirs`](/oss/deepagents/code/configuration#skills-extra-allowed-directories).
+When a skill is loaded, Deep Agents Code verifies that the resolved file path stays within one of these directories. Symlinks that resolve outside all skill roots are rejected. To allow symlink targets in additional directories, see [`[skills].extra_allowed_dirs`](/oss/deepagents/code/configuration#skill-directory-allowlist).
 
 ### Subagents
 

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -11,73 +11,35 @@ Deep Agents Code integrates automatically with the [following model providers](#
 
 1. **Install provider packages**
 
-    Each model provider requires installing its corresponding LangChain integration package. These are available as optional extras when installing Deep Agents Code, done intentionally to keep the application lightweight:
+    Each model provider requires its corresponding LangChain integration package. These ship as optional extras to keep the application lightweight. OpenAI, Anthropic, and Gemini are included by default. Install any other extra from within a session with `/install`, or from the shell with `dcode --install`:
+
+    <CodeGroup>
+        ```txt In session
+        /install groq
+        ```
+
+        ```bash Shell
+        dcode --install groq
+        ```
+    </CodeGroup>
+
+    Run `/install` with no argument to list the valid extras. To preinstall extras during the initial CLI install, set `DEEPAGENTS_CODE_EXTRAS`:
 
     ```bash
-    # Quick install with chosen providers
-    # OpenAI, Anthropic, and Gemini are included by default
     DEEPAGENTS_CODE_EXTRAS="baseten,groq" curl -LsSf https://langch.in/dcode | bash
-
-    # Or install directly with uv
-    uv tool install 'deepagents-code[baseten,groq]'
-
-    # Add additional packages at a later date
-    uv tool install deepagents-code --with langchain-ollama
-
-    # All providers
-    uv tool install 'deepagents-code[anthropic,baseten,bedrock,cohere,deepseek,fireworks,google-genai,groq,huggingface,ibm,litellm,mistralai,nvidia,ollama,openai,openrouter,perplexity,vertex,xai]'
     ```
 
 2. **Set credentials**
 
-    Store API keys in `~/.deepagents/.env` so they're available across all projects, or export them in your shell:
+    Add an API key for your provider with the [`/auth`](/oss/deepagents/code/configuration#use-auth-recommended) credential manager:
 
-    <Tabs>
-        <Tab title="OpenAI">
-            <CodeGroup>
-                ```bash Add permanently
-                mkdir -p ~/.deepagents
-                echo 'OPENAI_API_KEY=your-api-key' >> ~/.deepagents/.env
-                ```
+    ```txt
+    /auth
+    ```
 
-                ```bash Add for current session
-                export OPENAI_API_KEY="your-api-key"
-                ```
-            </CodeGroup>
-        </Tab>
-        <Tab title="Anthropic">
-            <CodeGroup>
-                ```bash Add permanently
-                mkdir -p ~/.deepagents
-                echo 'ANTHROPIC_API_KEY=your-api-key' >> ~/.deepagents/.env
-                ```
+    For non-interactive runs, CI/CD, or anywhere a TUI isn't available, set the provider's environment variable instead. See [Provider credentials](/oss/deepagents/code/configuration#provider-credentials) for the full key resolution order, the [`DEEPAGENTS_CODE_` prefix](/oss/deepagents/code/configuration#deepagents_code_-prefix) for scoping a key to Deep Agents Code, and the [Provider reference](#provider-reference) for each provider's environment variable.
 
-                ```bash Add for current session
-                export ANTHROPIC_API_KEY="your-api-key"
-                ```
-            </CodeGroup>
-        </Tab>
-        <Tab title="Google">
-            <CodeGroup>
-                ```bash Add permanently
-                mkdir -p ~/.deepagents
-                echo 'GOOGLE_API_KEY=your-api-key' >> ~/.deepagents/.env
-                ```
-
-                ```bash Add for current session
-                export GOOGLE_API_KEY="your-api-key"
-                ```
-            </CodeGroup>
-        </Tab>
-        <Tab title="Other">
-            Deep Agents Code works with any LLM that supports tool calling. See [Provider reference](#provider-reference) for the full list of supported providers and their required environment variables.
-
-        </Tab>
-    </Tabs>
-
-    To configure model parameters, see [Model parameters](/oss/deepagents/code/providers#model-parameters).
-
-    You can also scope credentials to Deep Agents Code with the [`DEEPAGENTS_CODE_` prefix](/oss/deepagents/code/configuration#deepagents_code_-prefix).
+    To configure model parameters, see [Model parameters](#model-parameters).
 
 ## Provider reference
 
@@ -145,17 +107,29 @@ Use the dedicated integration packages for these services:
 | OpenRouter | [`langchain-openrouter`](/oss/integrations/chat/openrouter) |
 :::
 
-**OpenRouter** is a built-in provider—install the package and use it directly:
+**OpenRouter** is a built-in provider—install the extra and use it directly:
 
-```bash
-uv tool install 'deepagents-code[openrouter]'
-```
+<CodeGroup>
+    ```txt In session
+    /install openrouter
+    ```
+
+    ```bash Shell
+    dcode --install openrouter
+    ```
+</CodeGroup>
 
 **LiteLLM** is also a built-in provider:
 
-```bash
-uv tool install 'deepagents-code[litellm]'
-```
+<CodeGroup>
+    ```txt In session
+    /install litellm
+    ```
+
+    ```bash Shell
+    dcode --install litellm
+    ```
+</CodeGroup>
 
 ## Switch models
 
@@ -191,7 +165,7 @@ The `/model` selector dynamically builds its list from installed provider packag
 <Accordion title="How the switcher builds its model list" icon="list-search">
     The interactive `/model` selector builds its list dynamically—it is not a hardcoded list baked into Deep Agents Code. A model appears in the switcher when **all** of the following are true:
 
-    1. **The provider package is installed.** Each provider (e.g. `langchain-anthropic`, `langchain-openai`) must be installed alongside `deepagents-code`—either as an [install extra](/oss/deepagents/code/providers#quickstart) (e.g. `uv tool install 'deepagents-code[ollama]'`) or added later with `uv tool install deepagents-code --with <package>`. If a package is missing, its entire provider section is absent from the switcher.
+    1. **The provider package is installed.** Each provider (e.g. `langchain-anthropic`, `langchain-openai`) must be installed alongside `deepagents-code`—either preinstalled as an [install extra](#quickstart) or added later with `/install <extra>` (e.g. `/install ollama`). If a package is missing, its entire provider section is absent from the switcher.
     2. **The model has a profile with `tool_calling` enabled.** Deep Agents Code requires tool-calling support, so models without `tool_calling: true` in their profile are excluded. This is the most common reason a model is missing from the list. For providers that don't bundle profiles (see the [Provider reference](#provider-reference) table), you can define one in `config.toml`:
 
         ```toml
@@ -214,7 +188,7 @@ The `/model` selector dynamically builds its list from installed provider packag
 
     | Symptom | Likely cause | Fix |
     | --- | --- | --- |
-    | Entire provider missing from switcher | Provider package not installed | Install the package (e.g. `uv tool install deepagents-code --with langchain-groq`) |
+    | Entire provider missing from switcher | Provider package not installed | Install the extra (e.g. `/install groq`) |
     | Provider shown but specific model missing | Model profile has `tool_calling: false` or no profile exists | Add the model to `[models.providers.<name>].models` in `config.toml`, or use `/model <provider>:<model>` directly |
 | Provider shows ⚠ "missing credentials" | API key env var not set | Set the credential env var from the [Provider reference](#provider-reference) table |
     | Provider shows ? "credentials unknown" | Provider uses non-standard auth that Deep Agents Code can't verify | Credentials may still work—try switching to the model. If auth fails, check the provider's docs |

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -31,7 +31,7 @@ Deep Agents Code integrates automatically with the [following model providers](#
 
 2. **Set credentials**
 
-    Add an API key for your provider with the [`/auth`](/oss/deepagents/code/configuration#use-auth-recommended) credential manager:
+    Add an API key for your provider with the [`/auth`](/oss/deepagents/code/configuration#use-%2Fauth-recommended) credential manager:
 
     ```txt
     /auth


### PR DESCRIPTION
Depends on https://github.com/langchain-ai/deepagents/pull/3770

Rework the Deep Agents Code configuration and providers reference around the `/auth` credential manager and the new key/endpoint resolution behavior. The old docs described a two-source credential model and leaned on raw `uv tool install 'deepagents-code[...]'` commands; this aligns the docs with how credentials, endpoints, and provider packages actually resolve, including managed gateways.

## Changes
- Rewrote **Provider credentials** around `/auth` as the recommended path, with an explicit **Key resolution order** (`DEEPAGENTS_CODE_`-prefixed env var > app-stored key > plain provider env var) replacing the prior "stored vs env" framing; updated the provider row labels to `[stored]` / `[env: VARNAME]` / `[missing]` and documented the optional base URL field.
- Added an **Endpoints, keys, and gateways** section covering `base_url` resolution order, key/endpoint pairing, and managed gateways (e.g. the LangSmith gateway), plus a new `base_url_env` provider config field in the reference.
- Reorganized **Environment variables**: dotenv loading order and precedence (nearest project `.env` walking up parents, then global `~/.deepagents/.env`, shell always wins) and the `DEEPAGENTS_CODE_` prefix as a per-variable override mechanism.
- Documented installing custom `class_path` provider packages via `dcode --install <pkg> --package` (and `/install … --package --force`), and reworked the **Arbitrary providers** section to explain why a plain `--install` doesn't cover non-extra packages.
- Reworked `providers.mdx` to use `/install` and `dcode --install` throughout — quickstart, OpenRouter/LiteLLM, and the `/model` switcher troubleshooting table — instead of raw `uv tool install 'deepagents-code[...]'` invocations.
- Linked `@[ModelProfile]` (new `link_map.py` entry), moved `--profile-override` into an Accordion, and renamed "Skills extra allowed directories" → "Skill directory allowlist" (updating the `data-locations.mdx` anchor).
