### PR TITLE
feat(docs): add docs to cover task primitive in code interpreter and subagent orchestrations

### DIFF
--- a/src/code-samples/deepagents/customization-skills-usage-filesystem.ts
+++ b/src/code-samples/deepagents/customization-skills-usage-filesystem.ts
@@ -1,5 +1,4 @@
 // :snippet-start: skills-usage-filesystem-js
-import { createCodeInterpreterMiddleware } from "@langchain/quickjs";
 import { createDeepAgent, FilesystemBackend } from "deepagents";
 import { MemorySaver } from "@langchain/langgraph";
 
@@ -17,7 +16,6 @@ const agent = await createDeepAgent({
     delete_file: true,
   },
   checkpointer, // Required!
-  middleware: [createCodeInterpreterMiddleware({ skillsBackend: backend })],
 });
 
 const config = { configurable: { thread_id: `thread-${Date.now()}` } };

--- a/src/code-samples/deepagents/customization-skills-usage-state.ts
+++ b/src/code-samples/deepagents/customization-skills-usage-state.ts
@@ -3,7 +3,6 @@ import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 
 // :snippet-start: skills-usage-state-js
-import { createCodeInterpreterMiddleware } from "@langchain/quickjs";
 import { createDeepAgent, StateBackend, type FileData } from "deepagents";
 import { MemorySaver } from "@langchain/langgraph";
 
@@ -37,7 +36,6 @@ const agent = await createDeepAgent({
   checkpointer, // Required !
   // IMPORTANT: deepagents skill source paths are virtual (POSIX) paths relative to the backend root.
   skills: ["/skills/"],
-  middleware: [createCodeInterpreterMiddleware({ skillsBackend: backend })],
 });
 
 const config = { configurable: { thread_id: `thread-${Date.now()}` } };

--- a/src/code-samples/deepagents/customization-skills-usage-store.ts
+++ b/src/code-samples/deepagents/customization-skills-usage-store.ts
@@ -1,5 +1,4 @@
 // :snippet-start: skills-usage-store-js
-import { createCodeInterpreterMiddleware } from "@langchain/quickjs";
 import { createDeepAgent, StoreBackend, type FileData } from "deepagents";
 import { InMemoryStore, MemorySaver } from "@langchain/langgraph";
 
