### PR TITLE
Add langchain-thalam to packages registry

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -797,3 +797,6 @@ packages:
   js: "n/a"
   downloads: 158
   downloads_updated_at: '2026-06-01T00:27:26.545071+00:00'
+- name: langchain-thalam
+  repo: thalam-ai/langchain-thalam
+  path: .


### PR DESCRIPTION
Registers the langchain-thalam integration package.

- PyPI: https://pypi.org/project/langchain-thalam
- Repo: https://github.com/thalam-ai/langchain-thalam

langchain-thalam provides ChatThalam, an OpenAI-compatible chat model for the
thalam. AI gateway (one API/key for many models — DeepSeek, Qwen, Kimi, GLM,
Claude, GPT, Llama, etc.). It wraps langchain-openai's ChatOpenAI, so streaming,
tool calling, structured output, and async all work.