### PR TITLE
docs: document install-script env vars in managed deployments

### DIFF
--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -749,7 +749,7 @@ The install script reads environment variables that let you pin a version, selec
 
 ```bash
 # Pin an exact version for reproducible installs across the fleet
-curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_VERSION="0.1.0" bash
+curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_VERSION="0.1.16" bash
 ```
 
 <ResponseField name="DEEPAGENTS_CODE_VERSION" type="string" post={["optional"]}>

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -748,15 +748,12 @@ Non-root installs are unaffected: all root-specific code paths short-circuit whe
 The install script reads environment variables that let you pin a version, select extras, and choose a Python version fleet-wide. Set them on the same line as the piped install:
 
 ```bash
-# Install an exact pre-release version
-curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_VERSION="0.1.0rc1" bash
-
-# Allow uv to consider alpha/beta/rc releases when resolving the latest version
-curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_PRERELEASE="allow" bash
+# Pin an exact version for reproducible installs across the fleet
+curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_VERSION="0.1.0" bash
 ```
 
 <ResponseField name="DEEPAGENTS_CODE_VERSION" type="string" post={["optional"]}>
-    Exact package version to install, e.g. `0.1.0rc1`. Mutually exclusive with `DEEPAGENTS_CODE_PRERELEASE` — setting both is an error, since an exact pin already selects a single version.
+    Exact package version to install, e.g. `0.1.0` (or a pre-release such as `0.1.0rc1`). Mutually exclusive with `DEEPAGENTS_CODE_PRERELEASE` — setting both is an error, since an exact pin already selects a single version.
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_PRERELEASE" type="string" post={["optional"]}>

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -743,6 +743,46 @@ When `id -u` is `0`, the script:
 
 Non-root installs are unaffected: all root-specific code paths short-circuit when not running as root.
 
+### Pin the install with environment variables
+
+The install script reads environment variables that let you pin a version, select extras, and choose a Python version fleet-wide. Set them on the same line as the piped install:
+
+```bash
+# Install an exact pre-release version
+curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_VERSION="0.1.0rc1" bash
+
+# Allow uv to consider alpha/beta/rc releases when resolving the latest version
+curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_PRERELEASE="allow" bash
+```
+
+<ResponseField name="DEEPAGENTS_CODE_VERSION" type="string" post={["optional"]}>
+    Exact package version to install, e.g. `0.1.0rc1`. Mutually exclusive with `DEEPAGENTS_CODE_PRERELEASE` — setting both is an error, since an exact pin already selects a single version.
+</ResponseField>
+
+<ResponseField name="DEEPAGENTS_CODE_PRERELEASE" type="string" post={["optional"]}>
+    uv pre-release strategy applied when resolving the latest version: `disallow`, `allow`, `if-necessary`, `explicit`, or `if-necessary-or-explicit`. Mutually exclusive with `DEEPAGENTS_CODE_VERSION`.
+</ResponseField>
+
+<ResponseField name="DEEPAGENTS_CODE_EXTRAS" type="string" post={["optional"]}>
+    Comma-separated pip extras to install, e.g. `ollama`, `ollama,groq`, or `daytona`. See [`pyproject.toml`](https://github.com/langchain-ai/deepagents/blob/main/libs/code/pyproject.toml) for the available extras.
+</ResponseField>
+
+<ResponseField name="DEEPAGENTS_CODE_PYTHON" type="string" default="3.13" post={["optional"]}>
+    Python version to use for the install.
+</ResponseField>
+
+<ResponseField name="DEEPAGENTS_CODE_SKIP_OPTIONAL" type="string" post={["optional"]}>
+    Set to `1` to skip optional tool checks.
+</ResponseField>
+
+<ResponseField name="DEEPAGENTS_CODE_VERBOSE" type="string" post={["optional"]}>
+    Set to `1` to show uv's raw stderr (timing lines, unfiltered package diff) and the quiet-by-default status lines (optional-tool checks, post-install footer). Useful when debugging an install.
+</ResponseField>
+
+<ResponseField name="UV_BIN" type="string" post={["optional"]}>
+    Path to the uv binary. Auto-detected if unset.
+</ResponseField>
+
 To pre-configure auto-update for managed installs, set `DEEPAGENTS_CODE_AUTO_UPDATE=1` in the user's shell profile or deploy a `config.toml` with `[update] auto_update = true` to `~/.deepagents/config.toml`. To suppress automatic updates and update checks entirely, set `DEEPAGENTS_CODE_NO_UPDATE_CHECK=1`.
 
 To route every user's model traffic through a managed gateway (provisioning a gateway key and base URL fleet-wide), see [Managed gateways](#managed-gateways).


### PR DESCRIPTION
Extends the **Managed deployments** section of the Deep Agents Code configuration page with the install-time environment variables documented in the [install script](https://github.com/langchain-ai/deepagents/blob/main/libs/code/scripts/install.sh) frontmatter (`DEEPAGENTS_CODE_VERSION`, `DEEPAGENTS_CODE_PRERELEASE`, `DEEPAGENTS_CODE_EXTRAS`, `DEEPAGENTS_CODE_PYTHON`, `DEEPAGENTS_CODE_SKIP_OPTIONAL`, `DEEPAGENTS_CODE_VERBOSE`, `UV_BIN`), so fleet operators can pin versions and configure installs.

Made by [Open SWE](https://openswe.vercel.app)