@@ -35,7 +34,6 @@ const agent = await createDeepAgent({
   checkpointer,
   // IMPORTANT: deepagents skill source paths are virtual (POSIX) paths relative to the backend root.
   skills: ["/skills/"],
-  middleware: [createCodeInterpreterMiddleware({ skillsBackend: backend })],
 });
 
 const config = {

--- a/src/code-samples/deepagents/customization-skills-usage.py
+++ b/src/code-samples/deepagents/customization-skills-usage.py
@@ -5,7 +5,6 @@ from urllib.request import urlopen
 from deepagents import create_deep_agent
 from deepagents.backends import StateBackend
 from deepagents.backends.utils import create_file_data
-from langchain_quickjs import CodeInterpreterMiddleware
 from langgraph.checkpoint.memory import MemorySaver
 
 checkpointer = MemorySaver()
@@ -24,7 +23,6 @@ agent = create_deep_agent(
     backend=backend,
     skills=["/skills/"],
     checkpointer=checkpointer,
-    middleware=[CodeInterpreterMiddleware(skills_backend=backend)], # for interpreter skills
 )
 
 result = agent.invoke(
@@ -43,7 +41,6 @@ from urllib.request import urlopen
 from deepagents import create_deep_agent
 from deepagents.backends import StoreBackend
 from deepagents.backends.utils import create_file_data
-from langchain_quickjs import CodeInterpreterMiddleware
 from langgraph.store.memory import InMemoryStore
 
 store = InMemoryStore()
@@ -65,7 +62,6 @@ agent = create_deep_agent(
     backend=backend,
     store=store,
     skills=["/skills/"],
-    middleware=[CodeInterpreterMiddleware(skills_backend=backend)],
 )
 
 result = agent.invoke(
@@ -78,7 +74,6 @@ from pathlib import Path
 # :snippet-start: skills-usage-filesystem-py
 from deepagents import create_deep_agent
 from deepagents.backends.filesystem import FilesystemBackend
-from langchain_quickjs import CodeInterpreterMiddleware
 from langgraph.checkpoint.memory import MemorySaver
 
 # Checkpointer is REQUIRED for human-in-the-loop
@@ -103,7 +98,6 @@ agent = create_deep_agent(
         "edit_file": True,
     },
     checkpointer=checkpointer, # Required!
-    middleware=[CodeInterpreterMiddleware(skills_backend=backend)], # for interpreter skills
 )
 
 result = agent.invoke(

--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -513,7 +513,7 @@ Use [interpreters](/oss/deepagents/interpreters) to add an `eval` tool that runs
 <CustomizationInterpretersJs />
 :::
 
-For setup, programmatic tool calling, interpreter skills, and limits, see [Interpreters](/oss/deepagents/interpreters).
+For setup, programmatic tool calling, subagent orchestration, and limits, see [Interpreters](/oss/deepagents/interpreters).
 
 ## Subagents
 

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -20,9 +20,7 @@ Where [sandboxes](/oss/deepagents/sandboxes) are a code-first way for acting on 
 
 ## When to use an interpreter
 
-Most agent work alternates between model reasoning and tool execution. That works for simple actions, but it becomes awkward when the agent needs to compose many steps, reason over structured data, or manage intermediate state.
-
-An interpreter gives the agent a runtime for that work. Instead of asking the model to choose every next step one tool call at a time, the agent can write a small program that runs control flow, calls allowlisted tools, stores variables, and returns a compact result to the model.
+Most agent work alternates between model reasoning and single tool calls. That breaks down when the agent needs to compose many steps, reason over structured data, or hold intermediate state. An interpreter gives it a runtime to do that work in code: run control flow, call allowlisted tools, store variables, and return only a compact result to the model.
 
 Use interpreters when the agent needs to:
 
@@ -51,9 +49,7 @@ graph LR
     class Result output
 ```
 
-This works by running code against [**QuickJS**](https://github.com/quickjs-ng/quickjs), a lightweight JavaScript runtime designed for embedded execution. The runtime gives the agent a place to evaluate code without exposing host filesystem, network, shell, package, or clock APIs by default.
-
-QuickJS is the execution boundary for interpreter code. Explicit bridges, such as programmatic tool calling, decide what capabilities the code can access.
+Code runs against [**QuickJS**](https://github.com/quickjs-ng/quickjs), a lightweight JavaScript runtime with no access to the host filesystem, network, shell, or clock by default. Explicit bridges decide what the code can reach.
 
 ## Choose the right execution path
 
@@ -359,7 +355,7 @@ releaseSummary;
 
 ### Orchestration patterns
 
-The agent picks a strategy from the shape of the task. These patterns emerge from how it writes interpreter code; you don't select them yourself, and the subagents you configure determine what's available. The diagrams below show the common shapes, each with a runnable example.
+The agent picks a strategy from the shape of the task; these emerge from how it writes interpreter code, not from configuration, and the subagents you make available determine what it can do. Every pattern shares one model: hold work in JS variables, dispatch subagents with `task()`, and combine results in code. The diagrams below show the common shapes, each with a runnable example.
 
 #### Classify and act
 
@@ -439,7 +435,7 @@ const result = await agent.invoke({
 
 #### Fan-out and synthesize
 
-The agent dispatches the same kind of work across many items in parallel, then combines the results. This is the most common pattern.
+The agent dispatches the same kind of work across many items in parallel, then combines the results.
 
 ```mermaid
 graph LR
@@ -720,7 +716,7 @@ agent = create_deep_agent(
 )
 
 result = await agent.ainvoke({
-    "messages": [{"role": "user", "content": "Find all the dead code in this repo. Be thorough — I want every unused export and unreachable function."}]
+    "messages": [{"role": "user", "content": "Find all the dead code in this repo. Be thorough. I want every unused export and unreachable function."}]
 })
 ```
 :::
@@ -738,7 +734,7 @@ const agent = createDeepAgent({
 });
 
 const result = await agent.invoke({
-  messages: [{ role: "user", content: "Find all the dead code in this repo. Be thorough — I want every unused export and unreachable function." }],
+  messages: [{ role: "user", content: "Find all the dead code in this repo. Be thorough. I want every unused export and unreachable function." }],
 });
 ```
 :::

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -61,8 +61,8 @@ QuickJS is the execution boundary for interpreter code. Explicit bridges, such a
 | --- | --- |
 | One or two simple external calls | Normal tool calling |
 | A small program that loops, branches, retries, or aggregates results | Interpreter |
-| Many selected tool calls that should run from code | Interpreter with programmatic tool calling |
-| Reusable helpers used across threads | Interpreter with [interpreter skills](/oss/deepagents/skills#interpreter-skills) |
+| Many selected tool calls that should run from code | Interpreter with [programmatic tool calling](#programmatic-tool-calling) |
+| Many independent units of work, or multiple perspectives on one task | Interpreter with [subagent orchestration](#orchestrate-subagents-from-code) |
 | Shell commands, package installs, tests, or full OS filesystem access | [Sandboxes](/oss/deepagents/sandboxes) |
 
 ## Add an interpreter to an agent
@@ -119,7 +119,7 @@ const agent = createDeepAgent({
 
 ## Run code in the interpreter
 
-The middleware adds an `eval` tool to the agent. The tool runs TypeScript in a persistent context, captures `console.log`, and returns the result of the last expression.
+The middleware adds an `eval` tool to the agent. The tool runs JavaScript in a persistent context, captures `console.log`, and returns the result of the last expression.
 
 The agent can write code like this:
 
@@ -143,444 +143,16 @@ totals;
 By default, interpreter state also persists across turns in the same thread by snapshotting the working state after each agent run, and restoring it before the next run.
 :::
 
-## Subagent orchestration
+## What interpreter code can reach
 
-Some tasks are too large for a single agent pass. Reviewing every file in a directory, triaging a batch of tickets, or auditing a codebase for security issues all share the same shape: many independent pieces of work that can run in parallel, with results combined at the end.
+By default, interpreter code runs against QuickJS with no access to the host filesystem, network, shell, package manager, or clock. It can compute, hold state, and write to `console.log`, and nothing more.
 
-With standard tool calling, the agent decides whether to spawn subagents one call at a time. This is non-deterministic and doesn't scale when the work requires dozens of parallel dispatches. When an agent has [subagents](/oss/deepagents/subagents) and interpreter middleware, the interpreter exposes a built-in `task()` function that lets the agent dispatch subagents programmatically. Because subagents are spawned as part of code execution rather than individual tool calls, the orchestration is deterministic: the agent writes a loop that fans out 50 reviewers, and all 50 run.
+Two explicit bridges extend that reach:
 
-You don't need to enable this explicitly. Configure your subagents, add interpreter middleware, and the agent uses `task()` whenever the work calls for it.
+- **Tools**, through [programmatic tool calling](#programmatic-tool-calling). Expose an allowlist of tools as async functions under the `tools` namespace. These can be the agent's own tools or standalone tools you define and pass in.
+- **Subagents**, through the built-in [`task()` global](#orchestrate-subagents-from-code). Dispatch configured subagents from code and orchestrate them in plain JavaScript.
 
-### How it works
-
-1. You send a message describing work that spans many items or needs multiple perspectives.
-2. The agent writes interpreter code that calls `task()` to dispatch subagents in parallel batches.
-3. Each subagent runs a full agentic loop (reading files, calling tools, iterating) and returns a result.
-4. The interpreter collects results, filters or transforms them in code, and returns a synthesis to the model.
-5. The model presents the final answer. Intermediate subagent results stay in the interpreter, not in your conversation context.
-
-`task()` takes a description (the prompt the subagent receives), a subagent type (which configured subagent to use), and an optional response schema for structured output. Here's a quick look at the kind of code the agent writes:
-
-```javascript
-const schema = {
-  type: "object",
-  properties: {
-    issues: { type: "array", items: { type: "object", properties: {
-      file: { type: "string" }, line: { type: "number" },
-      severity: { type: "string" }, description: { type: "string" },
-    }}},
-  },
-};
-
-const reviews = await Promise.all(
-  files.map((file) => task({
-    description: `Review ${file} for auth issues. Cite line numbers.`,
-    subagentType: "reviewer",
-    responseSchema: schema,
-  }))
-);
-
-const critical = reviews
-  .flatMap((r) => JSON.parse(r).issues)
-  .filter((i) => i.severity === "high");
-
-const fixes = await Promise.all(
-  critical.map((issue) => task({
-    description: `Explain how to fix: ${issue.description} in ${issue.file}:${issue.line}`,
-    subagentType: "reviewer",
-  }))
-);
-```
-
-### When the agent uses it
-
-Messages like these naturally lead to subagent orchestration:
-
-- "Review every file in `src/api/` for security issues and give me a summary"
-- "Analyze the last 50 support tickets and categorize them by type"
-- "Check each of these migration scripts for breaking changes"
-- "Generate three approaches to this refactor, then pick the best one"
-
-The common thread is work with a repeated structure across many inputs, or work that benefits from multiple independent perspectives. The agent recognizes these shapes and orchestrates accordingly.
-
-### Workflow patterns
-
-The agent chooses an orchestration strategy based on the task. These patterns naturally emerge from how the agent writes its interpreter code. You don't select them yourself. The subagents you configure determine what's available; the agent handles the rest.
-
-#### Classify and act
-
-Items are classified first, then each is handled by a specialized subagent based on its classification. This lets you process mixed inputs where different items need different expertise.
-
-```mermaid
-graph LR
-    Task[Task] --> Classify{Classifier}
-    Classify --> |bug| A[Agent A]
-    Classify --> |feature| B[Agent B]
-    Classify --> |question| C[Agent C]
-```
-
-**Use cases:** Triaging support tickets, error logs, user feedback, or any batch of items that need different handling depending on their type.
-
-:::python
-```python
-agent = create_deep_agent(
-    model="openai:gpt-5.4",
-    subagents=[
-        {
-            "name": "bug-fixer",
-            "description": "Investigates bug reports and provides reproduction steps",
-            "system_prompt": "You are a bug triage specialist. Investigate each bug report and provide clear reproduction steps.",
-        },
-        {
-            "name": "feature-analyst",
-            "description": "Evaluates feature requests for feasibility and effort",
-            "system_prompt": "You are a product analyst. Evaluate each feature request for technical feasibility, estimated effort, and potential impact.",
-        },
-        {
-            "name": "support-agent",
-            "description": "Answers user questions based on documentation",
-            "system_prompt": "You are a support specialist. Answer user questions clearly based on the available documentation.",
-        },
-    ],
-    middleware=[CodeInterpreterMiddleware()],
-)
-
-result = await agent.ainvoke({
-    "messages": [{"role": "user", "content": "Go through these 30 support tickets. Categorize each one, then for bugs give me reproduction steps, and for feature requests give me a feasibility assessment."}]
-})
-```
-:::
-
-:::js
-```typescript
-const agent = createDeepAgent({
-  model: "openai:gpt-5.4",
-  subagents: [
-    {
-      name: "bug-fixer",
-      description: "Investigates bug reports and provides reproduction steps",
-      systemPrompt: "You are a bug triage specialist. Investigate each bug report and provide clear reproduction steps.",
-    },
-    {
-      name: "feature-analyst",
-      description: "Evaluates feature requests for feasibility and effort",
-      systemPrompt: "You are a product analyst. Evaluate each feature request for technical feasibility, estimated effort, and potential impact.",
-    },
-    {
-      name: "support-agent",
-      description: "Answers user questions based on documentation",
-      systemPrompt: "You are a support specialist. Answer user questions clearly based on the available documentation.",
-    },
-  ],
-  middleware: [createCodeInterpreterMiddleware()],
-});
-
-const result = await agent.invoke({
-  messages: [{ role: "user", content: "Go through these 30 support tickets. Categorize each one, then for bugs give me reproduction steps, and for feature requests give me a feasibility assessment." }],
-});
-```
-:::
-
-#### Fan-out and synthesize
-
-The agent dispatches the same kind of work across many items in parallel, then combines the results. This is the most common pattern.
-
-```mermaid
-graph LR
-    Items[Items] --> W1[Worker]
-    Items --> W2[Worker]
-    Items --> W3[Worker]
-    W1 --> Collect[Collect]
-    W2 --> Collect
-    W3 --> Collect
-    Collect --> Synth[Synthesize]
-```
-
-**Use cases:** Code review across a directory, analyzing a batch of documents, processing log files, running the same check across many services.
-
-:::python
-```python
-from deepagents import create_deep_agent
-from langchain_quickjs import CodeInterpreterMiddleware
-
-agent = create_deep_agent(
-    model="openai:gpt-5.4",
-    subagents=[{
-        "name": "reviewer",
-        "description": "Reviews code for security issues, citing lines and severity",
-        "system_prompt": "You are a security-focused code reviewer. Read the file carefully and report any authentication or authorization issues with line numbers and severity.",
-    }],
-    middleware=[CodeInterpreterMiddleware()],
-)
-
-result = await agent.ainvoke({
-    "messages": [{"role": "user", "content": "Review all the route handlers in src/routes/ for authentication issues. Summarize the top risks."}]
-})
-```
-:::
-
-:::js
-```typescript
-import { createDeepAgent } from "deepagents";
-import { createCodeInterpreterMiddleware } from "@langchain/quickjs";
-
-const agent = createDeepAgent({
-  model: "openai:gpt-5.4",
-  subagents: [{
-    name: "reviewer",
-    description: "Reviews code for security issues, citing lines and severity",
-    systemPrompt: "You are a security-focused code reviewer. Read the file carefully and report any authentication or authorization issues with line numbers and severity.",
-  }],
-  middleware: [createCodeInterpreterMiddleware()],
-});
-
-const result = await agent.invoke({
-  messages: [{ role: "user", content: "Review all the route handlers in src/routes/ for authentication issues. Summarize the top risks." }],
-});
-```
-:::
-
-#### Adversarial verification
-
-A two-pass pattern. The first pass produces findings. The second pass sends each finding to independent verifiers, and only findings that survive agreement are kept. This reduces false positives when confidence matters more than speed.
-
-```mermaid
-graph LR
-    Items[Items] --> Workers[Workers]
-    Workers --> Findings[Findings]
-    Findings --> V1[Verifier]
-    Findings --> V2[Verifier]
-    Findings --> V3[Verifier]
-    V1 --> Vote[Majority vote]
-    V2 --> Vote
-    V3 --> Vote
-    Vote --> Confirmed[Confirmed]
-```
-
-**Use cases:** Security audits where false positives are costly, compliance checks, any review where you need high confidence in findings.
-
-:::python
-```python
-agent = create_deep_agent(
-    model="openai:gpt-5.4",
-    subagents=[
-        {
-            "name": "reviewer",
-            "description": "Finds potential security vulnerabilities in code",
-            "system_prompt": "You are a security auditor. Find potential vulnerabilities and report each with file, line, and description.",
-        },
-        {
-            "name": "verifier",
-            "description": "Independently verifies whether a reported vulnerability is real",
-            "system_prompt": "You are a security verification specialist. Given a reported vulnerability, independently verify whether it is exploitable. Be skeptical. Only confirm real issues.",
-        },
-    ],
-    middleware=[CodeInterpreterMiddleware()],
-)
-
-result = await agent.ainvoke({
-    "messages": [{"role": "user", "content": "Do a thorough security audit of the payments module. I only want confirmed vulnerabilities, not maybes."}]
-})
-```
-:::
-
-:::js
-```typescript
-const agent = createDeepAgent({
-  model: "openai:gpt-5.4",
-  subagents: [
-    {
-      name: "reviewer",
-      description: "Finds potential security vulnerabilities in code",
-      systemPrompt: "You are a security auditor. Find potential vulnerabilities and report each with file, line, and description.",
-    },
-    {
-      name: "verifier",
-      description: "Independently verifies whether a reported vulnerability is real",
-      systemPrompt: "You are a security verification specialist. Given a reported vulnerability, independently verify whether it is exploitable. Be skeptical. Only confirm real issues.",
-    },
-  ],
-  middleware: [createCodeInterpreterMiddleware()],
-});
-
-const result = await agent.invoke({
-  messages: [{ role: "user", content: "Do a thorough security audit of the payments module. I only want confirmed vulnerabilities, not maybes." }],
-});
-```
-:::
-
-#### Generate and filter
-
-Multiple subagents generate independent solutions to the same problem. The agent compares, scores, and filters the results in code, keeping only the best.
-
-```mermaid
-graph LR
-    Prompt[Prompt] --> G1[Generator]
-    Prompt --> G2[Generator]
-    Prompt --> G3[Generator]
-    G1 --> Filter[Filter + rank]
-    G2 --> Filter
-    G3 --> Filter
-    Filter --> Best[Best result]
-```
-
-**Use cases:** Architecture proposals, refactoring strategies, content variations, any task where exploring multiple options before committing produces a better outcome.
-
-:::python
-```python
-agent = create_deep_agent(
-    model="openai:gpt-5.4",
-    subagents=[{
-        "name": "architect",
-        "description": "Proposes a database schema design with tradeoff analysis",
-        "system_prompt": "You are a database architect. Propose a schema design for the given requirements. Include tradeoffs, migration considerations, and a clear rationale.",
-    }],
-    middleware=[CodeInterpreterMiddleware()],
-)
-
-result = await agent.ainvoke({
-    "messages": [{"role": "user", "content": "Generate three different approaches to restructure the database schema for the orders system, then pick the best one."}]
-})
-```
-:::
-
-:::js
-```typescript
-const agent = createDeepAgent({
-  model: "openai:gpt-5.4",
-  subagents: [{
-    name: "architect",
-    description: "Proposes a database schema design with tradeoff analysis",
-    systemPrompt: "You are a database architect. Propose a schema design for the given requirements. Include tradeoffs, migration considerations, and a clear rationale.",
-  }],
-  middleware: [createCodeInterpreterMiddleware()],
-});
-
-const result = await agent.invoke({
-  messages: [{ role: "user", content: "Generate three different approaches to restructure the database schema for the orders system, then pick the best one." }],
-});
-```
-:::
-
-#### Tournament
-
-Variations are compared head-to-head by a judge subagent, with winners advancing through elimination rounds.
-
-```mermaid
-graph LR
-    A1[Attempt] --> J1{Judge}
-    A2[Attempt] --> J1
-    A3[Attempt] --> J2{Judge}
-    A4[Attempt] --> J2
-    J1 --> JF{Final}
-    J2 --> JF
-    JF --> Winner[Winner]
-```
-
-**Use cases:** Optimization under subjective criteria, style selection, choosing between competing implementations.
-
-:::python
-```python
-agent = create_deep_agent(
-    model="openai:gpt-5.4",
-    subagents=[
-        {
-            "name": "writer",
-            "description": "Rewrites a function with a focus on readability and clarity",
-            "system_prompt": "You are an expert programmer focused on clean code. Rewrite the given function to maximize readability. Explain your choices.",
-        },
-        {
-            "name": "judge",
-            "description": "Compares two code implementations and picks the more readable one",
-            "system_prompt": "You are a code quality judge. Compare two implementations and pick the more readable one. Justify your choice with specific criteria.",
-        },
-    ],
-    middleware=[CodeInterpreterMiddleware()],
-)
-
-result = await agent.ainvoke({
-    "messages": [{"role": "user", "content": "Rewrite the processOrder function in src/checkout.ts five different ways and find the most readable version."}]
-})
-```
-:::
-
-:::js
-```typescript
-const agent = createDeepAgent({
-  model: "openai:gpt-5.4",
-  subagents: [
-    {
-      name: "writer",
-      description: "Rewrites a function with a focus on readability and clarity",
-      systemPrompt: "You are an expert programmer focused on clean code. Rewrite the given function to maximize readability. Explain your choices.",
-    },
-    {
-      name: "judge",
-      description: "Compares two code implementations and picks the more readable one",
-      systemPrompt: "You are a code quality judge. Compare two implementations and pick the more readable one. Justify your choice with specific criteria.",
-    },
-  ],
-  middleware: [createCodeInterpreterMiddleware()],
-});
-
-const result = await agent.invoke({
-  messages: [{ role: "user", content: "Rewrite the processOrder function in src/checkout.ts five different ways and find the most readable version." }],
-});
-```
-:::
-
-#### Loop until done
-
-The agent runs a discovery loop, deduplicating against what it has already found, until no new results appear. Useful when the scope of the work isn't known upfront.
-
-```mermaid
-graph LR
-    Agent[Agent] --> Check{New findings?}
-    Check --> |yes| Agent
-    Check --> |no| Done[Done]
-```
-
-**Use cases:** Exhaustive search, dead code detection, dependency audits, any sweep where you want completeness rather than a fixed number of results.
-
-:::python
-```python
-agent = create_deep_agent(
-    model="openai:gpt-5.4",
-    subagents=[{
-        "name": "analyzer",
-        "description": "Analyzes code for unused exports, functions, and dead code paths",
-        "system_prompt": "You are a code analyst specializing in dead code detection. Find unused exports, unreachable functions, and orphaned modules. Report each with file path and evidence.",
-    }],
-    middleware=[CodeInterpreterMiddleware()],
-)
-
-result = await agent.ainvoke({
-    "messages": [{"role": "user", "content": "Find all the dead code in this repo. Be thorough — I want every unused export and unreachable function."}]
-})
-```
-:::
-
-:::js
-```typescript
-const agent = createDeepAgent({
-  model: "openai:gpt-5.4",
-  subagents: [{
-    name: "analyzer",
-    description: "Analyzes code for unused exports, functions, and dead code paths",
-    systemPrompt: "You are a code analyst specializing in dead code detection. Find unused exports, unreachable functions, and orphaned modules. Report each with file path and evidence.",
-  }],
-  middleware: [createCodeInterpreterMiddleware()],
-});
-
-const result = await agent.invoke({
-  messages: [{ role: "user", content: "Find all the dead code in this repo. Be thorough — I want every unused export and unreachable function." }],
-});
-```
-:::
-
-<Warning>
-    `task()` dispatches from inside an already-running `eval` call. It does not go through the normal tool calling path, so `interrupt_on` approval workflows on the parent agent are not enforced per dispatch. Gate the `eval` tool itself if you need approval before subagent orchestration runs.
-</Warning>
+Programmatic tool calling is off until you pass an allowlist. Subagent dispatch is on by default whenever the agent has subagents, and you can turn it off. Nothing else crosses the QuickJS boundary unless you expose it.
 
 ## Programmatic tool calling
 
@@ -589,6 +161,8 @@ Programmatic tool calling (PTC) exposes selected agent tools inside the interpre
 This is useful when intermediate tool results are only inputs to the next step. The interpreter can process, filter, or aggregate those results before anything returns to the model context, which can make multi-tool/multi-step workflows more token efficient.
 
 PTC is model-agnostic in Deep Agents. It is implemented by middleware rather than a provider-specific code-execution or tool-calling API.
+
+Tools are opt-in: you pass an explicit allowlist, and nothing is bridged by default. Every tool you expose is an outside capability the interpreter can use, so treat the allowlist as a permission boundary and keep it to the tools the agent actually needs.
 
 ### How it works
 
@@ -675,11 +249,56 @@ try {
     PTC calls currently execute through the interpreter bridge and do not go through the normal tool calling path. As a result, `interrupt_on` approval workflows are not enforced per PTC-invoked tool call.
 </Warning>
 
-## Recursive language models
+## Orchestrate subagents from code
 
-Recursive language models use an interpreter as a workspace for decomposition. The model keeps a large input or working set in runtime variables, writes code to inspect and split it, calls subagents or other model tools on smaller pieces, and then stitches the returned results together in code.
+Some tasks don't fit a single agent pass: reviewing every file in a directory, triaging a batch of tickets, auditing a module for security issues. They share one shape: many independent units of work, often combined at the end.
 
-This separates the variable space from the agent's context. The variable space is information stored in the interpreter, and the agent's context is what the model actually processes in the next model call. The model can decide which snippets become subagent tasks, which results need another pass, and what final synthesis should return to the main conversation.
+When an agent has [subagents](/oss/deepagents/subagents) and interpreter middleware, the interpreter exposes a built-in `task()` global that dispatches subagents from code. The agent writes a loop that fans the work out, and all of it runs, so orchestration is deterministic rather than the model choosing whether to spawn one subagent at a time.
+
+This is on by default. Configure subagents, add interpreter middleware, and the agent reaches for `task()` whenever the work calls for it. Messages like "review every handler in `src/api/` for auth issues," "categorize the last 50 support tickets," or "generate three refactors and pick the best one" all lead here.
+
+### The `task()` primitive
+
+`task()` takes the prompt the subagent receives (`description`), which configured subagent to run (`subagentType`), and an optional `responseSchema` for structured output. It runs a full agentic loop and resolves to the subagent's result:
+
+```javascript
+const review = await task({
+  description: "Review src/auth/login.ts for auth issues. Cite line numbers.",
+  subagentType: "reviewer",
+  responseSchema: {
+    type: "object",
+    properties: {
+      issues: { type: "array", items: { type: "object", properties: {
+        file: { type: "string" }, line: { type: "number" },
+        severity: { type: "string" }, description: { type: "string" },
+      }}},
+    },
+  },
+});
+
+// With responseSchema, the result is already a typed value, so no JSON.parse is needed.
+const critical = review.issues.filter((issue) => issue.severity === "high");
+```
+
+When you pass `responseSchema`, the resolved value is already a typed JavaScript object; only call `JSON.parse` if a subagent intentionally returned a JSON string. The agent holds results in variables, filters and merges them in code, and returns only a synthesis to the model. Intermediate subagent output stays in the interpreter, not in your conversation context.
+
+### Steering orchestration
+
+The interpreter middleware ships orchestration guidance in the system prompt, so the agent already knows how to fan out in bounded batches, filter between passes, and synthesize results. You don't hand-write that logic or prompt for it turn by turn.
+
+To shape *what* the agent orchestrates, work through the inputs it already responds to:
+
+- **The subagents you configure.** Their `name` and `description` define the roles available. A `reviewer` paired with a `verifier` invites a two-pass check; a single `analyzer` invites a straight fan-out.
+- **The task message.** Phrasing like "I only want confirmed issues, not maybes" or "be exhaustive" nudges the agent toward verification or an open-ended sweep.
+- **The system prompt.** Use `systemPrompt` (or the agent's instructions) to add standing guidance when you want a consistent strategy across runs.
+
+The built-in guidance covers the mechanics of orchestration. Reach for the inputs above when you want to bias the agent toward a particular strategy for your task.
+
+### Working with large inputs
+
+The same `task()` mechanism handles inputs too large to reason over in one pass, the approach described in the [Recursive Language Models paper](https://arxiv.org/abs/2512.24601). Keep the large input or working set in interpreter variables (the *variable space*), then let the model write code to inspect it, split it into slices, dispatch a subagent per slice, and stitch the returned results back together.
+
+This separates the variable space from the agent's context. The variable space is everything stored in the interpreter; the context is only what the model processes on its next call. The model decides which slices become subagent tasks, which results need another pass, and what final synthesis returns to the conversation.
 
 ```mermaid
 flowchart TB
@@ -715,9 +334,7 @@ flowchart TB
     class Answer output
 ```
 
-For background on this pattern, see the [Recursive Language Models paper](https://arxiv.org/abs/2512.24601).
-
-In Deep Agents, the recursive call uses the [`task()` global](#subagent-orchestration). The interpreter can call subagents over many slices, combine their answers, and return a single synthesized result:
+The recursive call is just `task()` over slices. The interpreter calls a subagent for each one, combines their answers, and returns a single synthesized result:
 
 ```javascript
 const candidates = notes
@@ -740,11 +357,396 @@ const releaseSummary = riskReports
 releaseSummary;
 ```
 
-## Interpreter skills
+### Orchestration patterns
 
-Interpreter skills are [skills](/oss/deepagents/skills) that expose code modules to an interpreter. When configured with interpreter middleware, the agent can import these modules from code and use them for deterministic helper logic.
+The agent picks a strategy from the shape of the task. These patterns emerge from how it writes interpreter code; you don't select them yourself, and the subagents you configure determine what's available. The diagrams below show the common shapes, each with a runnable example.
 
-Interpreter skills are useful when the agent needs reusable helpers for structured data workflows, such as sorting, grouping, scoring, parsing, validating, or aggregating data. For setup details, see [Interpreter skills](/oss/deepagents/skills#interpreter-skills).
+#### Classify and act
+
+Items are classified first, then each is handled by a specialized subagent based on its classification. This lets you process mixed inputs where different items need different expertise.
+
+```mermaid
+graph LR
+    Task[Task] --> Classify{Classifier}
+    Classify --> |bug| A[Agent A]
+    Classify --> |feature| B[Agent B]
+    Classify --> |question| C[Agent C]
+```
+
+**Use cases:** Triaging support tickets, error logs, user feedback, or any batch of items that need different handling depending on their type.
+
+<Accordion title="Example: classify and act">
+:::python
+```python
+agent = create_deep_agent(
+    model="openai:gpt-5.4",
+    subagents=[
+        {
+            "name": "bug-fixer",
+            "description": "Investigates bug reports and provides reproduction steps",
+            "system_prompt": "You are a bug triage specialist. Investigate each bug report and provide clear reproduction steps.",
+        },
+        {
+            "name": "feature-analyst",
+            "description": "Evaluates feature requests for feasibility and effort",
+            "system_prompt": "You are a product analyst. Evaluate each feature request for technical feasibility, estimated effort, and potential impact.",
+        },
+        {
+            "name": "support-agent",
+            "description": "Answers user questions based on documentation",
+            "system_prompt": "You are a support specialist. Answer user questions clearly based on the available documentation.",
+        },
+    ],
+    middleware=[CodeInterpreterMiddleware()],
+)
+
+result = await agent.ainvoke({
+    "messages": [{"role": "user", "content": "Go through these 30 support tickets. Categorize each one, then for bugs give me reproduction steps, and for feature requests give me a feasibility assessment."}]
+})
+```
+:::
+
+:::js
+```typescript
+const agent = createDeepAgent({
+  model: "openai:gpt-5.4",
+  subagents: [
+    {
+      name: "bug-fixer",
+      description: "Investigates bug reports and provides reproduction steps",
+      systemPrompt: "You are a bug triage specialist. Investigate each bug report and provide clear reproduction steps.",
+    },
+    {
+      name: "feature-analyst",
+      description: "Evaluates feature requests for feasibility and effort",
+      systemPrompt: "You are a product analyst. Evaluate each feature request for technical feasibility, estimated effort, and potential impact.",
+    },
+    {
+      name: "support-agent",
+      description: "Answers user questions based on documentation",
+      systemPrompt: "You are a support specialist. Answer user questions clearly based on the available documentation.",
+    },
+  ],
+  middleware: [createCodeInterpreterMiddleware()],
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Go through these 30 support tickets. Categorize each one, then for bugs give me reproduction steps, and for feature requests give me a feasibility assessment." }],
+});
+```
+:::
+</Accordion>
+
+#### Fan-out and synthesize
+
+The agent dispatches the same kind of work across many items in parallel, then combines the results. This is the most common pattern.
+
+```mermaid
+graph LR
+    Items[Items] --> W1[Worker]
+    Items --> W2[Worker]
+    Items --> W3[Worker]
+    W1 --> Collect[Collect]
+    W2 --> Collect
+    W3 --> Collect
+    Collect --> Synth[Synthesize]
+```
+
+**Use cases:** Code review across a directory, analyzing a batch of documents, processing log files, running the same check across many services.
+
+<Accordion title="Example: fan-out and synthesize">
+:::python
+```python
+from deepagents import create_deep_agent
+from langchain_quickjs import CodeInterpreterMiddleware
+
+agent = create_deep_agent(
+    model="openai:gpt-5.4",
+    subagents=[{
+        "name": "reviewer",
+        "description": "Reviews code for security issues, citing lines and severity",
+        "system_prompt": "You are a security-focused code reviewer. Read the file carefully and report any authentication or authorization issues with line numbers and severity.",
+    }],
+    middleware=[CodeInterpreterMiddleware()],
+)
+
+result = await agent.ainvoke({
+    "messages": [{"role": "user", "content": "Review all the route handlers in src/routes/ for authentication issues. Summarize the top risks."}]
+})
+```
+:::
+
+:::js
+```typescript
+import { createDeepAgent } from "deepagents";
+import { createCodeInterpreterMiddleware } from "@langchain/quickjs";
+
+const agent = createDeepAgent({
+  model: "openai:gpt-5.4",
+  subagents: [{
+    name: "reviewer",
+    description: "Reviews code for security issues, citing lines and severity",
+    systemPrompt: "You are a security-focused code reviewer. Read the file carefully and report any authentication or authorization issues with line numbers and severity.",
+  }],
+  middleware: [createCodeInterpreterMiddleware()],
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Review all the route handlers in src/routes/ for authentication issues. Summarize the top risks." }],
+});
+```
+:::
+</Accordion>
+
+#### Adversarial verification
+
+A two-pass pattern. The first pass produces findings. The second pass sends each finding to independent verifiers, and only findings that survive agreement are kept. This reduces false positives when confidence matters more than speed.
+
+```mermaid
+graph LR
+    Items[Items] --> Workers[Workers]
+    Workers --> Findings[Findings]
+    Findings --> V1[Verifier]
+    Findings --> V2[Verifier]
+    Findings --> V3[Verifier]
+    V1 --> Vote[Majority vote]
+    V2 --> Vote
+    V3 --> Vote
+    Vote --> Confirmed[Confirmed]
+```
+
+**Use cases:** Security audits where false positives are costly, compliance checks, any review where you need high confidence in findings.
+
+<Accordion title="Example: adversarial verification">
+:::python
+```python
+agent = create_deep_agent(
+    model="openai:gpt-5.4",
+    subagents=[
+        {
+            "name": "reviewer",
+            "description": "Finds potential security vulnerabilities in code",
+            "system_prompt": "You are a security auditor. Find potential vulnerabilities and report each with file, line, and description.",
+        },
+        {
+            "name": "verifier",
+            "description": "Independently verifies whether a reported vulnerability is real",
+            "system_prompt": "You are a security verification specialist. Given a reported vulnerability, independently verify whether it is exploitable. Be skeptical. Only confirm real issues.",
+        },
+    ],
+    middleware=[CodeInterpreterMiddleware()],
+)
+
+result = await agent.ainvoke({
+    "messages": [{"role": "user", "content": "Do a thorough security audit of the payments module. I only want confirmed vulnerabilities, not maybes."}]
+})
+```
+:::
+
+:::js
+```typescript
+const agent = createDeepAgent({
+  model: "openai:gpt-5.4",
+  subagents: [
+    {
+      name: "reviewer",
+      description: "Finds potential security vulnerabilities in code",
+      systemPrompt: "You are a security auditor. Find potential vulnerabilities and report each with file, line, and description.",
+    },
+    {
+      name: "verifier",
+      description: "Independently verifies whether a reported vulnerability is real",
+      systemPrompt: "You are a security verification specialist. Given a reported vulnerability, independently verify whether it is exploitable. Be skeptical. Only confirm real issues.",
+    },
+  ],
+  middleware: [createCodeInterpreterMiddleware()],
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Do a thorough security audit of the payments module. I only want confirmed vulnerabilities, not maybes." }],
+});
+```
+:::
+</Accordion>
+
+#### Generate and filter
+
+Multiple subagents generate independent solutions to the same problem. The agent compares, scores, and filters the results in code, keeping only the best.
+
+```mermaid
+graph LR
+    Prompt[Prompt] --> G1[Generator]
+    Prompt --> G2[Generator]
+    Prompt --> G3[Generator]
+    G1 --> Filter[Filter + rank]
+    G2 --> Filter
+    G3 --> Filter
+    Filter --> Best[Best result]
+```
+
+**Use cases:** Architecture proposals, refactoring strategies, content variations, any task where exploring multiple options before committing produces a better outcome.
+
+<Accordion title="Example: generate and filter">
+:::python
+```python
+agent = create_deep_agent(
+    model="openai:gpt-5.4",
+    subagents=[{
+        "name": "architect",
+        "description": "Proposes a database schema design with tradeoff analysis",
+        "system_prompt": "You are a database architect. Propose a schema design for the given requirements. Include tradeoffs, migration considerations, and a clear rationale.",
+    }],
+    middleware=[CodeInterpreterMiddleware()],
+)
+
+result = await agent.ainvoke({
+    "messages": [{"role": "user", "content": "Generate three different approaches to restructure the database schema for the orders system, then pick the best one."}]
+})
+```
+:::
+
+:::js
+```typescript
+const agent = createDeepAgent({
+  model: "openai:gpt-5.4",
+  subagents: [{
+    name: "architect",
+    description: "Proposes a database schema design with tradeoff analysis",
+    systemPrompt: "You are a database architect. Propose a schema design for the given requirements. Include tradeoffs, migration considerations, and a clear rationale.",
+  }],
+  middleware: [createCodeInterpreterMiddleware()],
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Generate three different approaches to restructure the database schema for the orders system, then pick the best one." }],
+});
+```
+:::
+</Accordion>
+
+#### Tournament
+
+Variations are compared head-to-head by a judge subagent, with winners advancing through elimination rounds.
+
+```mermaid
+graph LR
+    A1[Attempt] --> J1{Judge}
+    A2[Attempt] --> J1
+    A3[Attempt] --> J2{Judge}
+    A4[Attempt] --> J2
+    J1 --> JF{Final}
+    J2 --> JF
+    JF --> Winner[Winner]
+```
+
+**Use cases:** Optimization under subjective criteria, style selection, choosing between competing implementations.
+
+<Accordion title="Example: tournament">
+:::python
+```python
+agent = create_deep_agent(
+    model="openai:gpt-5.4",
+    subagents=[
+        {
+            "name": "writer",
+            "description": "Rewrites a function with a focus on readability and clarity",
+            "system_prompt": "You are an expert programmer focused on clean code. Rewrite the given function to maximize readability. Explain your choices.",
+        },
+        {
+            "name": "judge",
+            "description": "Compares two code implementations and picks the more readable one",
+            "system_prompt": "You are a code quality judge. Compare two implementations and pick the more readable one. Justify your choice with specific criteria.",
+        },
+    ],
+    middleware=[CodeInterpreterMiddleware()],
+)
+
+result = await agent.ainvoke({
+    "messages": [{"role": "user", "content": "Rewrite the processOrder function in src/checkout.ts five different ways and find the most readable version."}]
+})
+```
+:::
+
+:::js
+```typescript
+const agent = createDeepAgent({
+  model: "openai:gpt-5.4",
+  subagents: [
+    {
+      name: "writer",
+      description: "Rewrites a function with a focus on readability and clarity",
+      systemPrompt: "You are an expert programmer focused on clean code. Rewrite the given function to maximize readability. Explain your choices.",
+    },
+    {
+      name: "judge",
+      description: "Compares two code implementations and picks the more readable one",
+      systemPrompt: "You are a code quality judge. Compare two implementations and pick the more readable one. Justify your choice with specific criteria.",
+    },
+  ],
+  middleware: [createCodeInterpreterMiddleware()],
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Rewrite the processOrder function in src/checkout.ts five different ways and find the most readable version." }],
+});
+```
+:::
+</Accordion>
+
+#### Loop until done
+
+The agent runs a discovery loop, deduplicating against what it has already found, until no new results appear. Useful when the scope of the work isn't known upfront.
+
+```mermaid
+graph LR
+    Agent[Agent] --> Check{New findings?}
+    Check --> |yes| Agent
+    Check --> |no| Done[Done]
+```
+
+**Use cases:** Exhaustive search, dead code detection, dependency audits, any sweep where you want completeness rather than a fixed number of results.
+
+<Accordion title="Example: loop until done">
+:::python
+```python
+agent = create_deep_agent(
+    model="openai:gpt-5.4",
+    subagents=[{
+        "name": "analyzer",
+        "description": "Analyzes code for unused exports, functions, and dead code paths",
+        "system_prompt": "You are a code analyst specializing in dead code detection. Find unused exports, unreachable functions, and orphaned modules. Report each with file path and evidence.",
+    }],
+    middleware=[CodeInterpreterMiddleware()],
+)
+
+result = await agent.ainvoke({
+    "messages": [{"role": "user", "content": "Find all the dead code in this repo. Be thorough — I want every unused export and unreachable function."}]
+})
+```
+:::
+
+:::js
+```typescript
+const agent = createDeepAgent({
+  model: "openai:gpt-5.4",
+  subagents: [{
+    name: "analyzer",
+    description: "Analyzes code for unused exports, functions, and dead code paths",
+    systemPrompt: "You are a code analyst specializing in dead code detection. Find unused exports, unreachable functions, and orphaned modules. Report each with file path and evidence.",
+  }],
+  middleware: [createCodeInterpreterMiddleware()],
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Find all the dead code in this repo. Be thorough — I want every unused export and unreachable function." }],
+});
+```
+:::
+</Accordion>
+
+<Warning>
+    `task()` dispatches from inside an already-running `eval` call. It does not go through the normal tool calling path, so `interrupt_on` approval workflows on the parent agent are not enforced per dispatch. Gate the `eval` tool itself if you need approval before subagent orchestration runs.
+</Warning>
 
 :::python
 ## Snapshots and time travel
@@ -802,7 +804,6 @@ Every tool you expose through PTC is an outside capability that interpreter code
 | Top-level `await` | Yes | Use promises in interpreter code |
 | `console.log` capture | Yes | Disable with `capture_console=False` |
 | Agent tools | No | Add a PTC allowlist |
-| Interpreter skill modules | No | Add a `module` entry and configure `skills_backend` or `skillsBackend` |
 | Filesystem access | No | Add the [built-in filesystem tools](/oss/deepagents/harness#virtual-filesystem-access) via the PTC allowlist |
 | Network access | No | Expose a specific network tool through PTC |
 | Wall-clock or datetime access | No | Expose an explicit time tool if needed |
@@ -815,7 +816,6 @@ Every tool you expose through PTC is an outside capability that interpreter code
 | Top-level `await` | Yes | Use promises in interpreter code |
 | `console.log` capture | Yes | Disable with `captureConsole: false` |
 | Agent tools | No | Add a PTC allowlist |
-| Interpreter skill modules | No | Add a `module` entry and configure `skills_backend` or `skillsBackend` |
 | Filesystem access | No | Add the [built-in filesystem tools](/oss/deepagents/harness#virtual-filesystem-access) via the PTC allowlist |
 | Network access | No | Expose a specific network tool through PTC |
 | Wall-clock or datetime access | No | Expose an explicit time tool if needed |
@@ -845,7 +845,7 @@ Every tool you expose through PTC is an outside capability that interpreter code
 | `tool_name` | `"eval"` | Name of the interpreter tool exposed to the model. |
 | `max_result_chars` | `4000` | Maximum characters returned from result and stdout blocks. |
 | `capture_console` | `True` | Whether `console.log`, `console.warn`, and `console.error` output is captured. |
-| `subagents` | `True` | Expose the built-in `task()` global for [subagent orchestration](#subagent-orchestration). Set to `False` to require subagent dispatch through the normal `task` tool path. |
+| `subagents` | `True` | Expose the built-in `task()` global for [subagent orchestration](#orchestrate-subagents-from-code). Set to `False` to require subagent dispatch through the normal `task` tool path. |
 | `ptc` | `None` | PTC allowlist: list of tool names or `BaseTool` instances. |
 | `snapshot_between_turns` | `True` | Whether interpreter state snapshots persist across agent turns. |
 | `max_snapshot_bytes` | `None` | Maximum serialized snapshot size. Defaults to `memory_limit`. |
@@ -865,5 +865,5 @@ Every tool you expose through PTC is an outside capability that interpreter code
 | `maxResultChars` | `4000` | Maximum characters retained from console output, result, and error strings. |
 | `toolName` | `"eval"` | Name of the interpreter tool exposed to the model. |
 | `captureConsole` | `true` | Whether `console.log`, `console.warn`, and `console.error` output is captured. |
-| `subagents` | `true` | Expose the built-in `task()` global for [subagent orchestration](#subagent-orchestration). Set to `false` to require subagent dispatch through the normal `task` tool path. |
+| `subagents` | `true` | Expose the built-in `task()` global for [subagent orchestration](#orchestrate-subagents-from-code). Set to `false` to require subagent dispatch through the normal `task` tool path. |
 :::

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -29,10 +29,10 @@ Interpreters give the agent a runtime for that work. A loop runs every iteration
     Call selected tools from interpreter code, including loops, retries, branching, and parallel batches.
   </Card>
   <Card title="Subagent orchestration" icon="arrows-split" href="#subagent-orchestration">
-    Dispatch subagents from code for fan-out, verification, and RLM workflows over large inputs.
+    Dispatch subagents from code for fan-out, verification, and recursive workflows over large inputs.
   </Card>
   <Card title="Stateful work" icon="database" href="#how-interpreters-work">
-    Preserve intermediate values in runtime state instead of sending every temporary result back through model context.
+    Keep intermediate values in runtime state without overloading the model context.
   </Card>
   <Card title="Deterministic transforms" icon="code" href="#how-interpreters-work">
     Sort, group, parse, validate, score, aggregate, and explore structured data in code.
@@ -48,7 +48,7 @@ Use interpreters for code inside the agent loop: composing tools, preserving sta
 | One or two simple external calls | Normal tool calling |
 | A small program that loops, branches, retries, or aggregates results | Interpreter |
 | Many selected tool calls that should run from code | Interpreter with [programmatic tool calling (PTC)](#programmatic-tool-calling-ptc) |
-| Many independent units of work, multiple perspectives, or recursive analysis over large inputs | Interpreter with [subagent orchestration](#subagent-orchestration), including [RLM workflows](#rlm-workflows) |
+| Many independent units of work, multiple perspectives, or recursive analysis over large inputs | Interpreter with [subagent orchestration](#subagent-orchestration) |
 | Shell commands, package installs, tests, or full OS filesystem access | [Sandboxes](/oss/deepagents/sandboxes) |
 
 ## Quickstart
@@ -209,6 +209,8 @@ results.join("\n\n");
 
 When an agent has [subagents](/oss/deepagents/subagents) and interpreter middleware, the interpreter exposes a built-in `task()` global that dispatches subagents from code. A task spanning many independent units (reviewing every file in a directory, triaging a batch of tickets) becomes a loop that fans the work out, so it runs deterministically instead of one model-chosen tool call at a time.
 
+Subagent orchestration also supports recursive language model (RLM) workflows, the approach described in the [Recursive Language Models paper](https://arxiv.org/abs/2512.24601): keep the working set in interpreter variables, select slices, call subagents with `task()`, and synthesize the results.
+
 `task()` takes the following inputs:
 
 - `description`: The prompt for the subagent
@@ -237,69 +239,6 @@ const critical = review.issues.filter((issue) => issue.severity === "high");
 ```
 
 When you pass `responseSchema`, the resolved value is already a typed JavaScript object; only call `JSON.parse` if a subagent intentionally returned a JSON string.
-
-### RLM workflows
-
-Recursive language model (RLM) workflows use subagent orchestration over large inputs. The interpreter keeps the working set in variables while the agent selects slices, calls subagents with `task()`, and synthesizes the results. This is the approach described in the [Recursive Language Models paper](https://arxiv.org/abs/2512.24601).
-
-Keep the large input or working set in interpreter variables (the *variable space*, distinct from the model's context), then let the model inspect it, split it into slices, dispatch a subagent per slice, and stitch the returned results back together.
-
-```mermaid
-flowchart TB
-    Model[Model] --> Runtime[Interpreter variable space]
-
-    subgraph Runtime[Interpreter variable space]
-        Data[Long input and working notes]
-        Select{Select next slice}
-        Task[Call subagent]
-        Store[Store subagent result]
-        Stitch[Stitch results in code]
-
-        Data --> Select
-        Select --> Task
-        Task --> Store
-        Store --> Select
-        Store --> Stitch
-    end
-
-    Stitch --> Answer[Compact synthesis]
-    Answer --> Model
-
-    classDef trigger fill:#F6FFDB,stroke:#6E8900,stroke-width:2px,color:#2E3900
-    classDef process fill:#E5F4FF,stroke:#006DDD,stroke-width:2px,color:#030710
-    classDef decision fill:#FDF3FF,stroke:#7E65AE,stroke-width:2px,color:#504B5F
-    classDef output fill:#EBD0F0,stroke:#885270,stroke-width:2px,color:#441E33
-    classDef neutral fill:#F2FAFF,stroke:#40668D,stroke-width:2px,color:#2F4B68
-
-    class Model trigger
-    class Runtime,Data,Store neutral
-    class Select decision
-    class Task,Stitch process
-    class Answer output
-```
-
-The recursive call runs `task()` over slices of the input. The interpreter calls a subagent for each one, combines their answers, and returns a single synthesized result:
-
-```javascript
-const candidates = notes
-  .filter((note) => note.includes("migration"))
-  .slice(0, 5);
-
-const riskReports = await Promise.all(
-  candidates.map((note) =>
-    task({
-      description: `Analyze this migration note for release risk. Return risks, affected users, and recommended follow-up:\n\n${note}`,
-      subagentType: "general-purpose",
-    }),
-  ),
-);
-
-const releaseSummary = riskReports
-  .map((report, index) => `## Candidate ${index + 1}\n${report}`)
-  .join("\n\n");
-
-releaseSummary;
-```
 
 ### Guide orchestration
 

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -865,5 +865,5 @@ Every tool you expose through PTC is an outside capability that interpreter code
 | `maxResultChars` | `4000` | Maximum characters retained from console output, result, and error strings. |
 | `toolName` | `"eval"` | Name of the interpreter tool exposed to the model. |
 | `captureConsole` | `true` | Whether `console.log`, `console.warn`, and `console.error` output is captured. |
-| `maxSubagentConcurrency` | `32` | Maximum concurrent `task()` dispatches per eval for [subagent orchestration](#subagent-orchestration). Set to `0` to disable the built-in `task()` global. |
+| `subagents` | `true` | Expose the built-in `task()` global for [subagent orchestration](#subagent-orchestration). Set to `false` to require subagent dispatch through the normal `task` tool path. |
 :::

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -135,7 +135,7 @@ Programmatic tool calling is off until you [enable it](#enable-ptc). Subagent di
 
 Programmatic tool calling (PTC) exposes selected agent tools inside the interpreter under the global `tools` namespace. Instead of asking the model to issue one tool call, wait for the result, and then decide the next call, the agent can write code that calls tools in loops, branches, retries, or parallel batches.
 
-This helps when intermediate results are only inputs to the next step: the interpreter filters or aggregates them before anything returns to the model, keeping multi-step workflows token efficient. It is model-agnostic, implemented by middleware rather than a provider-specific tool-calling API.
+This helps when intermediate results are only inputs to the next step: the interpreter filters or aggregates them before anything returns to the model, keeping multi-step workflows token-efficient. It is model-agnostic, implemented by middleware rather than a provider-specific tool-calling API.
 
 The middleware exposes each allowlisted tool as an async function under `tools`. The agent calls it with `await`, processes the result in code, and the model sees only the final interpreter output, not every intermediate value. Tool names are converted to camel case while the input object still follows the tool's schema, so a tool named `web_search` becomes `tools.webSearch(...)`:
 

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -28,8 +28,8 @@ Interpreters give the agent a runtime for that work. A loop runs every iteration
   <Card title="Programmatic tool calling (PTC)" icon="tool" href="#programmatic-tool-calling-ptc">
     Call selected tools from interpreter code, including loops, retries, branching, and parallel batches.
   </Card>
-  <Card title="Recursive language models (RLMs)" icon="arrows-split" href="#rlm-workflows">
-    Use subagent orchestration over large inputs by keeping working state in interpreter variables.
+  <Card title="Subagent orchestration" icon="arrows-split" href="#subagent-orchestration">
+    Dispatch subagents from code for fan-out, verification, and RLM workflows over large inputs.
   </Card>
   <Card title="Stateful work" icon="database" href="#how-interpreters-work">
     Preserve intermediate values in runtime state instead of sending every temporary result back through model context.

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -310,6 +310,9 @@ graph LR
 **Use cases:** Triaging support tickets, error logs, user feedback, or any batch of items that need different handling depending on their type.
 
 <Accordion title="Example: classify and act">
+
+**What you configure**
+
 :::python
 ```python
 agent = create_deep_agent(
@@ -369,6 +372,25 @@ const result = await agent.invoke({
 });
 ```
 :::
+
+**What the agent writes**
+
+```javascript
+// The agent has already classified each ticket; this routes every item to
+// the right specialist and collects the handled results.
+const SPECIALIST = { bug: "bug-fixer", feature: "feature-analyst", question: "support-agent" };
+
+const handled = await Promise.all(
+  tickets.map((ticket) =>
+    task({
+      description: `Handle this ${ticket.category}:\n${ticket.text}`,
+      subagentType: SPECIALIST[ticket.category],
+    }),
+  ),
+);
+// ... group handled results by category into a single triage report
+handled;
+```
 </Accordion>
 
 #### Fan-out and synthesize
@@ -389,6 +411,9 @@ graph LR
 **Use cases:** Code review across a directory, analyzing a batch of documents, processing log files, running the same check across many services.
 
 <Accordion title="Example: fan-out and synthesize">
+
+**What you configure**
+
 :::python
 ```python
 from deepagents import create_deep_agent
@@ -430,6 +455,29 @@ const result = await agent.invoke({
 });
 ```
 :::
+
+**What the agent writes**
+
+```javascript
+// One reviewer per file, dispatched in parallel, then findings merged.
+const files = (await tools.glob({ pattern: "src/routes/**/*.ts" }))
+  .split("\n")
+  .filter(Boolean);
+
+const reviews = await Promise.all(
+  files.map((file) =>
+    task({
+      description: `Review ${file} for authentication issues. Cite line numbers.`,
+      subagentType: "reviewer",
+      responseSchema: issuesSchema, // -> { issues: [{ file, line, severity }] }
+    }),
+  ),
+);
+
+const issues = reviews.flatMap((r) => r.issues);
+// ... sort by severity, drop duplicates, summarize the top risks
+issues;
+```
 </Accordion>
 
 #### Adversarial verification
@@ -452,6 +500,9 @@ graph LR
 **Use cases:** Security audits where false positives are costly, compliance checks, any review where you need high confidence in findings.
 
 <Accordion title="Example: adversarial verification">
+
+**What you configure**
+
 :::python
 ```python
 agent = create_deep_agent(
@@ -501,6 +552,31 @@ const result = await agent.invoke({
 });
 ```
 :::
+
+**What the agent writes**
+
+```javascript
+// Pass 1: audit. Pass 2: verify each finding independently; keep only confirmed.
+const { findings } = await task({
+  description: "Audit the payments module for vulnerabilities.",
+  subagentType: "auditor",
+  responseSchema: findingsSchema, // -> { findings: [{ id, file, line, description }] }
+});
+
+const verdicts = await Promise.all(
+  findings.map((f) =>
+    task({
+      description: `Verify ${f.file}:${f.line} (${f.description}). Confirm or refute.`,
+      subagentType: "verifier",
+      responseSchema: verdictSchema, // -> { confirmed: boolean }
+    }),
+  ),
+);
+
+const confirmed = findings.filter((_, i) => verdicts[i]?.confirmed);
+// ... report only the confirmed vulnerabilities
+confirmed;
+```
 </Accordion>
 
 #### Generate and filter
@@ -521,6 +597,9 @@ graph LR
 **Use cases:** Architecture proposals, refactoring strategies, content variations, any task where exploring multiple options before committing produces a better outcome.
 
 <Accordion title="Example: generate and filter">
+
+**What you configure**
+
 :::python
 ```python
 agent = create_deep_agent(
@@ -556,6 +635,25 @@ const result = await agent.invoke({
 });
 ```
 :::
+
+**What the agent writes**
+
+```javascript
+// Generate independent proposals in parallel, then score and keep the best.
+const proposals = await Promise.all(
+  [1, 2, 3].map((n) =>
+    task({
+      description: `Approach ${n}: redesign the orders schema, with tradeoffs.`,
+      subagentType: "architect",
+      responseSchema: designSchema, // -> { design, tradeoffs }
+    }),
+  ),
+);
+
+// ... score each proposal against the requirements
+const best = proposals.sort((a, b) => score(b) - score(a))[0];
+best;
+```
 </Accordion>
 
 #### Tournament
@@ -576,6 +674,9 @@ graph LR
 **Use cases:** Optimization under subjective criteria, style selection, choosing between competing implementations.
 
 <Accordion title="Example: tournament">
+
+**What you configure**
+
 :::python
 ```python
 agent = create_deep_agent(
@@ -625,6 +726,32 @@ const result = await agent.invoke({
 });
 ```
 :::
+
+**What the agent writes**
+
+```javascript
+// Generate variants, then judge pairwise until a single winner remains.
+let bracket = await Promise.all(
+  [1, 2, 3, 4, 5].map((n) =>
+    task({ description: `Rewrite processOrder for readability (variant ${n}).`, subagentType: "writer" }),
+  ),
+);
+
+while (bracket.length > 1) {
+  const winners = [];
+  for (let i = 0; i < bracket.length; i += 2) {
+    if (bracket[i + 1] === undefined) { winners.push(bracket[i]); break; }
+    const { winner } = await task({
+      description: `Pick the more readable:\n\nA:\n${bracket[i]}\n\nB:\n${bracket[i + 1]}`,
+      subagentType: "judge",
+      responseSchema: pickSchema, // -> { winner: "A" | "B" }
+    });
+    winners.push(winner === "A" ? bracket[i] : bracket[i + 1]);
+  }
+  bracket = winners;
+}
+bracket[0]; // the winning rewrite
+```
 </Accordion>
 
 #### Loop until done
@@ -641,6 +768,9 @@ graph LR
 **Use cases:** Exhaustive search, dead code detection, dependency audits, any sweep where you want completeness rather than a fixed number of results.
 
 <Accordion title="Example: loop until done">
+
+**What you configure**
+
 :::python
 ```python
 agent = create_deep_agent(
@@ -676,6 +806,26 @@ const result = await agent.invoke({
 });
 ```
 :::
+
+**What the agent writes**
+
+```javascript
+// Keep dispatching rounds, deduping against what's found, until a round adds nothing.
+const seen = new Set();
+const found = [];
+
+while (true) {
+  const { items } = await task({
+    description: `Find dead code. Already found: ${[...seen].join(", ") || "(none)"}.`,
+    subagentType: "analyzer",
+    responseSchema: itemsSchema, // -> { items: [{ id, file }] }
+  });
+  const fresh = items.filter((i) => !seen.has(i.id));
+  if (fresh.length === 0) break; // converged: nothing new
+  for (const i of fresh) { seen.add(i.id); found.push(i); }
+}
+found;
+```
 </Accordion>
 
 <Warning>

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -281,7 +281,7 @@ flowchart TB
     class Answer output
 ```
 
-The recursive call is just `task()` over slices. The interpreter calls a subagent for each one, combines their answers, and returns a single synthesized result:
+The recursive call runs `task()` over slices of the input. The interpreter calls a subagent for each one, combines their answers, and returns a single synthesized result:
 
 ```javascript
 const candidates = notes

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -245,7 +245,7 @@ To shape *what* the agent orchestrates, work through the inputs it already respo
 
 ### Working with large inputs
 
-The same `task()` mechanism handles inputs too large to reason over in one pass, the approach described in the [Recursive Language Models paper](https://arxiv.org/abs/2512.24601). Keep the large input or working set in interpreter variables (the *variable space*, distinct from the model's context), then let the model inspect it, split it into slices, dispatch a subagent per slice, and stitch the returned results back together.
+The `task()` mechanism handles inputs too large to reason over in one pass, the approach described in the [Recursive Language Models paper](https://arxiv.org/abs/2512.24601). Keep the large input or working set in interpreter variables (the *variable space*, distinct from the model's context), then let the model inspect it, split it into slices, dispatch a subagent per slice, and stitch the returned results back together.
 
 ```mermaid
 flowchart TB

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -18,31 +18,40 @@ Where [sandboxes](/oss/deepagents/sandboxes) are a code-first way for acting on 
 </Note>
 :::
 
-## When to use an interpreter
+## Why use interpreters?
 
-Most agent work alternates between model reasoning and tool calls. A model can fire several tool calls in one turn, but that batch is fixed the moment it's emitted. Nothing can loop, branch on a result, retry a failure, or feed one call's output into the next without another model turn, and every result returns to the model's context. The model also decides how many calls to issue, so asking it to dispatch work across hundreds of items is unreliable, and it tends to cover a sample rather than every one. That breaks down when the agent needs to compose many steps, reason over structured data, or hold intermediate state. An interpreter gives it a runtime to do that work in code. A loop runs every iteration, tools are called from code, intermediate values stay in variables, and only a compact result returns to the model.
+Most agent work alternates between model reasoning and tool calls. A model can fire several tool calls in one turn, but that batch is fixed the moment it is emitted. Nothing can loop, branch on a result, retry a failure, or feed one call's output into the next without another model turn, and every result returns to the model's context. The model also decides how many calls to issue, so asking it to dispatch work across hundreds of items is unreliable, and it tends to cover a sample rather than every one.
 
-Use interpreters when the agent needs to:
+Interpreters give the agent a runtime for that work. A loop runs every iteration, tools are called from code, intermediate values stay in variables, and only a compact result returns to the model.
 
-- Compose multiple tool calls with code, including loops, branching, retries, and concurrency.
-- Coordinate subagents from code by splitting work into focused calls, storing their results, and stitching those results into a final synthesis.
-- Keep intermediate values in runtime state instead of sending every temporary result back through the model context.
-- Transform structured data deterministically, such as sorting, grouping, parsing, validating, scoring, or aggregating.
-- Explore a large variable space and return only selected evidence, summaries, or outputs to the model.
+<CardGroup cols={2}>
+  <Card title="Programmatic tool calling (PTC)" icon="tool" href="#programmatic-tool-calling-ptc">
+    Call selected tools from interpreter code, including loops, retries, branching, and parallel batches.
+  </Card>
+  <Card title="Recursive language models (RLMs)" icon="arrows-split" href="#rlm-workflows">
+    Use subagent orchestration over large inputs by keeping working state in interpreter variables.
+  </Card>
+  <Card title="Stateful work" icon="database" href="#how-interpreters-work">
+    Preserve intermediate values in runtime state instead of sending every temporary result back through model context.
+  </Card>
+  <Card title="Deterministic transforms" icon="code" href="#how-interpreters-work">
+    Sort, group, parse, validate, score, aggregate, and explore structured data in code.
+  </Card>
+</CardGroup>
 
-Code runs against [**QuickJS**](https://github.com/quickjs-ng/quickjs), a lightweight JavaScript runtime with no access to the host filesystem, network, shell, or clock by default. Explicit bridges decide what the code can reach.
+## Choose a pattern
 
-## Choose the right execution path
+Use interpreters for code inside the agent loop: composing tools, preserving state, and controlling what returns to the model. Use [sandboxes](/oss/deepagents/sandboxes) for code against an environment: shell commands, package installs, tests, filesystem edits, and OS-level execution.
 
 | Need | Use |
 | --- | --- |
 | One or two simple external calls | Normal tool calling |
 | A small program that loops, branches, retries, or aggregates results | Interpreter |
-| Many selected tool calls that should run from code | Interpreter with [programmatic tool calling](#programmatic-tool-calling) |
-| Many independent units of work, or multiple perspectives on one task | Interpreter with [subagent orchestration](#orchestrate-subagents-from-code) |
+| Many selected tool calls that should run from code | Interpreter with [programmatic tool calling (PTC)](#programmatic-tool-calling-ptc) |
+| Many independent units of work, multiple perspectives, or recursive analysis over large inputs | Interpreter with [subagent orchestration](#subagent-orchestration), including [RLM workflows](#rlm-workflows) |
 | Shell commands, package installs, tests, or full OS filesystem access | [Sandboxes](/oss/deepagents/sandboxes) |
 
-## Add an interpreter to an agent
+## Quickstart
 
 Install the QuickJS middleware package, then pass interpreter middleware using the `middleware` argument on `create_deep_agent`.
 
@@ -94,9 +103,9 @@ const agent = createDeepAgent({
 ```
 :::
 
-## Run code in the interpreter
+## How interpreters work
 
-The middleware adds an `eval` tool to the agent. The tool runs JavaScript in a persistent context, captures `console.log`, and returns the result of the last expression.
+The middleware adds an `eval` tool to the agent. When useful, the agent writes JavaScript and calls `eval`; you do not call the interpreter directly. The tool runs code in a persistent context, captures `console.log`, and returns the result of the last expression.
 
 The agent can write code like this:
 
@@ -120,18 +129,16 @@ totals;
 By default, interpreter state also persists across turns in the same thread by snapshotting the working state after each agent run, and restoring it before the next run.
 :::
 
-## What interpreter code can reach
-
-By default, interpreter code runs against QuickJS with no access to the host filesystem, network, shell, package manager, or clock. It can compute, hold state, and write to `console.log`, and nothing more.
+Code runs against [**QuickJS**](https://github.com/quickjs-ng/quickjs), a lightweight JavaScript runtime. By default, interpreter code has no access to the host filesystem, network, shell, package manager, or clock. It can compute, hold state, and write to `console.log`, and nothing more.
 
 Two explicit bridges extend that reach:
 
-- **Tools**, through [programmatic tool calling](#programmatic-tool-calling). Expose an allowlist of tools as async functions under the `tools` namespace. These can be the agent's own tools or standalone tools you define and pass in.
-- **Subagents**, through the built-in [`task()` global](#orchestrate-subagents-from-code). Dispatch configured subagents from code and orchestrate them in plain JavaScript.
+- **Tools**, through [programmatic tool calling (PTC)](#programmatic-tool-calling-ptc). Expose an allowlist of tools as async functions under the `tools` namespace. These can be the agent's own tools or standalone tools you define and pass in.
+- **Subagents**, through [subagent orchestration](#subagent-orchestration). Dispatch configured subagents from code and orchestrate them in plain JavaScript.
 
 Programmatic tool calling is off until you [enable it](#enable-ptc). Subagent dispatch is on by default whenever the agent has subagents, and you can turn it off. Nothing else crosses the QuickJS boundary unless you expose it.
 
-## Programmatic tool calling
+## Programmatic tool calling (PTC)
 
 Programmatic tool calling (PTC) exposes selected agent tools inside the interpreter under the global `tools` namespace. Instead of asking the model to issue one tool call, wait for the result, and then decide the next call, the agent can write code that calls tools in loops, branches, retries, or parallel batches.
 
@@ -198,19 +205,17 @@ results.join("\n\n");
 </Warning>
 :::
 
-## Orchestrate subagents from code
+## Subagent orchestration
 
 When an agent has [subagents](/oss/deepagents/subagents) and interpreter middleware, the interpreter exposes a built-in `task()` global that dispatches subagents from code. A task spanning many independent units (reviewing every file in a directory, triaging a batch of tickets) becomes a loop that fans the work out, so it runs deterministically instead of one model-chosen tool call at a time.
 
-### The `task()` global
-
 `task()` takes the following inputs:
 
- - `description`: the prompt for the subagent
- - `subagentType`: which configured subagent to run
- - `responseSchema` (optional): structured output
- 
-a `task()` runs a full agentic loop and resolves to the subagent's result:
+- `description`: The prompt for the subagent
+- `subagentType`: Which configured subagent to run
+- `responseSchema` (optional): Structured output
+
+A `task()` runs a full agentic loop and resolves to the subagent's result:
 
 ```javascript
 const review = await task({
@@ -233,19 +238,11 @@ const critical = review.issues.filter((issue) => issue.severity === "high");
 
 When you pass `responseSchema`, the resolved value is already a typed JavaScript object; only call `JSON.parse` if a subagent intentionally returned a JSON string.
 
-### Steering orchestration
+### RLM workflows
 
-The interpreter middleware ships orchestration guidance in the system prompt, so the agent already knows how to fan out in bounded batches, filter between passes, and synthesize results. You don't hand-write that logic or prompt for it turn by turn.
+Recursive language model (RLM) workflows use subagent orchestration over large inputs. The interpreter keeps the working set in variables while the agent selects slices, calls subagents with `task()`, and synthesizes the results. This is the approach described in the [Recursive Language Models paper](https://arxiv.org/abs/2512.24601).
 
-To shape *what* the agent orchestrates, work through the inputs it already responds to:
-
-- **The subagents you configure.** Their `name` and `description` define the roles available. A `reviewer` paired with a `verifier` invites a two-pass check; a single `analyzer` invites a straight fan-out.
-- **The task message.** Phrasing like "I only want confirmed issues, not maybes" or "be exhaustive" nudges the agent toward verification or an open-ended sweep.
-- **The system prompt.** Use `systemPrompt` (or the agent's instructions) to add standing guidance when you want a consistent strategy across runs.
-
-### Working with large inputs
-
-The `task()` mechanism handles inputs too large to reason over in one pass, the approach described in the [Recursive Language Models paper](https://arxiv.org/abs/2512.24601). Keep the large input or working set in interpreter variables (the *variable space*, distinct from the model's context), then let the model inspect it, split it into slices, dispatch a subagent per slice, and stitch the returned results back together.
+Keep the large input or working set in interpreter variables (the *variable space*, distinct from the model's context), then let the model inspect it, split it into slices, dispatch a subagent per slice, and stitch the returned results back together.
 
 ```mermaid
 flowchart TB
@@ -304,7 +301,17 @@ const releaseSummary = riskReports
 releaseSummary;
 ```
 
-### Orchestration patterns
+### Guide orchestration
+
+The interpreter middleware ships orchestration guidance in the system prompt, so the agent already knows how to fan out in bounded batches, filter between passes, and synthesize results. You don't hand-write that logic or prompt for it turn by turn.
+
+To shape *what* the agent orchestrates, work through the inputs it already responds to:
+
+- **The subagents you configure.** Their `name` and `description` define the roles available. A `reviewer` paired with a `verifier` invites a two-pass check; a single `analyzer` invites a straight fan-out.
+- **The task message.** Phrasing like "I only want confirmed issues, not maybes" or "be exhaustive" nudges the agent toward verification or an open-ended sweep.
+- **The system prompt.** Use `systemPrompt` (or the agent's instructions) to add standing guidance when you want a consistent strategy across runs.
+
+### Patterns
 
 The agent picks a strategy from the shape of the task; these emerge from how it writes interpreter code, not from configuration, and the subagents you make available determine what it can do. Every pattern shares one model: hold work in JS variables, dispatch subagents with `task()`, and combine results in code. The diagrams below show the common shapes, each with a runnable example.
 
@@ -853,7 +860,7 @@ found;
 :::
 
 :::python
-## Snapshots and time travel
+## Persistence
 
 `CodeInterpreterMiddleware` snapshots interpreter state after each agent run and restores it before the next run by default. A snapshot is a serialized copy of the interpreter's in-memory JavaScript state, including globals, variables, functions, and imported modules that exist when the agent finishes running code.
 
@@ -895,7 +902,7 @@ agent = create_deep_agent(
 You can disable cross-turn snapshots with `snapshot_between_turns=False`.
 :::
 
-## Security and limits
+## Security
 
 Interpreters use QuickJS to run untrusted JavaScript with strict default isolation. Treat that as a scoped interpreter runtime, not a full production sandbox backend.
 
@@ -936,7 +943,7 @@ Every tool you expose through PTC is an outside capability that interpreter code
 </Note>
 :::
 
-## Middleware options
+## Configuration
 
 :::python
 `CodeInterpreterMiddleware` accepts the following options:
@@ -949,7 +956,7 @@ Every tool you expose through PTC is an outside capability that interpreter code
 | `tool_name` | `"eval"` | Name of the interpreter tool exposed to the model. |
 | `max_result_chars` | `4000` | Maximum characters returned from result and stdout blocks. |
 | `capture_console` | `True` | Whether `console.log`, `console.warn`, and `console.error` output is captured. |
-| `subagents` | `True` | Expose the built-in `task()` global for [subagent orchestration](#orchestrate-subagents-from-code). Set to `False` to require subagent dispatch through the normal `task` tool path. |
+| `subagents` | `True` | Expose the built-in `task()` global for [subagent orchestration](#subagent-orchestration). Set to `False` to require subagent dispatch through the normal `task` tool path. |
 | `ptc` | `None` | PTC allowlist: list of tool names or `BaseTool` instances. |
 | `snapshot_between_turns` | `True` | Whether interpreter state snapshots persist across agent turns. |
 | `max_snapshot_bytes` | `None` | Maximum serialized snapshot size. Defaults to `memory_limit`. |
@@ -969,5 +976,5 @@ Every tool you expose through PTC is an outside capability that interpreter code
 | `maxResultChars` | `4000` | Maximum characters retained from console output, result, and error strings. |
 | `toolName` | `"eval"` | Name of the interpreter tool exposed to the model. |
 | `captureConsole` | `true` | Whether `console.log`, `console.warn`, and `console.error` output is captured. |
-| `subagents` | `true` | Expose the built-in `task()` global for [subagent orchestration](#orchestrate-subagents-from-code). Set to `false` to require subagent dispatch through the normal `task` tool path. |
+| `subagents` | `true` | Expose the built-in `task()` global for [subagent orchestration](#subagent-orchestration). Set to `false` to require subagent dispatch through the normal `task` tool path. |
 :::

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -143,6 +143,445 @@ totals;
 By default, interpreter state also persists across turns in the same thread by snapshotting the working state after each agent run, and restoring it before the next run.
 :::
 
+## Subagent orchestration
+
+Some tasks are too large for a single agent pass. Reviewing every file in a directory, triaging a batch of tickets, or auditing a codebase for security issues all share the same shape: many independent pieces of work that can run in parallel, with results combined at the end.
+
+With standard tool calling, the agent decides whether to spawn subagents one call at a time. This is non-deterministic and doesn't scale when the work requires dozens of parallel dispatches. When an agent has [subagents](/oss/deepagents/subagents) and interpreter middleware, the interpreter exposes a built-in `task()` function that lets the agent dispatch subagents programmatically. Because subagents are spawned as part of code execution rather than individual tool calls, the orchestration is deterministic: the agent writes a loop that fans out 50 reviewers, and all 50 run.
+
+You don't need to enable this explicitly. Configure your subagents, add interpreter middleware, and the agent uses `task()` whenever the work calls for it.
+
+### How it works
+
+1. You send a message describing work that spans many items or needs multiple perspectives.
+2. The agent writes interpreter code that calls `task()` to dispatch subagents in parallel batches.
+3. Each subagent runs a full agentic loop (reading files, calling tools, iterating) and returns a result.
+4. The interpreter collects results, filters or transforms them in code, and returns a synthesis to the model.
+5. The model presents the final answer. Intermediate subagent results stay in the interpreter, not in your conversation context.
+
+`task()` takes a description (the prompt the subagent receives), a subagent type (which configured subagent to use), and an optional response schema for structured output. Here's a quick look at the kind of code the agent writes:
+
+```javascript
+const schema = {
+  type: "object",
+  properties: {
+    issues: { type: "array", items: { type: "object", properties: {
+      file: { type: "string" }, line: { type: "number" },
+      severity: { type: "string" }, description: { type: "string" },
+    }}},
+  },
+};
+
+const reviews = await Promise.all(
+  files.map((file) => task({
+    description: `Review ${file} for auth issues. Cite line numbers.`,
+    subagentType: "reviewer",
+    responseSchema: schema,
+  }))
+);
+
+const critical = reviews
+  .flatMap((r) => JSON.parse(r).issues)
+  .filter((i) => i.severity === "high");
+
+const fixes = await Promise.all(
+  critical.map((issue) => task({
+    description: `Explain how to fix: ${issue.description} in ${issue.file}:${issue.line}`,
+    subagentType: "reviewer",
+  }))
+);
+```
+
+### When the agent uses it
+
+Messages like these naturally lead to subagent orchestration:
+
+- "Review every file in `src/api/` for security issues and give me a summary"
+- "Analyze the last 50 support tickets and categorize them by type"
+- "Check each of these migration scripts for breaking changes"
+- "Generate three approaches to this refactor, then pick the best one"
+
+The common thread is work with a repeated structure across many inputs, or work that benefits from multiple independent perspectives. The agent recognizes these shapes and orchestrates accordingly.
+
+### Workflow patterns
+
+The agent chooses an orchestration strategy based on the task. These patterns naturally emerge from how the agent writes its interpreter code. You don't select them yourself. The subagents you configure determine what's available; the agent handles the rest.
+
+#### Classify and act
+
+Items are classified first, then each is handled by a specialized subagent based on its classification. This lets you process mixed inputs where different items need different expertise.
+
+```mermaid
+graph LR
+    Task[Task] --> Classify{Classifier}
+    Classify --> |bug| A[Agent A]
+    Classify --> |feature| B[Agent B]
+    Classify --> |question| C[Agent C]
+```
+
+**Use cases:** Triaging support tickets, error logs, user feedback, or any batch of items that need different handling depending on their type.
+
+:::python
+```python
+agent = create_deep_agent(
+    model="openai:gpt-5.4",
+    subagents=[
+        {
+            "name": "bug-fixer",
+            "description": "Investigates bug reports and provides reproduction steps",
+            "system_prompt": "You are a bug triage specialist. Investigate each bug report and provide clear reproduction steps.",
+        },
+        {
+            "name": "feature-analyst",
+            "description": "Evaluates feature requests for feasibility and effort",
+            "system_prompt": "You are a product analyst. Evaluate each feature request for technical feasibility, estimated effort, and potential impact.",
+        },
+        {
+            "name": "support-agent",
+            "description": "Answers user questions based on documentation",
+            "system_prompt": "You are a support specialist. Answer user questions clearly based on the available documentation.",
+        },
+    ],
+    middleware=[CodeInterpreterMiddleware()],
+)
+
+result = await agent.ainvoke({
+    "messages": [{"role": "user", "content": "Go through these 30 support tickets. Categorize each one, then for bugs give me reproduction steps, and for feature requests give me a feasibility assessment."}]
+})
+```
+:::
+
+:::js
+```typescript
+const agent = createDeepAgent({
+  model: "openai:gpt-5.4",
+  subagents: [
+    {
+      name: "bug-fixer",
+      description: "Investigates bug reports and provides reproduction steps",
+      systemPrompt: "You are a bug triage specialist. Investigate each bug report and provide clear reproduction steps.",
+    },
+    {
+      name: "feature-analyst",
+      description: "Evaluates feature requests for feasibility and effort",
+      systemPrompt: "You are a product analyst. Evaluate each feature request for technical feasibility, estimated effort, and potential impact.",
+    },
+    {
+      name: "support-agent",
+      description: "Answers user questions based on documentation",
+      systemPrompt: "You are a support specialist. Answer user questions clearly based on the available documentation.",
+    },
+  ],
+  middleware: [createCodeInterpreterMiddleware()],
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Go through these 30 support tickets. Categorize each one, then for bugs give me reproduction steps, and for feature requests give me a feasibility assessment." }],
+});
+```
+:::
+
+#### Fan-out and synthesize
+
+The agent dispatches the same kind of work across many items in parallel, then combines the results. This is the most common pattern.
+
+```mermaid
+graph LR
+    Items[Items] --> W1[Worker]
+    Items --> W2[Worker]
+    Items --> W3[Worker]
+    W1 --> Collect[Collect]
+    W2 --> Collect
+    W3 --> Collect
+    Collect --> Synth[Synthesize]
+```
+
+**Use cases:** Code review across a directory, analyzing a batch of documents, processing log files, running the same check across many services.
+
+:::python
+```python
+from deepagents import create_deep_agent
+from langchain_quickjs import CodeInterpreterMiddleware
+
+agent = create_deep_agent(
+    model="openai:gpt-5.4",
+    subagents=[{
+        "name": "reviewer",
+        "description": "Reviews code for security issues, citing lines and severity",
+        "system_prompt": "You are a security-focused code reviewer. Read the file carefully and report any authentication or authorization issues with line numbers and severity.",
+    }],
+    middleware=[CodeInterpreterMiddleware()],
+)
+
+result = await agent.ainvoke({
+    "messages": [{"role": "user", "content": "Review all the route handlers in src/routes/ for authentication issues. Summarize the top risks."}]
+})
+```
+:::
+
+:::js
+```typescript
+import { createDeepAgent } from "deepagents";
+import { createCodeInterpreterMiddleware } from "@langchain/quickjs";
+
+const agent = createDeepAgent({
+  model: "openai:gpt-5.4",
+  subagents: [{
+    name: "reviewer",
+    description: "Reviews code for security issues, citing lines and severity",
+    systemPrompt: "You are a security-focused code reviewer. Read the file carefully and report any authentication or authorization issues with line numbers and severity.",
+  }],
+  middleware: [createCodeInterpreterMiddleware()],
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Review all the route handlers in src/routes/ for authentication issues. Summarize the top risks." }],
+});
+```
+:::
+
+#### Adversarial verification
+
+A two-pass pattern. The first pass produces findings. The second pass sends each finding to independent verifiers, and only findings that survive agreement are kept. This reduces false positives when confidence matters more than speed.
+
+```mermaid
+graph LR
+    Items[Items] --> Workers[Workers]
+    Workers --> Findings[Findings]
+    Findings --> V1[Verifier]
+    Findings --> V2[Verifier]
+    Findings --> V3[Verifier]
+    V1 --> Vote[Majority vote]
+    V2 --> Vote
+    V3 --> Vote
+    Vote --> Confirmed[Confirmed]
+```
+
+**Use cases:** Security audits where false positives are costly, compliance checks, any review where you need high confidence in findings.
+
+:::python
+```python
+agent = create_deep_agent(
+    model="openai:gpt-5.4",
+    subagents=[
+        {
+            "name": "reviewer",
+            "description": "Finds potential security vulnerabilities in code",
+            "system_prompt": "You are a security auditor. Find potential vulnerabilities and report each with file, line, and description.",
+        },
+        {
+            "name": "verifier",
+            "description": "Independently verifies whether a reported vulnerability is real",
+            "system_prompt": "You are a security verification specialist. Given a reported vulnerability, independently verify whether it is exploitable. Be skeptical. Only confirm real issues.",
+        },
+    ],
+    middleware=[CodeInterpreterMiddleware()],
+)
+
+result = await agent.ainvoke({
+    "messages": [{"role": "user", "content": "Do a thorough security audit of the payments module. I only want confirmed vulnerabilities, not maybes."}]
+})
+```
+:::
+
+:::js
+```typescript
+const agent = createDeepAgent({
+  model: "openai:gpt-5.4",
+  subagents: [
+    {
+      name: "reviewer",
+      description: "Finds potential security vulnerabilities in code",
+      systemPrompt: "You are a security auditor. Find potential vulnerabilities and report each with file, line, and description.",
+    },
+    {
+      name: "verifier",
+      description: "Independently verifies whether a reported vulnerability is real",
+      systemPrompt: "You are a security verification specialist. Given a reported vulnerability, independently verify whether it is exploitable. Be skeptical. Only confirm real issues.",
+    },
+  ],
+  middleware: [createCodeInterpreterMiddleware()],
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Do a thorough security audit of the payments module. I only want confirmed vulnerabilities, not maybes." }],
+});
+```
+:::
+
+#### Generate and filter
+
+Multiple subagents generate independent solutions to the same problem. The agent compares, scores, and filters the results in code, keeping only the best.
+
+```mermaid
+graph LR
+    Prompt[Prompt] --> G1[Generator]
+    Prompt --> G2[Generator]
+    Prompt --> G3[Generator]
+    G1 --> Filter[Filter + rank]
+    G2 --> Filter
+    G3 --> Filter
+    Filter --> Best[Best result]
+```
+
+**Use cases:** Architecture proposals, refactoring strategies, content variations, any task where exploring multiple options before committing produces a better outcome.
+
+:::python
+```python
+agent = create_deep_agent(
+    model="openai:gpt-5.4",
+    subagents=[{
+        "name": "architect",
+        "description": "Proposes a database schema design with tradeoff analysis",
+        "system_prompt": "You are a database architect. Propose a schema design for the given requirements. Include tradeoffs, migration considerations, and a clear rationale.",
+    }],
+    middleware=[CodeInterpreterMiddleware()],
+)
+
+result = await agent.ainvoke({
+    "messages": [{"role": "user", "content": "Generate three different approaches to restructure the database schema for the orders system, then pick the best one."}]
+})
+```
+:::
+
+:::js
+```typescript
+const agent = createDeepAgent({
+  model: "openai:gpt-5.4",
+  subagents: [{
+    name: "architect",
+    description: "Proposes a database schema design with tradeoff analysis",
+    systemPrompt: "You are a database architect. Propose a schema design for the given requirements. Include tradeoffs, migration considerations, and a clear rationale.",
+  }],
+  middleware: [createCodeInterpreterMiddleware()],
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Generate three different approaches to restructure the database schema for the orders system, then pick the best one." }],
+});
+```
+:::
+
+#### Tournament
+
+Variations are compared head-to-head by a judge subagent, with winners advancing through elimination rounds.
+
+```mermaid
+graph LR
+    A1[Attempt] --> J1{Judge}
+    A2[Attempt] --> J1
+    A3[Attempt] --> J2{Judge}
+    A4[Attempt] --> J2
+    J1 --> JF{Final}
+    J2 --> JF
+    JF --> Winner[Winner]
+```
+
+**Use cases:** Optimization under subjective criteria, style selection, choosing between competing implementations.
+
+:::python
+```python
+agent = create_deep_agent(
+    model="openai:gpt-5.4",
+    subagents=[
+        {
+            "name": "writer",
+            "description": "Rewrites a function with a focus on readability and clarity",
+            "system_prompt": "You are an expert programmer focused on clean code. Rewrite the given function to maximize readability. Explain your choices.",
+        },
+        {
+            "name": "judge",
+            "description": "Compares two code implementations and picks the more readable one",
+            "system_prompt": "You are a code quality judge. Compare two implementations and pick the more readable one. Justify your choice with specific criteria.",
+        },
+    ],
+    middleware=[CodeInterpreterMiddleware()],
+)
+
+result = await agent.ainvoke({
+    "messages": [{"role": "user", "content": "Rewrite the processOrder function in src/checkout.ts five different ways and find the most readable version."}]
+})
+```
+:::
+
+:::js
+```typescript
+const agent = createDeepAgent({
+  model: "openai:gpt-5.4",
+  subagents: [
+    {
+      name: "writer",
+      description: "Rewrites a function with a focus on readability and clarity",
+      systemPrompt: "You are an expert programmer focused on clean code. Rewrite the given function to maximize readability. Explain your choices.",
+    },
+    {
+      name: "judge",
+      description: "Compares two code implementations and picks the more readable one",
+      systemPrompt: "You are a code quality judge. Compare two implementations and pick the more readable one. Justify your choice with specific criteria.",
+    },
+  ],
+  middleware: [createCodeInterpreterMiddleware()],
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Rewrite the processOrder function in src/checkout.ts five different ways and find the most readable version." }],
+});
+```
+:::
+
+#### Loop until done
+
+The agent runs a discovery loop, deduplicating against what it has already found, until no new results appear. Useful when the scope of the work isn't known upfront.
+
+```mermaid
+graph LR
+    Agent[Agent] --> Check{New findings?}
+    Check --> |yes| Agent
+    Check --> |no| Done[Done]
+```
+
+**Use cases:** Exhaustive search, dead code detection, dependency audits, any sweep where you want completeness rather than a fixed number of results.
+
+:::python
+```python
+agent = create_deep_agent(
+    model="openai:gpt-5.4",
+    subagents=[{
+        "name": "analyzer",
+        "description": "Analyzes code for unused exports, functions, and dead code paths",
+        "system_prompt": "You are a code analyst specializing in dead code detection. Find unused exports, unreachable functions, and orphaned modules. Report each with file path and evidence.",
+    }],
+    middleware=[CodeInterpreterMiddleware()],
+)
+
+result = await agent.ainvoke({
+    "messages": [{"role": "user", "content": "Find all the dead code in this repo. Be thorough — I want every unused export and unreachable function."}]
+})
+```
+:::
+
+:::js
+```typescript
+const agent = createDeepAgent({
+  model: "openai:gpt-5.4",
+  subagents: [{
+    name: "analyzer",
+    description: "Analyzes code for unused exports, functions, and dead code paths",
+    systemPrompt: "You are a code analyst specializing in dead code detection. Find unused exports, unreachable functions, and orphaned modules. Report each with file path and evidence.",
+  }],
+  middleware: [createCodeInterpreterMiddleware()],
+});
+
+const result = await agent.invoke({
+  messages: [{ role: "user", content: "Find all the dead code in this repo. Be thorough — I want every unused export and unreachable function." }],
+});
+```
+:::
+
+<Warning>
+    `task()` dispatches from inside an already-running `eval` call. It does not go through the normal tool calling path, so `interrupt_on` approval workflows on the parent agent are not enforced per dispatch. Gate the `eval` tool itself if you need approval before subagent orchestration runs.
+</Warning>
+
 ## Programmatic tool calling
 
 Programmatic tool calling (PTC) exposes selected agent tools inside the interpreter under the global `tools` namespace. Instead of asking the model to issue one tool call, wait for the result, and then decide the next call, the agent can write code that calls tools in loops, branches, retries, or parallel batches.
@@ -176,7 +615,6 @@ const result: string = await tools.webSearch({
 | Conditional logic | Choose the next tool call based on earlier results. |
 | Early termination | Stop calling tools once a success condition is met. |
 | Data filtering | Return only relevant rows, snippets, errors, or summaries to the model. |
-| Recursive orchestration | Call `task` repeatedly, then combine subagent results in code. |
 
 ### Enable PTC
 
@@ -189,7 +627,7 @@ from langchain_quickjs import CodeInterpreterMiddleware
 
 agent = create_deep_agent(
     model="openai:gpt-5.5",
-    middleware=[CodeInterpreterMiddleware(ptc=["task"])],
+    middleware=[CodeInterpreterMiddleware(ptc=["web_search"])],
 )
 ```
 :::
@@ -201,39 +639,35 @@ import { createCodeInterpreterMiddleware } from "@langchain/quickjs";
 
 const agent = createDeepAgent({
   model: "openai:gpt-5.5",
-  middleware: [createCodeInterpreterMiddleware({ ptc: ["task"] })],
+  middleware: [createCodeInterpreterMiddleware({ ptc: ["web_search"] })],
 });
 ```
 :::
 
-After PTC is enabled, the agent can call the allowlisted tool from interpreter code. This example launches several subagents in parallel and combines their final reports before returning to the model:
+After PTC is enabled, the agent can call the allowlisted tool from interpreter code. This example searches several topics in parallel and combines the results before returning to the model:
 
 ```javascript
 const topics = ["retrieval", "memory", "evaluation"];
 
-const reports = await Promise.all(
+const results = await Promise.all(
   topics.map((topic) =>
-    tools.task({
-      description: `Research ${topic} in Deep Agents and return three concise findings.`,
-      subagent_type: "general-purpose",
-    }),
+    tools.webSearch({ query: `${topic} best practices 2025` }),
   ),
 );
 
-reports.join("\n\n");
+results.join("\n\n");
 ```
 
 Because this is code, the agent can also handle failures locally:
 
 ```javascript
 try {
-  const report = await tools.task({
-    description: "Check the migration notes and return breaking changes.",
-    subagent_type: "general-purpose",
+  const result = await tools.webSearch({
+    query: "migration breaking changes",
   });
-  console.log(report);
+  console.log(result);
 } catch (error) {
-  console.log(`Subagent failed: ${error.message}`);
+  console.log(`Search failed: ${error.message}`);
 }
 ```
 
@@ -283,7 +717,7 @@ flowchart TB
 
 For background on this pattern, see the [Recursive Language Models paper](https://arxiv.org/abs/2512.24601).
 
-In Deep Agents, the recursive call is often the `task` tool exposed through programmatic tool calling. The interpreter can call subagents over many slices, combine their answers, and return a single synthesized result:
+In Deep Agents, the recursive call uses the [`task()` global](#subagent-orchestration). The interpreter can call subagents over many slices, combine their answers, and return a single synthesized result:
 
 ```javascript
 const candidates = notes
@@ -292,9 +726,9 @@ const candidates = notes
 
 const riskReports = await Promise.all(
   candidates.map((note) =>
-    tools.task({
+    task({
       description: `Analyze this migration note for release risk. Return risks, affected users, and recommended follow-up:\n\n${note}`,
-      subagent_type: "general-purpose",
+      subagentType: "general-purpose",
     }),
   ),
 );
@@ -411,8 +845,8 @@ Every tool you expose through PTC is an outside capability that interpreter code
 | `tool_name` | `"eval"` | Name of the interpreter tool exposed to the model. |
 | `max_result_chars` | `4000` | Maximum characters returned from result and stdout blocks. |
 | `capture_console` | `True` | Whether `console.log`, `console.warn`, and `console.error` output is captured. |
+| `subagents` | `True` | Expose the built-in `task()` global for [subagent orchestration](#subagent-orchestration). Set to `False` to require subagent dispatch through the normal `task` tool path. |
 | `ptc` | `None` | PTC allowlist: list of tool names or `BaseTool` instances. |
-| `skills_backend` | `None` | Backend used to resolve interpreter skill modules. |
 | `snapshot_between_turns` | `True` | Whether interpreter state snapshots persist across agent turns. |
 | `max_snapshot_bytes` | `None` | Maximum serialized snapshot size. Defaults to `memory_limit`. |
 :::
@@ -427,9 +861,9 @@ Every tool you expose through PTC is an outside capability that interpreter code
 | `maxStackSizeBytes` | `320 * 1024` | QuickJS stack size limit in bytes. |
 | `executionTimeoutMs` | `5000` | Per-eval timeout in milliseconds. Negative values disable the timeout. |
 | `systemPrompt` | `null` | Override the built-in interpreter system prompt. |
-| `skillsBackend` | omitted | Backend used to resolve interpreter skill modules. |
 | `maxPtcCalls` | `256` | Maximum `tools.*` calls per eval. Use `null` only in trusted environments. |
 | `maxResultChars` | `4000` | Maximum characters retained from console output, result, and error strings. |
 | `toolName` | `"eval"` | Name of the interpreter tool exposed to the model. |
 | `captureConsole` | `true` | Whether `console.log`, `console.warn`, and `console.error` output is captured. |
+| `maxSubagentConcurrency` | `32` | Maximum concurrent `task()` dispatches per eval for [subagent orchestration](#subagent-orchestration). Set to `0` to disable the built-in `task()` global. |
 :::

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -30,25 +30,6 @@ Use interpreters when the agent needs to:
 - Transform structured data deterministically, such as sorting, grouping, parsing, validating, scoring, or aggregating.
 - Explore a large variable space and return only selected evidence, summaries, or outputs to the model.
 
-```mermaid
-graph LR
-    Model[Model] --> Program[Writes a small program]
-    Program --> Runtime[Interpreter runtime]
-    Runtime --> Tools[Calls tools and updates variables]
-    Runtime --> Result[Yields compact result]
-    Result --> Model
-
-    classDef trigger fill:#F6FFDB,stroke:#6E8900,stroke-width:2px,color:#2E3900
-    classDef process fill:#E5F4FF,stroke:#006DDD,stroke-width:2px,color:#030710
-    classDef output fill:#EBD0F0,stroke:#885270,stroke-width:2px,color:#441E33
-    classDef neutral fill:#F2FAFF,stroke:#40668D,stroke-width:2px,color:#2F4B68
-
-    class Model trigger
-    class Program,Runtime process
-    class Tools neutral
-    class Result output
-```
-
 Code runs against [**QuickJS**](https://github.com/quickjs-ng/quickjs), a lightweight JavaScript runtime with no access to the host filesystem, network, shell, or clock by default. Explicit bridges decide what the code can reach.
 
 ## Choose the right execution path
@@ -154,37 +135,15 @@ Programmatic tool calling is off until you pass an allowlist. Subagent dispatch 
 
 Programmatic tool calling (PTC) exposes selected agent tools inside the interpreter under the global `tools` namespace. Instead of asking the model to issue one tool call, wait for the result, and then decide the next call, the agent can write code that calls tools in loops, branches, retries, or parallel batches.
 
-This is useful when intermediate tool results are only inputs to the next step. The interpreter can process, filter, or aggregate those results before anything returns to the model context, which can make multi-tool/multi-step workflows more token efficient.
+This helps when intermediate results are only inputs to the next step: the interpreter filters or aggregates them before anything returns to the model, keeping multi-step workflows token efficient. It is model-agnostic, implemented by middleware rather than a provider-specific tool-calling API.
 
-PTC is model-agnostic in Deep Agents. It is implemented by middleware rather than a provider-specific code-execution or tool-calling API.
-
-Tools are opt-in: you pass an explicit allowlist, and nothing is bridged by default. Every tool you expose is an outside capability the interpreter can use, so treat the allowlist as a permission boundary and keep it to the tools the agent actually needs.
-
-### How it works
-
-1. You choose which tools the interpreter can call with the `ptc` allowlist.
-2. The middleware exposes those tools as async JavaScript functions under `tools`.
-3. The agent writes interpreter code that calls those functions with `await`.
-4. The interpreter runs the tool bridge, receives the tool result, and continues executing code.
-5. The model receives the final interpreter output, not every intermediate value.
-
-Each allowlisted tool becomes an async function. Tool names are converted to camel case, but the input object still follows the tool's schema. For example, a tool named `web_search` becomes `tools.webSearch(...)`:
+The middleware exposes each allowlisted tool as an async function under `tools`. The agent calls it with `await`, processes the result in code, and the model sees only the final interpreter output, not every intermediate value. Tool names are converted to camel case while the input object still follows the tool's schema, so a tool named `web_search` becomes `tools.webSearch(...)`:
 
 ```typescript
 const result: string = await tools.webSearch({
   query: "deepagents interpreters",
 });
 ```
-
-### Useful patterns
-
-| **Pattern** | **What the interpreter can do** |
-| --- | --- |
-| Batch processing | Loop over many inputs and call a tool for each one. |
-| Parallel work | Use `Promise.all` for independent calls. |
-| Conditional logic | Choose the next tool call based on earlier results. |
-| Early termination | Stop calling tools once a success condition is met. |
-| Data filtering | Return only relevant rows, snippets, errors, or summaries to the model. |
 
 ### Enable PTC
 
@@ -228,30 +187,13 @@ const results = await Promise.all(
 results.join("\n\n");
 ```
 
-Because this is code, the agent can also handle failures locally:
-
-```javascript
-try {
-  const result = await tools.webSearch({
-    query: "migration breaking changes",
-  });
-  console.log(result);
-} catch (error) {
-  console.log(`Search failed: ${error.message}`);
-}
-```
-
 <Warning>
     PTC calls currently execute through the interpreter bridge and do not go through the normal tool calling path. As a result, `interrupt_on` approval workflows are not enforced per PTC-invoked tool call.
 </Warning>
 
 ## Orchestrate subagents from code
 
-Some tasks don't fit a single agent pass: reviewing every file in a directory, triaging a batch of tickets, auditing a module for security issues. They share one shape: many independent units of work, often combined at the end.
-
-When an agent has [subagents](/oss/deepagents/subagents) and interpreter middleware, the interpreter exposes a built-in `task()` global that dispatches subagents from code. The agent writes a loop that fans the work out, and all of it runs, so orchestration is deterministic rather than the model choosing whether to spawn one subagent at a time.
-
-This is on by default. Configure subagents, add interpreter middleware, and the agent reaches for `task()` whenever the work calls for it. Messages like "review every handler in `src/api/` for auth issues," "categorize the last 50 support tickets," or "generate three refactors and pick the best one" all lead here.
+When an agent has [subagents](/oss/deepagents/subagents) and interpreter middleware, the interpreter exposes a built-in `task()` global that dispatches subagents from code. A task spanning many independent units (reviewing every file in a directory, triaging a batch of tickets) becomes a loop that fans the work out, so it runs deterministically instead of one model-chosen tool call at a time.
 
 ### The `task()` global
 
@@ -276,7 +218,7 @@ const review = await task({
 const critical = review.issues.filter((issue) => issue.severity === "high");
 ```
 
-When you pass `responseSchema`, the resolved value is already a typed JavaScript object; only call `JSON.parse` if a subagent intentionally returned a JSON string. The agent holds results in variables, filters and merges them in code, and returns only a synthesis to the model. Intermediate subagent output stays in the interpreter, not in your conversation context.
+When you pass `responseSchema`, the resolved value is already a typed JavaScript object; only call `JSON.parse` if a subagent intentionally returned a JSON string.
 
 ### Steering orchestration
 
@@ -288,13 +230,9 @@ To shape *what* the agent orchestrates, work through the inputs it already respo
 - **The task message.** Phrasing like "I only want confirmed issues, not maybes" or "be exhaustive" nudges the agent toward verification or an open-ended sweep.
 - **The system prompt.** Use `systemPrompt` (or the agent's instructions) to add standing guidance when you want a consistent strategy across runs.
 
-The built-in guidance covers the mechanics of orchestration. Reach for the inputs above when you want to bias the agent toward a particular strategy for your task.
-
 ### Working with large inputs
 
-The same `task()` mechanism handles inputs too large to reason over in one pass, the approach described in the [Recursive Language Models paper](https://arxiv.org/abs/2512.24601). Keep the large input or working set in interpreter variables (the *variable space*), then let the model write code to inspect it, split it into slices, dispatch a subagent per slice, and stitch the returned results back together.
-
-This separates the variable space from the agent's context. The variable space is everything stored in the interpreter; the context is only what the model processes on its next call. The model decides which slices become subagent tasks, which results need another pass, and what final synthesis returns to the conversation.
+The same `task()` mechanism handles inputs too large to reason over in one pass, the approach described in the [Recursive Language Models paper](https://arxiv.org/abs/2512.24601). Keep the large input or working set in interpreter variables (the *variable space*, distinct from the model's context), then let the model inspect it, split it into slices, dispatch a subagent per slice, and stitch the returned results back together.
 
 ```mermaid
 flowchart TB

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -20,7 +20,7 @@ Where [sandboxes](/oss/deepagents/sandboxes) are a code-first way for acting on 
 
 ## When to use an interpreter
 
-Most agent work alternates between model reasoning and single tool calls. That breaks down when the agent needs to compose many steps, reason over structured data, or hold intermediate state. An interpreter gives it a runtime to do that work in code: run control flow, call allowlisted tools, store variables, and return only a compact result to the model.
+Most agent work alternates between model reasoning and tool calls. A model can fire several tool calls in one turn, but that batch is fixed the moment it's emitted. Nothing can loop, branch on a result, retry a failure, or feed one call's output into the next without another model turn, and every result returns to the model's context. The model also decides how many calls to issue, so asking it to dispatch work across hundreds of items is unreliable, and it tends to cover a sample rather than every one. That breaks down when the agent needs to compose many steps, reason over structured data, or hold intermediate state. An interpreter gives it a runtime to do that work in code. A loop runs every iteration, tools are called from code, intermediate values stay in variables, and only a compact result returns to the model.
 
 Use interpreters when the agent needs to:
 
@@ -187,9 +187,16 @@ const results = await Promise.all(
 results.join("\n\n");
 ```
 
+:::python
 <Warning>
     PTC calls currently execute through the interpreter bridge and do not go through the normal tool calling path. As a result, `interrupt_on` approval workflows are not enforced per PTC-invoked tool call.
 </Warning>
+:::
+:::js
+<Warning>
+    PTC calls currently execute through the interpreter bridge and do not go through the normal tool calling path. As a result, `interruptOn` approval workflows are not enforced per PTC-invoked tool call.
+</Warning>
+:::
 
 ## Orchestrate subagents from code
 
@@ -316,7 +323,7 @@ graph LR
 :::python
 ```python
 agent = create_deep_agent(
-    model="openai:gpt-5.4",
+    model="openai:gpt-5.5",
     subagents=[
         {
             "name": "bug-fixer",
@@ -346,7 +353,7 @@ result = await agent.ainvoke({
 :::js
 ```typescript
 const agent = createDeepAgent({
-  model: "openai:gpt-5.4",
+  model: "openai:gpt-5.5",
   subagents: [
     {
       name: "bug-fixer",
@@ -420,7 +427,7 @@ from deepagents import create_deep_agent
 from langchain_quickjs import CodeInterpreterMiddleware
 
 agent = create_deep_agent(
-    model="openai:gpt-5.4",
+    model="openai:gpt-5.5",
     subagents=[{
         "name": "reviewer",
         "description": "Reviews code for security issues, citing lines and severity",
@@ -441,7 +448,7 @@ import { createDeepAgent } from "deepagents";
 import { createCodeInterpreterMiddleware } from "@langchain/quickjs";
 
 const agent = createDeepAgent({
-  model: "openai:gpt-5.4",
+  model: "openai:gpt-5.5",
   subagents: [{
     name: "reviewer",
     description: "Reviews code for security issues, citing lines and severity",
@@ -506,7 +513,7 @@ graph LR
 :::python
 ```python
 agent = create_deep_agent(
-    model="openai:gpt-5.4",
+    model="openai:gpt-5.5",
     subagents=[
         {
             "name": "reviewer",
@@ -531,7 +538,7 @@ result = await agent.ainvoke({
 :::js
 ```typescript
 const agent = createDeepAgent({
-  model: "openai:gpt-5.4",
+  model: "openai:gpt-5.5",
   subagents: [
     {
       name: "reviewer",
@@ -603,7 +610,7 @@ graph LR
 :::python
 ```python
 agent = create_deep_agent(
-    model="openai:gpt-5.4",
+    model="openai:gpt-5.5",
     subagents=[{
         "name": "architect",
         "description": "Proposes a database schema design with tradeoff analysis",
@@ -621,7 +628,7 @@ result = await agent.ainvoke({
 :::js
 ```typescript
 const agent = createDeepAgent({
-  model: "openai:gpt-5.4",
+  model: "openai:gpt-5.5",
   subagents: [{
     name: "architect",
     description: "Proposes a database schema design with tradeoff analysis",
@@ -680,7 +687,7 @@ graph LR
 :::python
 ```python
 agent = create_deep_agent(
-    model="openai:gpt-5.4",
+    model="openai:gpt-5.5",
     subagents=[
         {
             "name": "writer",
@@ -705,7 +712,7 @@ result = await agent.ainvoke({
 :::js
 ```typescript
 const agent = createDeepAgent({
-  model: "openai:gpt-5.4",
+  model: "openai:gpt-5.5",
   subagents: [
     {
       name: "writer",
@@ -774,7 +781,7 @@ graph LR
 :::python
 ```python
 agent = create_deep_agent(
-    model="openai:gpt-5.4",
+    model="openai:gpt-5.5",
     subagents=[{
         "name": "analyzer",
         "description": "Analyzes code for unused exports, functions, and dead code paths",
@@ -792,7 +799,7 @@ result = await agent.ainvoke({
 :::js
 ```typescript
 const agent = createDeepAgent({
-  model: "openai:gpt-5.4",
+  model: "openai:gpt-5.5",
   subagents: [{
     name: "analyzer",
     description: "Analyzes code for unused exports, functions, and dead code paths",
@@ -828,9 +835,16 @@ found;
 ```
 </Accordion>
 
+:::python
 <Warning>
     `task()` dispatches from inside an already-running `eval` call. It does not go through the normal tool calling path, so `interrupt_on` approval workflows on the parent agent are not enforced per dispatch. Gate the `eval` tool itself if you need approval before subagent orchestration runs.
 </Warning>
+:::
+:::js
+<Warning>
+    `task()` dispatches from inside an already-running `eval` call. It does not go through the normal tool calling path, so `interruptOn` approval workflows on the parent agent are not enforced per dispatch. Gate the `eval` tool itself if you need approval before subagent orchestration runs.
+</Warning>
+:::
 
 :::python
 ## Snapshots and time travel

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -257,7 +257,7 @@ When an agent has [subagents](/oss/deepagents/subagents) and interpreter middlew
 
 This is on by default. Configure subagents, add interpreter middleware, and the agent reaches for `task()` whenever the work calls for it. Messages like "review every handler in `src/api/` for auth issues," "categorize the last 50 support tickets," or "generate three refactors and pick the best one" all lead here.
 
-### The `task()` primitive
+### The `task()` global
 
 `task()` takes the prompt the subagent receives (`description`), which configured subagent to run (`subagentType`), and an optional `responseSchema` for structured output. It runs a full agentic loop and resolves to the subagent's result:
 

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -204,7 +204,13 @@ When an agent has [subagents](/oss/deepagents/subagents) and interpreter middlew
 
 ### The `task()` global
 
-`task()` takes the prompt the subagent receives (`description`), which configured subagent to run (`subagentType`), and an optional `responseSchema` for structured output. It runs a full agentic loop and resolves to the subagent's result:
+`task()` takes the following inputs:
+
+ - `description`: the prompt for the subagent
+ - `subagentType`: which configured subagent to run
+ - `responseSchema` (optional): structured output
+ 
+a `task()` runs a full agentic loop and resolves to the subagent's result:
 
 ```javascript
 const review = await task({

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -129,7 +129,7 @@ Two explicit bridges extend that reach:
 - **Tools**, through [programmatic tool calling](#programmatic-tool-calling). Expose an allowlist of tools as async functions under the `tools` namespace. These can be the agent's own tools or standalone tools you define and pass in.
 - **Subagents**, through the built-in [`task()` global](#orchestrate-subagents-from-code). Dispatch configured subagents from code and orchestrate them in plain JavaScript.
 
-Programmatic tool calling is off until you pass an allowlist. Subagent dispatch is on by default whenever the agent has subagents, and you can turn it off. Nothing else crosses the QuickJS boundary unless you expose it.
+Programmatic tool calling is off until you [enable it](#enable-ptc). Subagent dispatch is on by default whenever the agent has subagents, and you can turn it off. Nothing else crosses the QuickJS boundary unless you expose it.
 
 ## Programmatic tool calling
 

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -310,7 +310,7 @@ The agent picks a strategy from the shape of the task; these emerge from how it 
 
 #### Classify and act
 
-Items are classified first, then each is handled by a specialized subagent based on its classification. This lets you process mixed inputs where different items need different expertise.
+Items are classified first, then each item is handled by a specialized subagent based on its classification. This lets you process mixed inputs where different items need different expertise.
 
 ```mermaid
 graph LR

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -298,7 +298,7 @@ The `scripts/` directory holds executable code the agent can run, such as API cl
 - Include helpful error messages
 - Handle edge cases gracefully
 
-Supported languages depend on your agent setup. Common options include Python, Bash, and JavaScript or TypeScript. To execute scripts rather than only read them, see [Execute code with skills](#execute-code-with-skills). Use [sandbox scripts](#sandbox-scripts) when the agent needs a shell, or [interpreter skills](#interpreter-skills) when the agent needs importable helpers in an interpreter.
+Supported languages depend on your agent setup. Common options include Python, Bash, and JavaScript or TypeScript. To execute scripts rather than only read them, see [Execute code with skills](#execute-code-with-skills). Use [sandbox scripts](#sandbox-scripts) when the agent needs a shell.
 
 ### `references/`
 
@@ -418,7 +418,7 @@ This works well when skills live on disk or in a shared backend and you just nee
         Then pass that ordered list as `skills` when creating your agent.
     </Accordion>
 </Note>
-      
+
 ### Namespaced skills
 
 For multi-tenant applications where each user's skill set is managed independently, route `/skills/` to a @[StoreBackend] with a namespace factory. Populate each namespace with only the skills that user should have access to, and the middleware resolves to the correct set at runtime:
@@ -704,10 +704,7 @@ The agent uses `write_file` and `edit_file` to create or update `SKILL.md` and s
 
 Without code execution, skills are passive: the agent reads instructions and follows them using its available tools. Code execution turns skills into active capabilities. A skill can ship a tested script that calls an API, transforms data, validates output, or runs a pipeline — and the agent executes it deterministically rather than regenerating the logic from instructions each time. This is especially valuable for workflows that require exact behavior (data transformations, API integrations, compliance checks) or that depend on libraries the agent cannot use through tool calls alone.
 
-Skills support code execution in two ways:
-
-- [Sandbox scripts](#sandbox-scripts) when the agent needs to install dependencies, run tests, call CLIs, or work with an operating-system filesystem.
-- [Interpreter skills](#interpreter-skills) when the agent needs reusable, importable helpers available from interpreter code.
+Skills execute code through [sandbox scripts](#sandbox-scripts): the agent runs a bundled script when it needs to install dependencies, run tests, call CLIs, or work with an operating-system filesystem.
 
 ### Sandbox scripts
 
@@ -796,128 +793,6 @@ The agent can _read_ scripts from any backend, but to _execute_ them, the agent 
 
 For a complete example that seeds both skills and memories before execution and syncs both back afterward, see [syncing skills and memories with custom middleware](/oss/deepagents/going-to-production#example-syncing-skills-and-memories-with-custom-middleware).
 
-### Interpreter skills
-
-Interpreter skills expose code modules to an [interpreter](/oss/deepagents/interpreters). Regular skills give the agent instructions and context. Interpreter skills also give the agent importable functions it can call from interpreter code.
-
-This lets you package domain-specific logic once and make it available as a deterministic building block. Instead of asking the model to re-create a parser, validator, or aggregation routine from scratch, the agent can import a tested helper and compose it with tools, subagents, and runtime state.
-
-Use interpreter skills for code that should be:
-
-- **Reusable** across prompts, agents, or projects
-- **Deterministic** enough that you want the same behavior every time
-- **Too detailed** to keep in the model context as instructions
-
-To make a skill importable:
-
-<Steps titleSize="h4">
-    <Step title="Add an entrypoint">
-        Add a [`metadata.entrypoint`](#frontmatter-fields) key to the skill's `SKILL.md` [frontmatter](#frontmatter-fields). The value is a JavaScript or TypeScript file path relative to the skill directory.
-    </Step>
-    <Step title="Configure skills normally">
-        Pass the skill source path with the `skills` argument when creating the agent.
-    </Step>
-    <Step title="Use the same backend">
-        Configure the interpreter middleware with the same backend that `SkillsMiddleware` uses to load skill files.
-    </Step>
-    <Step title="Import from interpreter code">
-        The agent imports the helper module with `await import("@/skills/<name>")`.
-    </Step>
-</Steps>
-
-Minimal skill layout:
-
-<Tree>
-  <Tree.Folder name="skills" defaultOpen>
-    <Tree.Folder name="order-helpers" defaultOpen>
-      <Tree.File name="SKILL.md" />
-      <Tree.Folder name="scripts" defaultOpen>
-        <Tree.File name="index.ts" />
-      </Tree.Folder>
-    </Tree.Folder>
-  </Tree.Folder>
-</Tree>
-
-````md
----
-name: order-helpers
-description: Helper functions for normalizing and grouping order records.
-metadata:
-  entrypoint: scripts/index.ts
----
-
-# order-helpers
-
-Use this skill when order records need deterministic cleanup or aggregation.
-
-Import these utilities into the REPL in order to interact with order data:
-
-```typescript
-const { groupByStatus } = await import("@/skills/order-helpers");
-groupByStatus(...);
-```
-````
-
-```typescript
-// skills/order-helpers/scripts/index.ts
-interface Order {
-  id: string;
-  status: string;
-}
-
-export function groupByStatus(orders: Order[]) {
-  return orders.reduce((acc, order) => {
-    acc[order.status] = acc[order.status] ?? [];
-    acc[order.status].push(order);
-    return acc;
-  }, {});
-}
-```
-
-Then configure the agent. Pass interpreter middleware via the `middleware` argument; it is appended to the [default stack](/oss/deepagents/customization#default-stack-main-agent):
-
-:::python
-```python
-from deepagents import create_deep_agent
-from deepagents.backends import StateBackend
-from langchain_quickjs import CodeInterpreterMiddleware
-
-backend = StateBackend()
-
-agent = create_deep_agent(
-    model="openai:gpt-5.5",
-    backend=backend,
-    skills=["/skills/"],
-    middleware=[CodeInterpreterMiddleware(skills_backend=backend)],
-)
-```
-:::
-
-:::js
-```typescript
-import { createDeepAgent, StateBackend } from "deepagents";
-import { createCodeInterpreterMiddleware } from "@langchain/quickjs";
-
-const backend = new StateBackend();
-
-const agent = createDeepAgent({
-  model: "openai:gpt-5.5",
-  backend,
-  skills: ["/skills/"],
-  middleware: [createCodeInterpreterMiddleware({ skillsBackend: backend })],
-});
-```
-:::
-
-The agent can now import the module from interpreter code:
-
-```javascript
-const { groupByStatus } = await import("@/skills/order-helpers");
-
-const grouped = groupByStatus(orders);
-grouped;
-```
-
 ## Troubleshooting
 
 Use [LangSmith](https://smith.langchain.com) traces to debug skill discovery, `read_file` calls on `SKILL.md`, and supporting resource access. Follow the [tracing quickstart](/langsmith/observability-quickstart) to get set up. We recommend you also set up [LangSmith Engine](/langsmith/engine), which monitors your traces, detects issues, and proposes fixes.
@@ -970,17 +845,11 @@ Use [LangSmith](https://smith.langchain.com) traces to debug skill discovery, `r
 
 3. **Sync skills into sandboxes.** If you use [sandbox backends](/oss/deepagents/sandboxes), skill files outside the container are not available until you copy them in. See [Sandbox scripts](#sandbox-scripts) and [syncing skills and memories with custom middleware](/oss/deepagents/going-to-production#example-syncing-skills-and-memories-with-custom-middleware).
 
-### Scripts or imports fail
+### Scripts fail to run
 
-**Problem**: The agent reads a script but cannot run it, or `import("@/skills/<name>")` fails in the interpreter.
+**Problem**: The agent reads a script but cannot run it.
 
-**Solutions**:
-
-1. **Use a sandbox for shell execution.** The agent can read scripts from any backend, but running them requires a [sandbox backend](/oss/deepagents/sandboxes). See [Execute code with skills](#execute-code-with-skills).
-
-2. **Configure interpreter middleware.** [Interpreter skills](#interpreter-skills) require [`metadata.entrypoint`](#frontmatter-fields) in `SKILL.md` [frontmatter](#frontmatter-fields) and interpreter middleware with the same backend that loads skill files.
-
-3. **Match skill and interpreter backends.** If `SkillsMiddleware` and the interpreter use different backends, import paths may not resolve to the files you expect.
+**Solution**: The agent can read scripts from any backend, but running them requires a [sandbox backend](/oss/deepagents/sandboxes). See [Execute code with skills](#execute-code-with-skills).
 
 ### Subagent cannot access a skill
 

--- a/src/snippets/code-samples/skills-usage-filesystem-js.mdx
+++ b/src/snippets/code-samples/skills-usage-filesystem-js.mdx
@@ -1,5 +1,4 @@
 ```ts
-import { createCodeInterpreterMiddleware } from "@langchain/quickjs";
 import { createDeepAgent, FilesystemBackend } from "deepagents";
 import { MemorySaver } from "@langchain/langgraph";
 
@@ -16,7 +15,6 @@ const agent = await createDeepAgent({
     delete_file: true,
   },
   checkpointer, // Required!
-  middleware: [createCodeInterpreterMiddleware({ skillsBackend: backend })],
 });
 
 const config = { configurable: { thread_id: `thread-${Date.now()}` } };

--- a/src/snippets/code-samples/skills-usage-filesystem-py.mdx
+++ b/src/snippets/code-samples/skills-usage-filesystem-py.mdx
@@ -1,7 +1,6 @@
 ```python
 from deepagents import create_deep_agent
 from deepagents.backends.filesystem import FilesystemBackend
-from langchain_quickjs import CodeInterpreterMiddleware
 from langgraph.checkpoint.memory import MemorySaver
 
 # Checkpointer is REQUIRED for human-in-the-loop
@@ -19,7 +18,6 @@ agent = create_deep_agent(
         "edit_file": True,
     },
     checkpointer=checkpointer, # Required!
-    middleware=[CodeInterpreterMiddleware(skills_backend=backend)], # for interpreter skills
 )
 
 result = agent.invoke(

--- a/src/snippets/code-samples/skills-usage-state-js.mdx
+++ b/src/snippets/code-samples/skills-usage-state-js.mdx
@@ -1,5 +1,4 @@
 ```ts
-import { createCodeInterpreterMiddleware } from "@langchain/quickjs";
 import { createDeepAgent, StateBackend, type FileData } from "deepagents";
 import { MemorySaver } from "@langchain/langgraph";
 
@@ -29,7 +28,6 @@ const agent = await createDeepAgent({
   checkpointer, // Required !
   // IMPORTANT: deepagents skill source paths are virtual (POSIX) paths relative to the backend root.
   skills: ["/skills/"],
-  middleware: [createCodeInterpreterMiddleware({ skillsBackend: backend })],
 });
 
 const config = { configurable: { thread_id: `thread-${Date.now()}` } };

--- a/src/snippets/code-samples/skills-usage-state-py.mdx
+++ b/src/snippets/code-samples/skills-usage-state-py.mdx
@@ -4,7 +4,6 @@
     from deepagents import create_deep_agent
     from deepagents.backends import StateBackend
     from deepagents.backends.utils import create_file_data
-    from langchain_quickjs import CodeInterpreterMiddleware
     from langgraph.checkpoint.memory import MemorySaver
     
     checkpointer = MemorySaver()
@@ -23,7 +22,6 @@
         backend=backend,
         skills=["/skills/"],
         checkpointer=checkpointer,
-        middleware=[CodeInterpreterMiddleware(skills_backend=backend)], # for interpreter skills
     )
     
     result = agent.invoke(
@@ -41,7 +39,6 @@
     from deepagents import create_deep_agent
     from deepagents.backends import StateBackend
     from deepagents.backends.utils import create_file_data
-    from langchain_quickjs import CodeInterpreterMiddleware
     from langgraph.checkpoint.memory import MemorySaver
     
     checkpointer = MemorySaver()
@@ -60,7 +57,6 @@
         backend=backend,
         skills=["/skills/"],
         checkpointer=checkpointer,
-        middleware=[CodeInterpreterMiddleware(skills_backend=backend)], # for interpreter skills
     )
     
     result = agent.invoke(
@@ -78,7 +74,6 @@
     from deepagents import create_deep_agent
     from deepagents.backends import StateBackend
     from deepagents.backends.utils import create_file_data
-    from langchain_quickjs import CodeInterpreterMiddleware
     from langgraph.checkpoint.memory import MemorySaver
     
     checkpointer = MemorySaver()
@@ -97,7 +92,6 @@
         backend=backend,
         skills=["/skills/"],
         checkpointer=checkpointer,
-        middleware=[CodeInterpreterMiddleware(skills_backend=backend)], # for interpreter skills
     )
     
     result = agent.invoke(
@@ -115,7 +109,6 @@
     from deepagents import create_deep_agent
     from deepagents.backends import StateBackend
     from deepagents.backends.utils import create_file_data
-    from langchain_quickjs import CodeInterpreterMiddleware
     from langgraph.checkpoint.memory import MemorySaver
     
     checkpointer = MemorySaver()
@@ -134,7 +127,6 @@
         backend=backend,
         skills=["/skills/"],
         checkpointer=checkpointer,
-        middleware=[CodeInterpreterMiddleware(skills_backend=backend)], # for interpreter skills
     )
     
     result = agent.invoke(
@@ -152,7 +144,6 @@
     from deepagents import create_deep_agent
     from deepagents.backends import StateBackend
     from deepagents.backends.utils import create_file_data
-    from langchain_quickjs import CodeInterpreterMiddleware
     from langgraph.checkpoint.memory import MemorySaver
     
     checkpointer = MemorySaver()
@@ -171,7 +162,6 @@
         backend=backend,
         skills=["/skills/"],
         checkpointer=checkpointer,
-        middleware=[CodeInterpreterMiddleware(skills_backend=backend)], # for interpreter skills
     )
     
     result = agent.invoke(
@@ -189,7 +179,6 @@
     from deepagents import create_deep_agent
     from deepagents.backends import StateBackend
     from deepagents.backends.utils import create_file_data
-    from langchain_quickjs import CodeInterpreterMiddleware
     from langgraph.checkpoint.memory import MemorySaver
     
     checkpointer = MemorySaver()
@@ -208,7 +197,6 @@
         backend=backend,
         skills=["/skills/"],
         checkpointer=checkpointer,
-        middleware=[CodeInterpreterMiddleware(skills_backend=backend)], # for interpreter skills
     )
     
     result = agent.invoke(
@@ -226,7 +214,6 @@
     from deepagents import create_deep_agent
     from deepagents.backends import StateBackend
     from deepagents.backends.utils import create_file_data
-    from langchain_quickjs import CodeInterpreterMiddleware
     from langgraph.checkpoint.memory import MemorySaver
     
     checkpointer = MemorySaver()
@@ -245,7 +232,6 @@
         backend=backend,
         skills=["/skills/"],
         checkpointer=checkpointer,
-        middleware=[CodeInterpreterMiddleware(skills_backend=backend)], # for interpreter skills
     )
     
     result = agent.invoke(

--- a/src/snippets/code-samples/skills-usage-store-js.mdx
+++ b/src/snippets/code-samples/skills-usage-store-js.mdx
@@ -1,5 +1,4 @@
 ```ts
-import { createCodeInterpreterMiddleware } from "@langchain/quickjs";
 import { createDeepAgent, StoreBackend, type FileData } from "deepagents";
 import { InMemoryStore, MemorySaver } from "@langchain/langgraph";
 
@@ -34,7 +33,6 @@ const agent = await createDeepAgent({
   checkpointer,
   // IMPORTANT: deepagents skill source paths are virtual (POSIX) paths relative to the backend root.
   skills: ["/skills/"],
-  middleware: [createCodeInterpreterMiddleware({ skillsBackend: backend })],
 });
 
 const config = {

--- a/src/snippets/code-samples/skills-usage-store-py.mdx
+++ b/src/snippets/code-samples/skills-usage-store-py.mdx
@@ -3,7 +3,6 @@ from urllib.request import urlopen
 from deepagents import create_deep_agent
 from deepagents.backends import StoreBackend
 from deepagents.backends.utils import create_file_data
-from langchain_quickjs import CodeInterpreterMiddleware
 from langgraph.store.memory import InMemoryStore
 
 store = InMemoryStore()
@@ -24,7 +23,6 @@ agent = create_deep_agent(
     backend=backend,
     store=store,
     skills=["/skills/"],
-    middleware=[CodeInterpreterMiddleware(skills_backend=backend)],
 )
 
 result = agent.invoke(


### PR DESCRIPTION
## Overview
Reworks the interpreters docs around the two ways interpreter code reaches outside its sandbox: calling tools, and dispatching subagents.

- Adds a Subagent orchestration section for the built-in task() global, covering how to steer orchestration through subagent config and prompting, working with large inputs, and six workflow patterns (classify and act, fan-out and synthesize, adversarial verification, generate and filter, tournament, loop until done) with diagrams and collapsible Python/JS examples.
- Adds a short What interpreter code can reach intro framing the two bridges.
- Folds the recursive-language-models material into the new section, since it's the same task() mechanism over a large variable space.
- Removes interpreter skills from interpreters.mdx and skills.mdx, plus the related skills_backend wiring in the skills-usage snippets and the security table.

## Type of change

**Type:** Update existing documentation

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
