### PR TITLE
docs(engine): explain LCU costs and expand spend limit guidance

### DIFF
--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -56,10 +56,10 @@ Engine charges in **LangChain Compute Units (LCUs)** — a normalized unit of wo
 
 Engine runs in two phases:
 
-| Phase | Trigger | Typical LCU usage | Issues found |
-|---|---|---|---|
-| **Initialization** | First time you enable Engine on a project | 30–40 LCUs | 5–10 issues |
-| **Recurring scans** | Every 6 hours automatically | 10–15 LCUs | 0–5 issues |
+| Phase | Trigger | Typical LCU usage |
+|---|---|---|
+| **Initialization** | First time you enable Engine on a project | 30–40 LCUs |
+| **Recurring scans** | Every 6 hours automatically | 10–15 LCUs |
 
 Actual usage varies based on trace volume and complexity.
 

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -52,7 +52,7 @@ Once Engine is enabled, any team member in your organization can set it up for t
 
 ### Understand LCU costs
 
-Engine charges in **LangChain Compute Units (LCUs)** — a normalized unit of work combining compute, storage, memory, and LLM spend. The more traces, deep thought, and work needed, the more LCUs Engine consumes. LCUs cost **$1.50 USD each**.
+Engine charges in **LangChain Compute Units (LCUs)**—a normalized unit of work combining compute, storage, memory, and LLM spend. The more traces, deep thought, and work needed, the more LCUs Engine consumes. LCUs cost **$1.50 USD each**.
 
 Engine runs in two phases:
 
@@ -72,7 +72,7 @@ Organization Admins can set spend limits at two levels:
 - **Org-wide limit**: Open **Settings**, select **Engine enablement** under **Engine**, then enter a value under **Monthly LCU spend limit**.
 - **Per-project limit**: Open the **Engine** tab in a tracing project, click the **Engine settings** gear icon, and set a limit under **Monthly LCU spend limit**.
 
-You can enter limits in LCU or USD — the values stay in sync at a rate of 1 LCU = $1.50. When a limit is reached, LangSmith pauses new Engine runs until the limit is raised or the next monthly billing period begins.
+You can enter limits in LCU or USD—the values stay in sync at a rate of 1 LCU = $1.50. When a limit is reached, LangSmith pauses new Engine runs until the limit is raised or the next monthly billing period begins.
 
 Leave the limit blank to allow unlimited Engine spend. To stop Engine entirely, use the **Enable Engine** toggle in **Settings > Engine enablement**.
 

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -50,13 +50,33 @@ Once Engine is enabled, any team member in your organization can set it up for t
   If you want to turn off Engine, toggle the same setting to off. This will stop all automatic runs of Engine and discontinue future billing in your account.
 </Tip>
 
-### Set a monthly spend limit
+### Understand LCU costs
 
-Organization Admins can set an org-wide monthly spend limit for the number of LangChain Compute Units (LCUs) their organization can spend on Engine each month. When the organization reaches the monthly limit, LangSmith pauses new Engine runs until the limit is raised or the next monthly billing period begins.
+Engine charges in **LangChain Compute Units (LCUs)** — a normalized unit of work combining compute, storage, memory, and LLM spend. The more traces, deep thought, and work needed, the more LCUs Engine consumes. LCUs cost **$1.50 USD each**.
 
-To set a limit, open **Settings**, select **Engine enablement** under **Engine**, then enter a value under **Monthly LCU spend limit**. You can enter the limit in LCU or USD. The values stay in sync at a rate of 1 LCU = $1.50.
+Engine runs in two phases:
 
-Leave the limit blank to allow unlimited Engine spend. To stop Engine entirely, use the **Enable Engine** toggle above the spend limit setting. Once Engine is running, you can see your monthly LCU spend on Engine per workspace on the Engine enablement page.
+| Phase | Trigger | Typical LCU usage | Issues found |
+|---|---|---|---|
+| **Initialization** | First time you enable Engine on a project | 30–40 LCUs | 5–10 issues |
+| **Recurring scans** | Every 6 hours automatically | 10–15 LCUs | 0–5 issues |
+
+Actual usage varies based on trace volume and complexity.
+
+On initialization, Engine audits past traces, clusters and prioritizes issues by severity, and proposes fixes to your prompts or code (if a repository is connected). Recurring scans surface new improvements not previously found.
+
+### Set spend limits and monitor usage
+
+Organization Admins can set spend limits at two levels:
+
+- **Org-wide limit**: Open **Settings**, select **Engine enablement** under **Engine**, then enter a value under **Monthly LCU spend limit**.
+- **Per-project limit**: Open the **Engine** tab in a tracing project, click the **Engine settings** gear icon, and set a limit under **Monthly LCU spend limit**.
+
+You can enter limits in LCU or USD — the values stay in sync at a rate of 1 LCU = $1.50. When a limit is reached, LangSmith pauses new Engine runs until the limit is raised or the next monthly billing period begins.
+
+Leave the limit blank to allow unlimited Engine spend. To stop Engine entirely, use the **Enable Engine** toggle in **Settings > Engine enablement**.
+
+To monitor usage, you can view your organization's monthly LCU spend on the **Engine enablement** page in **Settings**, or view per-project spend in the **Engine settings** panel for each tracing project.
 
 ### Set up Engine for a tracing project
 

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -52,7 +52,7 @@ Once Engine is enabled, any team member in your organization can set it up for t
 
 ### Understand LCU costs
 
-Engine charges in **LangChain Compute Units (LCUs)**—a normalized unit of work combining compute, storage, memory, and LLM spend. The more traces, deep thought, and work needed, the more LCUs Engine consumes. LCUs cost **$1.50 USD each**.
+Engine charges in **LangChain Compute Units (LCUs)**, a normalized unit of work combining compute, storage, memory, and LLM spend. The more traces, deep thought, and work needed, the more LCUs Engine consumes. LCUs cost **$1.50 USD each**.
 
 Engine runs in two phases:
 
@@ -72,7 +72,7 @@ Organization Admins can set spend limits at two levels:
 - **Org-wide limit**: Open **Settings**, select **Engine enablement** under **Engine**, then enter a value under **Monthly LCU spend limit**.
 - **Per-project limit**: Open the **Engine** tab in a tracing project, click the **Engine settings** gear icon, and set a limit under **Monthly LCU spend limit**.
 
-You can enter limits in LCU or USD—the values stay in sync at a rate of 1 LCU = $1.50. When a limit is reached, LangSmith pauses new Engine runs until the limit is raised or the next monthly billing period begins.
+You can enter limits in LCU or USD (1 LCU = $1.50). When a limit is reached, LangSmith pauses new Engine runs until the limit is raised or the next monthly billing period begins.
 
 Leave the limit blank to allow unlimited Engine spend. To stop Engine entirely, use the **Enable Engine** toggle in **Settings > Engine enablement**.
 


### PR DESCRIPTION
## Summary

- Adds a new **Understand LCU costs** subsection explaining what LCUs are (normalized unit of compute, storage, memory, and LLM spend), typical usage per phase, and how costs vary
- Expands spend limit guidance to cover both org-wide and per-project caps
- Adds pointers to where admins can monitor usage (org admin settings + per-project engine settings panel)

## Changes

**New: Understand LCU costs section**
- LCU definition and $1.50/LCU rate
- Table showing initialization (30–40 LCUs, 5–10 issues) vs recurring scans (10–15 LCUs, 0–5 issues)
- Plain-English description of what each phase does

**Updated: Set a monthly spend limit → Set spend limits and monitor usage**
- Documents both org-wide and per-project spend limits
- Clarifies where to view usage in both org admin settings and per-project engine settings
