### PR TITLE
docs: document child-run trace predicates [closes LSO-2783]

### DIFF
--- a/src/langsmith/export-traces.mdx
+++ b/src/langsmith/export-traces.mdx
@@ -10,6 +10,7 @@ This page covers:
 
 - [Use filter arguments](#use-filter-arguments): keyword-based filtering using SDK parameters.
 - [Use filter query language](#use-filter-query-language): complex queries using LangSmith's filter syntax.
+- [Query trace trees with child-run predicates](#query-trace-trees-with-child-run-predicates): combine server-side narrowing with local child-run traversal.
 - [Rate limits](#rate-limits): per-tenant limits and best practices for staying within them.
 
 <Note>
@@ -815,6 +816,97 @@ RunQueryParams runs = RunQueryParams.builder()
     .traceFilter("and(eq(feedback_key, 'user_score'), eq(feedback_score, 1))")
     .treeFilter("eq(name, 'ExpandQuery')")
     .build();
+```
+
+</CodeGroup>
+
+## Query trace trees with child-run predicates
+
+Use `trace_filter` to match fields on the root run and `tree_filter` to match supported searchable fields on any run in the trace tree. For predicates over arbitrary returned child-run fields, such as nested `inputs`, `outputs`, or `extra` payloads, use the steps below:
+
+1. Narrow candidate root traces server-side with `filter`, `trace_filter`, `tree_filter`, `run_type`, metadata filters, `parent_run_id`, and the `ls_run_depth` [system metadata key](/langsmith/ls-metadata-parameters#ls_run_depth).
+2. Hydrate each candidate root trace with child runs by calling `read_run(..., load_child_runs=True)` in Python or `readRun(..., { loadChildRuns: true })` in TypeScript.
+3. Traverse the hydrated `child_runs` tree locally and apply your predicate to the fields that are not available as server-side filter fields.
+
+The following example (Python 0.8 and JS 0.7) returns root traces that contain a tool run whose output contains a specific value. The server-side `tree_filter` narrows candidates to traces that contain the relevant tool run, and the local predicate checks the hydrated `outputs` payload.
+
+<CodeGroup>
+
+```python Python
+from datetime import datetime, timedelta
+
+from langsmith import Client
+
+client = Client()
+project_name = "<your_project>"
+
+
+def iter_runs(run):
+    yield run
+    for child in run.child_runs or []:
+        yield from iter_runs(child)
+
+
+candidate_roots = client.list_runs(
+    project_name=project_name,
+    is_root=True,
+    start_time=datetime.now() - timedelta(days=7),
+    tree_filter='and(eq(run_type, "tool"), eq(name, "<tool_name>"))',
+    select=["id"],
+)
+
+matching_roots = []
+for candidate in candidate_roots:
+    root = client.read_run(candidate.id, load_child_runs=True)
+    has_matching_child = any(
+        child.id != root.id
+        and child.run_type == "tool"
+        and child.name == "<tool_name>"
+        and "<expected_value>" in str(child.outputs or {})
+        for child in iter_runs(root)
+    )
+    if has_matching_child:
+        matching_roots.append(root)
+```
+
+```typescript TypeScript
+import { Client, Run } from "langsmith";
+
+const client = new Client();
+const projectName = "<your_project>";
+
+function* iterRuns(run: Run): Generator<Run> {
+  yield run;
+  for (const child of run.child_runs ?? []) {
+    yield* iterRuns(child);
+  }
+}
+
+const candidateRoots: Run[] = [];
+for await (const run of client.listRuns({
+  projectName,
+  isRoot: true,
+  startTime: new Date(Date.now() - 1000 * 60 * 60 * 24 * 7),
+  treeFilter: 'and(eq(run_type, "tool"), eq(name, "<tool_name>"))',
+  select: ["id"],
+})) {
+  candidateRoots.push(run);
+}
+
+const matchingRoots: Run[] = [];
+for (const candidate of candidateRoots) {
+  const root = await client.readRun(candidate.id, { loadChildRuns: true });
+  const hasMatchingChild = [...iterRuns(root)].some(
+    (child) =>
+      child.id !== root.id &&
+      child.run_type === "tool" &&
+      child.name === "<tool_name>" &&
+      JSON.stringify(child.outputs ?? {}).includes("<expected_value>"),
+  );
+  if (hasMatchingChild) {
+    matchingRoots.push(root);
+  }
+}
 ```
 
 </CodeGroup>

--- a/src/langsmith/trace-query-syntax.mdx
+++ b/src/langsmith/trace-query-syntax.mdx
@@ -46,3 +46,7 @@ The filtering grammar is based on common comparators on fields in the run object
 Additionally, you can combine multiple comparisons through the `and` operator.
 
 These can be applied on fields of the run object, such as its `id`, `name`, `run_type`, `start_time` / `end_time`, `latency`, `total_tokens`, `error`, `execution_order`, `tags`, and any associated feedback through `feedback_key` and `feedback_score`.
+
+<Note>
+`tree_filter` applies the same query syntax to runs anywhere in the trace tree. For predicates over arbitrary nested child-run fields, such as returned `inputs`, `outputs`, or `extra` payload paths, first narrow candidates with server-side filters, then hydrate root traces with child runs and traverse them locally. See [Query trace trees with child-run predicates](/langsmith/export-traces#query-trace-trees-with-child-run-predicates).
+</Note>


### PR DESCRIPTION
## Description
Documents the current two-stage pattern for trace-level queries that depend on arbitrary child-run fields, and clarifies when to use server-side `tree_filter` versus hydrated local traversal.

## Release Note
none

## Test Plan
- [x] Verified prose lint and the new cross-link with the docs broken-link check.

Made by [Open SWE](https://openswe.vercel.app)