### PR TITLE
document MCP tool error-handling behavior

### DIFF
--- a/src/oss/langchain/mcp.mdx
+++ b/src/oss/langchain/mcp.mdx
@@ -556,6 +556,14 @@ client = MultiServerMCPClient({...})
 tools = await client.get_tools()  # [!code highlight]
 agent = create_agent("claude-sonnet-4-6", tools)
 ```
+
+By default, when an MCP tool fails, the error is passed back to the model as a tool message with `status="error"` instead of raising an exception. This lets the agent read the error and try again. To raise an exception instead, set `handle_tool_errors=False` on `MultiServerMCPClient` or `load_mcp_tools`.
+
+This applies only to tool execution errors (`CallToolResult(isError=True)`). Transport, session, and content-conversion failures always raise.
+
+<Note>
+    Returning MCP tool errors as failed tool messages requires `langchain-mcp-adapters>=0.3.0`. Earlier versions raise a `ToolException`.
+</Note>
 :::
 
 :::js
@@ -569,6 +577,8 @@ const client = new MultiServerMCPClient({...});
 const tools = await client.getTools();  // [!code highlight]
 const agent = createAgent({ model: "claude-sonnet-4-6", tools });
 ```
+
+When an MCP tool execution fails (`CallToolResult` with `isError: true`), `@langchain/mcp-adapters` raises a `ToolException`. Wrap tool calls in a try/catch to handle these errors. Unlike the Python adapter, the TypeScript adapter does not return the error to the model as a failed tool message.
 :::
 
 :::python
@@ -1073,7 +1083,7 @@ client = MultiServerMCPClient(
 
 **Error handling**
 
-Use interceptors to catch tool execution errors and implement retry logic:
+Use interceptors to catch exceptions from tool execution, such as transport or runtime failures, and add retry logic. Tool execution errors (`CallToolResult(isError=True)`) do not raise by default, so exception-catching interceptors never trigger on them. To catch those as exceptions here, set `handle_tool_errors=False`.
 
 ```python Retry on error
 import asyncio


### PR DESCRIPTION
Documents how MCP tool failures surface to the agent across the Python and TypeScript adapters, prompted by the `langchain-mcp-adapters>=0.3.0` behavior change where tool execution errors are returned to the model instead of raised.

## Changes
- Explain that the Python adapter returns MCP tool execution errors (`CallToolResult(isError=True)`) as tool messages with `status="error"` by default, letting the agent retry, with `handle_tool_errors=False` to opt back into raising.
- Clarify which failures are exempt: transport, session, and content-conversion errors always raise regardless of `handle_tool_errors`.
- Note the TypeScript adapter's divergent behavior: `@langchain/mcp-adapters` raises a `ToolException` on tool execution failure rather than returning it to the model.
- Correct the interceptor "Error handling" section to state that exception-catching interceptors do not fire on tool execution errors by default, and how to make them.
- Add a version `<Note>` pinning the new Python behavior to `langchain-mcp-adapters>=0.3.0`.
