### PR TITLE
docs: add Voxell Forge embeddings integration

### DIFF
--- a/src/oss/python/integrations/embeddings/index.mdx
+++ b/src/oss/python/integrations/embeddings/index.mdx
@@ -269,4 +269,5 @@ In production, you would typically use a more robust persistent store, such as a
 <Card title="Text Embeddings Inference" icon="link" href="/oss/integrations/embeddings/text_embeddings_inference" arrow="true" cta="View guide" />
 <Card title="Together AI" icon="link" href="/oss/integrations/embeddings/together" arrow="true" cta="View guide" />
 <Card title="Upstage" icon="link" href="/oss/integrations/embeddings/upstage" arrow="true" cta="View guide" />
+<Card title="Voxell" icon="link" href="/oss/integrations/embeddings/voxell" arrow="true" cta="View guide" />
 </Columns>

--- a/src/oss/python/integrations/embeddings/voxell.mdx
+++ b/src/oss/python/integrations/embeddings/voxell.mdx
@@ -1,0 +1,94 @@
+---
+title: "Voxell integration"
+description: "Integrate with the Voxell Forge embedding models using LangChain Python."
+---
+
+This guide walks you through generating embeddings with [Voxell's](/oss/integrations/providers/voxell) Forge API and the LangChain integration.
+
+Voxell's Ingot-8B-R3 ranks #1 for English on the public MTEB leaderboard (English v2), with a 75.98 mean task score across 41 tasks. It is the top usable English embedding model.
+
+## 1. Create an API key
+
+Head to [dash.voxell.ai](https://dash.voxell.ai) to create a free account and an API key. New accounts include 10M free tokens. You can also try Forge with no signup on the [playground](https://playground.voxell.ai).
+
+## 2. Install the integration package
+
+<CodeGroup>
+```bash pip
+pip install langchain-voxell
+```
+
+```bash uv
+uv add langchain-voxell
+```
+</CodeGroup>
+
+## 3. Choose a tier
+
+Forge offers three tiers on one API. Pick your point on the quality and cost curve:
+
+| Tier | Dimensions |
+| ------- | ---------- |
+| `turbo` | 1024 |
+| `pro` | 2560 |
+| `ultra` | 4096 |
+
+## 4. Embed text
+
+Initialize the client with your API key, set either through the `FORGE_API_KEY` environment variable or passed directly with `api_key=...`.
+
+```python
+from langchain_voxell import ForgeEmbeddings
+
+emb = ForgeEmbeddings(model="turbo")  # reads FORGE_API_KEY from the environment
+```
+
+Embed documents and queries. The integration sets the Forge `input_type` for you, so document and query vectors are optimized for retrieval.
+
+```python
+document_embedding = emb.embed_documents(["Voxell Forge turns text into vectors."])[0]
+query_embedding = emb.embed_query("How do I turn text into vectors?")
+```
+
+## 5. Score similarity
+
+Forge returns unit-norm vectors, so the dot product equals cosine similarity.
+
+```python
+import numpy as np
+
+doc = emb.embed_documents(["Voxell Forge turns text into vectors."])[0]
+relevant = emb.embed_query("How do I turn text into vectors?")
+unrelated = emb.embed_query("What time does the store close?")
+
+print(f"relevant:  {np.dot(relevant, doc) * 100:.2f}")
+print(f"unrelated: {np.dot(unrelated, doc) * 100:.2f}")
+```
+
+## Shorter vectors with Matryoshka
+
+Forge supports Matryoshka truncation. Pass `dimensions` to get a shorter, re-normalized vector, which means a smaller index with minimal quality loss.
+
+```python
+emb = ForgeEmbeddings(model="turbo", dimensions=256)
+short_vector = emb.embed_query("a compact embedding")
+```
+
+## Async
+
+Every method has an async counterpart.
+
+```python
+vectors = await emb.aembed_documents(["alpha", "beta"])
+query_vector = await emb.aembed_query("a search query")
+```
+
+## Use with a vector store
+
+```python
+from langchain_community.vectorstores import FAISS
+from langchain_voxell import ForgeEmbeddings
+
+store = FAISS.from_texts(["doc one", "doc two"], ForgeEmbeddings(model="pro"))
+hits = store.similarity_search("query", k=2)
+```

--- a/src/oss/python/integrations/providers/voxell.mdx
+++ b/src/oss/python/integrations/providers/voxell.mdx
@@ -1,0 +1,57 @@
+---
+title: "Voxell integrations"
+description: "Integrate with Voxell using LangChain Python."
+---
+
+[Voxell](https://voxell.ai/forge) builds Forge, a hosted text-embedding API with three tiers (turbo, pro, and ultra) on an OpenAI-compatible endpoint.
+
+Voxell's Ingot-8B-R3 ranks #1 for English on the public MTEB leaderboard (English v2), with a 75.98 mean task score across 41 tasks. It is the top usable English embedding model. See the [model card](https://huggingface.co/JCorners/Ingot-8B-R3).
+
+You can try Forge with no signup on the [playground](https://playground.voxell.ai), and new accounts at [dash.voxell.ai](https://dash.voxell.ai) include a free key with 10M tokens.
+
+Voxell supports LangChain's embedding interface through the [`langchain-voxell`](https://pypi.org/project/langchain-voxell/) integration package.
+
+## Setup
+
+Create a free API key at [dash.voxell.ai](https://dash.voxell.ai), then install the package:
+
+<CodeGroup>
+```bash pip
+pip install langchain-voxell
+```
+
+```bash uv
+uv add langchain-voxell
+```
+</CodeGroup>
+
+Set your `FORGE_API_KEY` environment variable:
+
+<CodeGroup>
+```bash bash
+export FORGE_API_KEY="your_api_key_here"
+```
+
+```powershell powershell
+$env:FORGE_API_KEY="your_api_key_here"
+```
+</CodeGroup>
+
+## Embeddings
+
+The snippet below embeds a document and two queries, then scores their similarity. Forge returns unit-norm vectors, so the dot product equals cosine similarity. A fuller walkthrough is in the [Voxell embeddings guide](/oss/integrations/embeddings/voxell).
+
+```python
+import numpy as np  # you may need to: pip install numpy
+
+from langchain_voxell import ForgeEmbeddings
+
+emb = ForgeEmbeddings(model="turbo")  # reads FORGE_API_KEY from the environment
+
+document_embedding = emb.embed_documents(["Forge is Voxell's text-embedding API."])[0]
+relevant = emb.embed_query("What does Forge do?")
+unrelated = emb.embed_query("How do I bake sourdough?")
+
+print(f"relevant:  {np.dot(relevant, document_embedding) * 100:.2f}")
+print(f"unrelated: {np.dot(unrelated, document_embedding) * 100:.2f}")
+```


### PR DESCRIPTION
## What this adds

Documentation for the Voxell Forge embeddings integration, published independently as the [`langchain-voxell`](https://pypi.org/project/langchain-voxell/) package.

- `src/oss/python/integrations/providers/voxell.mdx`: provider page
- `src/oss/python/integrations/embeddings/voxell.mdx`: embeddings guide with a runnable quickstart
- a card for Voxell in the embeddings index

## About Voxell Forge

Forge is a hosted text-embedding API with three tiers (turbo, pro, ultra) on an OpenAI-compatible endpoint. Voxell's Ingot-8B-R3 ranks #1 for English on the public MTEB leaderboard (English v2), with a 75.98 mean task score across 41 tasks. There is a free playground with no signup and a free key with 10M tokens.

## Verification

The quickstart was run end to end against the live API. A relevant query scored 75.20 cosine similarity against the sample document and an unrelated query scored 18.92, and Matryoshka truncation to 256 dimensions works as documented.

The integration package follows the standard LangChain `Embeddings` interface with sync and async support, and is maintained at [VoxellInc/langchain-voxell](https://github.com/VoxellInc/langchain-voxell).