### PR TITLE
fix(oss): remove 2 parameters that don't exist anymore

### DIFF
--- a/src/langsmith/managed-deep-agents-invoke.mdx
+++ b/src/langsmith/managed-deep-agents-invoke.mdx
@@ -351,8 +351,7 @@ const client = managedDeepAgents.getLangGraphClient({ agentId });
 export function ManagedDeepAgentStream() {
   const stream = useStream({
     client,
-    assistantId: agentId,
-    fetchStateHistory: false,
+    assistantId: agentId
   });
 
   return (

--- a/src/langsmith/managed-deep-agents-quickstart.mdx
+++ b/src/langsmith/managed-deep-agents-quickstart.mdx
@@ -218,8 +218,7 @@ const client = managedDeepAgents.getLangGraphClient({ agentId });
 export function ManagedDeepAgentStream() {
   const stream = useStream({
     client,
-    assistantId: agentId,
-    fetchStateHistory: false,
+    assistantId: agentId
   });
 
   return (

--- a/src/langsmith/managed-deep-agents-sdk.mdx
+++ b/src/langsmith/managed-deep-agents-sdk.mdx
@@ -222,8 +222,7 @@ const client = managedDeepAgents.getLangGraphClient({ agentId });
 export function ManagedDeepAgentStream() {
   const stream = useStream({
     client,
-    assistantId: agentId,
-    fetchStateHistory: false,
+    assistantId: agentId
   });
 
   return (

--- a/src/oss/deepagents/frontend/sandbox.mdx
+++ b/src/oss/deepagents/frontend/sandbox.mdx
@@ -431,8 +431,7 @@ chat panel. It uses @[`useStream`] for the agent conversation and the custom API
 endpoints for file browsing.
 
 For production deployment, point `apiUrl` at your
-[LangSmith Deployment](/langsmith/deployment), enable
-`reconnectOnMount` and `fetchStateHistory`, and pass a stable
+[LangSmith Deployment](/langsmith/deployment), and pass a stable
 `thread_id` on each run. See
 [Frontend](/oss/deepagents/going-to-production#frontend) in
 [Going to production](/oss/deepagents/going-to-production) for those settings

--- a/src/oss/deepagents/going-to-production.mdx
+++ b/src/oss/deepagents/going-to-production.mdx
@@ -1053,13 +1053,9 @@ function App() {
   const stream = useStream<typeof agent>({
     apiUrl: "https://your-deployment.langsmith.dev",
     assistantId: "agent",
-    reconnectOnMount: true,    // Resume stream after page refresh or navigation
-    fetchStateHistory: true,   // Load full thread history on mount
   });
 }
 ```
-
-`reconnectOnMount` picks up an in-progress run automatically. If a user refreshes while the agent is working, they'll see it continue rather than a blank screen. `fetchStateHistory` loads the full conversation history for the thread, so returning users see previous messages.
 
 For deep agent workflows that spawn many subagents, set a high `recursionLimit` when submitting to avoid cutting off long-running executions:
 


### PR DESCRIPTION
## Overview
`reconnectOnMount` and `fetchStateHistory` are no options in `@langchain/react` v1 anymore. The SDK now automaticallu reconnects on mount of a thread id is provided. `fetchStateHistory` is also automatically done if needed.