### PR TITLE
docs(langsmith): add required `--model` to Harbor Deep Agents example

### DIFF
--- a/src/langsmith/sandbox-harbor.mdx
+++ b/src/langsmith/sandbox-harbor.mdx
@@ -92,6 +92,7 @@ export ANTHROPIC_API_KEY="<ANTHROPIC_API_KEY>"
 
 harbor run -d "terminal-bench@2.0" \
   --agent-import-path deepagents_harbor:DeepAgentsWrapper \
+  --model anthropic:claude-opus-4-8 \
   -e langsmith \
   -n 10 \
   -l 10 \
@@ -118,6 +119,7 @@ environment:
     delete_after_stop_seconds: 7200
 agents:
   - import_path: deepagents_harbor:DeepAgentsWrapper
+    model_name: anthropic:claude-opus-4-8
 datasets:
   - name: terminal-bench
     version: "2.0"

--- a/src/langsmith/sandbox-harbor.mdx
+++ b/src/langsmith/sandbox-harbor.mdx
@@ -61,6 +61,7 @@ Tune the sandbox lifecycle with environment kwargs, passed on the command line w
 
 ```bash
 harbor run -d "<org/name>" \
+  -m "<model>" \
   -a "<agent>" \
   -e langsmith \
   -n "<n-parallel-trials>" \


### PR DESCRIPTION
## Why

The Deep Agents example added in #4400 omits `--model`. `DeepAgentsWrapper` requires a model and raises `ValueError: model_name must be a non-empty string` without one, so the published example fails as written. The sandbox-lifecycle example also omitted the model flag, unlike the other `harbor run` snippets on the page.

## What

- Add `-m "<model>"` to the sandbox-lifecycle (`--ek`) example, for consistency with the other `harbor run` snippets.
- Add `--model anthropic:claude-opus-4-8` to the Deep Agents `harbor run` CLI example.
- Add the matching `model_name: anthropic:claude-opus-4-8` to the job-config YAML (`model_name` is the `AgentConfig` field `--model` maps to).

Uses Opus 4.8, the current GA Opus. `make lint_prose` passes.