### PR TITLE
docs: backfill self-hosted changelog release notes

### DIFF
--- a/src/langsmith/self-hosted-changelog.mdx
+++ b/src/langsmith/self-hosted-changelog.mdx
@@ -14,6 +14,26 @@ rss: true
 <Update label="2026-06-11" tags={["self-hosted"]} rss={{ title: "2026-06-11 - self-hosted" }}>
 ## langsmith-0.16.0-rc.2
 
+- For the full list of changes in the 0.16.0 release candidate, refer to the [langsmith-0.16.0-rc.1](#langsmith-0-16-0-rc-1) release notes below.
+
+**Download the Helm chart:** [`langsmith-0.16.0-rc.2.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.16.0-rc.2/langsmith-0.16.0-rc.2.tgz)
+{/* langsmith-release-image: 0.16.0-rc.2 0.16.4rc1 */}
+</Update>
+
+<Update label="2026-06-11" tags={["self-hosted"]} rss={{ title: "2026-06-11 - self-hosted" }}>
+## langsmith-0.15.10
+
+- Patched dependencies.
+
+- Fixed security vulnerabilities. See CVE-2026-25087, CVE-2026-45134, CVE-2026-9256 for details.
+
+**Download the Helm chart:** [`langsmith-0.15.10.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.10/langsmith-0.15.10.tgz)
+{/* langsmith-release-image: 0.15.10 0.15.15 */}
+</Update>
+
+<Update label="2026-06-09" tags={["self-hosted"]} rss={{ title: "2026-06-09 - self-hosted" }}>
+## langsmith-0.16.0-rc.1
+
 - Evaluator detach confirmation dialog showed a "Detach" button instead of "Delete."
 - Included extended stats became available to all organizations for code evaluators.
 - Added two dedicated permissions `bulk-exports:read` and `bulk-exports:manage` for fetching and creating/updating bulk exports.
@@ -84,90 +104,85 @@ rss: true
 
 - Fixed security vulnerabilities. See CVE-2026-45736, CVE-2026-44664, CVE-2025-71176 for details.
 
-**Download the Helm chart:** [`langsmith-0.16.0-rc.2.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.16.0-rc.2/langsmith-0.16.0-rc.2.tgz)
-</Update>
-
-<Update label="2026-06-11" tags={["self-hosted"]} rss={{ title: "2026-06-11 - self-hosted" }}>
-## langsmith-0.15.10
-
-- Internal improvements and maintenance updates
-
-- Fixed security vulnerabilities. See CVE-2026-25087, CVE-2026-45134, CVE-2026-9256 for details.
-
-**Download the Helm chart:** [`langsmith-0.15.10.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.10/langsmith-0.15.10.tgz)
-</Update>
-
-<Update label="2026-06-09" tags={["self-hosted"]} rss={{ title: "2026-06-09 - self-hosted" }}>
-## langsmith-0.16.0-rc.1
-
-- Internal improvements and maintenance updates
-
 **Download the Helm chart:** [`langsmith-0.16.0-rc.1.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.16.0-rc.1/langsmith-0.16.0-rc.1.tgz)
+{/* langsmith-release-image: 0.16.0-rc.1 0.16.1rc1 */}
 </Update>
 
 <Update label="2026-06-09" tags={["self-hosted"]} rss={{ title: "2026-06-09 - self-hosted" }}>
 ## langsmith-0.15.9
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.15.7. Refer to the [langsmith-0.15.7](#langsmith-0-15-7) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.9.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.9/langsmith-0.15.9.tgz)
+{/* langsmith-release-image: 0.15.9 0.15.13 */}
 </Update>
 
 <Update label="2026-06-08" tags={["self-hosted"]} rss={{ title: "2026-06-08 - self-hosted" }}>
 ## langsmith-0.15.8
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.15.7. Refer to the [langsmith-0.15.7](#langsmith-0-15-7) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.8.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.8/langsmith-0.15.8.tgz)
+{/* langsmith-release-image: 0.15.8 0.15.13 */}
 </Update>
 
 <Update label="2026-06-06" tags={["self-hosted"]} rss={{ title: "2026-06-06 - self-hosted" }}>
 ## langsmith-0.15.7
 
-- Internal improvements and maintenance updates
+- Added support for API key authentication with Amazon Bedrock in the Playground. Bedrock API keys let you authenticate requests with a bearer token instead of AWS credentials.
+- Fixed the LLM auth proxy for two cases: evaluator batch requests and Bedrock model configurations.
 
 **Download the Helm chart:** [`langsmith-0.15.7.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.7/langsmith-0.15.7.tgz)
+{/* langsmith-release-image: 0.15.7 0.15.13 */}
 </Update>
 
 <Update label="2026-06-03" tags={["self-hosted"]} rss={{ title: "2026-06-03 - self-hosted" }}>
 ## langsmith-0.15.6
 
+- Fixed a bug in SSO Groups Sync where the group-name separator was ignored and did not behave like SCIM sync.
+- Added structured server logs identifying which workspace group claims resolved and which did not, simplifying SSO Groups Sync diagnosis.
 - Patched dependencies.
 
 **Download the Helm chart:** [`langsmith-0.15.6.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.6/langsmith-0.15.6.tgz)
+{/* langsmith-release-image: 0.15.6 0.15.12 */}
 </Update>
 
 <Update label="2026-06-02" tags={["self-hosted"]} rss={{ title: "2026-06-02 - self-hosted" }}>
 ## langsmith-0.15.5
 
+- Fixed the SSRF policy for the `playground` service so that it respected `SSRF_ALLOW_K8S_INTERNAL`.
 - Patched dependencies.
 - Fixed security vulnerabilities. See CVE-2026-45736, CVE-2026-44664 for details.
 
 **Download the Helm chart:** [`langsmith-0.15.5.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.5/langsmith-0.15.5.tgz)
+{/* langsmith-release-image: 0.15.5 0.15.11 */}
 </Update>
 
 <Update label="2026-06-01" tags={["self-hosted"]} rss={{ title: "2026-06-01 - self-hosted" }}>
 ## langsmith-0.15.4
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.15.2. Refer to the [langsmith-0.15.2](#langsmith-0-15-2) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.4.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.4/langsmith-0.15.4.tgz)
+{/* langsmith-release-image: 0.15.4 0.15.10 */}
 </Update>
 
 <Update label="2026-05-29" tags={["self-hosted"]} rss={{ title: "2026-05-29 - self-hosted" }}>
 ## langsmith-0.15.3
 
-- Internal improvements and maintenance updates
+- This release packages the same LangSmith application version as langsmith-0.15.2. Refer to the [langsmith-0.15.2](#langsmith-0-15-2) release notes below.
 
 **Download the Helm chart:** [`langsmith-0.15.3.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.3/langsmith-0.15.3.tgz)
+{/* langsmith-release-image: 0.15.3 0.15.10 */}
 </Update>
 
 <Update label="2026-05-29" tags={["self-hosted"]} rss={{ title: "2026-05-29 - self-hosted" }}>
 ## langsmith-0.15.2
 
-- Internal improvements and maintenance updates
+- Fixed an OIDC login redirect loop (`ERR_TOO_MANY_REDIRECTS`) for identity providers that use the hybrid flow with a `form_post` callback.
 
 **Download the Helm chart:** [`langsmith-0.15.2.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.2/langsmith-0.15.2.tgz)
+{/* langsmith-release-image: 0.15.2 0.15.10 */}
 </Update>
 
 <Update label="2026-05-29" tags={["self-hosted"]} rss={{ title: "2026-05-29 - self-hosted" }}>
@@ -177,6 +192,7 @@ rss: true
 - Fixed an issue in self-hosted OIDC (v15) where the SSO Groups Sync silently no-op'ed during login.
 
 **Download the Helm chart:** [`langsmith-0.15.1.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.15.1/langsmith-0.15.1.tgz)
+{/* langsmith-release-image: 0.15.1 0.15.9 */}
 </Update>
 
 <Update label="2026-05-26" tags={["self-hosted"]}>


### PR DESCRIPTION
Several recent **self-hosted changelog** entries showed placeholder text ("Internal improvements and maintenance updates" / "Patched dependencies") or cross-linked away despite real fixes shipping in those releases.

## Why
The helm GitHub releases carry empty bodies — the real notes live in the underlying `langchainplus` app image, resolved via each chart tag's `appVersion`. The bot failed to resolve those for this batch (transient fetch miss / upstream notes published after its poll window), and `strip_duplicate_versions` then permanently blocked regeneration. I traced each entry to its source and filled it in from the teams' own "Self-Hosted Release Note" PR sections (nothing fabricated).

## Changes
- `0.16.0-rc.1` now carries the full 0.16.0 change list; `0.16.0-rc.2` points to it (per request)
- `0.15.7`: Bedrock Playground API-key auth + LLM auth-proxy fixes
- `0.15.6`: SSO Groups Sync separator fix + SCIM/SSO group-name unification
- `0.15.5`: `SSRF_ALLOW_K8S_INTERNAL` fix (alongside existing CVE/deps notes)
- `0.15.2`: OIDC `ERR_TOO_MANY_REDIRECTS` login-loop fix
- `0.15.10`: clarified as dependency patches
- `0.15.3`/`0.15.4` → refer to `0.15.2`; `0.15.8`/`0.15.9` → refer to `0.15.7` (same image)
- Restored the missing `langsmith-release-image` markers on every recent entry (`0.15.1`→`0.16.0-rc.2`) so future bot runs dedupe correctly

## Review notes
- All descriptions are derived from upstream PR release notes / release bodies, not invented.
- `make lint_prose` and `make broken-links` both pass.
- The underlying bot bug (why these went stale) is fixed in a separate `helm-changelog-bot` PR.

_Authored with assistance from Claude Code._