### PR TITLE
docs(js): add VoyageEmbeddings integration page for @langchain/mongodb

### DIFF
--- a/src/oss/javascript/integrations/embeddings/index.mdx
+++ b/src/oss/javascript/integrations/embeddings/index.mdx
@@ -324,6 +324,41 @@ const embeddings = new OllamaEmbeddings({
 ```
 
 </Accordion>
+<Accordion title="Voyage AI">
+
+Install dependencies:
+
+<CodeGroup>
+```bash npm
+npm install @langchain/mongodb @langchain/core
+```
+
+```bash yarn
+yarn add @langchain/mongodb @langchain/core
+```
+
+```bash pnpm
+pnpm add @langchain/mongodb @langchain/core
+```
+</CodeGroup>
+
+Add environment variables:
+
+```bash
+VOYAGE_API_KEY=your-api-key
+```
+
+Instantiate the model:
+
+```typescript
+import { VoyageEmbeddings } from "@langchain/mongodb";
+
+const embeddings = new VoyageEmbeddings({
+  model: "voyage-4"
+});
+```
+
+</Accordion>
 </AccordionGroup>
 
 ## Caching
@@ -491,6 +526,13 @@ In production, you would typically use a more robust persistent store, such as a
     title="TogetherAI"
     icon="link"
     href="/oss/integrations/embeddings/togetherai"
+    arrow="true"
+    cta="View guide"
+  />
+  <Card
+    title="Voyage AI"
+    icon="link"
+    href="/oss/integrations/embeddings/voyageai"
     arrow="true"
     cta="View guide"
   />

--- a/src/oss/javascript/integrations/embeddings/voyageai.mdx
+++ b/src/oss/javascript/integrations/embeddings/voyageai.mdx
@@ -1,0 +1,127 @@
+---
+title: "VoyageEmbeddings integration"
+description: "Integrate with the VoyageEmbeddings embedding model using LangChain JavaScript."
+---
+
+This will help you get started with VoyageEmbeddings [embedding models](/oss/integrations/embeddings) using LangChain. For detailed documentation on `VoyageEmbeddings` features and configuration options, please refer to the [API reference](https://reference.langchain.com/javascript/langchain-mongodb/VoyageEmbeddings).
+
+## Overview
+
+### Integration details
+
+| Class | Package | Local | [Py support](https://python.langchain.com/docs/integrations/embeddings/voyageai/) | Downloads | Version |
+| :--- | :--- | :---: | :---: |  :---: | :---: |
+| [`VoyageEmbeddings`](https://reference.langchain.com/javascript/langchain-mongodb/VoyageEmbeddings) | [`@langchain/mongodb`](https://www.npmjs.com/package/@langchain/mongodb) | ❌ | ✅ | ![NPM - Downloads](https://img.shields.io/npm/dm/@langchain/mongodb?style=flat-square&label=%20&) | ![NPM - Version](https://img.shields.io/npm/v/@langchain/mongodb?style=flat-square&label=%20&) |
+
+## Setup
+
+To access Voyage AI embedding models you'll need to create a Voyage AI account, get an API key, and install the `@langchain/mongodb` integration package.
+
+### Credentials
+
+Head to [voyageai.com](https://www.voyageai.com) to sign up and generate an API key. Once you've done this set the `VOYAGE_API_KEY` environment variable:
+
+```bash
+export VOYAGE_API_KEY="your-api-key"
+```
+
+If you want to get automated tracing of your model calls you can also set your [LangSmith](/langsmith/home) API key by uncommenting below:
+
+```bash
+# export LANGSMITH_TRACING="true"
+# export LANGSMITH_API_KEY="your-api-key"
+```
+
+### Installation
+
+The LangChain VoyageEmbeddings integration lives in the `@langchain/mongodb` package:
+
+<CodeGroup>
+```bash npm
+npm install @langchain/mongodb @langchain/core
+```
+```bash yarn
+yarn add @langchain/mongodb @langchain/core
+```
+```bash pnpm
+pnpm add @langchain/mongodb @langchain/core
+```
+</CodeGroup>
+
+## Instantiation
+
+Now we can instantiate our model object and embed text:
+
+```typescript
+import { VoyageEmbeddings } from "@langchain/mongodb";
+
+const embeddings = new VoyageEmbeddings({
+  apiKey: "YOUR-API-KEY", // In Node.js defaults to process.env.VOYAGE_API_KEY
+  model: "voyage-4",
+});
+```
+
+## Indexing and retrieval
+
+Embedding models are often used in retrieval-augmented generation (RAG) flows, both as part of indexing data as well as later retrieving it. For more detailed instructions, please see our RAG tutorials under the [**Learn** tab](/oss/learn/).
+
+Below, see how to index and retrieve data using the `embeddings` object we initialized above. In this example, we will index and retrieve a sample document using the demo [`MemoryVectorStore`](/oss/integrations/vectorstores/memory).
+
+```typescript
+// Create a vector store with a sample text
+import { MemoryVectorStore } from "@langchain/classic/vectorstores/memory";
+
+const text = "LangChain is the framework for building context-aware reasoning applications";
+
+const vectorstore = await MemoryVectorStore.fromDocuments(
+  [{ pageContent: text, metadata: {} }],
+  embeddings,
+);
+
+// Use the vector store as a retriever that returns a single document
+const retriever = vectorstore.asRetriever(1);
+
+// Retrieve the most similar text
+const retrievedDocuments = await retriever.invoke("What is LangChain?");
+
+retrievedDocuments[0].pageContent;
+```
+
+```text
+LangChain is the framework for building context-aware reasoning applications
+```
+
+## Direct usage
+
+Under the hood, the vectorstore and retriever implementations are calling `embeddings.embedDocument(...)` and `embeddings.embedQuery(...)` to create embeddings for the text(s) used in `fromDocuments` and the retriever's `invoke` operations, respectively.
+
+You can directly call these methods to get embeddings for your own use cases.
+
+### Embed single texts
+
+You can embed queries for search with `embedQuery`. This generates a vector representation specific to the query:
+
+```typescript
+const singleVector = await embeddings.embedQuery(text);
+
+console.log(singleVector.slice(0, 3));
+```
+
+### Embed multiple texts
+
+You can embed multiple texts for indexing with `embedDocuments`. The internals used for this method may (but do not have to) differ from embedding queries:
+
+```typescript
+const text2 = "LangGraph is a library for building stateful, multi-actor applications with LLMs";
+
+const vectors = await embeddings.embedDocuments([text, text2]);
+
+console.log(vectors[0].slice(0, 3));
+console.log(vectors[1].slice(0, 3));
+```
+
+---
+
+## API reference
+
+For detailed documentation of all `VoyageEmbeddings` features and configurations head to the [API reference](https://reference.langchain.com/javascript/langchain-mongodb/VoyageEmbeddings).


### PR DESCRIPTION
Adds a `VoyageEmbeddings` integration page for the JavaScript docs and updates the embeddings index, reflecting the move of `VoyageEmbeddings` from `@langchain/community` (removed from main) into `@langchain/mongodb`.

Changes:
- New page: `src/oss/javascript/integrations/embeddings/voyageai.mdx` — full integration guide with install instructions, credentials, instantiation, indexing/retrieval, and direct usage examples
- Updated `src/oss/javascript/integrations/embeddings/index.mdx` — added Voyage AI to the "Install and use" accordion group and the "All integrations" card grid

## Type of change

**Type:** New documentation page

## Related issues/PRs

- GitHub issue:
- Feature PR: [langchainjs #11406](https://github.com/langchain-ai/langchainjs/pull/11046)

<!-- For LangChain employees, if applicable: -->
- Linear issue: [NODE-7600](https://jira.mongodb.org/browse/NODE-7600)
- Slack thread:

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes

This PR was authored with AI agent assistance (Claude Code).

`@langchain/community` has been removed from main. `VoyageEmbeddings` now lives in `@langchain/mongodb` — the import path in all examples reflects this. The dedicated page follows the same structure as other JS embedding integration pages (e.g., `cohere.mdx`).