### PR TITLE
Remove SmithDB release notes from self-hosted changelog

### DIFF
--- a/src/langsmith/self-hosted-changelog.mdx
+++ b/src/langsmith/self-hosted-changelog.mdx
@@ -65,11 +65,9 @@ rss: true
 - Fixed ACE subprocess handling so early child-process exits returned request failures instead of crashing the service.
 - Fixed large integer preservation in native run ingest payloads.
 - Waterfall turn view now took full height if available.
-- Added `is one of` operator for metadata value filters when SmithDB was enabled.
 - Organization admins could now disable Engine even when their plan auto-enabled it; their explicit choice persisted across the UI and the backend gates.
 - Workspace admins could now override the workspace-default weekly spend cap on a per-evaluator-rule basis from the evaluator side panel; non-admins saw the resolved cap as read-only text.
 - Fixed incorrect metadata facet suggestions and improved group stats latency for projects with rich run metadata.
-- SmithDB experiments-endpoint reads (`ExecuteQuery`, `QueryRuns`, `QueryRunStats`) now transparently retried up to 3 times on `UNAVAILABLE` with exponential backoff.
 - Alert rules for Run Count, Errors, Latency, and Cost now supported `<`, `<=`, `>`, and `>=` comparison operators (previously the UI only allowed `>=`).
 - Fleet `/v1/fleet/auth-agents/{agent_id}/connections` endpoints moved to `/v1/fleet/agents/{agent_id}/connections` with typed responses, request validation, and the standard Fleet error envelope. The old URL returned 404.
 - Fixed Fleet redirect after deleting the active agent.
@@ -307,7 +305,6 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Added a new evaluator reuse feature to streamline the use of existing evaluators.
 - Improved frontend evaluators to include feedback key and resource filters, enhancing usability.
 - Added support for tracing tool usage and displaying agent names in the usage dashboard, enhancing performance insights.
-- Expanded session management features with Redis tracking for SmithDB run rules.
 - Enhanced mobile friendliness and PWA support for login interfaces.
 - Improved performance by optimizing session synchronization and indexing strategies.
 - Added mTLS support for ClickHouse migrations.
@@ -315,7 +312,6 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Introduced a new endpoint to update licenses for self-hosted instances via JWT.
 - Added a new UI section for displaying evaluator actions required when creating an issue board.
 - Implemented mobile-friendly login and an installable PWA to enhance accessibility for mobile users.
-- Streamlined session and dataset tracking by integrating Redis for run rules in SmithDB.
 - Enhanced DataGrid components for better UI performance in tracing views.
 
 These updates focus on improving user experience, performance, security, and feature set for self-hosted deployments.
@@ -635,7 +631,6 @@ Follow the [upgrade instructions](/langsmith/self-host-upgrades) to get access t
 - Enabled audit logs by default for self-hosted deployments.
 - MCP servers now respect granular RBAC permissions in the UI; users only see actions their role allows.
 - Enabled ABAC by default for self-hosted deployments.
-- Fixed low-frequency SmithDB ingestion errors ("incomplete chunked payload") during multipart uploads when the HTTP body is truncated.
 - Fixed a bug with OpenAI tools rendering.
 
 **Download the Helm chart:** [`langsmith-0.13.37.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.13.37/langsmith-0.13.37.tgz)


### PR DESCRIPTION
## Why

SmithDB is not yet available for self-hosted deployments. Five release notes in `src/langsmith/self-hosted-changelog.mdx` referenced SmithDB, implying a capability that self-hosted operators cannot use. This removes those entries.

## Changes

Removed the following SmithDB-related bullets:
- `is one of` operator for metadata value filters when SmithDB was enabled
- SmithDB experiments-endpoint read retries
- Redis tracking for SmithDB run rules (two entries)
- Fixed low-frequency SmithDB ingestion errors

## Review notes

This is the one-time cleanup. A companion PR in `langchain-ai/helm-changelog-bot` adds a filter so the bot stops re-introducing SmithDB entries on future runs.

This PR was prepared with the assistance of an AI agent (Claude Code).