### PR TITLE
clarify Deep Agents Code trace project separation

### DIFF
--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -706,7 +706,7 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_LANGSMITH_PROJECT" type="string" post={["optional"]}>
-    Override the LangSmith project name for agent traces. See [Trace with LangSmith](/oss/deepagents/code/overview#trace-with-langsmith).
+    Override the LangSmith project name for Deep Agents Code's own agent traces. Shell commands still run with the user's original `LANGSMITH_PROJECT`, so app, test, or script traces can appear in a separate project. See [Trace with LangSmith](/oss/deepagents/code/overview#trace-with-langsmith).
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_NO_UPDATE_CHECK" type="string" post={["optional"]}>

--- a/src/oss/deepagents/code/overview.mdx
+++ b/src/oss/deepagents/code/overview.mdx
@@ -419,21 +419,31 @@ export LANGSMITH_TRACING=false
 ```
 
 <Accordion title="Separate agent traces from app traces">
-    When invoking Deep Agents Code programmatically from a LangChain application (e.g., as a subprocess in [non-interactive mode](#non-interactive-mode-and-piping)), both your app and Deep Agents Code produce LangSmith traces. By default, these all land in the same project.
+    Deep Agents Code can produce two kinds of LangSmith traces:
 
-    To send Deep Agents Code traces to a dedicated project, set `DEEPAGENTS_CODE_LANGSMITH_PROJECT`:
+    - `Agent traces` are Deep Agents Code's own model calls, tool calls, orchestration, and middleware.
+    - `Shell-command traces` are traces emitted by code that Deep Agents Code runs for you in a shell, such as tests, scripts, or a local LangGraph app.
 
-    ```bash title="~/.deepagents/.env"
-    DEEPAGENTS_CODE_LANGSMITH_PROJECT=my-deep-agent-execution
-    ```
-
-    Then configure `LANGSMITH_PROJECT` for your parent application's traces:
+    To send Deep Agents Code's own traces to a dedicated project, set `DEEPAGENTS_CODE_LANGSMITH_PROJECT`:
 
     ```bash title="~/.deepagents/.env"
-    LANGSMITH_PROJECT=my-app-traces
+    # Example value; use any LangSmith project name you want.
+    DEEPAGENTS_CODE_LANGSMITH_PROJECT=deepagents-code
     ```
 
-    This keeps your app-level observability clean while still capturing the agent's internal execution in a separate project.
+    Then configure `LANGSMITH_PROJECT` for your application traces:
+
+    ```bash title=".env"
+    LANGSMITH_PROJECT=customer-support-agent
+    ```
+
+    For example, suppose you ask Deep Agents Code to debug a failing LangGraph test:
+
+    ```bash
+    uv run pytest tests/test_escalation_flow.py
+    ```
+
+    If that test runs your app with LangSmith tracing enabled, those app traces are created by the shell process and go to `customer-support-agent`. Deep Agents Code's own reasoning and tool-use traces go to `deepagents-code`.
 
     You can also scope LangSmith credentials to Deep Agents Code using the [`DEEPAGENTS_CODE_` prefix](/oss/deepagents/code/configuration#deepagents_code_-prefix) (e.g., `DEEPAGENTS_CODE_LANGSMITH_API_KEY`).
 </Accordion>


### PR DESCRIPTION
Clarifies how Deep Agents Code routes LangSmith traces when it runs alongside traced application code. The docs now distinguish Deep Agents Code's own agent traces from traces emitted by shell commands, tests, scripts, or local apps.

## Changes
- Define `Agent traces` and `Shell-command traces` in the LangSmith tracing guide so users can tell which process owns each trace.
- Explain how `DEEPAGENTS_CODE_LANGSMITH_PROJECT` sends Deep Agents Code's own traces to a dedicated LangSmith project without overriding the user's `LANGSMITH_PROJECT` for shell commands.
- Replace the abstract app-tracing example with concrete `deepagents-code` and `customer-support-agent` project names plus a failing LangGraph test scenario.
- Update the `DEEPAGENTS_CODE_LANGSMITH_PROJECT` environment variable reference to call out the same agent-trace versus shell-command-trace behavior.