### PR TITLE
Describe Deep Agents as a complete agent harness on build landing page

### DIFF
--- a/src/oss/javascript/build-overview.mdx
+++ b/src/oss/javascript/build-overview.mdx
@@ -24,7 +24,7 @@ icon: "hammer"
           href="/oss/deepagents/overview"
           icon="/images/brand/deep-agents-icon.png"
         >
-        Build agents for complex, long-running tasks, with planning, subagents, a virtual filesystem, and long-term memory built in. The fastest way to start.
+        Build agents for complex, long-running tasks. A complete agent harness with planning, subagents, a virtual filesystem, and long-term memory built in. The fastest way to start.
         </Card>
 
         <Card

--- a/src/oss/python/build-overview.mdx
+++ b/src/oss/python/build-overview.mdx
@@ -24,7 +24,7 @@ icon: "hammer"
           href="/oss/deepagents/overview"
           icon="/images/brand/deep-agents-icon.png"
         >
-        Build agents for complex, long-running tasks, with planning, subagents, a virtual filesystem, and long-term memory built in. The fastest way to start.
+        Build agents for complex, long-running tasks. A complete agent harness with planning, subagents, a virtual filesystem, and long-term memory built in. The fastest way to start.
         </Card>
 
         <Card


### PR DESCRIPTION
## Why

The Deep Agents card on the build landing page lists the capabilities Deep Agents ships with but does not name what it is: a complete agent harness. This makes that explicit so users scanning the "Choose your starting point" cards understand Deep Agents provides the full harness out of the box.

## Changes

Updated the Deep Agents card description on both build overview pages (`src/oss/python/build-overview.mdx` and `src/oss/javascript/build-overview.mdx`):

> Build agents for complex, long-running tasks. A complete agent harness with planning, subagents, a virtual filesystem, and long-term memory built in. The fastest way to start.

`make lint_prose` passes on both files.

This PR was prepared with the assistance of an AI agent (Claude Code).