### PR TITLE
docs: remove private beta note from LangSmith sandbox provider

### DIFF
--- a/src/snippets/deepagents-sandbox-basic-py.mdx
+++ b/src/snippets/deepagents-sandbox-basic-py.mdx
@@ -135,10 +135,6 @@
     </Tab>
     <Tab title="LangSmith">
 
-        <Note>
-            LangSmith sandboxes are currently in private beta.
-        </Note>
-
         <CodeGroup>
             ```bash pip
             pip install "langsmith[sandbox]"


### PR DESCRIPTION
## Description
LangSmith sandboxes are GA, so the "currently in private beta" callout in the Deep Agents sandbox docs is out of date. Removes the `<Note>` from the LangSmith tab of the basic sandbox usage snippet.

## Release Note
none

## Test Plan
- [ ] Verify the LangSmith tab on the Deep Agents Sandboxes page no longer shows the private beta note.

Made by [Open SWE](https://openswe.vercel.app)