### PR TITLE
docs(deepagents): ChatGPT OAuth sign-in for Codex models

### DIFF
--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -76,6 +76,10 @@ The `/auth` prompt also has an optional **base URL** field. Leave it blank to us
     Keys are scoped to your user account on this machine — Deep Agents Code never transmits them anywhere except to the configured provider's API.
 </Note>
 
+#### Sign in with ChatGPT
+
+Selecting the `openai_codex` provider in `/auth` starts a browser-based OAuth flow instead of prompting for an API key, letting you use OpenAI's Codex models through a ChatGPT subscription. The resulting token is stored at `~/.deepagents/.state/chatgpt-auth.json` and refreshed automatically. To re-authenticate or sign out, select `openai_codex` again. See [Sign in with ChatGPT (Codex models)](/oss/deepagents/code/providers#sign-in-with-chatgpt-codex-models) for the full flow.
+
 `/auth` only manages **LLM provider** credentials. Tool credentials such as `TAVILY_API_KEY` (web search) and `LANGSMITH_API_KEY` (tracing) are read from the environment instead — [set them in `~/.deepagents/.env` or your shell](#environment-variables).
 
 ### Environment variables (CI and headless)

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -78,7 +78,7 @@ The `/auth` prompt also has an optional **base URL** field. Leave it blank to us
 
 #### Sign in with ChatGPT
 
-Selecting the `openai_codex` provider in `/auth` starts a browser sign-in instead of prompting for an API key, letting you use OpenAI's Codex models with a ChatGPT subscription. To re-authenticate or sign out, select `openai_codex` again. See [Sign in with ChatGPT (Codex models)](/oss/deepagents/code/providers) for the full flow.
+Selecting the `openai_codex` provider in `/auth` starts a browser sign-in instead of prompting for an API key, letting you use OpenAI models with a ChatGPT subscription. To re-authenticate or sign out, select `openai_codex` again. See [Sign in with ChatGPT (Codex models)](/oss/deepagents/code/providers) for the full flow.
 
 `/auth` only manages **LLM provider** credentials. Tool credentials such as `TAVILY_API_KEY` (web search) and `LANGSMITH_API_KEY` (tracing) are read from the environment instead — [set them in `~/.deepagents/.env` or your shell](#environment-variables).
 

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -76,9 +76,11 @@ The `/auth` prompt also has an optional **base URL** field. Leave it blank to us
     Keys are scoped to your user account on this machine — Deep Agents Code never transmits them anywhere except to the configured provider's API.
 </Note>
 
+:::python
 #### Sign in with ChatGPT
 
-Selecting the `openai_codex` provider in `/auth` starts a browser-based OAuth flow instead of prompting for an API key, letting you use OpenAI's Codex models through a ChatGPT subscription. The resulting token is stored at `~/.deepagents/.state/chatgpt-auth.json` and refreshed automatically. To re-authenticate or sign out, select `openai_codex` again. See [Sign in with ChatGPT (Codex models)](/oss/deepagents/code/providers#sign-in-with-chatgpt-codex-models) for the full flow.
+Selecting the `openai_codex` provider in `/auth` starts a browser sign-in instead of prompting for an API key, letting you use OpenAI's Codex models with a ChatGPT subscription. To re-authenticate or sign out, select `openai_codex` again. See [Sign in with ChatGPT (Codex models)](/oss/deepagents/code/providers#sign-in-with-chatgpt-codex-models) for the full flow.
+:::
 
 `/auth` only manages **LLM provider** credentials. Tool credentials such as `TAVILY_API_KEY` (web search) and `LANGSMITH_API_KEY` (tracing) are read from the environment instead — [set them in `~/.deepagents/.env` or your shell](#environment-variables).
 

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -76,11 +76,9 @@ The `/auth` prompt also has an optional **base URL** field. Leave it blank to us
     Keys are scoped to your user account on this machine — Deep Agents Code never transmits them anywhere except to the configured provider's API.
 </Note>
 
-:::python
 #### Sign in with ChatGPT
 
-Selecting the `openai_codex` provider in `/auth` starts a browser sign-in instead of prompting for an API key, letting you use OpenAI's Codex models with a ChatGPT subscription. To re-authenticate or sign out, select `openai_codex` again. See [Sign in with ChatGPT (Codex models)](/oss/deepagents/code/providers#sign-in-with-chatgpt-codex-models) for the full flow.
-:::
+Selecting the `openai_codex` provider in `/auth` starts a browser sign-in instead of prompting for an API key, letting you use OpenAI's Codex models with a ChatGPT subscription. To re-authenticate or sign out, select `openai_codex` again. See [Sign in with ChatGPT (Codex models)](/oss/deepagents/code/providers) for the full flow.
 
 `/auth` only manages **LLM provider** credentials. Tool credentials such as `TAVILY_API_KEY` (web search) and `LANGSMITH_API_KEY` (tracing) are read from the environment instead — [set them in `~/.deepagents/.env` or your shell](#environment-variables).
 

--- a/src/oss/deepagents/code/data-locations.mdx
+++ b/src/oss/deepagents/code/data-locations.mdx
@@ -54,7 +54,7 @@ Deep Agents Code stores data in two directory hierarchies:
 |------|----------|------------|-------|
 | **Sessions** | `~/.deepagents/.state/sessions.db` | R/W | SQLite checkpoint database |
 | **Input history** | `~/.deepagents/.state/history.jsonl` | R/W | JSON-lines, up/down arrow recall |
-| **ChatGPT OAuth token** | `~/.deepagents/.state/chatgpt-auth.json` | R/W | Owner-only; backs the [`openai_codex`](/oss/deepagents/code/providers#sign-in-with-chatgpt-codex-models) provider, refreshed automatically |
+| **ChatGPT OAuth token** | `~/.deepagents/.state/chatgpt-auth.json` | R/W | Backs the [`openai_codex`](/oss/deepagents/code/providers) provider; created when you sign in with ChatGPT and refreshed automatically. Readable only by your user account. |
 | **Base instructions** | Package `default_agent_prompt.md` | R | Immutable, updated with Deep Agents Code upgrades |
 | **User customizations** | `~/.deepagents/{agent}/AGENTS.md` | R/W | Appended to base instructions |
 | **Project instructions** | `.deepagents/AGENTS.md` or `AGENTS.md` | R | Both loaded if present |

--- a/src/oss/deepagents/code/data-locations.mdx
+++ b/src/oss/deepagents/code/data-locations.mdx
@@ -16,6 +16,7 @@ Deep Agents Code stores data in two directory hierarchies:
 ├── .state/                  # Per-machine Deep Agents Code state (managed automatically)
 │   ├── sessions.db          #   SQLite database for conversation checkpoints
 │   ├── history.jsonl        #   Command input history
+│   ├── chatgpt-auth.json    #   ChatGPT OAuth token for the openai_codex provider
 │   ├── ...                  #   Other markers & credentials
 └── {agent}/                 # Per-agent directory (default: "agent")
     ├── AGENTS.md            # User customizations to agent instructions
@@ -53,6 +54,7 @@ Deep Agents Code stores data in two directory hierarchies:
 |------|----------|------------|-------|
 | **Sessions** | `~/.deepagents/.state/sessions.db` | R/W | SQLite checkpoint database |
 | **Input history** | `~/.deepagents/.state/history.jsonl` | R/W | JSON-lines, up/down arrow recall |
+| **ChatGPT OAuth token** | `~/.deepagents/.state/chatgpt-auth.json` | R/W | Owner-only; backs the [`openai_codex`](/oss/deepagents/code/providers#sign-in-with-chatgpt-codex-models) provider, refreshed automatically |
 | **Base instructions** | Package `default_agent_prompt.md` | R | Immutable, updated with Deep Agents Code upgrades |
 | **User customizations** | `~/.deepagents/{agent}/AGENTS.md` | R/W | Appended to base instructions |
 | **Project instructions** | `.deepagents/AGENTS.md` or `AGENTS.md` | R | Both loaded if present |

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -85,7 +85,7 @@ Using a provider not listed here? See [Arbitrary providers](/oss/deepagents/code
     [Model profiles](/oss/langchain/models#model-profiles) provide model metadata used by the interactive `/model` switcher. If a model is missing from the switcher, pass the model name directly or add it via `config.toml`.
 </Tip>
 
-### Sign in with ChatGPT (Codex models)
+### Sign in with ChatGPT
 
 The `openai_codex` provider lets you use OpenAI's Codex models with your paid **ChatGPT** subscription instead of an `OPENAI_API_KEY`. You sign in with your ChatGPT account, and it shows up as its own provider in both `/auth` and the `/model` switcher, separate from the API-key-based `openai` provider.
 

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -54,7 +54,7 @@ Using a provider not listed here? See [Arbitrary providers](/oss/deepagents/code
 | Provider | Package | Credential env var | Model profiles |
 | --- | --- | --- | --- |
 | OpenAI | [`langchain-openai`](/oss/integrations/chat/openai) | `OPENAI_API_KEY` | ✅ |
-| OpenAI (Codex) | [`langchain-openai`](/oss/integrations/chat/openai) | None — [sign in with ChatGPT](#sign-in-with-chatgpt-codex-models) | ✅ |
+| OpenAI (Codex) | [`langchain-openai`](/oss/integrations/chat/openai) | None — [sign in with ChatGPT](#sign-in-with-chatgpt) | ✅ |
 | Azure OpenAI | [`langchain-openai`](/oss/integrations/chat/azure_chat_openai) | `AZURE_OPENAI_API_KEY` | ✅ |
 | Anthropic | [`langchain-anthropic`](/oss/integrations/chat/anthropic) | `ANTHROPIC_API_KEY` | ✅ |
 | Google Gemini API | [`langchain-google-genai`](/oss/integrations/chat/google_generative_ai) | `GOOGLE_API_KEY` | ✅ |

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -54,6 +54,7 @@ Using a provider not listed here? See [Arbitrary providers](/oss/deepagents/code
 | Provider | Package | Credential env var | Model profiles |
 | --- | --- | --- | --- |
 | OpenAI | [`langchain-openai`](/oss/integrations/chat/openai) | `OPENAI_API_KEY` | ✅ |
+| OpenAI (Codex) | [`langchain-openai`](/oss/integrations/chat/openai) | None — [sign in with ChatGPT](#sign-in-with-chatgpt-codex-models) | ✅ |
 | Azure OpenAI | [`langchain-openai`](/oss/integrations/chat/azure_chat_openai) | `AZURE_OPENAI_API_KEY` | ✅ |
 | Anthropic | [`langchain-anthropic`](/oss/integrations/chat/anthropic) | `ANTHROPIC_API_KEY` | ✅ |
 | Google Gemini API | [`langchain-google-genai`](/oss/integrations/chat/google_generative_ai) | `GOOGLE_API_KEY` | ✅ |
@@ -83,6 +84,40 @@ Using a provider not listed here? See [Arbitrary providers](/oss/deepagents/code
 <Tip>
     [Model profiles](/oss/langchain/models#model-profiles) provide model metadata used by the interactive `/model` switcher. If a model is missing from the switcher, pass the model name directly or add it via `config.toml`.
 </Tip>
+
+### Sign in with ChatGPT (Codex models)
+
+The `openai_codex` provider lets you use OpenAI's Codex models through your existing paid **ChatGPT** subscription (such as Plus or Pro) instead of a metered `OPENAI_API_KEY`. It authenticates with a browser-based OAuth flow rather than an API key, so it appears as its own provider in `/auth` and `/model`, separate from the API-key-backed `openai` provider.
+
+A curated set of Codex-eligible models is exposed under this provider, including `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, and `gpt-5.2`. The Codex backend serves a narrower lineup than the full OpenAI API, so only these models surface under `openai_codex`.
+
+<Note>
+    Requires `langchain-openai>=1.3.1`, which ships the ChatGPT OAuth primitives. OpenAI is installed by default, so no extra `/install` step is needed.
+</Note>
+
+<Steps>
+    <Step title="Open the credential manager">
+        Run `/auth` in any session and select **`openai_codex`**. ChatGPT uses a browser OAuth flow, so this opens a sign-in modal instead of an API-key prompt.
+    </Step>
+
+    <Step title="Authorize in your browser">
+        Deep Agents Code opens your browser to the ChatGPT authorization page and waits on a local loopback callback. If the browser can't launch (for example over SSH), the modal also shows the authorize URL inline so you can copy it to a browser on another machine.
+    </Step>
+
+    <Step title="Select a Codex model">
+        Once signed in, the Codex models appear in the `/model` switcher under the `openai_codex` provider. Switch to one directly with its spec:
+
+        ```txt
+        /model openai_codex:gpt-5.5
+        ```
+    </Step>
+</Steps>
+
+The OAuth token is stored at `~/.deepagents/.state/chatgpt-auth.json` with owner-only permissions and is refreshed automatically, so the sign-in persists across sessions. To check your status or sign out, run `/auth`, select `openai_codex`, and choose to re-authenticate or sign out. See [Data locations](/oss/deepagents/code/data-locations) for the token store details.
+
+<Note>
+    `openai_codex` is distinct from `openai`: it uses a different model class, auth source, and request endpoint. To use Codex models with a standard API key instead, use the regular `openai` provider (e.g. `/model openai:gpt-5.5`).
+</Note>
 
 :::
 

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -87,21 +87,21 @@ Using a provider not listed here? See [Arbitrary providers](/oss/deepagents/code
 
 ### Sign in with ChatGPT (Codex models)
 
-The `openai_codex` provider lets you use OpenAI's Codex models through your existing paid **ChatGPT** subscription (such as Plus or Pro) instead of a metered `OPENAI_API_KEY`. It authenticates with a browser-based OAuth flow rather than an API key, so it appears as its own provider in `/auth` and `/model`, separate from the API-key-backed `openai` provider.
+The `openai_codex` provider lets you use OpenAI's Codex models with your paid **ChatGPT** subscription (such as Plus or Pro) instead of an `OPENAI_API_KEY`. You sign in with your ChatGPT account, and it shows up as its own provider in both `/auth` and the `/model` switcher, separate from the API-key-based `openai` provider.
 
-A curated set of Codex-eligible models is exposed under this provider, including `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, and `gpt-5.2`. The Codex backend serves a narrower lineup than the full OpenAI API, so only these models surface under `openai_codex`.
+The Codex models available through this provider are `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, and `gpt-5.2`.
 
 <Note>
-    Requires `langchain-openai>=1.3.1`, which ships the ChatGPT OAuth primitives. OpenAI is installed by default, so no extra `/install` step is needed.
+    Requires `langchain-openai>=1.3.1`. OpenAI is installed by default, so no extra `/install` step is needed.
 </Note>
 
 <Steps>
-    <Step title="Open the credential manager">
-        Run `/auth` in any session and select **`openai_codex`**. ChatGPT uses a browser OAuth flow, so this opens a sign-in modal instead of an API-key prompt.
+    <Step title="Start the sign-in">
+        Run `/auth` in any session and select **`openai_codex`**. Because ChatGPT signs you in through your browser, this starts a browser sign-in instead of asking for an API key.
     </Step>
 
     <Step title="Authorize in your browser">
-        Deep Agents Code opens your browser to the ChatGPT authorization page and waits on a local loopback callback. If the browser can't launch (for example over SSH), the modal also shows the authorize URL inline so you can copy it to a browser on another machine.
+        Deep Agents Code opens your browser to the ChatGPT sign-in page. If it can't open a browser (for example, over SSH), it also shows the sign-in URL on screen so you can copy it to a browser on another device.
     </Step>
 
     <Step title="Select a Codex model">
@@ -113,10 +113,10 @@ A curated set of Codex-eligible models is exposed under this provider, including
     </Step>
 </Steps>
 
-The OAuth token is stored at `~/.deepagents/.state/chatgpt-auth.json` with owner-only permissions and is refreshed automatically, so the sign-in persists across sessions. To check your status or sign out, run `/auth`, select `openai_codex`, and choose to re-authenticate or sign out. See [Data locations](/oss/deepagents/code/data-locations) for the token store details.
+Your sign-in persists across sessions. To check your status or sign out, run `/auth`, select `openai_codex`, and choose to re-authenticate or sign out.
 
 <Note>
-    `openai_codex` is distinct from `openai`: it uses a different model class, auth source, and request endpoint. To use Codex models with a standard API key instead, use the regular `openai` provider (e.g. `/model openai:gpt-5.5`).
+    `openai_codex` is separate from `openai`. To use OpenAI models with a standard API key instead, use the regular `openai` provider (e.g. `/model openai:gpt-5.5`).
 </Note>
 
 :::

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -87,13 +87,7 @@ Using a provider not listed here? See [Arbitrary providers](/oss/deepagents/code
 
 ### Sign in with ChatGPT (Codex models)
 
-The `openai_codex` provider lets you use OpenAI's Codex models with your paid **ChatGPT** subscription (such as Plus or Pro) instead of an `OPENAI_API_KEY`. You sign in with your ChatGPT account, and it shows up as its own provider in both `/auth` and the `/model` switcher, separate from the API-key-based `openai` provider.
-
-The Codex models available through this provider are `gpt-5.5`, `gpt-5.4`, `gpt-5.4-mini`, `gpt-5.3-codex`, and `gpt-5.2`.
-
-<Note>
-    Requires `langchain-openai>=1.3.1`. OpenAI is installed by default, so no extra `/install` step is needed.
-</Note>
+The `openai_codex` provider lets you use OpenAI's Codex models with your paid **ChatGPT** subscription instead of an `OPENAI_API_KEY`. You sign in with your ChatGPT account, and it shows up as its own provider in both `/auth` and the `/model` switcher, separate from the API-key-based `openai` provider.
 
 <Steps>
     <Step title="Start the sign-in">


### PR DESCRIPTION
Documents the new `openai_codex` provider and browser-based "Sign in with ChatGPT" OAuth flow added in langchain-ai/deepagents#3532. Adds a provider-reference row and step-by-step sign-in section to the Deep Agents Code providers page, a note in the `/auth` configuration section, and the `chatgpt-auth.json` token store to the data-locations page.

Made by [Open SWE](https://openswe.vercel.app)