### PR TITLE
docs(deepagents): fix stray "python" in subagents streaming section

### DIFF
--- a/src/oss/deepagents/subagents.mdx
+++ b/src/oss/deepagents/subagents.mdx
@@ -210,10 +210,14 @@ const agent = createDeepAgent({
 ## Streaming
 
 Deep Agents support streaming updates from both the coordinator and every delegated subagent.
+
 :::python
 Use [`stream_events`](/oss/deepagents/event-streaming) to get typed projections—separate iterators for subagents, messages, tool calls, and values—so you can consume each independently.
-::::::js
+:::
+
+:::js
 Use [`streamEvents`](/oss/deepagents/event-streaming) to get typed projections—separate iterators for subagents, messages, tool calls, and values—so you can consume each independently.
+:::
 
 ### Stream subagent progress
 


### PR DESCRIPTION
The python/js content tabs in the Subagents "Streaming" section were malformed — the python block's closing fence was merged with the js opening (`::::::js`) and the js block was never closed, so a literal "python" rendered on the page. This properly closes each language block.

Made by [Open SWE](https://openswe.vercel.app)