### PR TITLE
docs: remove Components reference section from Fireworks page

### DIFF
--- a/src/oss/python/integrations/providers/fireworks.mdx
+++ b/src/oss/python/integrations/providers/fireworks.mdx
@@ -30,10 +30,3 @@ Get an API key from [fireworks.ai](https://app.fireworks.ai/login) and set the `
         Embedding models served by Fireworks AI.
     </Card>
 </Columns>
-
-## Components reference
-
-| Class | Abstraction | Import path | Description |
-|-------|-------------|-------------|-------------|
-| `ChatFireworks` | Chat model | `from langchain_fireworks import ChatFireworks` | Chat model for Fireworks AI language models. |
-| `FireworksEmbeddings` | Embeddings | `from langchain_fireworks import FireworksEmbeddings` | Embedding model for Fireworks AI. |


### PR DESCRIPTION
## Description
Removes the "Components reference" section from the Fireworks provider page, as the same classes are already covered by the "Model interfaces" cards above.

## Release Note
none

## Test Plan
- [ ] N/A — content-only removal

Made by [Open SWE](https://openswe.vercel.app)