### PR TITLE
docs: add Vercel Sandbox provider docs

### DIFF
--- a/src/oss/deepagents/code/remote-sandboxes.mdx
+++ b/src/oss/deepagents/code/remote-sandboxes.mdx
@@ -1,7 +1,7 @@
 ---
 title: Use remote sandboxes
 sidebarTitle: Remote sandboxes
-description: Run Deep Agents Code tool execution in LangSmith, Daytona, Modal, Runloop, or AgentCore sandboxes. Install provider extras, set credentials, and use flags and setup scripts.
+description: Run Deep Agents Code tool execution in LangSmith, Daytona, Modal, Runloop, Vercel, or AgentCore sandboxes. Install provider extras, set credentials, and use flags and setup scripts.
 ---
 
 Deep Agents Code uses the [sandbox as tool](/oss/deepagents/sandboxes#sandbox-as-tool-pattern) pattern: the `dcode` process (LLM loop, memory, tool dispatch) runs on your machine, but agent tool calls (`read_file`, `write_file`, `execute`, etc.) target the remote sandbox, not your local filesystem. To get files into the sandbox, use a [setup script](#setup-scripts) or the provider's file transfer APIs (see [Working with files](/oss/deepagents/sandboxes#working-with-files)).
@@ -27,6 +27,11 @@ For a deeper look at sandbox architecture, integration patterns, and security be
             <Tab title="Runloop">
                 ```bash
                 uv tool install 'deepagents-code[runloop]'
+                ```
+            </Tab>
+            <Tab title="Vercel">
+                ```bash
+                uv tool install 'deepagents-code[vercel]'
                 ```
             </Tab>
             <Tab title="AgentCore">
@@ -60,6 +65,15 @@ For a deeper look at sandbox architecture, integration patterns, and security be
                 ```bash
                 export RUNLOOP_API_KEY="your-key"
                 ```
+            </Tab>
+            <Tab title="Vercel">
+                ```bash
+                export VERCEL_TOKEN="your-token"
+                export VERCEL_PROJECT_ID="your-project-id"
+                export VERCEL_TEAM_ID="your-team-id"
+                ```
+
+                When running on Vercel, [OIDC](https://vercel.com/docs/oidc) credentials are used automatically instead.
             </Tab>
             <Tab title="AgentCore">
                 ```bash
@@ -96,6 +110,11 @@ For a deeper look at sandbox architecture, integration patterns, and security be
                 dcode --sandbox runloop
                 ```
             </Tab>
+            <Tab title="Vercel">
+                ```bash
+                dcode --sandbox vercel
+                ```
+            </Tab>
             <Tab title="AgentCore">
                 ```bash
                 dcode --sandbox agentcore
@@ -109,7 +128,7 @@ For a deeper look at sandbox architecture, integration patterns, and security be
 
 | Flag | Description |
 |------|-------------|
-| `--sandbox TYPE` | Sandbox provider to use. Built-ins: `langsmith`, `agentcore`, `modal`, `daytona`, `runloop` (default: `none`). [Third-party](#third-party-providers) and [config-declared](#config-declared-providers) providers are also accepted. Pass `--sandbox` with no value to use `[sandboxes].default` from your config |
+| `--sandbox TYPE` | Sandbox provider to use. Built-ins: `langsmith`, `agentcore`, `modal`, `daytona`, `runloop`, `vercel` (default: `none`). [Third-party](#third-party-providers) and [config-declared](#config-declared-providers) providers are also accepted. Pass `--sandbox` with no value to use `[sandboxes].default` from your config |
 | `--sandbox-id ID` | Reuse an existing sandbox by ID instead of creating a new one. Skips creation and cleanup. Only for providers that support reattaching by ID. Refer to your sandbox documentation for more |
 | `--sandbox-snapshot-name NAME` | Use or create a sandbox snapshot. Supported by `langsmith` and `runloop` (and any third-party provider that advertises snapshot support). Cannot be combined with `--sandbox-id` |
 | `--sandbox-setup PATH` | Path to a setup script to run inside the sandbox upon creation |
@@ -122,6 +141,7 @@ Each provider exposes a default working directory inside the sandbox. Setup scri
 | Daytona | `/home/daytona` |
 | Modal | `/workspace` |
 | Runloop | `/home/user` |
+| Vercel | `/vercel/sandbox` |
 | AgentCore | `/tmp` |
 
 Examples:
@@ -146,7 +166,7 @@ dcode --sandbox
 
 ## Pluggable providers
 
-The five built-in providers above aren't the only options. Deep Agents Code discovers sandbox providers from three sources, so you can use providers shipped by other packages or declare your own without changing Deep Agents Code:
+The six built-in providers above aren't the only options. Deep Agents Code discovers sandbox providers from three sources, so you can use providers shipped by other packages or declare your own without changing Deep Agents Code:
 
 1. **Built-in providers** — the curated set above, installed as `deepagents-code` extras.
 2. **[Third-party providers](#third-party-providers)** — published by other installed packages via a Python entry point.

--- a/src/oss/deepagents/sandboxes.mdx
+++ b/src/oss/deepagents/sandboxes.mdx
@@ -417,6 +417,32 @@ You can also call the backend `execute()` method directly in your application co
             devbox.shutdown()
         ```
     </Tab>
+    <Tab title="Vercel">
+        <CodeGroup>
+            ```bash pip
+            pip install langchain-vercel-sandbox
+            ```
+
+            ```bash uv
+            uv add langchain-vercel-sandbox
+            ```
+        </CodeGroup>
+
+        ```python
+        from vercel.sandbox import Sandbox
+
+        from langchain_vercel_sandbox import VercelSandbox
+
+        sandbox = Sandbox.create()
+        backend = VercelSandbox(sandbox=sandbox)
+
+        try:
+            result = backend.execute("python --version")
+            print(result.output)
+        finally:
+            sandbox.stop()
+        ```
+    </Tab>
     <Tab title="AgentCore">
         <CodeGroup>
             ```bash pip
@@ -643,6 +669,33 @@ Use `upload_files()` to populate the sandbox before the agent runs. Paths must b
         )
         ```
     </Tab>
+    <Tab title="Vercel">
+        <CodeGroup>
+            ```bash pip
+            pip install langchain-vercel-sandbox
+            ```
+
+            ```bash uv
+            uv add langchain-vercel-sandbox
+            ```
+        </CodeGroup>
+
+        ```python
+        from vercel.sandbox import Sandbox
+
+        from langchain_vercel_sandbox import VercelSandbox
+
+        sandbox = Sandbox.create()
+        backend = VercelSandbox(sandbox=sandbox)
+
+        backend.upload_files(
+            [
+                ("/src/index.py", b"print('Hello')\n"),
+                ("/pyproject.toml", b"[project]\nname = 'my-app'\n"),
+            ]
+        )
+        ```
+    </Tab>
     <Tab title="AgentCore">
         <CodeGroup>
             ```bash pip
@@ -764,6 +817,33 @@ Use `download_files()` to retrieve files from the sandbox after the agent finish
 
         devbox = client.devbox.create()
         backend = RunloopSandbox(devbox=devbox)
+
+        results = backend.download_files(["/src/index.py", "/output.txt"])
+        for result in results:
+            if result.content is not None:
+                print(f"{result.path}: {result.content.decode()}")
+            else:
+                print(f"Failed to download {result.path}: {result.error}")
+        ```
+    </Tab>
+    <Tab title="Vercel">
+        <CodeGroup>
+            ```bash pip
+            pip install langchain-vercel-sandbox
+            ```
+
+            ```bash uv
+            uv add langchain-vercel-sandbox
+            ```
+        </CodeGroup>
+
+        ```python
+        from vercel.sandbox import Sandbox
+
+        from langchain_vercel_sandbox import VercelSandbox
+
+        sandbox = Sandbox.create()
+        backend = VercelSandbox(sandbox=sandbox)
 
         results = backend.download_files(["/src/index.py", "/output.txt"])
         for result in results:

--- a/src/oss/python/integrations/sandboxes/index.mdx
+++ b/src/oss/python/integrations/sandboxes/index.mdx
@@ -30,6 +30,12 @@ Sandboxes provide isolated execution environments for running agent-generated co
         <span className="font-semibold">Runloop</span>
     </a>
 
+    <a href="/oss/integrations/sandboxes/vercel" className="flex items-center justify-center gap-1.5 p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 no-underline">
+        <img className="block dark:hidden w-5 h-5" src="/images/providers/light/vercel.svg" alt="" />
+        <img className="hidden dark:block w-5 h-5" src="/images/providers/dark/vercel.svg" alt="" />
+        <span className="font-semibold">Vercel</span>
+    </a>
+
     <a href="/oss/integrations/sandboxes/aws" className="flex items-center justify-center gap-1.5 p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 no-underline">
         <img className="block dark:hidden w-5 h-5" src="/images/providers/light/agentcore.svg" alt="" />
         <img className="hidden dark:block w-5 h-5" src="/images/providers/dark/agentcore.svg" alt="" />

--- a/src/oss/python/integrations/sandboxes/vercel.mdx
+++ b/src/oss/python/integrations/sandboxes/vercel.mdx
@@ -1,0 +1,79 @@
+---
+title: "VercelSandbox integration"
+description: "Integrate with the VercelSandbox sandbox backend using LangChain Python."
+---
+
+[Vercel Sandbox](https://vercel.com/docs/vercel-sandbox) provides ephemeral, isolated Linux environments for running untrusted code. See the [Vercel Sandbox docs](https://vercel.com/docs/vercel-sandbox) for signup, authentication, and platform details.
+
+## Installation
+
+<CodeGroup>
+```bash pip
+pip install langchain-vercel-sandbox
+```
+
+```bash uv
+uv add langchain-vercel-sandbox
+```
+</CodeGroup>
+
+## Authentication
+
+The Vercel SDK reads credentials from the environment. Set the following variables, or use [OIDC](https://vercel.com/docs/oidc) when running on Vercel:
+
+```bash
+export VERCEL_TOKEN="your-token"
+export VERCEL_PROJECT_ID="your-project-id"
+export VERCEL_TEAM_ID="your-team-id"
+```
+
+## Create a sandbox backend
+
+In Python, you create the sandbox using the provider SDK, then wrap it with the [deepagents backend](/oss/deepagents/backends).
+
+```python
+from vercel.sandbox import Sandbox
+
+from langchain_vercel_sandbox import VercelSandbox
+
+sandbox = Sandbox.create()
+backend = VercelSandbox(sandbox=sandbox)
+
+try:
+    result = backend.execute("echo hello")
+    print(result.output)
+finally:
+    sandbox.stop()
+```
+
+## Use with Deep Agents
+
+```python
+from vercel.sandbox import Sandbox
+from langchain_anthropic import ChatAnthropic
+
+from deepagents import create_deep_agent
+from langchain_vercel_sandbox import VercelSandbox
+
+sandbox = Sandbox.create()
+backend = VercelSandbox(sandbox=sandbox)
+
+agent = create_deep_agent(
+    model=ChatAnthropic(model="claude-sonnet-4-20250514"),
+    system_prompt="You are a coding assistant with sandbox access.",
+    backend=backend,
+)
+
+try:
+    result = agent.invoke(
+        {"messages": [{"role": "user", "content": "Create a small Python project and run tests"}]}
+    )
+finally:
+    sandbox.stop()
+```
+
+## Cleanup
+
+Always stop the sandbox when you are done to avoid ongoing resource usage.
+
+See also: [Sandboxes](/oss/deepagents/sandboxes).

--- a/src/snippets/deepagents-sandbox-basic-py.mdx
+++ b/src/snippets/deepagents-sandbox-basic-py.mdx
@@ -133,6 +133,49 @@
         ```
 
     </Tab>
+    <Tab title="Vercel">
+
+        <CodeGroup>
+            ```bash pip
+            pip install langchain-vercel-sandbox
+            ```
+
+            ```bash uv
+            uv add langchain-vercel-sandbox
+            ```
+        </CodeGroup>
+
+        ```python
+        from deepagents import create_deep_agent
+        from langchain_anthropic import ChatAnthropic
+        from langchain_vercel_sandbox import VercelSandbox
+        from vercel.sandbox import Sandbox
+
+        sandbox = Sandbox.create()
+        backend = VercelSandbox(sandbox=sandbox)
+
+        agent = create_deep_agent(
+            model=ChatAnthropic(model="claude-sonnet-4-6"),
+            system_prompt="You are a Python coding assistant with sandbox access.",
+            backend=backend,
+        )
+
+        try:
+            result = agent.invoke(
+                {
+                    "messages": [
+                        {
+                            "role": "user",
+                            "content": "Create a small Python package and run pytest",
+                        }
+                    ]
+                }
+            )
+        finally:
+            sandbox.stop()
+        ```
+
+    </Tab>
     <Tab title="LangSmith">
 
         <CodeGroup>


### PR DESCRIPTION
Documents the Vercel Sandbox support added in langchain-ai/deepagents#3588: a new `langchain-vercel-sandbox` partner integration page plus the `vercel` dcode built-in sandbox provider (install extra, credentials, `--sandbox vercel`, working dir `/vercel/sandbox`). Also adds Vercel tabs/cards to the existing sandbox examples for parity.

Made by [Open SWE](https://openswe.vercel.app)