### PR TITLE
Document output parsing error handling for chains

### DIFF
--- a/src/oss/langchain/structured-output.mdx
+++ b/src/oss/langchain/structured-output.mdx
@@ -1218,3 +1218,102 @@ const responseFormat = toolStrategy(ProductRating, {
 )
 ```
 :::
+
+## Handle parsing errors in chains
+
+:::python
+The strategies above, including `handle_errors` retries, apply to agents created with @[`create_agent`]. Chains composed with the pipe operator (for example, `prompt | model | parser`) have no built-in retry mechanism for output parsing failures. To handle malformed model output in a chain, use one of the following approaches:
+
+- **Model-level structured output**: Bind the schema to the model with @[`with_structured_output`][BaseChatModel.with_structured_output]. The provider enforces the schema, which avoids most parsing failures. See [Models - Structured output](/oss/langchain/models#structured-output). Use this approach when the model supports it.
+- **Fix malformed output with a model**: Wrap the output parser in an `OutputFixingParser` from [`langchain-classic`](https://pypi.org/project/langchain-classic). On a parsing failure, the wrapper sends the malformed output, the parser's format instructions, and the error message to a model and parses the corrected response.
+
+<Note>
+    `OutputFixingParser` requires the `langchain-classic` package. Before v1, it was available as `langchain.output_parsers.OutputFixingParser`.
+</Note>
+
+```python
+from langchain.chat_models import init_chat_model
+from langchain_classic.output_parsers import OutputFixingParser
+from langchain_core.output_parsers import JsonOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from pydantic import BaseModel, Field
+
+
+class ProductReview(BaseModel):
+    """Analysis of a product review."""
+
+    rating: int = Field(description="The rating of the product (1-5)", ge=1, le=5)
+    sentiment: str = Field(description="The sentiment of the review")
+
+
+model = init_chat_model("gpt-5.4")
+
+base_parser = JsonOutputParser(pydantic_object=ProductReview)
+fixing_parser = OutputFixingParser.from_llm(
+    parser=base_parser,
+    llm=model,
+    max_retries=3,
+)
+
+prompt = ChatPromptTemplate.from_messages([
+    ("system", "Analyze the product review.\n{format_instructions}"),
+    ("user", "{review}"),
+]).partial(format_instructions=base_parser.get_format_instructions())
+
+chain = prompt | model | fixing_parser
+
+result = chain.invoke({"review": "Great product, 5 stars! Fast shipping, but expensive."})
+# {'rating': 5, 'sentiment': 'positive'}
+```
+
+The wrapped parser only invokes the fixing model when the initial parse fails, so well-formed output incurs no extra model calls. `max_retries` controls how many fix attempts are made before the original `OutputParserException` is raised. Both sync (`invoke`) and async (`ainvoke`) execution are supported.
+
+`OutputFixingParser` sends only the malformed completion and the error to the fixing model. If correcting the output requires the original prompt for context, use `RetryOutputParser` from `langchain-classic` instead. It is invoked through its `parse_with_prompt(completion, prompt_value)` method rather than `parse`, so it cannot be piped directly as the final step of a chain.
+:::
+:::js
+The strategies above, including `handleError` retries, apply to agents created with `createAgent`. Chains composed with `.pipe()` (for example, `prompt.pipe(model).pipe(parser)`) have no built-in retry mechanism for output parsing failures. To handle malformed model output in a chain, use one of the following approaches:
+
+- **Model-level structured output**: Bind the schema to the model with @[`withStructuredOutput`][BaseChatModel.with_structured_output]. The provider enforces the schema, which avoids most parsing failures. See [Models - Structured output](/oss/langchain/models#structured-output). Use this approach when the model supports it.
+- **Fix malformed output with a model**: Wrap the output parser in an `OutputFixingParser` from [`@langchain/classic`](https://www.npmjs.com/package/@langchain/classic). On a parsing failure, the wrapper sends the malformed output, the parser's format instructions, and the error message to a model and parses the corrected response.
+
+<Note>
+    `OutputFixingParser` requires the `@langchain/classic` package. Before v1, it was available from `langchain/output_parsers`.
+</Note>
+
+```ts
+import { OutputFixingParser } from "@langchain/classic/output_parsers";
+import { StructuredOutputParser } from "@langchain/core/output_parsers";
+import { ChatPromptTemplate } from "@langchain/core/prompts";
+import { initChatModel } from "langchain";
+import * as z from "zod";
+
+const ProductReview = z.object({
+    rating: z.number().min(1).max(5).describe("The rating of the product (1-5)"),
+    sentiment: z.enum(["positive", "negative"]).describe("The sentiment of the review"),
+});
+
+const model = await initChatModel("gpt-5.4");
+
+const baseParser = StructuredOutputParser.fromZodSchema(ProductReview);
+const fixingParser = OutputFixingParser.fromLLM(model, baseParser);
+
+const prompt = ChatPromptTemplate.fromMessages([
+    ["system", "Analyze the product review.\n{format_instructions}"],
+    ["user", "{review}"],
+]);
+
+const chain = prompt.pipe(model).pipe(fixingParser);
+
+const result = await chain.invoke({
+    review: "Great product, 5 stars! Fast shipping, but expensive.",
+    format_instructions: baseParser.getFormatInstructions(),
+});
+// { rating: 5, sentiment: "positive" }
+```
+
+The wrapped parser only invokes the fixing model when the initial parse fails, so well-formed output incurs no extra model calls.
+
+<Warning>
+    `OutputFixingParser` retries only errors thrown as `OutputParserException`. Parsers that throw raw errors are not retried: for example, `JsonOutputParser` throws a plain `SyntaxError` on invalid JSON, which propagates uncaught. Wrap a parser that throws `OutputParserException`, such as `StructuredOutputParser`.
+</Warning>
+:::

--- a/src/oss/python/releases/langchain-v1.mdx
+++ b/src/oss/python/releases/langchain-v1.mdx
@@ -336,6 +336,7 @@ Legacy functionality has moved to [`langchain-classic`](https://pypi.org/project
 
 - Legacy chains and chain implementations
 - Retrievers (e.g. `MultiQueryRetriever` or anything from the previous `langchain.retrievers` module)
+- Output parsers that repair malformed model output (e.g. `OutputFixingParser` or anything from the previous `langchain.output_parsers` module)
 - The indexing API
 - The hub module (for managing prompts programmatically)
 - [`langchain-community`](https://pypi.org/project/langchain-community) exports
@@ -364,6 +365,9 @@ from langchain_classic.chains import ...  # [!code ++]
 
 from langchain.retrievers import ...  # [!code --]
 from langchain_classic.retrievers import ...  # [!code ++]
+
+from langchain.output_parsers import ...  # [!code --]
+from langchain_classic.output_parsers import ...  # [!code ++]
 
 from langchain import hub  # [!code --]
 from langchain_classic import hub  # [!code ++]


### PR DESCRIPTION
## Overview

Adds a **Handle parsing errors in chains** section to the structured output page, and lists output parsers in the `langchain-classic` section of the v1 release notes.

The structured output page currently only documents retry/error handling for agents (`ToolStrategy(handle_errors=...)` with `create_agent`). For chains composed directly (`prompt | model | parser`), there is no documented way to recover from output parsing failures, and `OutputFixingParser` is not mentioned anywhere in the docs since it moved to `langchain-classic`. Users migrating LCEL-based code from pre-v1 have no clear path.

This follows up on langchain-ai/langchain#34753, where @mdrxy outlined the intended v1 direction (agents → `ToolStrategy(handle_errors=True)`; provider-native structured output where supported; `langchain-classic`'s `OutputFixingParser` for chains) and noted "the docs could make this distinction clearer for LCEL users migrating from pre-v1."

The new section covers:

- Pointing users to model-level structured output (`with_structured_output`) as the preferred option when supported
- Wrapping a parser with `OutputFixingParser.from_llm(...)` in a chain, with tested Python and JS examples
- Python: a note on `RetryOutputParser` for cases where the fix needs the original prompt, including the `parse_with_prompt` constraint
- JS: a warning that the fixing parser only retries `OutputParserException`, so it must wrap a parser like `StructuredOutputParser` (`JsonOutputParser` throws a raw `SyntaxError` that propagates uncaught — verified by running it)

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Feature PR: langchain-ai/langchain#34753 (closed; this PR addresses the docs gap acknowledged there)
- See also langchain-ai/langchain#34098 for user reports of the same gap

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed (no nav changes — sections added to existing pages)

## Additional notes

Both code examples were verified end-to-end against `langchain-classic` 1.0.7 (Python) and `@langchain/classic` 1.0.34 (JS) using deterministic fake chat models that return malformed JSON, confirming the base parser fails and the fixing parser recovers (sync and async in Python). `make lint_prose` passes on both changed files.

**AI disclosure:** this PR was drafted with the help of Claude Code. I directed the scope (following up on langchain-ai/langchain#34753) and reviewed everything. Both code examples were verified end-to-end rather than written from memory — that testing is also what surfaced the JS `OutputParserException` gotcha now covered in the Warning callout.

