### PR TITLE
docs: mark Deep Agents profiles page as Beta in sidebar

### DIFF
--- a/src/oss/deepagents/profiles.mdx
+++ b/src/oss/deepagents/profiles.mdx
@@ -1,6 +1,7 @@
 ---
 title: Profiles
 description: Package per-provider and per-model defaults that Deep Agents applies when a model is selected
+tag: "Beta"
 ---
 
 **Harness profiles** let you package configuration that Deep Agents applies whenever a given provider or specific model is selected: system-prompt tweaks, tool description overrides, excluded tools or middleware, extra middleware, and general-purpose subagent edits. They are the main way to tune how the harness behaves for a particular model without changing your `create_deep_agent` call site. Use `HarnessProfile` when building profiles in Python; use `HarnessProfileConfig` when [loading or saving YAML/JSON files](#load-profiles-from-config-files). Deep Agents ships built-in harness profiles for OpenAI and Anthropic (Claude) models.


### PR DESCRIPTION
`deepagents.profiles` exposes beta APIs (per its docstrings/`!!! beta` markers), but the docs `profiles` page was missing the `tag: "Beta"` frontmatter that its sibling beta pages (`interpreters`, `event-streaming`, `rubric`) already use. This adds the tag so the sidebar shows **Beta** for both the Python and JavaScript Deep Agents navigation entries.

Made by [Open SWE](https://openswe.vercel.app)