### PR TITLE
simplify provider docs and contribution requirements

### DIFF
--- a/src/oss/contributing/overview.mdx
+++ b/src/oss/contributing/overview.mdx
@@ -119,14 +119,14 @@ LangChain has helped form the largest developer community in generative AI, and 
 ## Pull request requirements
 
 <Warning>
-    **All pull requests must link to an issue or discussion where a solution has been approved by a maintainer.** PRs without prior approval will be closed.
+    **All pull requests must link to an issue or discussion where a solution has been approved by a maintainer.** Do not open a pull request before a maintainer has approved your approach and assigned the linked issue to you. Early PRs may be closed automatically and are not reviewed until assignment.
 </Warning>
 
 All pull requests should demonstrate meaningful effort and contextual understanding. **If the effort required to create a pull request is less than the effort required for maintainers to review it, that contribution should not be submitted.** Low-effort drive-by contributions—regardless of how they are produced—often miss the mark in terms of contextual relevance, accuracy, and quality. Mass automated contributions represent a denial-of-service attack on our human effort.
 
 The following requirements must be met for all external pull requests:
 
-* The pull request must link to an issue or discussion where a solution has been approved by a maintainer.
+* The pull request must link to an issue or discussion where a solution has been approved by a maintainer, and the contributor must be assigned to that issue before opening the PR.
 * The pull request must fill in the repository's pull request template.
 
 Maintainers reserve the right to close PRs without comment if these requirements are not met. **We will close pull requests and issues that appear to be low-effort spam.**

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -81,9 +81,7 @@ Using a provider not listed here? See [Arbitrary providers](/oss/deepagents/code
 </Tip>
 
 <Tip>
-    A **[model profile](/oss/langchain/models#model-profiles)** is a bundle of metadata (model name, default parameters, capabilities, etc.) that ships with a provider package, largely powered by the [models.dev](https://models.dev/) project.
-
-    Providers that include model profiles have their models listed automatically in the interactive `/model` switcher, subject to the [filtering criteria](#which-models-appear-in-the-switcher) (notably, `tool_calling` must be enabled). Providers without model profiles require you to specify the model name directly or add models via `config.toml`.
+    [Model profiles](/oss/langchain/models#model-profiles) provide model metadata used by the interactive `/model` switcher. If a model is missing from the switcher, pass the model name directly or add it via `config.toml`.
 </Tip>
 
 :::
@@ -135,10 +133,10 @@ Use the dedicated integration packages for these services:
 
 To switch models in Deep Agents Code, either:
 
-1. **Use the interactive model switcher** with the `/model` command. This displays available models sourced from each installed LangChain provider package's [model profiles](/oss/langchain/models#model-profiles).
+1. **Use the interactive model switcher** with the `/model` command.
 
     <Note>
-        Not all models appear here. If yours is missing, pass the model name directly (e.g. `/model gpt-5.5`). See [Which models appear in the switcher](#which-models-appear-in-the-switcher) for details.
+        Not all models appear here. If yours is missing, pass the model name directly (e.g. `/model gpt-5.5`) or add it to `config.toml`.
     </Note>
 2. **Specify a model name directly** as an argument, e.g. `/model gpt-5.5`. You can use any model supported by the chosen provider, regardless of whether it appears in the list from option 1. The model name will be passed to the API request.
 3. **Specify the model at launch** via `--model`, e.g.
@@ -163,35 +161,19 @@ To switch models in Deep Agents Code, either:
 The `/model` selector dynamically builds its list from installed provider packages. Expand below for the full criteria and troubleshooting.
 
 <Accordion title="How the switcher builds its model list" icon="list-search">
-    The interactive `/model` selector builds its list dynamically—it is not a hardcoded list baked into Deep Agents Code. A model appears in the switcher when **all** of the following are true:
+    The interactive `/model` selector builds its list from installed provider packages and models configured in `config.toml`.
 
-    1. **The provider package is installed.** Each provider (e.g. `langchain-anthropic`, `langchain-openai`) must be installed alongside `deepagents-code`—either preinstalled as an [install extra](#quickstart) or added later with `/install <extra>` (e.g. `/install ollama`). If a package is missing, its entire provider section is absent from the switcher.
-    2. **The model has a profile with `tool_calling` enabled.** Deep Agents Code requires tool-calling support, so models without `tool_calling: true` in their profile are excluded. This is the most common reason a model is missing from the list. For providers that don't bundle profiles (see the [Provider reference](#provider-reference) table), you can define one in `config.toml`:
+    A model appears when:
 
-        ```toml
-        [models.providers.ollama.profile."qwen3:4b"]
-        tool_calling = true
-        max_input_tokens = 32768
-        max_output_tokens = 8192
-        ```
+    1. The provider package is installed.
+    2. The model is available from the provider package, a local provider, or your `config.toml`.
+    3. The model profile does not mark text input or output as unsupported.
 
-        This is not strictly required for the model to appear in the switcher — adding it to the [`models` list](/oss/deepagents/code/configuration#adding-models-to-the-interactive-switcher) also works and is simpler. A profile is useful when you want Deep Agents Code to know the model's context window and capabilities for features like auto-summarization. See [Profile overrides](/oss/deepagents/code/configuration#profile-overrides-advanced) for all overridable fields.
-    3. **The model accepts and produces text.** Models whose profile explicitly sets `text_inputs` or `text_outputs` to `false` (e.g. embedding or image-generation models) are excluded.
-
-    Models defined in `config.toml` under [`[models.providers.<name>].models`](/oss/deepagents/code/configuration#adding-models-to-the-interactive-switcher) bypass the profile filter—they always appear in the switcher regardless of profile metadata. This is the recommended way to add models that are missing from the list.
+    If a model is missing, use `/model <provider>:<model>` directly or add it to [`[models.providers.<name>].models`](/oss/deepagents/code/configuration#adding-models-to-the-interactive-switcher).
 
     <Tip>
-        Credential status does **not** affect whether a model is listed. The switcher shows all qualifying models and displays a credential indicator next to each provider header: a checkmark for confirmed credentials, a warning for missing credentials, or a question mark when credential status is unknown. You can still select a model with missing credentials—the provider will report an authentication error at request time.
+        Credential status does **not** affect whether a model is listed. You can still select a model with missing credentials. The provider reports an authentication error at request time.
     </Tip>
-
-    #### Troubleshooting missing models
-
-    | Symptom | Likely cause | Fix |
-    | --- | --- | --- |
-    | Entire provider missing from switcher | Provider package not installed | Install the extra (e.g. `/install groq`) |
-    | Provider shown but specific model missing | Model profile has `tool_calling: false` or no profile exists | Add the model to `[models.providers.<name>].models` in `config.toml`, or use `/model <provider>:<model>` directly |
-| Provider shows ⚠ "missing credentials" | API key env var not set | Set the credential env var from the [Provider reference](#provider-reference) table |
-    | Provider shows ? "credentials unknown" | Provider uses non-standard auth that Deep Agents Code can't verify | Credentials may still work—try switching to the model. If auth fails, check the provider's docs |
 </Accordion>
 
 ### Open weights models
@@ -200,62 +182,83 @@ If you want to use an open weights model, there are two common paths depending o
 
 **Local inference with Ollama** is the easiest way to get started for free, with no API key required:
 
-1. [Install Ollama](https://ollama.com/) and pull a model that supports tool calling, for example:
+1. [Install Ollama](https://ollama.com/) and pull a model, for example:
 
     ```bash
     ollama pull qwen3:4b
     ```
 
-2. Install the Ollama extra and launch Deep Agents Code with that model:
+2. Install the Ollama extra:
 
     <CodeGroup>
         ```txt In session
         /install ollama
-        /model ollama:qwen3:4b
         ```
 
         ```bash Shell
-        dcode --install ollama --model ollama:qwen3:4b
+        dcode --install ollama
         ```
     </CodeGroup>
 
-    Because Ollama doesn't ship model profiles, the `/model` switcher won't list Ollama models automatically. Use `/model ollama:<model-name>` directly, or add models to your `config.toml` so they appear in the switcher—see [Adding models to the interactive switcher](/oss/deepagents/code/configuration#adding-models-to-the-interactive-switcher).
+3. Select the model:
 
-<Tip>
-    Not all open weights models support tool calling reliably. Models in the Llama 3.x, Qwen 3, Mistral, and Gemma 3 families are a good starting point. Check the [Ollama model library](https://ollama.com/library) and look for models tagged with tool-calling support.
-</Tip>
+    <CodeGroup>
+        ```txt In session
+        /model
+        ```
+
+        ```bash Shell
+        dcode --model ollama:qwen3:4b
+        ```
+    </CodeGroup>
+
+    Use the interactive switcher, or pass the model directly with `/model ollama:qwen3:4b`.
 
 **Cloud-hosted open weights via Groq** gives you fast inference without running anything locally:
 
 1. Get a free API key at [console.groq.com](https://console.groq.com/).
 
-2. Install the Groq extra and launch with a Llama or Qwen model:
+2. Install the Groq extra:
 
     <CodeGroup>
         ```txt In session
         /install groq
-        /model groq:llama-3.3-70b-versatile
         ```
 
         ```bash Shell
-        GROQ_API_KEY="your-api-key" dcode --install groq --model groq:llama-3.3-70b-versatile
+        dcode --install groq
         ```
     </CodeGroup>
 
-    Groq ships with model profiles (see [Provider reference](#provider-reference)), so its models appear automatically in the `/model` switcher once the extra is installed and your API key is set.
+3. Select a model:
 
-**Fireworks** and **Together** are also popular cloud providers for open weights models with model profiles (see [Provider reference](#provider-reference)):
+    <CodeGroup>
+        ```txt In session
+        /model
+        ```
+
+        ```bash Shell
+        GROQ_API_KEY="your-api-key" dcode --model groq:openai/gpt-oss-120b
+        ```
+    </CodeGroup>
+
+    Use the interactive switcher, or pass the model directly with `/model groq:openai/gpt-oss-120b`.
+
+**Fireworks** is another popular cloud provider for open weights models:
 
 <CodeGroup>
     ```txt In session
     /install fireworks
-    /model fireworks:accounts/fireworks/models/llama-v3p1-70b-instruct
+    /model
     ```
 
     ```bash Shell
-    FIREWORKS_API_KEY="your-api-key" dcode --install fireworks --model fireworks:accounts/fireworks/models/llama-v3p1-70b-instruct
+    dcode --install fireworks
+    FIREWORKS_API_KEY="your-api-key" dcode --model fireworks:accounts/fireworks/models/deepseek-v4-pro
     ```
 </CodeGroup>
+
+Use the interactive switcher, or pass the model directly with `/model fireworks:accounts/fireworks/models/deepseek-v4-pro`.
 
 <Tip>
     If you want a provider preinstalled at the same time as the CLI itself, use `DEEPAGENTS_CODE_EXTRAS` during the initial install:
@@ -264,10 +267,10 @@ If you want to use an open weights model, there are two common paths depending o
     DEEPAGENTS_CODE_EXTRAS="fireworks" curl -LsSf https://langch.in/dcode | bash
     ```
 
-    You can combine multiple providers: `DEEPAGENTS_CODE_EXTRAS="groq,fireworks,ollama"`. If Deep Agents Code is already installed, just use `/install <extra>` in a session or `dcode --install <extra>` from the shell instead.
+    You can combine multiple providers: `DEEPAGENTS_CODE_EXTRAS="groq,fireworks,ollama"`. If Deep Agents Code is already installed, use `/install <extra>` in a session or `dcode --install <extra>` from the shell instead.
 </Tip>
 
-**OpenRouter** and **Hugging Face** (`langchain-huggingface`) are other options for cloud-hosted open weights. See the [Provider reference](#provider-reference) for credentials and package names.
+**Together**, **OpenRouter**, and **Hugging Face** (`langchain-huggingface`) are other options for cloud-hosted open weights. See the [Provider reference](#provider-reference) for credentials and package names.
 
 ### Set a default model
 


### PR DESCRIPTION
Clarifies Deep Agents Code provider guidance by keeping model selection docs focused on the interactive switcher, direct model names, and `config.toml` fallbacks. Also tightens the external contribution requirements so contributors know they need maintainer approval and issue assignment before opening a PR.

## Changes
- Simplified the model profile explanation to avoid provider-specific implementation details in the provider reference.
- Reduced the `/model` switcher troubleshooting section to the core rules for when models appear and what to do when one is missing.
- Reworked the open weights examples so Ollama, Groq, and Fireworks each separate provider installation from model selection.
- Updated the Groq and Fireworks examples to use `groq:openai/gpt-oss-120b` and `fireworks:accounts/fireworks/models/deepseek-v4-pro`.
- Removed the open weights tool-calling tip and other extra provider business logic from the docs.
- Clarified that external PRs need an approved linked issue or discussion, plus issue assignment, before submission.