### PR TITLE
docs: update Composio integration for current LangChain

### DIFF
--- a/src/oss/python/integrations/tools/composio.mdx
+++ b/src/oss/python/integrations/tools/composio.mdx
@@ -1,402 +1,290 @@
 ---
 title: Composio integration
-description: "Access 500+ tools and integrations through Composio's unified API platform for AI agents, with OAuth handling, event-driven workflows, and multi-user support."
+description: Give agents secure access to 1,000+ toolkits and 20,000+ tools through Composio's unified API platform, with OAuth handling, event-driven workflows, and multi-user support.
 integration:
   name: Composio
   pypi: composio-langchain
 ---
 
+[Composio](https://composio.dev) is an integration platform that gives agents secure access to 1,000+ toolkits and 20,000+ tools across popular applications like GitHub, Slack, Notion, and more. Agents can use Composio through MCP or direct APIs to interact with external services while Composio handles authentication, permissions, and event-driven workflows.
 
-
-[Composio](https://composio.dev) is an integration platform that provides access to 500+ tools across popular applications like GitHub, Slack, Notion, and more. It enables AI agents to interact with external services through a unified API, handling authentication, permissions, and event-driven workflows.
+The `composio-langchain` package wraps Composio tools as LangChain tools and works with LangChain's current `create_agent` API.
 
 ## Overview
 
 ### Integration details
 
-| Class | Package | Serializable | [JS support](https://js.langchain.com/docs/integrations/tools/composio) | Version |
-|:---|:---|:---:|:---:|:---:|
-| Composio | [`composio-langchain`](https://pypi.org/project/composio-langchain/) | ❌ | ✅ | ![PyPI - Version](https://img.shields.io/pypi/v/composio-langchain?style=flat-square&label=%20) |
+| Class | Package | Serializable | JS support | Version |
+| :--- | :--- | :---: | :---: | :---: |
+| `Composio` | [`composio-langchain`](https://pypi.org/project/composio-langchain/) | No | Yes | ![PyPI - Version](https://img.shields.io/pypi/v/composio-langchain?style=flat-square&label=%20) |
+
+See the [Composio JS integration docs](https://js.langchain.com/docs/integrations/tools/composio) for JavaScript and TypeScript usage.
 
 ### Tool features
 
-- **500+ Tool Access**: Prebuilt integrations for GitHub, Slack, Gmail, Jira, Notion, and more
-- **Authentication Management**: Handles OAuth flows, API keys, and authentication state
-- **Event-Driven Workflows**: Trigger agents based on external events (new Slack messages, GitHub issues, etc.)
-- **Fine-Grained Permissions**: Control tool access and data exposure per user
-- **Custom Tool Support**: Add proprietary APIs and internal tools
+- **1,000+ toolkits and 20,000+ tools**: Prebuilt integrations for GitHub, Slack, Gmail, Jira, Notion, and more, available through MCP or direct APIs.
+- **Authentication management**: Handles OAuth flows, API keys, and authentication state.
+- **Event-driven workflows**: Trigger agents based on external events, such as new Slack messages or GitHub commits.
+- **Fine-grained permissions**: Control tool access and data exposure per user.
+- **Enterprise controls**: Supports governance, auditability, SSO, org-wide controls, and SOC 2 / ISO 27001:2022 certifications for enterprise security reviews.
+- **Custom tool support**: Add proprietary APIs and internal tools.
 
 ## Setup
 
 The integration lives in the `composio-langchain` package.
 
 <CodeGroup>
-```python pip
-pip install -U composio-langchain
+```bash pip
+pip install -U composio-langchain langchain langchain-openai
 ```
-```python uv
-uv add composio-langchain
+
+```bash uv
+uv add composio-langchain langchain langchain-openai
 ```
+
 </CodeGroup>
 
 ### Credentials
 
-You'll need a Composio API key. Sign up for free at [composio.dev](https://composio.dev) to get your API key.
+You will need a Composio API key. Sign up at [composio.dev](https://composio.dev) to get your API key.
 
-```python Set API key icon="key"
+```python
 import getpass
 import os
 
 if not os.environ.get("COMPOSIO_API_KEY"):
-    os.environ["COMPOSIO_API_KEY"] = getpass.getpass("Enter your Composio API key: ")
+    os.environ["COMPOSIO_API_KEY"] = getpass.getpass("Composio API key:\n")
 ```
 
-It's also helpful to set up [LangSmith](/langsmith/observability) for tracing:
+It's also helpful to set up [LangSmith](/langsmith/home) for tracing:
 
-```python Enable tracing icon="flask"
-# os.environ["LANGSMITH_API_KEY"] = getpass.getpass("Enter your LangSmith API key: ")
+```python
+# os.environ["LANGSMITH_API_KEY"] = getpass.getpass("LangSmith API key:\n")
 # os.environ["LANGSMITH_TRACING"] = "true"
 ```
 
 ## Instantiation
 
-Initialize Composio with the LangChain provider and get tools from specific toolkits. Each toolkit represents a service (e.g., GitHub, Slack) with multiple tools (actions you can perform).
+Initialize Composio with the LangChain provider. Create a session for the user and toolkit set you want the agent to access:
 
-```python Initialize Composio icon="robot"
+```python
 from composio import Composio
 from composio_langchain import LangchainProvider
 
-# Initialize Composio with LangChain provider
 composio = Composio(provider=LangchainProvider())
-
-# Get tools from specific toolkits
-# You can specify one or more toolkits
-tools = composio.tools.get(
-    user_id="default",
-    toolkits=["GITHUB"]
-)
-
-print(f"Loaded {len(tools)} tools from GitHub toolkit")
+session = composio.create(user_id="user_123", toolkits=["GITHUB"])
+tools = session.tools()
 ```
+
+`session.tools()` returns Composio router tools such as `COMPOSIO_SEARCH_TOOLS`, `COMPOSIO_GET_TOOL_SCHEMAS`, and `COMPOSIO_MANAGE_CONNECTIONS`. The agent uses these tools to discover concrete toolkit tools, inspect schemas, manage authentication, and execute actions.
 
 ### Available toolkits
 
-Composio provides toolkits for various services:
+Composio provides toolkits for many services:
 
-**Productivity**: GitHub, Slack, Gmail, Jira, Notion, Asana, Trello, ClickUp
-**Communication**: Discord, Telegram, WhatsApp, Microsoft Teams
-**Development**: GitLab, Bitbucket, Linear, Sentry
-**Data & Analytics**: Google Sheets, Airtable, HubSpot, Salesforce
-**And 100+ more...**
+| Category           | Example toolkits                                              |
+| :----------------- | :------------------------------------------------------------ |
+| Productivity       | GitHub, Slack, Gmail, Jira, Notion, Asana, Trello, ClickUp    |
+| Communication      | Discord, Telegram, WhatsApp, Microsoft Teams                  |
+| Development        | GitLab, Bitbucket, Linear, Sentry                             |
+| Data and analytics | Google Sheets, Airtable, HubSpot, Salesforce                  |
+
+See the [Composio toolkits catalog](https://docs.composio.dev/toolkits/introduction) for the complete list.
 
 ## Invocation
 
-### Get tools from multiple toolkits
+### Discover tools
 
-You can load tools from multiple services at once:
+Use `session.search(...)` to inspect matching concrete toolkit tools and connection status before asking an agent to execute anything:
 
 ```python
-# Get tools from multiple toolkits
-tools = composio.tools.get(
-    user_id="default",
-    toolkits=["GITHUB", "SLACK", "GMAIL"]
-)
+search = session.search(query="get authenticated github user")
+
+for result in search.results:
+    print(result.primary_tool_slugs)
+
+for status in search.toolkit_connection_statuses:
+    print(status.toolkit, status.has_active_connection, status.status_message)
 ```
 
-### Get specific tools
+If the toolkit is not connected, Composio will guide the agent to use `COMPOSIO_MANAGE_CONNECTIONS`, or you can create an authorization link yourself as shown in [Authentication setup](#authentication-setup).
 
-Instead of entire toolkits, you can load specific tools:
+### Low-level tool loading
 
-```python
-# Get specific tools by name
-tools = composio.tools.get(
-    user_id="default",
-    tools=["GITHUB_CREATE_ISSUE", "SLACK_SEND_MESSAGE"]
-)
-```
-
-### User-specific tools
-
-Composio supports multi-user scenarios with user-specific authentication:
+For most agent workflows, prefer `composio.create(...)` and `session.tools()`. The lower-level `composio.tools.get(...)` API is also available when you want to load direct tool lists yourself:
 
 ```python
-# Get tools for a specific user
-# This user must have authenticated their accounts first
-tools = composio.tools.get(
+github_tools = composio.tools.get(
     user_id="user_123",
-    toolkits=["GITHUB"]
+    toolkits=["GITHUB"],
+    limit=10,
+)
+
+read_scoped_tools = composio.tools.get(
+    user_id="user_123",
+    toolkits=["GITHUB"],
+    scopes=["read"],
+    limit=10,
+)
+
+specific_tool = composio.tools.get(
+    user_id="user_123",
+    tools=["GITHUB_GET_THE_AUTHENTICATED_USER"],
 )
 ```
 
 ## Use within an agent
 
-Here's a complete example using Composio tools with a LangChain agent to interact with GitHub:
-
-<ChatModelTabs customVarName="llm" />
+Here's a complete, read-only example using Composio tools with a LangChain agent. It asks the model to inspect available GitHub profile-reading tools without mutating external state.
 
 ```python
-import os
 import getpass
+import os
 
 if not os.environ.get("OPENAI_API_KEY"):
-    os.environ["OPENAI_API_KEY"] = getpass.getpass("Enter your OpenAI API key: ")
+    os.environ["OPENAI_API_KEY"] = getpass.getpass("OpenAI API key:\n")
 ```
 
 ```python
-# | output: false
-# | echo: false
-
-from langchain.chat_models import init_chat_model
-
-llm = init_chat_model(model="gpt-5.5", model_provider="openai")
-```
-
-```python Agent with Composio tools icon="robot"
 from composio import Composio
 from composio_langchain import LangchainProvider
-from langchain import hub
-from langchain.agents import AgentExecutor, create_openai_functions_agent
+from langchain.agents import create_agent
+from langchain_openai import ChatOpenAI
 
-# Pull the prompt template
-prompt = hub.pull("hwchase17/openai-functions-agent")
-
-# Initialize Composio
 composio = Composio(provider=LangchainProvider())
+session = composio.create(user_id="user_123", toolkits=["GITHUB"])
+tools = session.tools()
 
-# Get GitHub tools
-tools = composio.tools.get(user_id="default", toolkits=["GITHUB"])
+model = ChatOpenAI(model="gpt-5.4-mini")
+agent = create_agent(model=model, tools=tools)
 
-# Define task
-task = "Star a repo composiohq/composio on GitHub"
-
-# Create agent
-agent = create_openai_functions_agent(llm, tools, prompt)
-agent_executor = AgentExecutor(agent=agent, tools=tools, verbose=True)
-
-# Execute using agent_executor
-agent_executor.invoke({"input": task})
-```
-
-### Event-driven workflows
-
-Composio supports triggering agents based on external events. When events occur in connected apps (like new GitHub commits or Slack messages), triggers automatically send structured payloads to your application.
-
-#### Creating a trigger
-
-First, create a trigger for the events you want to monitor:
-
-```python
-from composio import Composio
-
-composio = Composio(api_key="your_api_key")
-user_id = "user_123"
-
-# Check what configuration is required for the trigger
-trigger_type = composio.triggers.get_type("GITHUB_COMMIT_EVENT")
-print(trigger_type.config)
-
-# Create trigger with required configuration
-trigger = composio.triggers.create(
-    slug="GITHUB_COMMIT_EVENT",
-    user_id=user_id,
-    trigger_config={
-        "owner": "composiohq",
-        "repo": "composio"
+result = agent.invoke(
+    {
+        "messages": [
+            (
+                "user",
+                "List available Composio tool names for reading GitHub user "
+                "profile data. Do not execute external account actions, do not "
+                "ask me to authenticate, and do not mutate anything.",
+            )
+        ]
     }
 )
 
-print(f"Trigger created: {trigger.trigger_id}")
+print(result["messages"][-1].content)
 ```
 
-#### Subscribing to triggers (Development)
+## Authentication setup
 
-For local development and prototyping, you can subscribe directly to triggers:
+Tools that access a user's external account require that user to connect the corresponding toolkit.
+
+For manual authentication, create a connection request from the session:
+
+```python
+connection_request = session.authorize("github")
+print(connection_request.redirect_url)
+```
+
+After the user completes the authorization flow, the same `user_id` can use that connected account.
+
+For in-chat authentication, allow the agent to call `COMPOSIO_MANAGE_CONNECTIONS` when a toolkit has no active connection. The agent can then guide the user through connecting the required account before executing toolkit actions.
+
+## Multi-user scenarios
+
+Use a stable `user_id` for each application user. Each user connects their own accounts, and Composio executes toolkit actions using the credentials associated with that `user_id`.
+
+```python
+session_alice = composio.create(user_id="alice", toolkits=["GITHUB"])
+session_bob = composio.create(user_id="bob", toolkits=["GITHUB"])
+
+alice_agent = create_agent(model=model, tools=session_alice.tools())
+bob_agent = create_agent(model=model, tools=session_bob.tools())
+```
+
+## Event-driven workflows
+
+Composio supports triggering agents based on external events. When events occur in connected apps, such as new GitHub commits or Slack messages, triggers can send structured payloads to your application.
+
+### Inspect trigger configuration
+
+Before creating a trigger, inspect the required configuration:
 
 ```python
 from composio import Composio
 
-composio = Composio(api_key="your_api_key")
+composio = Composio()
 
-# Subscribe to trigger events
-subscription = composio.triggers.subscribe()
-
-# Define event handler
-@subscription.handle(trigger_id="your_trigger_id")
-def handle_github_commit(data):
-    print(f"New commit detected: {data}")
-    # Process the event with your agent
-    # ... invoke your agent with the task
-
-# Note: For production, use webhooks instead
+trigger_type = composio.triggers.get_type("GITHUB_COMMIT_EVENT")
+print(trigger_type.config)
 ```
 
-#### Webhooks (Production)
+### Create a trigger
+
+Create triggers after the relevant account is connected and you have the required configuration:
+
+```python
+trigger = composio.triggers.create(
+    slug="GITHUB_COMMIT_EVENT",
+    user_id="user_123",
+    trigger_config={
+        "owner": "composiohq",
+        "repo": "composio",
+    },
+)
+
+print(trigger.trigger_id)
+```
+
+### Webhooks
 
 For production, configure webhooks in the [Composio dashboard](https://platform.composio.dev/settings/events):
 
 ```python
 from fastapi import FastAPI, Request
-import json
 
 app = FastAPI()
 
+
 @app.post("/webhook")
 async def webhook_handler(request: Request):
-    # Get the webhook payload
     payload = await request.json()
 
-    print("Received trigger event:")
-    print(json.dumps(payload, indent=2))
-
-    # Process the event with your agent
     if payload.get("triggerSlug") == "GITHUB_COMMIT_EVENT":
         commit_data = payload.get("payload")
-        # ... invoke your agent with commit_data
+        # Invoke your agent with commit_data here.
 
     return {"status": "success"}
 ```
 
-For more details, see the [Composio Triggers documentation](https://docs.composio.dev/docs/using-triggers)
+For more details, see the [Composio triggers documentation](https://docs.composio.dev/docs/using-triggers).
 
-## Authentication setup
+## Custom tools
 
-Before using tools that require authentication, users need to connect their accounts:
-
-```python
-from composio import Composio
-
-composio = Composio()
-
-# Get authentication URL for a user
-auth_connection = composio.integrations.create(
-    user_id="user_123",
-    integration="github"
-)
-
-print(f"Authenticate at: {auth_connection.redirect_url}")
-
-# After authentication, the user's connected account will be available
-# and tools will work with their credentials
-```
-
-## Multi-user scenarios
-
-For applications with multiple users:
-
-```python
-# Each user authenticates their own accounts
-tools_user_1 = composio.tools.get(user_id="user_1", toolkits=["GITHUB"])
-tools_user_2 = composio.tools.get(user_id="user_2", toolkits=["GITHUB"])
-
-# Tools will use the respective user's credentials
-# User 1's agent will act on User 1's GitHub account
-agent_1 = create_agent(llm, tools_user_1)
-
-# User 2's agent will act on User 2's GitHub account
-agent_2 = create_agent(llm, tools_user_2)
-```
-
-## Advanced features
-
-### Custom tools
-
-Composio allows you to create custom tools that can be used alongside built-in tools. There are two types:
-
-#### Standalone tools
-
-Simple tools that don't require authentication:
+Composio allows you to create custom tools that can be used alongside built-in tools.
 
 ```python
 from pydantic import BaseModel, Field
-from composio import Composio
 
-composio = Composio()
 
 class AddTwoNumbersInput(BaseModel):
     a: int = Field(description="The first number to add")
     b: int = Field(description="The second number to add")
 
-# Function name will be used as the tool slug
+
 @composio.tools.custom_tool
 def add_two_numbers(request: AddTwoNumbersInput) -> int:
     """Add two numbers."""
     return request.a + request.b
 
-# Use with your agent
-tools = composio.tools.get(user_id="default", toolkits=["GITHUB"])
+
+tools = session.tools()
 tools.append(add_two_numbers)
 ```
 
-#### Toolkit-based tools
-
-Tools that require authentication and can use toolkit credentials:
-
-```python
-from composio.types import ExecuteRequestFn
-
-class GetIssueInfoInput(BaseModel):
-    issue_number: int = Field(
-        ..., description="The number of the issue to get information about"
-    )
-
-@composio.tools.custom_tool(toolkit="github")
-def get_issue_info(
-    request: GetIssueInfoInput,
-    execute_request: ExecuteRequestFn,
-    auth_credentials: dict,
-) -> dict:
-    """Get information about a GitHub issue."""
-    response = execute_request(
-        endpoint=f"/repos/composiohq/composio/issues/{request.issue_number}",
-        method="GET",
-        parameters=[
-            {
-                "name": "Accept",
-                "value": "application/vnd.github.v3+json",
-                "type": "header",
-            },
-            {
-                "name": "Authorization",
-                "value": f"Bearer {auth_credentials['access_token']}",
-                "type": "header",
-            },
-        ],
-    )
-    return {"data": response.data}
-```
-
-Execute custom tools:
-
-```python
-response = composio.tools.execute(
-    user_id="default",
-    slug="get_issue_info",  # Use function name as slug
-    arguments={"issue_number": 1},
-)
-```
-
-For more details, see the [Composio Custom Tools documentation](https://docs.composio.dev/docs/custom-tools)
-
-### Fine-grained permissions
-
-Control what actions tools can perform:
-
-```python
-# Get tools with specific permissions
-tools = composio.tools.get(
-    user_id="default",
-    toolkits=["GITHUB"],
-    # Limit to read-only operations
-    permissions=["read"]
-)
-```
-
----
-
 ## API reference
 
-For detailed documentation of all Composio features and configurations, visit:
-- [Composio Documentation](https://docs.composio.dev)
-- [LangChain Provider Guide](https://docs.composio.dev/providers/langchain)
-- [Available Tools & Actions](https://docs.composio.dev/toolkits/introduction)
+For detailed documentation of Composio features and configuration options, see:
 
+- [Composio documentation](https://docs.composio.dev)
+- [Composio LangChain provider guide](https://docs.composio.dev/docs/providers/langchain)
+- [Available tools and actions](https://docs.composio.dev/toolkits/introduction)


### PR DESCRIPTION
## Description

Updates the Python Composio integration docs to use the current LangChain and Composio APIs.

This replaces stale examples that used older LangChain agent APIs and outdated Composio auth/tool-loading patterns with the current Composio session/router flow:

- `Composio(provider=LangchainProvider())`
- `composio.create(user_id=..., toolkits=[...])`
- `session.tools()`
- `session.search(...)`
- `session.authorize("github")`
- `langchain.agents.create_agent`

This is a docs-only maintenance PR from the Composio side for an existing integration page. The original Composio docs page was added in https://github.com/langchain-ai/docs/pull/952, merged from `ComposioHQ:docs/composio` into `langchain-ai:main` on 2025-10-24.

## What changed

- Removed old `AgentExecutor`, `create_openai_functions_agent`, and `hub.pull("hwchase17/openai-functions-agent")` examples.
- Removed nonexistent `composio.integrations.create(...)` auth example.
- Replaced the previous side-effecting "star a repo" agent task with a read-only GitHub tool-discovery task.
- Updated Composio positioning to 1,000+ toolkits and 20,000+ tools, available through MCP or direct APIs.
- Added a concise enterprise/security note covering governance, auditability, SSO, org-wide controls, and SOC 2 / ISO 27001:2022.
- Added an explanation that `session.tools()` returns Composio router/meta tools such as `COMPOSIO_SEARCH_TOOLS`, `COMPOSIO_GET_TOOL_SCHEMAS`, and `COMPOSIO_MANAGE_CONNECTIONS`.
- Added `session.search(...)` discovery and connection-status example.
- Documented `session.authorize("github")` for manual authentication.
- Kept `composio.tools.get(...)` as a lower-level option and updated the permissions example to current `scopes=["read"]`.
- Scoped trigger and custom-tool examples to locally verified patterns.

## Validation

Local dogfooding passed with:

- `composio==0.13.1`
- `composio-langchain==0.13.1`
- `langchain==1.3.7`
- `langchain-openai==1.3.0`
- `pydantic==2.13.4`
- Python 3.11.2 for the dogfood script

Commands/checks run:

```bash
npx --yes markdownlint-cli src/oss/python/integrations/tools/composio.mdx
git diff --check
rg -n "AgentExecutor|create_openai_functions_agent|integrations\\.create|permissions=|hub\\.pull|Star a repo|langchain import hub|create_openai_tools_agent" src/oss/python/integrations/tools/composio.mdx
. .venv/bin/activate && python dogfood/fixed_langchain_composio_docs/fixed_composio_examples.py
. .venv/bin/activate && RUN_SAFE_AGENT_INVOKE=1 python dogfood/fixed_langchain_composio_docs/fixed_composio_examples.py
```

The safe agent invocation asked the model to list available GitHub profile-reading tool names only; it did not authenticate or mutate external state.

## Notes

I did not change navigation because `src/docs.json` already includes the Composio tools page.

I did not run the full docs build in this sparse checkout. The local checkout was intentionally sparse after full clone attempts were slow, and the docs build requires the full docs pipeline/toolchain and Python `>=3.13`.

## Checklist

- [x] I read the contributing guidelines.
- [x] I tested the changed examples locally.
- [x] I linted the changed MDX file.
- [x] The diff is limited to the Composio integration docs page.
- [x] No secrets, `.env` files, or dogfood artifacts are included.
