### PR TITLE
dcode config command group

### DIFF
--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -35,7 +35,7 @@ Each option resolves from the first source that is set, in this order: a `DEEPAG
 All four commands accept `--json` for machine-readable output.
 
 <Warning>
-    Provider credentials and other secrets are reported as configured / not configured only — their values are never printed by `config show` or `config get`, so the output is safe to paste into a bug report.
+    Provider credentials and other secrets are reported as configured / not configured only—their values are never printed by `config show` or `config get`, so the output is safe to paste into a bug report.
 </Warning>
 
 ---

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -19,6 +19,27 @@ Deep Agents Code stores its configuration in the `~/.deepagents/` directory. The
 
 ---
 
+## Inspect configuration
+
+The `dcode config` command group reports what configuration is in effect and where each value comes from, without starting a session. This is useful for confirming that an environment variable or `config.toml` setting is being picked up, and for sharing a redacted snapshot in a bug report.
+
+| Command | Description |
+|---------|-------------|
+| `dcode config show` | Resolve every option against the live environment and `config.toml`, printing the effective value and which source provided it |
+| `dcode config list` (alias `ls`) | List every available option with its type, default, and where it can be set, without resolving values |
+| `dcode config get <key>` | Show the effective value and source for a single option, e.g. `dcode config get interpreter.memory_limit_mb` |
+| `dcode config path` | Show the on-disk config file locations (`config.toml`, project and global `.env`, `hooks.json`, and managed state files) and whether each exists |
+
+Each option resolves from the first source that is set, in this order: a `DEEPAGENTS_CODE_`-prefixed env var, the canonical env var, `config.toml`, then the built-in default.
+
+All four commands accept `--json` for machine-readable output.
+
+<Warning>
+    Provider credentials and other secrets are reported as configured / not configured only — their values are never printed by `config show` or `config get`, so the output is safe to paste into a bug report.
+</Warning>
+
+---
+
 ## Provider credentials
 
 Deep Agents Code needs an API key for each model provider you use. The recommended way to add one is the [`/auth`](#use-%2Fauth-recommended) credential manager. For non-interactive runs, set [environment variables](#environment-variables-ci-and-headless) instead.

--- a/src/oss/deepagents/code/overview.mdx
+++ b/src/oss/deepagents/code/overview.mdx
@@ -200,6 +200,10 @@ dcode --startup-cmd "git diff --stat" -n "Review these changes"
         | `dcode threads delete ID`       | Delete a session. Supports `--dry-run` |
         | `dcode mcp login NAME [--mcp-config PATH]` | Run the OAuth login flow for an MCP server marked `auth: "oauth"`. See [MCP tools](/oss/deepagents/code/mcp-tools#oauth-login) |
         | `dcode mcp config`              | Show MCP config discovery paths        |
+        | `dcode config show`             | Show every config option's effective value and the source it resolves from. See [Inspect configuration](/oss/deepagents/code/configuration#inspect-configuration) |
+        | `dcode config list`             | List all available config options with their type, default, and where each can be set (alias: `ls`) |
+        | `dcode config get KEY`          | Show the effective value and source for one option (e.g. `interpreter.memory_limit_mb`) |
+        | `dcode config path`             | Show config file locations and whether each exists |
 
         All management subcommands support `--json` for machine-readable output. See [command-line options](#command-line-options) for details.
 


### PR DESCRIPTION
Following [deepagents#3763](https://github.com/langchain-ai/deepagents/pull/3763), which adds a `dcode config` command group (`show`, `list`/`ls`, `get <key>`, `path`) for inspecting the configuration surface. Adds an "Inspect configuration" section to the Configuration page and the four commands to the CLI commands table in the Overview, noting `--json` support and secret redaction.

Made by [Open SWE](https://openswe.vercel.app)