### PR TITLE
dcode remove one-off shell export snippet from configuration

### DIFF
--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -136,12 +136,6 @@ The built-in `web_search` tool uses [Tavily](https://tavily.com). Deep Agents Co
         TAVILY_API_KEY=tvly-...
         ```
 
-        Or export it in your shell for a one-off session:
-
-        ```bash
-        export TAVILY_API_KEY=tvly-...
-        ```
-
         Shell exports take precedence over `.env` values (see [Loading order and precedence](#loading-order-and-precedence)). To scope a key to Deep Agents Code only without affecting other tools that read `TAVILY_API_KEY`, use the [`DEEPAGENTS_CODE_` prefix](#deepagents_code_-prefix): `DEEPAGENTS_CODE_TAVILY_API_KEY=tvly-...`.
     </Step>
 


### PR DESCRIPTION
## Description
Removes the "Or export it in your shell for a one-off session" instruction and its `export TAVILY_API_KEY=tvly-...` code block from the Deep Agents Code configuration page, per request.

## Release Note
none

## Test Plan
- [ ] Confirm the Tavily configuration step renders without the removed export snippet.

Made by [Open SWE](https://openswe.vercel.app)