### PR TITLE
docs: correct invalid create_agent kwargs in Hugging Face example

### DIFF
--- a/src/oss/langchain/overview.mdx
+++ b/src/oss/langchain/overview.mdx
@@ -207,12 +207,9 @@ This example demonstrates how to create a simple LangChain agent with a custom t
         return f"It's always sunny in {city}!"
 
     agent = create_agent(
-        model="microsoft/Phi-3-mini-4k-instruct",
-        model_provider="huggingface",
+        model="huggingface:microsoft/Phi-3-mini-4k-instruct",
         tools=[get_weather],
         system_prompt="You are a helpful assistant",
-        temperature=0.7,
-        max_tokens=1024,
     )
 
     result = agent.invoke(


### PR DESCRIPTION
The `create_agent` snippet on the Hugging Face integration page passes keyword arguments that `create_agent` doesn't accept, so it fails immediately with a `TypeError`.

**What's wrong**

- `model_provider` isn't a valid argument. The provider has to be prefixed to the model id with a colon (`"huggingface:<model>"`) instead of being passed as a separate kwarg.
- `temperature` and `max_tokens` aren't valid arguments either. They're model-level settings — you can pass them when constructing the chat model (e.g. `init_chat_model(..., temperature=0.7, max_tokens=1024)`), but not directly to `create_agent`.

**Change** (only the `create_agent` call)

Before:
```python
agent = create_agent(
    model="microsoft/Phi-3-mini-4k-instruct",
    model_provider="huggingface",
    tools=[get_weather],
    system_prompt="You are a helpful assistant",
    temperature=0.7,
    max_tokens=1024,
)
```

After:
```python
agent = create_agent(
    model="huggingface:microsoft/Phi-3-mini-4k-instruct",
    tools=[get_weather],
    system_prompt="You are a helpful assistant",
)
```

**Error before the fix**
```
TypeError: create_agent() got an unexpected keyword argument 'model_provider'
```
After removing that argument, it still raises `... unexpected keyword argument 'temperature'`. The version above runs cleanly.

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
