### PR TITLE
[codex] Remove self-hosted sandbox endpoint docs

### DIFF
--- a/src/langsmith/sandbox-cli.mdx
+++ b/src/langsmith/sandbox-cli.mdx
@@ -22,12 +22,6 @@ Authenticate the CLI with your LangSmith API key:
 export LANGSMITH_API_KEY="<LANGSMITH_API_KEY>"
 ```
 
-If you use a [self-hosted](/langsmith/self-hosted) LangSmith deployment, also set the endpoint:
-
-```bash
-export LANGSMITH_ENDPOINT="https://your-langsmith-instance.com"
-```
-
 CLI output is JSON by default. Add `--format pretty` to list commands for human-readable tables:
 
 ```bash


### PR DESCRIPTION
## Overview

Remove the self-hosted LangSmith endpoint setup from the Sandbox CLI docs because LangSmith sandboxes are not supported on self-hosted deployments yet.

## Type of change

**Type:** Remove outdated content

## Related issues/PRs

- GitHub issue: N/A (maintainer-requested docs cleanup)
- Feature PR: N/A
- Linear issue: N/A
- Slack thread: N/A

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly (N/A: no code examples changed)
- [x] I have used **root relative** paths for internal links (N/A: no internal links added)
- [x] I have updated navigation in `src/docs.json` if needed (N/A: navigation unchanged)

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes

Validation run:

- `make check-cross-refs`
- Commit hook: Vale prose lint passed
- Pre-push hook: Vale prose lint passed

`docs dev` was not run because this is a six-line removal from one MDX page; cross-reference validation and Vale covered the changed surface.
