### PR TITLE
feat: add Vercel provider page to Python integrations

### DIFF
--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -1386,6 +1386,14 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
+        title="Vercel"
+        href="/oss/integrations/providers/vercel"
+        icon="link"
+    >
+        Ephemeral, isolated Linux sandboxes for running untrusted code.
+    </Card>
+
+    <Card
         title="VoyageAI"
         href="/oss/integrations/providers/voyageai"
         icon="link"

--- a/src/oss/python/integrations/providers/vercel.mdx
+++ b/src/oss/python/integrations/providers/vercel.mdx
@@ -1,0 +1,13 @@
+---
+title: "Vercel integrations"
+sidebarTitle: "Vercel"
+description: "Integrate with Vercel using LangChain Python."
+---
+
+[Vercel](https://vercel.com) provides [Vercel Sandbox](https://vercel.com/docs/vercel-sandbox), ephemeral, isolated Linux environments for running untrusted code. See the [Vercel Sandbox docs](https://vercel.com/docs/vercel-sandbox) for signup, authentication, and platform details.
+
+<Columns cols={2}>
+    <Card title="VercelSandbox" href="/oss/integrations/sandboxes/vercel" cta="Get started" icon="terminal" arrow>
+        Vercel sandbox backend for deepagents.
+    </Card>
+</Columns>


### PR DESCRIPTION
Vercel already had a sandbox integration page (`integrations/sandboxes/vercel`) and appeared in the sandboxes index, but it had no provider page and was missing from the "All providers" listing. This adds `providers/vercel.mdx` (mirroring the other sandbox providers like Daytona/Modal/Runloop) and a Vercel card on the all-providers page.

Made by [Open SWE](https://openswe.vercel.app)