### PR TITLE
docs: add hosted MCP example

### DIFF
--- a/src/oss/langchain/mcp.mdx
+++ b/src/oss/langchain/mcp.mdx
@@ -402,14 +402,32 @@ MCP supports different transport mechanisms for client-server communication.
 
 The `http` transport (also referred to as `streamable-http`) uses HTTP requests for client-server communication. See the [MCP HTTP transport specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http) for more details.
 
+Use a local URL for servers you run yourself, or a hosted URL such as the [LangChain docs MCP server](/use-these-docs) (`https://docs.langchain.com/mcp`), which is public and does not require an API key.
+
 :::python
 ```python
+from langchain.agents import create_agent
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
 client = MultiServerMCPClient(
     {
-        "weather": {
+        "mcp": {
             "transport": "http",
-            "url": "http://localhost:8000/mcp",
+            # "url": "http://localhost:8000/mcp",  # Local server
+            "url": "https://docs.langchain.com/mcp",  # Hosted server
         }
+    }
+)
+tools = await client.get_tools()
+agent = create_agent("openai:gpt-5.4", tools)
+response = await agent.ainvoke(
+    {
+        "messages": [
+            {
+                "role": "user",
+                "content": "How do I connect LangChain to an MCP server over HTTP?",
+            }
+        ]
     }
 )
 ```
@@ -417,11 +435,26 @@ client = MultiServerMCPClient(
 
 :::js
 ```typescript
+import { MultiServerMCPClient } from "@langchain/mcp-adapters";
+import { createAgent } from "langchain";
+
 const client = new MultiServerMCPClient({
-    weather: {
-        transport: "sse",
-        url: "http://localhost:8000/mcp",
+    mcp: {
+        transport: "http",
+        // url: "http://localhost:8000/mcp", // Local server
+        url: "https://docs.langchain.com/mcp", // Hosted server
     },
+});
+
+const tools = await client.getTools();
+const agent = createAgent({ model: "openai:gpt-5.4", tools });
+const response = await agent.invoke({
+    messages: [
+        {
+            role: "user",
+            content: "How do I connect LangChain to an MCP server over HTTP?",
+        },
+    ],
 });
 ```
 :::
@@ -450,73 +483,6 @@ client = MultiServerMCPClient(
 tools = await client.get_tools()
 agent = create_agent("openai:gpt-5.4", tools)
 response = await agent.ainvoke({"messages": "what is the weather in nyc?"})
-```
-:::
-
-#### Connect to a hosted server
-
-Use the same HTTP configuration for hosted MCP servers. The [Ignav flight API](https://ignav.com) exposes `https://ignav.com/mcp` for live flight search and booking links. Anonymous use is rate-limited; include `X-Api-Key` for keyed usage.
-
-:::python
-```python Hosted flight search MCP server
-import os
-
-from langchain.agents import create_agent
-from langchain_mcp_adapters.client import MultiServerMCPClient
-
-client = MultiServerMCPClient(
-    {
-        "flights": {
-            "transport": "http",
-            "url": "https://ignav.com/mcp",
-            "headers": {"X-Api-Key": os.environ["IGNAV_API_KEY"]},
-        }
-    }
-)
-tools = await client.get_tools()
-agent = create_agent("openai:gpt-5.4", tools)
-response = await agent.ainvoke(
-    {
-        "messages": [
-            {
-                "role": "user",
-                "content": "Find a one-way flight from SFO to JFK on 2026-07-15 and include a booking URL.",
-            }
-        ]
-    }
-)
-```
-:::
-
-:::js
-```typescript Hosted flight search MCP server
-import { MultiServerMCPClient } from "@langchain/mcp-adapters";
-import { createAgent } from "langchain";
-
-const apiKey = process.env.IGNAV_API_KEY;
-
-if (!apiKey) {
-    throw new Error("Set IGNAV_API_KEY before running this example.");
-}
-
-const client = new MultiServerMCPClient({
-    flights: {
-        transport: "http",
-        url: "https://ignav.com/mcp",
-        headers: { "X-Api-Key": apiKey },
-    },
-});
-
-const tools = await client.getTools();
-const agent = createAgent({ model: "openai:gpt-5.4", tools });
-const response = await agent.invoke({
-    messages: [
-        {
-            role: "user",
-            content: "Find a one-way flight from SFO to JFK on 2026-07-15 and include a booking URL.",
-        },
-    ],
-});
 ```
 :::
 

--- a/src/oss/langchain/mcp.mdx
+++ b/src/oss/langchain/mcp.mdx
@@ -453,6 +453,73 @@ response = await agent.ainvoke({"messages": "what is the weather in nyc?"})
 ```
 :::
 
+#### Connect to a hosted server
+
+Use the same HTTP configuration for hosted MCP servers. The [Ignav flight API](https://ignav.com) exposes `https://ignav.com/mcp` for live flight search and booking links. Anonymous use is rate-limited; include `X-Api-Key` for keyed usage.
+
+:::python
+```python Hosted flight search MCP server
+import os
+
+from langchain.agents import create_agent
+from langchain_mcp_adapters.client import MultiServerMCPClient
+
+client = MultiServerMCPClient(
+    {
+        "flights": {
+            "transport": "http",
+            "url": "https://ignav.com/mcp",
+            "headers": {"X-Api-Key": os.environ["IGNAV_API_KEY"]},
+        }
+    }
+)
+tools = await client.get_tools()
+agent = create_agent("openai:gpt-5.4", tools)
+response = await agent.ainvoke(
+    {
+        "messages": [
+            {
+                "role": "user",
+                "content": "Find a one-way flight from SFO to JFK on 2026-07-15 and include a booking URL.",
+            }
+        ]
+    }
+)
+```
+:::
+
+:::js
+```typescript Hosted flight search MCP server
+import { MultiServerMCPClient } from "@langchain/mcp-adapters";
+import { createAgent } from "langchain";
+
+const apiKey = process.env.IGNAV_API_KEY;
+
+if (!apiKey) {
+    throw new Error("Set IGNAV_API_KEY before running this example.");
+}
+
+const client = new MultiServerMCPClient({
+    flights: {
+        transport: "http",
+        url: "https://ignav.com/mcp",
+        headers: { "X-Api-Key": apiKey },
+    },
+});
+
+const tools = await client.getTools();
+const agent = createAgent({ model: "openai:gpt-5.4", tools });
+const response = await agent.invoke({
+    messages: [
+        {
+            role: "user",
+            content: "Find a one-way flight from SFO to JFK on 2026-07-15 and include a booking URL.",
+        },
+    ],
+});
+```
+:::
+
 #### Authentication
 
 :::python


### PR DESCRIPTION
## Overview
Adds a hosted HTTP MCP server example to the LangChain MCP docs. The example connects to the [Ignav flight API](https://ignav.com) with `X-Api-Key` and asks an agent to return a flight option with a booking URL.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- GitHub issue: N/A
- Feature PR: N/A

<!-- For LangChain employees, if applicable: -->
- Linear issue: N/A
- Slack thread: N/A

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
Checks run:
- `make lint_prose FILES=src/oss/langchain/mcp.mdx`
- `uvx --from codespell codespell src/oss/langchain/mcp.mdx`

`docs dev` and live code execution were not run for this small existing-page docs change.