### PR TITLE
dcode: document `DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS`

### DIFF
--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -862,7 +862,7 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS" type="string" post={["optional"]}>
-    Comma-separated LangSmith project names to *also* write agent traces to. When set and tracing is active, each agent run is dual-written to the primary project (from `DEEPAGENTS_CODE_LANGSMITH_PROJECT`, or `deepagents-code` by default) and every listed project. Off by default. See [Dual-write traces to additional projects](/oss/deepagents/code/overview#trace-with-langsmith).
+    A second LangSmith project to *also* write agent traces to. When set and tracing is active, each agent run is dual-written to the primary project (from `DEEPAGENTS_CODE_LANGSMITH_PROJECT`, or `deepagents-code` by default) and this project. Off by default. See [Dual-write traces to a second project](/oss/deepagents/code/overview#trace-with-langsmith).
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_NO_UPDATE_CHECK" type="string" post={["optional"]}>

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -861,6 +861,10 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
     Override the LangSmith project name for Deep Agents Code's own agent traces. Shell commands still run with the user's original `LANGSMITH_PROJECT`, so app, test, or script traces can appear in a separate project. See [Trace with LangSmith](/oss/deepagents/code/overview#trace-with-langsmith).
 </ResponseField>
 
+<ResponseField name="DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS" type="string" post={["optional"]}>
+    Comma-separated LangSmith project names to *also* write agent traces to. When set and tracing is active, each agent run is dual-written to the primary project (from `DEEPAGENTS_CODE_LANGSMITH_PROJECT`, or `deepagents-code` by default) and every listed project. Off by default. See [Dual-write traces to additional projects](/oss/deepagents/code/overview#trace-with-langsmith).
+</ResponseField>
+
 <ResponseField name="DEEPAGENTS_CODE_NO_UPDATE_CHECK" type="string" post={["optional"]}>
     Disable automatic update checking when set. This also prevents automatic update installs at startup.
 </ResponseField>

--- a/src/oss/deepagents/code/overview.mdx
+++ b/src/oss/deepagents/code/overview.mdx
@@ -458,14 +458,14 @@ export LANGSMITH_TRACING=false
     You can also scope LangSmith credentials to Deep Agents Code using the [`DEEPAGENTS_CODE_` prefix](/oss/deepagents/code/configuration#deepagents_code_-prefix) (e.g., `DEEPAGENTS_CODE_LANGSMITH_API_KEY`).
 </Accordion>
 
-<Accordion title="Dual-write traces to additional projects">
-    To mirror agent traces to more than one LangSmith project, set `DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS` to a comma-separated list of project names. This is useful for sending the same traces to both a personal project and a shared team project.
+<Accordion title="Dual-write traces to a second project">
+    To mirror agent traces to a second LangSmith project, set `DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS`. This is useful for sending the same traces to both a personal project and a shared team project.
 
     ```bash title="~/.deepagents/.env"
-    DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS=team-shared,audit-log
+    DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS=team-shared
     ```
 
-    When set and tracing is active, each agent run is written to the primary project (`DEEPAGENTS_CODE_LANGSMITH_PROJECT`, or `deepagents-code` by default) *and* every listed project. Names are de-duplicated, so listing the primary project again has no effect. Leave the variable unset to write to a single project as usual.
+    When set and tracing is active, each agent run is written to both the primary project (`DEEPAGENTS_CODE_LANGSMITH_PROJECT`, or `deepagents-code` by default) and the project you name here. Leave the variable unset to write to a single project as usual.
 </Accordion>
 
 When configured, Deep Agents Code displays a status line with a link to the LangSmith project. In supported terminals, click the link to open it directly. You can also use `/trace` to print the URL and open it in your browser.

--- a/src/oss/deepagents/code/overview.mdx
+++ b/src/oss/deepagents/code/overview.mdx
@@ -458,6 +458,16 @@ export LANGSMITH_TRACING=false
     You can also scope LangSmith credentials to Deep Agents Code using the [`DEEPAGENTS_CODE_` prefix](/oss/deepagents/code/configuration#deepagents_code_-prefix) (e.g., `DEEPAGENTS_CODE_LANGSMITH_API_KEY`).
 </Accordion>
 
+<Accordion title="Dual-write traces to additional projects">
+    To mirror agent traces to more than one LangSmith project, set `DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS` to a comma-separated list of project names. This is useful for sending the same traces to both a personal project and a shared team project.
+
+    ```bash title="~/.deepagents/.env"
+    DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS=team-shared,audit-log
+    ```
+
+    When set and tracing is active, each agent run is written to the primary project (`DEEPAGENTS_CODE_LANGSMITH_PROJECT`, or `deepagents-code` by default) *and* every listed project. Names are de-duplicated, so listing the primary project again has no effect. Leave the variable unset to write to a single project as usual.
+</Accordion>
+
 When configured, Deep Agents Code displays a status line with a link to the LangSmith project. In supported terminals, click the link to open it directly. You can also use `/trace` to print the URL and open it in your browser.
 
 ```sh


### PR DESCRIPTION
Depends on langchain-ai/deepagents#3998

Documents the new `DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS` env var, which dual-writes dcode agent traces to additional LangSmith projects. Adds an entry to the environment variable reference in the Configuration page and a "Dual-write traces to additional projects" accordion in the overview's Trace with LangSmith section.


Made by [Open SWE](https://openswe.vercel.app)