### PR TITLE
reorder skills page

### DIFF
--- a/src/oss/deepagents/code/memory-and-skills.mdx
+++ b/src/oss/deepagents/code/memory-and-skills.mdx
@@ -122,7 +122,7 @@ At startup, Deep Agents Code reads the name and description from each `SKILL.md`
         Open the generated `SKILL.md` and edit the file to include your instructions.
     </Step>
     <Step title="Add optional resources">
-        Optionally add additional scripts or other resources to the `test-skill` folder. For more information, see [What are skills](/oss/deepagents/skills#what-are-skills).
+        Optionally add additional scripts or other resources to the `test-skill` folder. For more information, see [Usage](/oss/deepagents/skills#add-supporting-resources).
     </Step>
 </Steps>
 

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -494,11 +494,33 @@ For more information on subagent configuration and skills inheritance, see [Suba
 
 ## Skill permissions
 
-By default, agents can write to skill files if the backend permits it. Use these mechanisms to control that behavior:
+Production deployments usually need to control three things: which skills each user can see, whether the agent can modify skill files, and whether writes require human approval. You control visibility with the `skills` argument and [backend routing](#backends-and-remote-skill-loading), access with [filesystem permissions](/oss/deepagents/permissions), and approval with [`interrupt_on`](/oss/deepagents/human-in-the-loop) or permission rules with `mode="interrupt"`.
 
-### Share read-only skills
+### Share skills across users
 
-A common production pattern is to give agents access to a curated skills library without allowing them to change it. Route `/skills/` to a shared `StoreBackend`, pass that route in `skills`, and deny write operations under `/skills/**` with [filesystem permissions](/oss/deepagents/permissions). The agent can discover and read skills, while only your application code or an admin workflow updates the store.
+To give every user access to the same curated library, route `/skills/` to a shared @[StoreBackend] and seed it from your application code or an admin workflow. Use an organization-scoped namespace so all agents in that org resolve to the same store:
+
+- Namespace by org ID for workspace-wide skills (see [Enforce read-only skills](#enforce-read-only-skills)).
+- Namespace by user ID when each user needs an independent library ([namespaced skills](#namespaced-skills)).
+
+Seed the store with keys like `/company-policies/SKILL.md` and values that include `content` and `encoding` fields. The `/skills/` route prefix is stripped before records are read from the store.
+
+For a managed solution that handles skill access, sharing, and workspace-level visibility, see [Fleet skills](/langsmith/fleet/skills).
+
+You can also combine shared and personal libraries: route `/skills/shared/` to an organization-scoped `StoreBackend`, route `/skills/personal/` to a user-scoped backend, and pass both paths in `skills`. See [Allow agents to write skills](#allow-agents-to-write-skills).
+
+### Limit skills by user context
+
+Not every user should see every skill. Control which skills load at runtime based on role, tenant, or other request context. There are two main approaches:
+
+- **[Dynamic skill lists](#dynamic-skill-lists)** — Build the `skills` array before creating the agent. Pass different path lists for different roles or request types. Works when skills live in a shared backend and you filter by path.
+- **[Namespaced skills](#namespaced-skills)** — Route `/skills/` to a `StoreBackend` with a namespace factory keyed on user or tenant ID. Populate each namespace with only the skills that identity should access.
+
+These patterns work alongside the read and write controls below. For example, you can give admins a larger skill set than engineers while keeping both libraries read-only.
+
+### Enforce read-only skills
+
+To share skills without letting agents modify them, route `/skills/` to a shared store and deny write operations under `/skills/**` with [filesystem permissions](/oss/deepagents/permissions). The agent can discover and read skills; only your application code or an admin workflow updates the store.
 
 :::python
 
@@ -512,19 +534,139 @@ A common production pattern is to give agents access to a curated skills library
 
 :::
 
-Seed the store under the same namespace with keys like `/company-policies/SKILL.md` and values that include `content` and `encoding` fields. The `/skills/` route prefix is stripped before records are read from the store.
+Use this for enterprise knowledge bases, approved tool instructions, or shared skill packs where the agent should benefit from centrally managed context but should not rewrite the source of truth.
 
-Use this for enterprise knowledge bases, approved tool instructions, or shared skill packs where the agent should benefit from centrally managed context but should not rewrite the source of truth. If you want agents to save their own learnings, route a separate path such as `/memories/` to another backend with write permissions enabled. See [Backends](/oss/deepagents/backends) for routing and store setup.
+### Require approval for skill writes
 
-### Use personal and shared skills
+If agents may write to skill files but you want a human in the loop first, use either [`interrupt_on`](/oss/deepagents/human-in-the-loop) or a permission rule with `mode="interrupt"`. Both pause before `write_file` or `edit_file` runs and use the same resume flow.
 
-Agents can maintain their own skill libraries without modifying shared ones. Route a shared path such as `/skills/shared/` to an organization-scoped `StoreBackend`, route a separate path such as `/skills/personal/` to a user-scoped backend, and pass both paths in `skills`. Deny writes under the shared path while leaving the personal path writable.
+:::python
+```python
+from deepagents import FilesystemPermission, create_deep_agent
+from langgraph.checkpoint.memory import MemorySaver
 
-This pairs well with [namespaced skills](#namespaced-skills) when each user should see both workspace-wide skills and their own additions. To capture general learnings outside the skills format, route a separate path such as `/memories/` to another writable backend.
+agent = create_deep_agent(
+    model="anthropic:claude-sonnet-4-6",
+    skills=["/skills/personal/"],
+    permissions=[
+        FilesystemPermission(
+            operations=["write"],
+            paths=["/skills/**"],
+            mode="interrupt",
+        ),
+    ],
+    checkpointer=MemorySaver(),  # Required to pause and resume
+)
+```
+:::
 
-### Approve skill writes
+:::js
+```typescript
+import { MemorySaver } from "@langchain/langgraph";
+import { createDeepAgent } from "deepagents";
 
-By default, agents can write to skill files if the backend permits it. If you want agents to propose updates without applying them immediately, use [`interrupt_on`](/oss/deepagents/human-in-the-loop) to require approval before write operations run. This adds a review step without fully blocking writes.
+const agent = await createDeepAgent({
+  model: "anthropic:claude-sonnet-4-6",
+  skills: ["/skills/personal/"],
+  permissions: [
+    {
+      operations: ["write"],
+      paths: ["/skills/**"],
+      mode: "interrupt",
+    },
+  ],
+  checkpointer: new MemorySaver(), // Required to pause and resume
+});
+```
+:::
+
+Alternatively, configure `interrupt_on={"write_file": True, "edit_file": True}` to require approval for all filesystem writes, not only skills paths. See [Human-in-the-loop](/oss/deepagents/human-in-the-loop) for handling and resuming interrupts.
+
+:::python
+<Note>
+    Filesystem permission interrupts require `deepagents>=0.6.8`.
+</Note>
+:::
+
+### Allow agents to edit personal skills
+
+By default, agents can write to skill files if the backend permits it and no permission rule blocks the path. To let agents create or refine skills without touching shared libraries:
+
+1. Route a writable path such as `/skills/personal/` to a user-scoped `StoreBackend`.
+2. Pass that path (along with any shared paths) in `skills`.
+3. Do not add a `deny` rule for the writable path. Place more specific rules before broader deny rules if you mix shared and personal paths ([rule ordering](/oss/deepagents/permissions#rule-ordering)).
+
+:::python
+```python
+from deepagents import FilesystemPermission, create_deep_agent
+from deepagents.backends import CompositeBackend, StateBackend, StoreBackend
+
+agent = create_deep_agent(
+    model="anthropic:claude-sonnet-4-6",
+    backend=CompositeBackend(
+        default=StateBackend(),
+        routes={
+            "/skills/shared/": StoreBackend(
+                namespace=lambda rt: ("curated-skills", rt.context.org_id),
+            ),
+            "/skills/personal/": StoreBackend(
+                namespace=lambda rt: (
+                    "user-skills",
+                    rt.server_info.user.identity,
+                ),
+            ),
+        },
+    ),
+    skills=["/skills/shared/", "/skills/personal/"],
+    permissions=[
+        FilesystemPermission(
+            operations=["write"],
+            paths=["/skills/shared/**"],
+            mode="deny",
+        ),
+    ],
+)
+```
+:::
+
+:::js
+```typescript
+import {
+  createDeepAgent,
+  CompositeBackend,
+  StateBackend,
+  StoreBackend,
+} from "deepagents";
+
+const agent = await createDeepAgent({
+  model: "anthropic:claude-sonnet-4-6",
+  backend: new CompositeBackend({
+    default: new StateBackend(),
+    routes: {
+      "/skills/shared/": new StoreBackend({
+        namespace: (rt) => ["curated-skills", rt.context.orgId],
+      }),
+      "/skills/personal/": new StoreBackend({
+        namespace: (ctx) => [
+          "user-skills",
+          ctx.config?.configurable?.user_id ?? "anonymous",
+        ],
+      }),
+    },
+  }),
+  skills: ["/skills/shared/", "/skills/personal/"],
+  permissions: [
+    {
+      operations: ["write"],
+      paths: ["/skills/shared/**"],
+      mode: "deny",
+    },
+  ],
+});
+```
+:::
+
+The agent uses `write_file` and `edit_file` to create or update `SKILL.md` and supporting files under the writable path. To capture general learnings outside the skills format, route a separate path such as `/memories/` to another writable backend. See [Backends](/oss/deepagents/backends) for routing and store setup.
 
 ## Execute code with skills
 

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -188,7 +188,15 @@ As agents take on more complex tasks, the context they need grows with them. Loa
 Skills use **progressive disclosure**: the agent loads skill information in layers instead of all at once. At startup, it sees only each skill's name and description. When a skill matches the task, it reads the full `SKILL.md` instructions. Supporting files load last, only when the skill references them.
 </Info>
 
-The following diagram below shows how skill components map into the agent context. At startup, the system prompt includes a description for every skill. When the agent activates a skill, it reads that skill's full body into context. Supporting files stay on disk until the skill instructions reference them.
+Skills load in three levels. Each level adds more detail only when the task needs it:
+
+| Level | What loads | When |
+| ----- | ---------- | ---- |
+| **1. Metadata** | [`name`](#frontmatter-fields) and [`description`](#frontmatter-fields) from `SKILL.md` [frontmatter](#frontmatter-fields) | Agent startup, for every configured skill |
+| **2. Instructions** | Full `SKILL.md` body | When the agent determines the skill matches the task |
+| **3. Resources** | [Supporting files](#add-supporting-resources) under `scripts/`, `references/`, and `assets/` | When the skill instructions reference them |
+
+The following diagram shows what appears in agent context at a given moment. At startup, level 1 metadata for every skill is in the system prompt. When a skill is activated, level 2 instructions join the context. Level 3 files stay on the backend until referenced.
 
 <div className="skills-composition-diagram">
 
@@ -204,11 +212,11 @@ As the agent works through a task, it loads skill information in layers:
 
 </div>
 
-In Deep Agents, `SkillsMiddleware` handles this in three stages:
+In Deep Agents, `SkillsMiddleware` handles the first two levels, with the third level being handled by the LLM:
 
-1. **Discovery**: At agent start, the middleware scans the configured skill paths, parses each `SKILL.md` [frontmatter](#frontmatter-fields), and injects the [`name`](#frontmatter-fields) and [`description`](#frontmatter-fields) fields into the system prompt.
-2. **Read**: When the agent determines a skill matches the current task, it reads the full `SKILL.md` content via `read_file`. There is no dedicated activation mechanism.
-3. **Execute**: The agent follows the skill's instructions and reads any supporting files (scripts, references, assets) as needed.
+1. **Discovery** (level 1): At agent start, the middleware scans the configured skill paths, parses each `SKILL.md` [frontmatter](#frontmatter-fields), and injects the [`name`](#frontmatter-fields) and [`description`](#frontmatter-fields) fields into the system prompt.
+2. **Read** (level 2): When the agent determines a skill matches the current task, it reads the full `SKILL.md` content via `read_file`.
+3. **Execute** (level 3): The agent follows the skill's instructions and reads any supporting files (scripts, references, assets) as needed.
 
 ## When to use skills
 

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -255,7 +255,7 @@ Skills are especially helpful for codifying:
 
 The [Agent Skills specification](https://agentskills.io/specification) includes guidance on structuring skills for reliable discovery and activation. The following recommendations build on that foundation with practical patterns for Deep Agents.
 
-**Write specific descriptions.** During [discovery](#what-are-skills), the `description` field is the only information the agent sees for each skill. A good description tells the agent both what the skill does and when to activate it, with specific keywords the agent can match against:
+**Write specific descriptions.** During [discovery](#how-skills-work), the `description` field is the only information the agent sees for each skill. A good description tells the agent both what the skill does and when to activate it, with specific keywords the agent can match against:
 
 ```yaml
 # Good: specific about what and when
@@ -820,7 +820,7 @@ Use [LangSmith](https://smith.langchain.com) traces to debug skill discovery, `r
 
 **Solutions**:
 
-1. **Reference files from `SKILL.md`.** The agent does not auto-discover supporting files. State what each file contains and when to use it. Use [relative paths](#reference-files-from-skillmd) from the skill root.
+1. **Reference files from `SKILL.md`.** The agent does not auto-discover supporting files. State what each file contains and when to use it. Use [relative paths](#reference-files-from-skill-md) from the skill root.
 
 2. **Keep paths within the skill directory.** File paths resolve against the backend. Confirm supporting files exist at the paths your instructions reference.
 
@@ -887,7 +887,7 @@ allowed-tools: fetch_url
 
 # langgraph-docs
 
-Instructions for the agent go here. See the [langgraph-docs example](#what-are-skills) for a complete example of skill instructions.
+Instructions for the agent go here. See [Usage](#usage) for a complete example of skill instructions.
 ````
 
 <Warning>

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -185,7 +185,7 @@ const result = await agent.invoke(
 As agents take on more complex tasks, the context they need grows with them. Loading all instructions into the system prompt wastes tokens on information irrelevant to the current task, and providing the same guidance manually across sessions does not scale.
 
 <Info>
-Skills use **progressive disclosure**: the agent loads skill information in layers instead of all at once. At startup, it sees only each skill's name and description. When a skill matches the task, it reads the full `SKILL.md` instructions. Supporting files load last, only when the skill references them.
+Skills use **progressive disclosure**: the agent loads skill information in layers instead of all at once. At startup, it sees only each skill's name and description. When a skill is invoked, it reads the full `SKILL.md` instructions. Supporting files load afterward, only when the instructions call for them.
 </Info>
 
 Skills load in three levels. Each level adds more detail only when the task needs it:
@@ -193,10 +193,10 @@ Skills load in three levels. Each level adds more detail only when the task need
 | Level | What loads | When |
 | ----- | ---------- | ---- |
 | **1. Metadata** | [`name`](#frontmatter-fields) and [`description`](#frontmatter-fields) from `SKILL.md` [frontmatter](#frontmatter-fields) | Agent startup, for every configured skill |
-| **2. Instructions** | Full `SKILL.md` body | When the agent determines the skill matches the task |
-| **3. Resources** | [Supporting files](#add-supporting-resources) under `scripts/`, `references/`, and `assets/` | When the skill instructions reference them |
+| **2. Instructions** | Full `SKILL.md` body | When the skill is invoked |
+| **3. Resources** | [Supporting files](#add-supporting-resources) under `scripts/`, `references/`, and `assets/` | As needed after invocation, when the instructions reference them |
 
-The following diagram shows what appears in agent context at a given moment. At startup, level 1 metadata for every skill is in the system prompt. When a skill is activated, level 2 instructions join the context. Level 3 files stay on the backend until referenced.
+The following diagram shows what appears in agent context at a given moment. At startup, level 1 metadata for every skill is in the system prompt. When a skill is invoked, level 2 instructions join the context. Level 3 files stay on the backend until the agent reads them after invocation.
 
 <div className="skills-composition-diagram">
 
@@ -215,8 +215,8 @@ As the agent works through a task, it loads skill information in layers:
 In Deep Agents, `SkillsMiddleware` handles the first two levels, with the third level being handled by the LLM:
 
 1. **Discovery** (level 1): At agent start, the middleware scans the configured skill paths, parses each `SKILL.md` [frontmatter](#frontmatter-fields), and injects the [`name`](#frontmatter-fields) and [`description`](#frontmatter-fields) fields into the system prompt.
-2. **Read** (level 2): When the agent determines a skill matches the current task, it reads the full `SKILL.md` content via `read_file`.
-3. **Execute** (level 3): The agent follows the skill's instructions and reads any supporting files (scripts, references, assets) as needed.
+2. **Read** (level 2): When the agent invokes a skill, it reads the full `SKILL.md` content via `read_file`.
+3. **Execute** (level 3): After invocation, the agent follows the skill's instructions and reads supporting files (scripts, references, assets) only as the instructions require.
 
 ## When to use skills
 
@@ -230,6 +230,7 @@ Skills are especially helpful for codifying:
 
 - **Step-by-step workflows**: Workflows that span multiple steps, similar to recipes.
 - **Domain-specific knowledge**: Instruct the agent on how to use tools for the workflow. For example, include information on where to pull information from, including other reference information or scripts that the skill may have access to.
+- **Instructions with executable code**: Bundle procedures with scripts or modules the agent can run, so it follows tested logic instead of regenerating it from instructions each time. See [Execute code with skills](#execute-code-with-skills).
 - **Guidelines**: Provide the agent with supporting instructions about guardrails to adhere to. For example, following a specific format or style guide, or specifying to always run tests as part of the workflow.
 
 ## Write effective skills

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -10,9 +10,9 @@ import SkillsSandboxJs from '/snippets/code-samples/skills-sandbox-js.mdx';
 import BackendReadonlySkillsPy from '/snippets/code-samples/backend-readonly-skills-py.mdx';
 import BackendReadonlySkillsJs from '/snippets/code-samples/backend-readonly-skills-js.mdx';
 
-As agents take on more complex tasks, the context they need grows with them. Loading all instructions into the system prompt wastes tokens on information irrelevant to the current task, and providing the same guidance manually across sessions does not scale.
+Skills package domain expertise, such as workflows, best practices, scripts, reference docs, and templates, into reusable directories. The agent gets a summary of the contents on startup and discovers and reads the contained files only when relevant.
 
-Skills solve this by packaging domain expertise, such as workflows, best practices, scripts, reference docs, and templates, into reusable directories. The agent gets a summary of the contents on startup and discovers and reads the contained files only when relevant.
+You can think of skills as the equivalent of wiki pages that you write for yourself or others to remember how to accomplish a task. Just like wiki pages, skills make instructions for tasks easily shareable whenever needed, without the need to re-explain all the steps and context for the task.
 
 :::js
 <Note>
@@ -20,21 +20,46 @@ Skills require `deepagents>=1.7.0`.
 </Note>
 :::
 
-Deep agent skills follow the [Agent Skills specification](https://agentskills.io/specification).
-
 <Tip>
 For ready-to-use skills that improve your agent's performance on LangChain ecosystem tasks, see the [LangChain Skills](https://github.com/langchain-ai/langchain-skills) repository.
 </Tip>
 
-## What are skills
+## Usage
 
-Each skill is a directory containing a `SKILL.md` file: a markdown file with YAML frontmatter (`name` and `description`) followed by instructions the agent follows when the skill is activated. A skill directory can also include supporting files such as scripts, reference docs, and templates.
+<Steps>
+<Step title="Create a top-level skills directory">
 
-```plaintext
-skills/
-└── langgraph-docs/
-    └── SKILL.md
-```
+Create a directory to hold all skills for your project, such as `skills/` under your backend root.
+
+</Step>
+<Step title="Create a subdirectory inside your skills directory for your skill">
+
+Each skill is a directory containing a `SKILL.md` file: a markdown file with YAML frontmatter (`name` and `description`) followed by instructions the agent follows when the skill is activated. A skill directory can also optionally include supporting files such as scripts, reference docs, and templates.
+
+<Tree>
+  <Tree.Folder name="skills" defaultOpen>
+    <Tree.Folder name="langgraph-docs" defaultOpen>
+      <Tree.File name="SKILL.md" />
+      <Tree.Folder name="scripts">
+        <Tree.File name="fetch_docs.py" />
+      </Tree.Folder>
+      <Tree.Folder name="references">
+        <Tree.File name="api-patterns.md" />
+        <Tree.File name="style-guide.md" />
+      </Tree.Folder>
+      <Tree.Folder name="assets">
+        <Tree.File name="report-template.md" />
+        <Tree.File name="schema.json" />
+      </Tree.Folder>
+    </Tree.Folder>
+    <Tree.File name="additional-files.md" />
+  </Tree.Folder>
+</Tree>
+
+Deep agent skills follow the [Agent Skills specification](https://agentskills.io/specification).
+
+</Step>
+<Step title="Add a `SKILL.md` file with YAML frontmatter and instructions.">
 
 The `SKILL.md` starts with YAML frontmatter followed by markdown instructions:
 
@@ -74,10 +99,103 @@ Use the fetch_url tool to read the selected documentation URLs, then answer the 
 ````
 
 <Note>
-    Reference any supporting files in your `SKILL.md` with a description of what each file contains and when to use it. The agent discovers these files through the references in the skill instructions.
+    Reference any [supporting resources](#add-supporting-resources) in your `SKILL.md` with a description of what each file contains and when to use it. The agent discovers these files through the references in the skill instructions.
 </Note>
 
+</Step>
+<Step title="Pass the skills path when creating your agent">
+
+Pass the path to your top-level skills directory in the `skills` argument when creating your agent:
+
+:::python
+```python
+from deepagents import create_deep_agent
+from deepagents.backends.filesystem import FilesystemBackend
+
+backend = FilesystemBackend(root_dir="./my-project")
+
+agent = create_deep_agent(
+    model="anthropic:claude-sonnet-4-6",
+    backend=backend,
+    skills=["./my-project/skills/"],
+)
+```
+:::
+
+:::js
+```typescript
+import { createDeepAgent, FilesystemBackend } from "deepagents";
+
+const backend = new FilesystemBackend({ rootDir: process.cwd() });
+
+const agent = await createDeepAgent({
+  model: "anthropic:claude-sonnet-4-6",
+  backend,
+  skills: ["/skills/"],
+});
+```
+:::
+
+This example uses `FilesystemBackend` to load skills from disk. For other storage options, including loading skills from remote sources, see [Backends and remote skill loading](#backends-and-remote-skill-loading).
+
+<ParamField body="skills" type="list[str]" optional>
+    List of skill source paths.
+
+    Paths must be specified using forward slashes and are relative to the backend's root.
+
+    - If omitted, no skills are loaded.
+    - When using `StateBackend` (default), provide skill files with `invoke(files={...})`. Use `create_file_data()` from `deepagents.backends.utils` to format file contents; raw strings are not supported.
+    - With `FilesystemBackend`, skills are loaded from disk relative to the backend's `root_dir`.
+
+    Later sources override earlier ones for skills with the same name (last one wins).
+
+    <Note>
+    When multiple skill sources contain a skill with the same name, the skill from the source listed later in the `skills` array takes precedence (last one wins). This lets you layer skills from different origins, such as base skills overridden by project-specific versions.
+    </Note>
+
+</ParamField>
+
+</Step>
+<Step title="Invoke the agent">
+
+Send a task to the agent with `invoke()`. At startup, the agent loads each skill's name and description into the system prompt. When your task matches a skill's description, the agent reads that skill's `SKILL.md` and follows its instructions.
+
+:::python
+```python
+result = agent.invoke(
+    {"messages": [{"role": "user", "content": "What is LangGraph?"}]},
+    config={"configurable": {"thread_id": "1"}},
+)
+```
+:::
+
+:::js
+```typescript
+const result = await agent.invoke(
+  { messages: [{ role: "user", content: "What is LangGraph?" }] },
+  { configurable: { thread_id: "1" } },
+);
+```
+:::
+
+</Step>
+</Steps>
+
+## How skills work
+
+As agents take on more complex tasks, the context they need grows with them. Loading all instructions into the system prompt wastes tokens on information irrelevant to the current task, and providing the same guidance manually across sessions does not scale.
+
 Skills use *progressive disclosure*: the agent loads skill information in layers, pulling in more detail only when the task calls for it.
+
+The following diagram below shows how skill components map into the agent context. At startup, the system prompt includes a description for every skill. When the agent activates a skill, it reads that skill's full body into context. Supporting files stay on disk until the skill instructions reference them.
+
+<div className="skills-composition-diagram">
+
+![How skill components map into agent context at startup and activation](/oss/images/deepagents/skills-composition.svg)
+
+</div>
+
+As the agent works through a task, it loads skill information in layers:
 
 ```mermaid
 %%{init: {'theme': 'base', 'themeVariables': {'lineColor': '#40668D', 'primaryColor': '#E5F4FF', 'primaryTextColor': '#030710', 'primaryBorderColor': '#006DDD'}}}%%
@@ -119,66 +237,19 @@ The [Agent Skills specification](https://agentskills.io/specification) recommend
     Write clear, specific descriptions in your `SKILL.md` frontmatter. The agent decides whether to activate a skill based on the description alone. Include specific keywords and use cases so the agent can match accurately.
 </Tip>
 
-## Usage
+## When to use skills
 
-Create a top level skills directory. Then create a directory inside that with a `SKILL.md` file for your first skill. Finally, pass the path to the top level skills directory when creating your agent:
+If you find yourself giving similar instructions to an agent, especially if they are detailed and contain multiple steps, consider codifying the instructions for the agent. That way, in future when you want to accomplish a similar task, the agent will already know what to do.
 
-:::python
-```python
-from deepagents import create_deep_agent
-from deepagents.backends.filesystem import FilesystemBackend
+<Tip>
+    You can also ask your agent to write a skill for a task you worked on with the agent.
+</Tip>
 
-backend = FilesystemBackend(root_dir="./my-project")
+Skills are especially helpful for codifying:
 
-agent = create_deep_agent(
-    model="anthropic:claude-sonnet-4-6",
-    backend=backend,
-    skills=["./my-project/skills/"],
-)
-
-result = agent.invoke(
-    {"messages": [{"role": "user", "content": "What is LangGraph?"}]},
-    config={"configurable": {"thread_id": "1"}},
-)
-```
-:::
-
-:::js
-```typescript
-import { createDeepAgent, FilesystemBackend } from "deepagents";
-
-const backend = new FilesystemBackend({ rootDir: process.cwd() });
-
-const agent = await createDeepAgent({
-  model: "anthropic:claude-sonnet-4-6",
-  backend,
-  skills: ["/skills/"],
-});
-
-const result = await agent.invoke(
-  { messages: [{ role: "user", content: "What is LangGraph?" }] },
-  { configurable: { thread_id: "1" } },
-);
-```
-:::
-
-This example uses `FilesystemBackend` to load skills from disk. For other storage options, including loading skills from remote sources, see [Backends and remote skill loading](#backends-and-remote-skill-loading).
-
-<ParamField body="skills" type="list[str]" optional>
-    List of skill source paths.
-
-    Paths must be specified using forward slashes and are relative to the backend's root.
-
-    - If omitted, no skills are loaded.
-    - When using `StateBackend` (default), provide skill files with `invoke(files={...})`. Use `create_file_data()` from `deepagents.backends.utils` to format file contents; raw strings are not supported.
-    - With `FilesystemBackend`, skills are loaded from disk relative to the backend's `root_dir`.
-
-    Later sources override earlier ones for skills with the same name (last one wins).
-</ParamField>
-
-<Note>
-    When multiple skill sources contain a skill with the same name, the skill from the source listed later in the `skills` array takes precedence (last one wins). This lets you layer skills from different origins, such as base skills overridden by project-specific versions.
-</Note>
+- **Step-by-step workflows**: Workflows that span multiple steps, similar to recipes.
+- **Domain-specific knowledge**: Instruct the agent on how to use tools for the workflow. For example, include information on where to pull information from, including other reference information or scripts that the skill may have access to.
+- **Guidelines**: Provide the agent with supporting instructions about guardrails to adhere to. For example, following a specific format or style guide, or specifying to always run tests as part of the workflow.
 
 ## Write effective skills
 
@@ -199,16 +270,19 @@ description: Helps with PDFs.
 
 When you have multiple skills in related domains, differentiate their descriptions clearly. Overlapping descriptions cause the agent to activate the wrong skill or hesitate between options. If two skills serve similar purposes, consolidate them into one.
 
-**Keep instructions focused.** The Agent Skills specification recommends keeping your `SKILL.md` under 500 lines. When instructions grow longer, move detailed reference material into separate files and reference them from the main `SKILL.md`:
+**Keep instructions focused.** The Agent Skills specification recommends keeping your `SKILL.md` under 500 lines. When instructions grow longer, move detailed reference material into [supporting resource files](#add-supporting-resources) and reference them from the main `SKILL.md`:
 
-```plaintext
-skills/
-└── data-pipeline/
-    ├── SKILL.md
-    └── references/
-        ├── schema-reference.md
-        └── error-codes.md
-```
+<Tree>
+  <Tree.Folder name="skills" defaultOpen>
+    <Tree.Folder name="data-pipeline" defaultOpen>
+      <Tree.File name="SKILL.md" />
+      <Tree.Folder name="references" defaultOpen>
+        <Tree.File name="schema-reference.md" />
+        <Tree.File name="error-codes.md" />
+      </Tree.Folder>
+    </Tree.Folder>
+  </Tree.Folder>
+</Tree>
 
 The agent loads reference files only when the instructions call for them, keeping each layer of progressive disclosure appropriately sized. Keep file references one level deep from `SKILL.md` and avoid deeply nested reference chains, which force the agent through multiple reads to reach the information it needs.
 
@@ -227,6 +301,53 @@ The agent loads reference files only when the instructions call for them, keepin
 <Tip>
     Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check that your `SKILL.md` frontmatter follows the Agent Skills specification naming and format conventions.
 </Tip>
+
+## Add supporting resources
+
+Beyond `SKILL.md`, a skill directory can include any additional files or directories. The [Agent Skills specification](https://agentskills.io/specification) defines three optional directories for common resource types. Deep Agents does not load these files at discovery or activation. The agent reads or executes them only when your `SKILL.md` instructions say to.
+
+### `scripts/`
+
+The `scripts/` directory holds executable code the agent can run, such as API clients, data transforms, or validation checks. Scripts should:
+
+- Be self-contained or clearly document dependencies
+- Include helpful error messages
+- Handle edge cases gracefully
+
+Supported languages depend on your agent setup. Common options include Python, Bash, and JavaScript or TypeScript. To execute scripts rather than only read them, see [Execute code with skills](#execute-code-with-skills). Use [sandbox scripts](#sandbox-scripts) when the agent needs a shell, or [interpreter skills](#interpreter-skills) when the agent needs importable helpers in an interpreter.
+
+### `references/`
+
+The `references/` directory holds supplementary documentation the agent reads on demand. Use it for material that is too detailed for `SKILL.md` but still task-specific, such as:
+
+- `REFERENCE.md` for detailed technical reference
+- `FORMS.md` for form templates or structured data formats
+- Domain-specific guides (`finance.md`, `legal.md`, and similar)
+
+Keep individual reference files focused. The agent loads them only when needed, so smaller files use less context.
+
+### `assets/`
+
+The `assets/` directory holds static resources the agent uses but does not need to read as instructions, such as:
+
+- Document or configuration templates
+- Images (diagrams, examples)
+- Data files (lookup tables, schemas)
+
+Describe in `SKILL.md` when the agent should open or copy each asset.
+
+### Reference files from `SKILL.md`
+
+When you reference supporting files, use paths relative to the skill root:
+
+````md
+For API details, see the [reference guide](references/api-patterns.md).
+
+To extract tables from a PDF, run:
+scripts/extract.py
+````
+
+For each file you reference, state what it contains and when the agent should use it. Keep references one level deep from `SKILL.md`. Avoid deeply nested reference chains that force the agent through multiple reads to reach the information it needs.
 
 ## Backends and remote skill loading
 
@@ -396,17 +517,14 @@ const agent = await createDeepAgent({
 
 For more information on subagent configuration and skills inheritance, see [Subagents](/oss/deepagents/subagents).
 
-## Skill permissions
+## Share skills
 
-By default, agents can write to skill files if the backend permits it. Use these mechanisms to control that behavior:
+Most production deployments share one curated skills library across agents and users. The agent reads those skills at runtime, but writes to shared files should stay under your control. Use [filesystem permissions](/oss/deepagents/permissions), backend routing, and [`interrupt_on`](/oss/deepagents/human-in-the-loop) to decide who can change what.
 
-- **Read-only skills**: Use [filesystem permissions](/oss/deepagents/permissions) to deny write operations under skill paths.
-- **Scoped permissions**: Allow writes to user-scoped skill paths while keeping workspace or shared skills read-only, so agents can personalize their own skills without modifying shared ones.
-- **Human-in-the-loop**: Use [`interrupt_on`](/oss/deepagents/human-in-the-loop) to require approval before the agent executes write operations, adding a review step without fully blocking writes.
+### Shared read-only libraries
 
-### Read-only skills
-
-A common production pattern is to give agents access to a curated skills library without allowing them to change it. Route `/skills/` to a shared `StoreBackend`, pass that route in `skills`, and deny write operations under `/skills/**` with [filesystem permissions](/oss/deepagents/permissions). The agent can discover and read skills, while only your application code or an admin workflow updates the store.
+A common production pattern is to give agents access to a curated skills library without
+allowing them to change it. Route `/skills/` to a shared `StoreBackend`, pass that route in `skills`, and deny write operations under `/skills/**` with [filesystem permissions](/oss/deepagents/permissions). The agent can discover and read skills, while only your application code or an admin workflow updates the store.
 
 :::python
 
@@ -422,7 +540,21 @@ A common production pattern is to give agents access to a curated skills library
 
 Seed the store under the same namespace with keys like `/company-policies/SKILL.md` and values that include `content` and `encoding` fields. The `/skills/` route prefix is stripped before records are read from the store.
 
-Use this for enterprise knowledge bases, approved tool instructions, or shared skill packs where the agent should benefit from centrally managed context but should not rewrite the source of truth. If you want agents to save their own learnings, route a separate path such as `/memories/` to another backend with write permissions enabled. See [Backends](/oss/deepagents/backends) for routing and store setup.
+Use this for enterprise knowledge bases, approved tool instructions, or shared skill packs
+where the agent should benefit from centrally managed context but should not rewrite the
+source of truth. If you want agents to save their own learnings, route a separate path such as
+`/memories/` to another backend with write permissions enabled. See [Backends](/oss/deepagents/
+backends) for routing and store setup.
+
+### Personal skills alongside shared skills
+
+Agents can maintain their own skill libraries without modifying shared ones. Route a shared path such as `/skills/shared/` to an organization-scoped `StoreBackend`, route a separate path such as `/skills/personal/` to a user-scoped backend, and pass both paths in `skills`. Deny writes under the shared path while leaving the personal path writable.
+
+This pairs well with [namespaced skills](#namespaced-skills) when each user should see both workspace-wide skills and their own additions. To capture general learnings outside the skills format, route a separate path such as `/memories/` to another writable backend.
+
+### Approve skill writes
+
+By default, agents can write to skill files if the backend permits it. If you want agents to propose updates without applying them immediately, use [`interrupt_on`](/oss/deepagents/human-in-the-loop) to require approval before write operations run. This adds a review step without fully blocking writes.
 
 ## Execute code with skills
 
@@ -438,23 +570,29 @@ Skills support code execution in two ways:
 Skills can include scripts alongside the `SKILL.md` file. Reference scripts in your `SKILL.md` so the agent knows they exist and when to run them:
 
 :::python
-```plaintext
-skills/
-└── arxiv-search/
-    ├── SKILL.md
-    └── scripts/
-        └── search.py
-```
+<Tree>
+  <Tree.Folder name="skills" defaultOpen>
+    <Tree.Folder name="arxiv-search" defaultOpen>
+      <Tree.File name="SKILL.md" />
+      <Tree.Folder name="scripts" defaultOpen>
+        <Tree.File name="search.py" />
+      </Tree.Folder>
+    </Tree.Folder>
+  </Tree.Folder>
+</Tree>
 :::
 
 :::js
-```plaintext
-skills/
-└── arxiv-search/
-    ├── SKILL.md
-    └── scripts/
-        └── search.ts
-```
+<Tree>
+  <Tree.Folder name="skills" defaultOpen>
+    <Tree.Folder name="arxiv-search" defaultOpen>
+      <Tree.File name="SKILL.md" />
+      <Tree.Folder name="scripts" defaultOpen>
+        <Tree.File name="search.ts" />
+      </Tree.Folder>
+    </Tree.Folder>
+  </Tree.Folder>
+</Tree>
 :::
 
 :::python
@@ -545,13 +683,16 @@ To make a skill importable:
 
 Minimal skill layout:
 
-```text
-skills/
-`-- order-helpers/
-    |-- SKILL.md
-    `-- scripts/
-        `-- index.ts
-```
+<Tree>
+  <Tree.Folder name="skills" defaultOpen>
+    <Tree.Folder name="order-helpers" defaultOpen>
+      <Tree.File name="SKILL.md" />
+      <Tree.Folder name="scripts" defaultOpen>
+        <Tree.File name="index.ts" />
+      </Tree.Folder>
+    </Tree.Folder>
+  </Tree.Folder>
+</Tree>
 
 ````md
 ---
@@ -633,6 +774,76 @@ const grouped = groupByStatus(orders);
 grouped;
 ```
 
+## Troubleshooting
+
+Use [LangSmith](https://smith.langchain.com) traces to debug skill discovery, `read_file` calls on `SKILL.md`, and supporting resource access. Follow the [tracing quickstart](/langsmith/observability-quickstart) to get set up. We recommend you also set up [LangSmith Engine](/langsmith/engine), which monitors your traces, detects issues, and proposes fixes.
+
+### Skill not activated
+
+**Problem**: The agent handles the task without reading the skill's `SKILL.md`.
+
+**Solutions**:
+
+1. **Make the description more specific.** The agent selects skills from `description` alone at discovery. Include what the skill does, when to use it, and keywords the agent can match:
+
+   ```yaml
+   # Good
+   description: >-
+     Search the arXiv preprint repository for research papers. Use when the
+     user asks about academic papers, recent research, or scientific literature.
+
+   # Poor
+   description: Helps with research.
+   ```
+
+2. **Reduce overlap between skills.** If multiple skills have similar descriptions, the agent may skip the right one or pick the wrong one. Differentiate descriptions or [consolidate related skills](#write-effective-skills).
+
+3. **Confirm the skill is in the `skills` array.** Skills load only from paths you pass at agent creation or from subagent-specific `skills` parameters.
+
+### Skills missing at startup
+
+**Problem**: The agent does not list a skill in its system prompt, or `read_file` on `SKILL.md` fails.
+
+**Solutions**:
+
+1. **Check the skill path.** Paths must use forward slashes and be relative to the backend root. With `FilesystemBackend`, the path is relative to `root_dir`. With `StateBackend`, pass skill files in `invoke(files={...})` using `create_file_data()`.
+
+2. **Validate `SKILL.md` frontmatter.** The `name` must match the parent directory name and follow the [Agent Skills specification](https://agentskills.io/specification). Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check formatting.
+
+3. **Check file size.** Deep Agents skips `SKILL.md` files over 10 MB during discovery.
+
+4. **Check layered sources.** When the same skill name appears in multiple sources, the [last source wins](#usage). An older or empty skill from a later path can override the one you expect.
+
+### Supporting files not found
+
+**Problem**: The agent reads `SKILL.md` but cannot access scripts, references, or assets.
+
+**Solutions**:
+
+1. **Reference files from `SKILL.md`.** The agent does not auto-discover supporting files. State what each file contains and when to use it. Use [relative paths](#reference-files-from-skillmd) from the skill root.
+
+2. **Keep paths within the skill directory.** File paths resolve against the backend. Confirm supporting files exist at the paths your instructions reference.
+
+3. **Sync skills into sandboxes.** If you use [sandbox backends](/oss/deepagents/sandboxes), skill files outside the container are not available until you copy them in. See [Sandbox scripts](#sandbox-scripts) and [syncing skills and memories with custom middleware](/oss/deepagents/going-to-production#example-syncing-skills-and-memories-with-custom-middleware).
+
+### Scripts or imports fail
+
+**Problem**: The agent reads a script but cannot run it, or `import("@/skills/<name>")` fails in the interpreter.
+
+**Solutions**:
+
+1. **Use a sandbox for shell execution.** The agent can read scripts from any backend, but running them requires a [sandbox backend](/oss/deepagents/sandboxes). See [Execute code with skills](#execute-code-with-skills).
+
+2. **Configure interpreter middleware.** [Interpreter skills](#interpreter-skills) require `metadata.entrypoint` in `SKILL.md` frontmatter and interpreter middleware with the same backend that loads skill files.
+
+3. **Match skill and interpreter backends.** If `SkillsMiddleware` and the interpreter use different backends, import paths may not resolve to the files you expect.
+
+### Subagent cannot access a skill
+
+**Problem**: A custom subagent does not see skills that the main agent uses.
+
+**Solution**: Custom subagents do not inherit the main agent's skills. Add a `skills` parameter to each [subagent definition](#skills-for-subagents) with that subagent's skill source paths. The general-purpose subagent inherits skills from `create_deep_agent` automatically.
+
 ## Reference
 
 ### Skills, memory, and tools
@@ -691,8 +902,3 @@ For more example skills, see [Deep Agents example skills](https://github.com/lan
 For more example skills, see [Deep Agents example skills](https://github.com/langchain-ai/deepagentsjs/tree/main/examples/skills).
 :::
 
-<Tip>
-Trace how your agent discovers and executes skills with [LangSmith](https://smith.langchain.com). Follow the [observability quickstart](/langsmith/observability-quickstart) to get set up.
-
-We recommend you also set up [LangSmith Engine](/langsmith/engine), which monitors your traces, detects issues, and proposes fixes.
-</Tip>

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -12,7 +12,7 @@ import BackendReadonlySkillsJs from '/snippets/code-samples/backend-readonly-ski
 
 Skills package domain expertise, such as workflows, best practices, scripts, reference docs, and templates, into reusable directories. The agent gets a summary of the contents on startup and discovers and reads the contained files only when relevant.
 
-You can think of skills as the equivalent of wiki pages that you write for yourself or others to remember how to accomplish a task. Just like wiki pages, skills make instructions for tasks easily shareable whenever needed, without the need to re-explain all the steps and context for the task.
+Skills help you avoid context bloat by loading only summaries at startup and reading full instructions when a task requires them. You can share skills across agents and projects, and compose multiple skills in a single agent so each one covers a distinct capability.
 
 :::js
 <Note>
@@ -34,7 +34,7 @@ Create a directory to hold all skills for your project, such as `skills/` under 
 </Step>
 <Step title="Create a subdirectory inside your skills directory for your skill">
 
-Each skill is a directory containing a `SKILL.md` file: a markdown file with YAML frontmatter (`name` and `description`) followed by instructions the agent follows when the skill is activated. A skill directory can also optionally include supporting files such as scripts, reference docs, and templates.
+Each skill is a directory containing a `SKILL.md` file: a markdown file with YAML [frontmatter](#frontmatter-fields) (`name` and `description`) followed by instructions the agent follows when the skill is activated. A skill directory can also optionally include supporting files such as scripts, reference docs, and templates.
 
 <Tree>
   <Tree.Folder name="skills" defaultOpen>
@@ -52,7 +52,6 @@ Each skill is a directory containing a `SKILL.md` file: a markdown file with YAM
         <Tree.File name="schema.json" />
       </Tree.Folder>
     </Tree.Folder>
-    <Tree.File name="additional-files.md" />
   </Tree.Folder>
 </Tree>
 
@@ -61,7 +60,7 @@ Deep agent skills follow the [Agent Skills specification](https://agentskills.io
 </Step>
 <Step title="Add a `SKILL.md` file with YAML frontmatter and instructions.">
 
-The `SKILL.md` starts with YAML frontmatter followed by markdown instructions:
+The `SKILL.md` starts with YAML [frontmatter](#frontmatter-fields) followed by markdown instructions:
 
 ````md
 ---
@@ -158,7 +157,7 @@ This example uses `FilesystemBackend` to load skills from disk. For other storag
 </Step>
 <Step title="Invoke the agent">
 
-Send a task to the agent with `invoke()`. At startup, the agent loads each skill's name and description into the system prompt. When your task matches a skill's description, the agent reads that skill's `SKILL.md` and follows its instructions.
+Send a task to the agent with `invoke()`. At startup, the agent loads each skill's [`name`](#frontmatter-fields) and [`description`](#frontmatter-fields) from [frontmatter](#frontmatter-fields) into the system prompt. When your task matches a skill's description, the agent reads that skill's `SKILL.md` and follows its instructions.
 
 :::python
 ```python
@@ -185,7 +184,9 @@ const result = await agent.invoke(
 
 As agents take on more complex tasks, the context they need grows with them. Loading all instructions into the system prompt wastes tokens on information irrelevant to the current task, and providing the same guidance manually across sessions does not scale.
 
-Skills use *progressive disclosure*: the agent loads skill information in layers, pulling in more detail only when the task calls for it.
+<Info>
+Skills use **progressive disclosure**: the agent loads skill information in layers instead of all at once. At startup, it sees only each skill's name and description. When a skill matches the task, it reads the full `SKILL.md` instructions. Supporting files load last, only when the skill references them.
+</Info>
 
 The following diagram below shows how skill components map into the agent context. At startup, the system prompt includes a description for every skill. When the agent activates a skill, it reads that skill's full body into context. Supporting files stay on disk until the skill instructions reference them.
 
@@ -197,45 +198,17 @@ The following diagram below shows how skill components map into the agent contex
 
 As the agent works through a task, it loads skill information in layers:
 
-```mermaid
-%%{init: {'theme': 'base', 'themeVariables': {'lineColor': '#40668D', 'primaryColor': '#E5F4FF', 'primaryTextColor': '#030710', 'primaryBorderColor': '#006DDD'}}}%%
-flowchart TB
-    subgraph L1[" Metadata "]
-        M["name + description\nLoaded at startup for all skills"]
-    end
+<div className="skills-composition-diagram">
 
-    L1 -- "Agent determines skill is relevant" --> L2
+![How skills load in layers from metadata to instructions to resources](/oss/images/deepagents/skills-progressive-disclosure.svg)
 
-    subgraph L2[" Instructions "]
-        I["Full SKILL.md body\nRead when the skill is activated"]
-    end
-
-    L2 -- "Instructions reference supporting files" --> L3
-
-    subgraph L3[" Resources "]
-        R["scripts/, references/, assets/\nLoaded only when referenced"]
-    end
-
-    classDef trigger fill:#F6FFDB,stroke:#6E8900,stroke-width:2px,color:#2E3900
-    classDef process fill:#E5F4FF,stroke:#006DDD,stroke-width:2px,color:#030710
-    classDef neutral fill:#F2FAFF,stroke:#40668D,stroke-width:2px,color:#2F4B68
-
-    class L1 trigger
-    class L2 process
-    class L3 neutral
-```
+</div>
 
 In Deep Agents, `SkillsMiddleware` handles this in three stages:
 
-1. **Discovery**: At agent start, the middleware scans the configured skill paths, parses each `SKILL.md` frontmatter, and injects skill names and descriptions into the system prompt.
+1. **Discovery**: At agent start, the middleware scans the configured skill paths, parses each `SKILL.md` [frontmatter](#frontmatter-fields), and injects the [`name`](#frontmatter-fields) and [`description`](#frontmatter-fields) fields into the system prompt.
 2. **Read**: When the agent determines a skill matches the current task, it reads the full `SKILL.md` content via `read_file`. There is no dedicated activation mechanism.
 3. **Execute**: The agent follows the skill's instructions and reads any supporting files (scripts, references, assets) as needed.
-
-The [Agent Skills specification](https://agentskills.io/specification) recommends keeping frontmatter concise and the `SKILL.md` body under 5,000 tokens. Following these guidelines matters because every skill's frontmatter is added to the system prompt at discovery, while the full body is only read when activated. Keeping both layers small means you can load many skills without crowding the context window.
-
-<Tip>
-    Write clear, specific descriptions in your `SKILL.md` frontmatter. The agent decides whether to activate a skill based on the description alone. Include specific keywords and use cases so the agent can match accurately.
-</Tip>
 
 ## When to use skills
 
@@ -255,7 +228,9 @@ Skills are especially helpful for codifying:
 
 The [Agent Skills specification](https://agentskills.io/specification) includes guidance on structuring skills for reliable discovery and activation. The following recommendations build on that foundation with practical patterns for Deep Agents.
 
-**Write specific descriptions.** During [discovery](#how-skills-work), the `description` field is the only information the agent sees for each skill. A good description tells the agent both what the skill does and when to activate it, with specific keywords the agent can match against:
+**Keep [frontmatter](#frontmatter-fields) concise** and the `SKILL.md` body under 5,000 tokens. Every skill's frontmatter is added to the system prompt at [discovery](#how-skills-work), while the full body is only read when activated. Keeping both layers small means you can load many skills without crowding the context window.
+
+**Write specific descriptions.** During [discovery](#how-skills-work), the [`description`](#frontmatter-fields) field is the only information the agent sees for each skill. A good description tells the agent both what the skill does and when to activate it, with specific keywords the agent can match against:
 
 ```yaml
 # Good: specific about what and when
@@ -299,7 +274,7 @@ The agent loads reference files only when the instructions call for them, keepin
 - Using reference files to keep the main `SKILL.md` concise while covering multiple sub-tasks
 
 <Tip>
-    Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check that your `SKILL.md` frontmatter follows the Agent Skills specification naming and format conventions.
+    Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check that your `SKILL.md` [frontmatter](#frontmatter-fields) follows the Agent Skills specification naming and format conventions.
 </Tip>
 
 ## Add supporting resources
@@ -517,14 +492,13 @@ const agent = await createDeepAgent({
 
 For more information on subagent configuration and skills inheritance, see [Subagents](/oss/deepagents/subagents).
 
-## Share skills
+## Skill permissions
 
-Most production deployments share one curated skills library across agents and users. The agent reads those skills at runtime, but writes to shared files should stay under your control. Use [filesystem permissions](/oss/deepagents/permissions), backend routing, and [`interrupt_on`](/oss/deepagents/human-in-the-loop) to decide who can change what.
+By default, agents can write to skill files if the backend permits it. Use these mechanisms to control that behavior:
 
-### Shared read-only libraries
+### Share read-only skills
 
-A common production pattern is to give agents access to a curated skills library without
-allowing them to change it. Route `/skills/` to a shared `StoreBackend`, pass that route in `skills`, and deny write operations under `/skills/**` with [filesystem permissions](/oss/deepagents/permissions). The agent can discover and read skills, while only your application code or an admin workflow updates the store.
+A common production pattern is to give agents access to a curated skills library without allowing them to change it. Route `/skills/` to a shared `StoreBackend`, pass that route in `skills`, and deny write operations under `/skills/**` with [filesystem permissions](/oss/deepagents/permissions). The agent can discover and read skills, while only your application code or an admin workflow updates the store.
 
 :::python
 
@@ -540,13 +514,9 @@ allowing them to change it. Route `/skills/` to a shared `StoreBackend`, pass th
 
 Seed the store under the same namespace with keys like `/company-policies/SKILL.md` and values that include `content` and `encoding` fields. The `/skills/` route prefix is stripped before records are read from the store.
 
-Use this for enterprise knowledge bases, approved tool instructions, or shared skill packs
-where the agent should benefit from centrally managed context but should not rewrite the
-source of truth. If you want agents to save their own learnings, route a separate path such as
-`/memories/` to another backend with write permissions enabled. See [Backends](/oss/deepagents/
-backends) for routing and store setup.
+Use this for enterprise knowledge bases, approved tool instructions, or shared skill packs where the agent should benefit from centrally managed context but should not rewrite the source of truth. If you want agents to save their own learnings, route a separate path such as `/memories/` to another backend with write permissions enabled. See [Backends](/oss/deepagents/backends) for routing and store setup.
 
-### Personal skills alongside shared skills
+### Use personal and shared skills
 
 Agents can maintain their own skill libraries without modifying shared ones. Route a shared path such as `/skills/shared/` to an organization-scoped `StoreBackend`, route a separate path such as `/skills/personal/` to a user-scoped backend, and pass both paths in `skills`. Deny writes under the shared path while leaving the personal path writable.
 
@@ -668,7 +638,7 @@ To make a skill importable:
 
 <Steps titleSize="h4">
     <Step title="Add an entrypoint">
-        Add a `metadata.entrypoint` key to the skill's `SKILL.md` frontmatter. The value is a JavaScript or TypeScript file path relative to the skill directory.
+        Add a [`metadata.entrypoint`](#frontmatter-fields) key to the skill's `SKILL.md` [frontmatter](#frontmatter-fields). The value is a JavaScript or TypeScript file path relative to the skill directory.
     </Step>
     <Step title="Configure skills normally">
         Pass the skill source path with the `skills` argument when creating the agent.
@@ -784,7 +754,7 @@ Use [LangSmith](https://smith.langchain.com) traces to debug skill discovery, `r
 
 **Solutions**:
 
-1. **Make the description more specific.** The agent selects skills from `description` alone at discovery. Include what the skill does, when to use it, and keywords the agent can match:
+1. **Make the description more specific.** The agent selects skills from the [`description`](#frontmatter-fields) field alone at [discovery](#how-skills-work). Include what the skill does, when to use it, and keywords the agent can match:
 
    ```yaml
    # Good
@@ -808,7 +778,7 @@ Use [LangSmith](https://smith.langchain.com) traces to debug skill discovery, `r
 
 1. **Check the skill path.** Paths must use forward slashes and be relative to the backend root. With `FilesystemBackend`, the path is relative to `root_dir`. With `StateBackend`, pass skill files in `invoke(files={...})` using `create_file_data()`.
 
-2. **Validate `SKILL.md` frontmatter.** The `name` must match the parent directory name and follow the [Agent Skills specification](https://agentskills.io/specification). Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check formatting.
+2. **Validate `SKILL.md` [frontmatter](#frontmatter-fields).** The [`name`](#frontmatter-fields) must match the parent directory name and follow the [Agent Skills specification](https://agentskills.io/specification). Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check formatting.
 
 3. **Check file size.** Deep Agents skips `SKILL.md` files over 10 MB during discovery.
 
@@ -834,7 +804,7 @@ Use [LangSmith](https://smith.langchain.com) traces to debug skill discovery, `r
 
 1. **Use a sandbox for shell execution.** The agent can read scripts from any backend, but running them requires a [sandbox backend](/oss/deepagents/sandboxes). See [Execute code with skills](#execute-code-with-skills).
 
-2. **Configure interpreter middleware.** [Interpreter skills](#interpreter-skills) require `metadata.entrypoint` in `SKILL.md` frontmatter and interpreter middleware with the same backend that loads skill files.
+2. **Configure interpreter middleware.** [Interpreter skills](#interpreter-skills) require [`metadata.entrypoint`](#frontmatter-fields) in `SKILL.md` [frontmatter](#frontmatter-fields) and interpreter middleware with the same backend that loads skill files.
 
 3. **Match skill and interpreter backends.** If `SkillsMiddleware` and the interpreter use different backends, import paths may not resolve to the files you expect.
 

--- a/src/oss/images/deepagents/skills-composition.svg
+++ b/src/oss/images/deepagents/skills-composition.svg
@@ -1,0 +1,79 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 920 500" role="img" aria-labelledby="skills-composition-title skills-composition-desc">
+  <title id="skills-composition-title">Skills composition diagram</title>
+  <desc id="skills-composition-desc">Skill descriptions load into the system prompt at startup; the active skill body loads on demand; scripts and references stay on disk until referenced.</desc>
+
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="45%" r="70%">
+      <stop offset="0%" stop-color="#161F34"/>
+      <stop offset="100%" stop-color="#030710"/>
+    </radialGradient>
+
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#7FC8FF"/>
+    </marker>
+
+    <style>
+      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+      .label { fill: #CCE9FF; font-size: 12px; font-weight: 500; }
+      .title { fill: #E5F4FF; font-size: 13px; font-weight: 600; }
+      .small { fill: #99D3FF; font-size: 11px; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="920" height="500" rx="16" fill="url(#bg)"/>
+  <rect x="1" y="1" width="918" height="498" rx="15" fill="none" stroke="#40668D" stroke-width="1" opacity="0.45"/>
+
+  <!-- Agent context panel -->
+  <rect x="36" y="48" width="340" height="404" rx="14" fill="#0D1322" stroke="#7FC8FF" stroke-width="1.5" opacity="0.95"/>
+  <text x="56" y="78" class="mono title">Agent context (system prompt)</text>
+
+  <!-- Base prompt -->
+  <text x="56" y="105" class="mono small">You are a helpful...</text>
+
+  <!-- Skill descriptions in context -->
+  <rect x="56" y="124" width="300" height="44" rx="10" fill="rgba(229,244,255,0.08)" stroke="#006DDD" stroke-width="1.5"/>
+  <text x="72" y="151" class="mono label">Skill description</text>
+
+  <rect x="56" y="180" width="300" height="44" rx="10" fill="rgba(229,244,255,0.08)" stroke="#006DDD" stroke-width="1.5"/>
+  <text x="72" y="207" class="mono label">Skill description</text>
+
+  <!-- Active skill body (dashed) -->
+  <rect x="56" y="248" width="300" height="52" rx="10" fill="rgba(253,243,255,0.06)" stroke="#7E65AE" stroke-width="1.5" stroke-dasharray="6 4"/>
+  <text x="72" y="279" class="mono label">Skill body</text>
+
+  <!-- Skill A panel -->
+  <rect x="544" y="36" width="340" height="188" rx="14" fill="#0D1322" stroke="#7FC8FF" stroke-width="1.5" opacity="0.95"/>
+  <text x="564" y="66" class="mono title">Skill A</text>
+
+  <rect x="564" y="84" width="300" height="40" rx="10" fill="rgba(229,244,255,0.08)" stroke="#006DDD" stroke-width="1.5"/>
+  <text x="580" y="109" class="mono label">Skill description</text>
+
+  <rect x="564" y="132" width="300" height="40" rx="10" fill="rgba(253,243,255,0.08)" stroke="#7E65AE" stroke-width="1.5"/>
+  <text x="580" y="157" class="mono label">Skill body</text>
+
+  <rect x="564" y="180" width="300" height="32" rx="10" fill="rgba(246,255,219,0.08)" stroke="#6E8900" stroke-width="1.5"/>
+  <text x="580" y="201" class="mono label">Scripts / refs</text>
+
+  <!-- Skill B panel -->
+  <rect x="544" y="276" width="340" height="188" rx="14" fill="#0D1322" stroke="#7FC8FF" stroke-width="1.5" opacity="0.95"/>
+  <text x="564" y="306" class="mono title">Skill B</text>
+
+  <rect x="564" y="324" width="300" height="40" rx="10" fill="rgba(229,244,255,0.08)" stroke="#006DDD" stroke-width="1.5"/>
+  <text x="580" y="349" class="mono label">Skill description</text>
+
+  <rect x="564" y="372" width="300" height="40" rx="10" fill="rgba(253,243,255,0.08)" stroke="#7E65AE" stroke-width="1.5"/>
+  <text x="580" y="397" class="mono label">Skill body</text>
+
+  <rect x="564" y="420" width="300" height="32" rx="10" fill="rgba(246,255,219,0.08)" stroke="#6E8900" stroke-width="1.5"/>
+  <text x="580" y="441" class="mono label">Scripts / refs</text>
+
+  <!-- Arrows: Skill A description -> context description 1 -->
+  <path d="M564 104 C520 104, 420 146, 356 146" fill="none" stroke="#7FC8FF" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#arrow)"/>
+
+  <!-- Skill B description -> context description 2 -->
+  <path d="M564 344 C500 344, 420 202, 356 202" fill="none" stroke="#7FC8FF" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#arrow)"/>
+
+  <!-- Skill B body -> context skill body -->
+  <path d="M564 392 C500 392, 430 274, 356 274" fill="none" stroke="#7FC8FF" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#arrow)"/>
+</svg>

--- a/src/oss/images/deepagents/skills-progressive-disclosure.svg
+++ b/src/oss/images/deepagents/skills-progressive-disclosure.svg
@@ -1,0 +1,56 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 720 460" role="img" aria-labelledby="skills-disclosure-title skills-disclosure-desc">
+  <title id="skills-disclosure-title">Skills progressive disclosure diagram</title>
+  <desc id="skills-disclosure-desc">Skills load in three layers: metadata at startup, instructions when activated, and resources when referenced.</desc>
+
+  <defs>
+    <radialGradient id="bg" cx="50%" cy="40%" r="75%">
+      <stop offset="0%" stop-color="#161F34"/>
+      <stop offset="100%" stop-color="#030710"/>
+    </radialGradient>
+
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 Z" fill="#7FC8FF"/>
+    </marker>
+
+    <style>
+      .mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace; }
+      .label { fill: #CCE9FF; font-size: 12px; font-weight: 500; }
+      .title { fill: #E5F4FF; font-size: 13px; font-weight: 600; }
+      .small { fill: #99D3FF; font-size: 11px; }
+      .edge-label { fill: #99D3FF; font-size: 10px; font-weight: 500; }
+    </style>
+  </defs>
+
+  <!-- Background -->
+  <rect width="720" height="460" rx="16" fill="url(#bg)"/>
+  <rect x="1" y="1" width="718" height="458" rx="15" fill="none" stroke="#40668D" stroke-width="1" opacity="0.45"/>
+
+  <!-- Layer 1: Metadata -->
+  <rect x="110" y="36" width="500" height="96" rx="14" fill="#0D1322" stroke="#6E8900" stroke-width="1.5" opacity="0.95"/>
+  <text x="130" y="66" class="mono title">Metadata</text>
+  <text x="130" y="92" class="mono label">name + description</text>
+  <text x="130" y="114" class="mono small">Loaded at startup for all skills</text>
+
+  <!-- Arrow 1 -->
+  <path d="M360 132 L360 182" fill="none" stroke="#7FC8FF" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#arrow)"/>
+  <text x="382" y="161" class="mono edge-label">Agent determines skill is relevant</text>
+
+  <!-- Layer 2: Instructions -->
+  <rect x="110" y="184" width="500" height="96" rx="14" fill="#0D1322" stroke="#006DDD" stroke-width="1.5" opacity="0.95"/>
+  <text x="130" y="214" class="mono title">Instructions</text>
+  <text x="130" y="240" class="mono label">Full SKILL.md body</text>
+  <text x="130" y="262" class="mono small">Read when the skill is activated</text>
+
+  <!-- Arrow 2 -->
+  <path d="M360 280 L360 330" fill="none" stroke="#7FC8FF" stroke-width="1.5" stroke-dasharray="5 4" marker-end="url(#arrow)"/>
+  <text x="382" class="mono edge-label">
+    <tspan x="382" y="299">Instructions reference</tspan>
+    <tspan x="382" dy="14">supporting files</tspan>
+  </text>
+
+  <!-- Layer 3: Resources -->
+  <rect x="110" y="332" width="500" height="96" rx="14" fill="#0D1322" stroke="#40668D" stroke-width="1.5" opacity="0.95"/>
+  <text x="130" y="362" class="mono title">Resources</text>
+  <text x="130" y="388" class="mono label">scripts/, references/, assets/</text>
+  <text x="130" y="410" class="mono small">Loaded only when referenced</text>
+</svg>

--- a/src/style.css
+++ b/src/style.css
@@ -221,6 +221,19 @@ a code {
   justify-content: center;
 }
 
+/* Skills composition diagram (custom SVG) */
+.skills-composition-diagram {
+  margin: 1.5rem 0 2rem;
+  text-align: center;
+}
+
+.skills-composition-diagram img {
+  width: 100%;
+  max-width: 920px;
+  border-radius: 16px;
+  display: inline-block;
+}
+
 /* Mermaid dark mode text overrides */
 /* Node labels: inherit color from classDef parent instead of being forced to white */
 .dark .nodeLabel,


### PR DESCRIPTION
- Start with skill definition - and adding a metaphor that I think helps
- moved some of the "what skills are" into usage and renamed what skills are to how they work. I think that works better.
- Reframed skill permissions into sharing skills (I think permissions is how to implement it, but the task people are trying to accomplish is sharing skills)
- added a section on when to use skills, kept it short
- added section on skills with other resources. It makes it very explicit that you need to reference files and how to do so
- Added skill diagram

---
Updates:
- Expanded Skill permissions
- added more layering info to how skills work
