### PR TITLE
dcode: enable auto-update by default and document opt-out controls

### DIFF
--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -719,27 +719,47 @@ Press `T` in the `/theme` picker to save the highlighted theme for the current t
 
 ## Auto-update
 
-Deep Agents Code can automatically check for and install updates.
+Deep Agents Code automatically checks for and installs updates by default.
+
+To opt out of automatic updates:
 
 <Tabs>
     <Tab title="Config file">
         ```toml
         [update]
-        auto_update = true
+        auto_update = false
         ```
     </Tab>
     <Tab title="Environment variable">
         ```bash
-        export DEEPAGENTS_CODE_AUTO_UPDATE=1
+        export DEEPAGENTS_CODE_AUTO_UPDATE=0
         ```
     </Tab>
 </Tabs>
 
 The environment variable takes precedence over the config file.
 
-When enabled, Deep Agents Code checks PyPI for a newer version at session start and automatically upgrades using the detected install method (uv, Homebrew, or pip). When disabled (default), Deep Agents Code shows an update hint with the appropriate install command instead.
+When enabled (default), Deep Agents Code checks PyPI for a newer version at session start and automatically upgrades. When disabled, Deep Agents Code shows an update hint with the appropriate install command instead.
 
-You can also check for and install updates manually at any time with the `/update` slash command, which bypasses the cache and reports success or failure inline.
+To suppress automatic update checks entirely:
+
+<Tabs>
+    <Tab title="Config file">
+        ```toml
+        [update]
+        check = false
+        ```
+    </Tab>
+    <Tab title="Environment variable">
+        ```bash
+        export DEEPAGENTS_CODE_NO_UPDATE_CHECK=1
+        ```
+    </Tab>
+</Tabs>
+
+Disabling update checks also prevents automatic update installs at startup.
+
+You can still check for and install updates manually at any time with the `/update` slash command, which runs an on-demand check and reports success or failure inline.
 
 After an upgrade, Deep Agents Code shows a "what's new" banner on the next launch with a link to the changelog.
 
@@ -811,7 +831,7 @@ curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_VERSION="0.1.16" bash
     Path to the uv binary. Auto-detected if unset.
 </ResponseField>
 
-To pre-configure auto-update for managed installs, set `DEEPAGENTS_CODE_AUTO_UPDATE=1` in the user's shell profile or deploy a `config.toml` with `[update] auto_update = true` to `~/.deepagents/config.toml`. To suppress automatic updates and update checks entirely, set `DEEPAGENTS_CODE_NO_UPDATE_CHECK=1`.
+Auto-update is enabled by default for managed installs. To opt out, set `DEEPAGENTS_CODE_AUTO_UPDATE=0` in the user's shell profile or deploy a `config.toml` with `[update] auto_update = false` to `~/.deepagents/config.toml`. To suppress automatic updates and update checks entirely, set `DEEPAGENTS_CODE_NO_UPDATE_CHECK=1` or deploy `[update] check = false`.
 
 To route every user's model traffic through a managed gateway (provisioning a gateway key and base URL fleet-wide), see [Managed gateways](#managed-gateways).
 
@@ -822,7 +842,7 @@ To route every user's model traffic through a managed gateway (provisioning a ga
 All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` prefix. See [`DEEPAGENTS_CODE_` prefix](#deepagents_code_-prefix) for how the prefix also works as an override for third-party credentials.
 
 <ResponseField name="DEEPAGENTS_CODE_AUTO_UPDATE" type="string" post={["optional"]}>
-    Enable automatic Deep Agents Code updates (`1`, `true`, or `yes`).
+    Toggle automatic Deep Agents Code updates. Enabled by default; set to `0`, `false`, `no`, or `off` to opt out.
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_DEBUG" type="string" post={["optional"]}>
@@ -842,7 +862,7 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_NO_UPDATE_CHECK" type="string" post={["optional"]}>
-    Disable automatic update checking when set.
+    Disable automatic update checking when set. This also prevents automatic update installs at startup.
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_SHELL_ALLOW_LIST" type="string" post={["optional"]}>


### PR DESCRIPTION
Updates the Deep Agents Code configuration docs to reflect that automatic updates are now enabled by default, and documents how users and managed-install administrators can opt out. The `Auto-update` section and environment variable reference in `configuration.mdx` now describe the new `check` option and explicitly differentiate between disabling auto-installs and suppressing update checks entirely.