### PR TITLE
fix: update stale Gemini safety settings link

### DIFF
--- a/src/oss/python/integrations/chat/google_generative_ai.mdx
+++ b/src/oss/python/integrations/chat/google_generative_ai.mdx
@@ -1310,7 +1310,7 @@ llm = ChatGoogleGenerativeAI(
 )
 ```
 
-For an enumeration of the categories and thresholds available, see Google's [safety setting types](https://ai.google.dev/api/python/google/generativeai/types/SafetySettingDict).
+For an enumeration of the categories and thresholds available, see Google's [safety settings guide](https://ai.google.dev/gemini-api/docs/safety-settings).
 
 ## Context caching
 

--- a/src/oss/python/integrations/llms/google_generative_ai.mdx
+++ b/src/oss/python/integrations/llms/google_generative_ai.mdx
@@ -167,4 +167,4 @@ llm = GoogleGenerativeAI(
 )
 ```
 
-For an enumeration of the categories and thresholds available, see Google's [safety setting types](https://ai.google.dev/api/python/google/generativeai/types/SafetySettingDict).
+For an enumeration of the categories and thresholds available, see Google's [safety settings guide](https://ai.google.dev/gemini-api/docs/safety-settings).


### PR DESCRIPTION
The Gemini chat/LLM integration pages linked to the legacy `google.generativeai` `SafetySettingDict` reference, which now redirects to the deprecated SDK repo. Since `langchain-google-genai` 4.0.0 uses the consolidated `google-genai` SDK, this points to the current Gemini API safety settings guide that enumerates the available harm categories and block thresholds.

Made by [Open SWE](https://openswe.vercel.app)