### PR TITLE
document Google GenAI HTTP options

### DIFF
--- a/src/oss/python/integrations/chat/google_generative_ai.mdx
+++ b/src/oss/python/integrations/chat/google_generative_ai.mdx
@@ -226,6 +226,56 @@ model = ChatGoogleGenerativeAI(
 )
 ```
 
+### Custom endpoints and headers
+
+Use `base_url` and `additional_headers` for model-level HTTP options, such as routing requests through an internal gateway:
+
+```python
+model = ChatGoogleGenerativeAI(
+    model="gemini-3.5-flash",
+    base_url="https://your-gemini-gateway.example.com",
+    additional_headers={"X-Custom-Header": "value"},
+)
+```
+
+To pass headers or other HTTP options for a single request, provide `http_options` when invoking the model:
+
+```python
+token = "..."
+messages = [("human", "Hello!")]
+
+response = model.invoke(
+    messages,
+    http_options={
+        "headers": {
+            "Authorization": f"Bearer {token}",
+        }
+    },
+)
+```
+
+The same call-time options work with async invocation:
+
+```python
+response = await model.ainvoke(
+    messages,
+    http_options={"headers": {"Authorization": f"Bearer {token}"}},
+)
+```
+
+The per-request `http_options` may be a dictionary or a `google.genai.types.HttpOptions` object. Header dictionaries are merged with model-level `additional_headers`, and per-request header values take precedence. Model-level `timeout` and `max_retries` settings are preserved unless you explicitly override `timeout` or `retry_options` in `http_options`.
+
+```python
+from google.genai.types import HttpOptions
+
+response = model.invoke(
+    messages,
+    http_options=HttpOptions(
+        headers={"Authorization": f"Bearer {token}"},
+    ),
+)
+```
+
 ## Invocation
 
 ```python


### PR DESCRIPTION
Adds documentation for configuring `ChatGoogleGenerativeAI` HTTP options at model construction and per request. Covers custom endpoints, headers, async invocation, and how call-time options interact with model-level retry and timeout settings.