### PR TITLE
docs: document `dcode auth` CLI subcommands

### DIFF
--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -94,13 +94,6 @@ The `dcode auth` command group is the scriptable equivalent of the `/auth` manag
 | `dcode auth remove <provider>` (aliases `rm`, `delete`) | Delete a stored credential |
 | `dcode auth path` | Print the resolved path to the credential store (`auth.json`) |
 
-`list` and `status` report the same source labels the `/auth` manager shows — `stored`, `env: VARNAME` (the [resolved variable](#deepagents_code_-prefix), such as `DEEPAGENTS_CODE_OPENAI_API_KEY` or `OPENAI_API_KEY`), or `missing` — so you can confirm which key Deep Agents Code will use:
-
-```bash
-dcode auth list
-dcode auth status anthropic
-```
-
 `set` reads the key from **stdin** by default, so it never lands in shell history or `argv`. Pipe the key in, or use `--from-env VAR` to copy it from a process environment variable:
 
 ```bash

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -42,7 +42,7 @@ All four commands accept `--json` for machine-readable output.
 
 ## Provider credentials
 
-Deep Agents Code needs an API key for each model provider you use. The recommended way to add one is the [`/auth`](#use-%2Fauth-recommended) credential manager. For non-interactive runs, set [environment variables](#environment-variables-ci-and-headless) instead.
+Deep Agents Code needs an API key for each model provider you use. The recommended way to add one is the [`/auth`](#use-%2Fauth-recommended) credential manager. For non-interactive runs, manage the same stored keys from the shell with [`dcode auth`](#manage-credentials-from-the-shell-dcode-auth) or set [environment variables](#environment-variables-ci-and-headless) instead.
 
 If the same key is set in more than one place, see [Key resolution order](#key-resolution-order) for which one wins.
 
@@ -81,6 +81,50 @@ The `/auth` prompt also has an optional **base URL** field. Leave it blank to us
 Selecting the `openai_codex` provider in `/auth` starts a browser sign-in instead of prompting for an API key, letting you use OpenAI models with a ChatGPT subscription. To re-authenticate or sign out, select `openai_codex` again. See [Sign in with ChatGPT (Codex models)](/oss/deepagents/code/providers) for the full flow.
 
 `/auth` only manages **LLM provider** credentials. Tool credentials such as `TAVILY_API_KEY` (web search) and `LANGSMITH_API_KEY` (tracing) are read from the environment instead — [set them in `~/.deepagents/.env` or your shell](#environment-variables).
+
+### Manage credentials from the shell (`dcode auth`)
+
+The `dcode auth` command group is the scriptable equivalent of the `/auth` manager: it manages the same stored credentials without launching the TUI, which makes it usable for dotfile bootstrap, CI/CD, and setting a key on a remote box over SSH. The subcommands mirror the modal's verbs:
+
+| Command | Description |
+|---------|-------------|
+| `dcode auth list` (alias `ls`) | List every known provider and where its key resolves from |
+| `dcode auth status <provider>` | Print the resolution source for one provider |
+| `dcode auth set <provider>` | Store an API key, read from stdin by default |
+| `dcode auth remove <provider>` (aliases `rm`, `delete`) | Delete a stored credential |
+| `dcode auth path` | Print the resolved path to the credential store (`auth.json`) |
+
+`list` and `status` report the same source labels the `/auth` manager shows — `stored`, `env: VARNAME` (the [resolved variable](#deepagents_code_-prefix), such as `DEEPAGENTS_CODE_OPENAI_API_KEY` or `OPENAI_API_KEY`), or `missing` — so you can confirm which key Deep Agents Code will use:
+
+```bash
+dcode auth list
+dcode auth status anthropic
+```
+
+`set` reads the key from **stdin** by default, so it never lands in shell history or `argv`. Pipe the key in, or use `--from-env VAR` to copy it from a process environment variable:
+
+```bash
+# Pipe the key in (stdin)
+echo "$ANTHROPIC_API_KEY" | dcode auth set anthropic
+
+# Copy it from an existing environment variable
+dcode auth set openai --from-env OPENAI_API_KEY
+```
+
+<Note>
+    `set` refuses to run in an interactive terminal so an accidental invocation cannot hang waiting on input — pipe the key via stdin or use `--from-env VAR`. Stored keys go through the same store as `/auth`, so warnings (for example, about file permissions on `auth.json`) are printed to stderr.
+</Note>
+
+Remove a stored key or print the store location:
+
+```bash
+dcode auth remove anthropic
+dcode auth path
+```
+
+<Note>
+    `dcode auth set` manages API keys only. The `openai_codex` provider uses a ChatGPT browser sign-in rather than an API key, so run [`/auth` and select `openai_codex`](#sign-in-with-chatgpt) to sign in instead. `dcode auth remove openai_codex` does sign you out.
+</Note>
 
 ### Environment variables (CI and headless)
 

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -37,7 +37,7 @@ Deep Agents Code integrates automatically with the [following model providers](#
     /auth
     ```
 
-    For non-interactive runs, CI/CD, or anywhere a TUI isn't available, set the provider's environment variable instead. See [Provider credentials](/oss/deepagents/code/configuration#provider-credentials) for the full key resolution order, the [`DEEPAGENTS_CODE_` prefix](/oss/deepagents/code/configuration#deepagents_code_-prefix) for scoping a key to Deep Agents Code, and the [Provider reference](#provider-reference) for each provider's environment variable.
+    For non-interactive runs, CI/CD, or anywhere a TUI isn't available, store the same key from the shell with [`dcode auth set`](/oss/deepagents/code/configuration#manage-credentials-from-the-shell-dcode-auth) or set the provider's environment variable instead. See [Provider credentials](/oss/deepagents/code/configuration#provider-credentials) for the full key resolution order, the [`DEEPAGENTS_CODE_` prefix](/oss/deepagents/code/configuration#deepagents_code_-prefix) for scoping a key to Deep Agents Code, and the [Provider reference](#provider-reference) for each provider's environment variable.
 
     To configure model parameters, see [Model parameters](#model-parameters).
 


### PR DESCRIPTION
Documents the non-interactive `dcode auth` command group (`list`, `set`, `remove`, `status`, `path`) added in langchain-ai/deepagents#3910 — the scriptable equivalent of the in-TUI `/auth` credential manager for dotfile bootstrap, CI/CD, and remote boxes. Added a new section to the Deep Agents Code configuration page and cross-linked it from the Provider credentials intro and the provider setup steps.

Made by [Open SWE](https://openswe.vercel.app)