### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.10.0

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -912,7 +912,7 @@
       "post": {
         "tags": ["Threads"],
         "summary": "Prune Threads",
-        "description": "Prune threads by ID. The 'delete' strategy removes threads entirely. The 'keep_latest' strategy prunes old checkpoints but keeps threads and their latest state.\n\nFor threads using [`DeltaChannel`](/oss/python/langgraph/pregel#deltachannel), the 'keep_latest' strategy retains the minimum set of ancestor checkpoints required to replay and reconstruct the latest delta channel state. These retained checkpoints retain only delta channel blobs, so they can no longer be used directly to fork the thread or time travel to those points.",
+        "description": "Prune threads by ID. The 'delete' strategy removes threads entirely. The 'keep_latest' strategy prunes old checkpoints but keeps threads and their latest state.",
         "operationId": "prune_threads_threads_prune_post",
         "requestBody": {
           "content": {
@@ -2164,7 +2164,7 @@
       "delete": {
         "tags": ["Thread Runs"],
         "summary": "Delete Run",
-        "description": "Delete a run by ID.\n\nFor threads using [`DeltaChannel`](/oss/python/langgraph/pregel#deltachannel), deleting a run skips checkpoint deletion and removes only the run record. The run's checkpoints may store delta writes that later checkpoints depend on for state reconstruction, so they are preserved. To reclaim checkpoint storage on delta-channel threads, use [Prune Threads](/langsmith/agent-server-api/threads/prune-threads) instead.",
+        "description": "Delete a run by ID.",
         "operationId": "delete_run_threads__thread_id__runs__run_id__delete",
         "parameters": [
           {
@@ -2186,7 +2186,7 @@
               "type": "string",
               "format": "uuid",
               "title": "Run Id",
-              "description": "For threads using [`DeltaChannel`](/oss/python/langgraph/pregel#deltachannel), deleting a run skips checkpoint deletion and removes only the run record. The run's checkpoints may store delta writes that later checkpoints depend on for state reconstruction, so they are preserved. To reclaim checkpoint storage on delta-channel threads, use [Prune Threads](/langsmith/agent-server-api/threads/prune-threads) instead."
+              "description": "The ID of the run."
             },
             "name": "run_id",
             "in": "path"
@@ -5893,7 +5893,7 @@
             "type": "string",
             "enum": ["delete", "keep_latest"],
             "title": "Strategy",
-            "description": "The prune strategy. 'delete' removes threads entirely. 'keep_latest' prunes old checkpoints but keeps threads and their latest state.\n\nFor threads using [`DeltaChannel`](/oss/python/langgraph/pregel#deltachannel), 'keep_latest' retains the minimum set of ancestor checkpoints required to replay and reconstruct the latest delta channel state. These retained checkpoints retain only delta channel blobs, so they can no longer be used directly to fork the thread or time travel to those points.",
+            "description": "The prune strategy. 'delete' removes threads entirely. 'keep_latest' prunes old checkpoints but keeps threads and their latest state.",
             "default": "delete"
           }
         },


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.10.0**

This update was automatically generated by the sync workflow in the langgraph-api repository.