### PR TITLE
chore: repoint support@langchain.dev mentions to the Support Portal

### DIFF
--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -212,7 +212,7 @@ We recommend storing each key in a predefined Kubernetes secret rather than sett
     <Warning>
     If you are migrating from the legacy `agentBootstrap` deployment model, disable `backend.agentBootstrap` and the old `config.agentBuilder`, `config.insights`, and `config.polly` flags. These are the flags under the `config` section, not the top-level `fleet`, `insights`, and `polly` flags shown above.
 
-    You must also manually delete the existing Fleet, Insights, and Chat deployments through the LangSmith Deployments UI. If you did not use an external PostgreSQL database for Fleet with the legacy `agentBootstrap` model and want to preserve existing Fleet agents, contact support@langchain.dev before applying this configuration.
+    You must also manually delete the existing Fleet, Insights, and Chat deployments through the LangSmith Deployments UI. If you did not use an external PostgreSQL database for Fleet with the legacy `agentBootstrap` model and want to preserve existing Fleet agents, contact technical support via the [Support Portal](https://support.langchain.com) before applying this configuration.
     </Warning>
 
     <Note>

--- a/src/langsmith/diagnostics-self-hosted.mdx
+++ b/src/langsmith/diagnostics-self-hosted.mdx
@@ -176,4 +176,4 @@ If you have followed these diagnostic steps and still need assistance, gather th
 - Relevant error messages and logs.
 - Description of what you were trying to do when the issue occurred.
 
-Having this information ready will help the [support](mailto:support@langchain.dev) team diagnose and resolve your issue more quickly.
+Having this information ready will help the [support](https://support.langchain.com) team diagnose and resolve your issue more quickly.

--- a/src/langsmith/faq.mdx
+++ b/src/langsmith/faq.mdx
@@ -101,7 +101,7 @@ See Okta's troubleshooting guide here: https://help.okta.com/en-us/content/topic
 
 ### *Are downgrades supported?*
 
-Downgrades are not officially supported. LangSmith upgrades may include database migrations and other changes that are not backward-compatible. If you need to roll back to a previous version, contact [support](mailto:support@langchain.dev) for guidance.
+Downgrades are not officially supported. LangSmith upgrades may include database migrations and other changes that are not backward-compatible. If you need to roll back to a previous version, contact technical support via the [Support Portal](https://support.langchain.com) for guidance.
 
 ## Deployment
 

--- a/src/langsmith/llm-auth-proxy-self-hosted.mdx
+++ b/src/langsmith/llm-auth-proxy-self-hosted.mdx
@@ -124,7 +124,7 @@ This setting has no effect on Personal organizations.
 </Tab>
 <Tab title="SaaS">
 
-Contact [LangChain support](mailto:support@langchain.dev) to enable LLM Auth Proxy for your organization.
+Contact technical support via the [Support Portal](https://support.langchain.com) to enable LLM Auth Proxy for your organization.
 
 </Tab>
 </Tabs>

--- a/src/langsmith/self-host-ui-customization.mdx
+++ b/src/langsmith/self-host-ui-customization.mdx
@@ -6,7 +6,7 @@ description: Customize support contact information in the LangSmith frontend for
 
 ## Custom error support message
 
-By default, error messages in LangSmith direct users to contact `support@langchain.dev`. You can replace this with your own support contact information.
+By default, error messages in LangSmith direct users to the [Support Portal](https://support.langchain.com). You can replace this with your own support contact information.
 
 When set, all error and support messages throughout the UI will display your custom text instead of the default LangChain support email.
 

--- a/src/langsmith/self-host-upgrades.mdx
+++ b/src/langsmith/self-host-upgrades.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Upgrade an installation
 ---
 
 <Warning>
-Downgrades are not officially supported. LangSmith upgrades may include database migrations and other changes that are not backward-compatible. If you need to roll back to a previous version, contact [support](mailto:support@langchain.dev) for guidance.
+Downgrades are not officially supported. LangSmith upgrades may include database migrations and other changes that are not backward-compatible. If you need to roll back to a previous version, contact technical support via the [Support Portal](https://support.langchain.com) for guidance.
 </Warning>
 
 If you don't have the repo added, run the following command to add it:

--- a/src/langsmith/self-hosted-changelog.mdx
+++ b/src/langsmith/self-hosted-changelog.mdx
@@ -74,7 +74,7 @@ rss: true
 
 LangSmith Self-Hosted v0.15 brings **reusable evaluators and a library of 30+ evaluator templates** that centralize evaluation across your workspace, ships **per-example assertions** alongside reference outputs in annotation queues, lets you download **Insights reports** as PDFs for offline analysis, and introduces the **Context Hub** for version-controlled, environment-aware management of agent instructions and tools. Several breaking changes are worth reviewing before upgrade: the `agent-bootstrap` script is deprecated, the Agent Builder rename to [Fleet](/langsmith/fleet) may require workload-identity service-account updates, and the `projects:update-retention` permission splits into `projects:increase-trace-tier` and `projects:decrease-trace-tier`.
 
-Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access to everything. To book time with LangChain support for your upgrade, contact `support@langchain.dev`.
+Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access to everything. To book time with LangChain support for your upgrade, contact the team via the [Support Portal](https://support.langchain.com).
 
 ### Breaking changes
 
@@ -360,7 +360,7 @@ These updates focus on improving user experience, performance, security, and fea
 
 LangSmith Self-Hosted v0.14 brings **Chat** (our in-product chat for traces and runs) to self-hosted, takes **ABAC and audit logs** GA (on by default), and enables the **LLM Auth Proxy** by default with URL allowlisting and richer JWT claims. Admins get **unified model configurations** shared across Agent Builder, Chat, Insights, Playground, and Evaluators, and fine-grained **Prompt Owners** for locking down who can promote or delete individual prompts. Evaluators gain **multi-modal support** and workspaces can now set **cost alerts** on tracing projects. Playground model support expands (Anthropic via Vertex AI, custom Azure models, Bedrock inference profiles, Gemini 3.1 Pro, GPT-5.3 / 5.4, Baseten + GLM-5), and new agent tools and triggers land for Google Sheets & Docs, Outlook, Teams, and Salesforce SOQL. On the infrastructure side, v0.14 adds **GCS Workload Identity** support for blob storage, **Valkey** as a drop-in Redis replacement, and a pre-upgrade migration hook for safer rollouts.
 
-Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access to everything. To book time with LangChain support for your upgrade, contact `support@langchain.dev`.
+Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access to everything. To book time with LangChain support for your upgrade, contact the team via the [Support Portal](https://support.langchain.com).
 
 ### Breaking changes
 


### PR DESCRIPTION
## What
Repoints customer-facing mentions of `support@langchain.dev` to the Support Portal (https://support.langchain.com), part of the org-wide cleanup to route users through the portal instead of a raw mailto.

## Notes
- User-facing strings/links only, no logic changes.
- "Support Portal" is the visible link text in rendered surfaces (JSX/MDX/HTML); plain-text error strings use "contact technical support via our Support Portal (https://support.langchain.com)".

🤖 Generated with [Claude Code](https://claude.com/claude-code)