### PR TITLE
docs(langchain): clarify JSON Schema title requirement

### DIFF
--- a/src/oss/langchain/structured-output.mdx
+++ b/src/oss/langchain/structured-output.mdx
@@ -127,7 +127,7 @@ class ProviderStrategy(Generic[SchemaT]):
     - **Pydantic models**: `BaseModel` subclasses with field validation. Returns validated Pydantic instance.
     - **Dataclasses**: Python dataclasses with type annotations. Returns dict.
     - **TypedDict**: Typed dictionary classes. Returns dict.
-    - **JSON Schema**: Dictionary with JSON schema specification. Returns dict.
+    - **JSON Schema**: Dictionary with JSON schema specification. Must include top-level `title` and `description` keys. Returns dict.
 </ParamField>
 
 <ParamField path="strict">
@@ -217,6 +217,7 @@ LangChain automatically uses `ProviderStrategy` when you pass a schema type dire
 
 
     contact_info_schema = {
+        "title": "ContactInfo",
         "type": "object",
         "description": "Contact information for a person.",
         "properties": {
@@ -382,7 +383,7 @@ class ToolStrategy(Generic[SchemaT]):
     - **Pydantic models**: `BaseModel` subclasses with field validation. Returns validated Pydantic instance.
     - **Dataclasses**: Python dataclasses with type annotations. Returns dict.
     - **TypedDict**: Typed dictionary classes. Returns dict.
-    - **JSON Schema**: Dictionary with JSON schema specification. Returns dict.
+    - **JSON Schema**: Dictionary with JSON schema specification. Must include top-level `title` and `description` keys. Returns dict.
     - **Union types**: Multiple schema options. The model will choose the most appropriate schema based on the context.
 </ParamField>
 
@@ -488,6 +489,7 @@ class ToolStrategy(Generic[SchemaT]):
 
 
     product_review_schema = {
+        "title": "ProductReview",
         "type": "object",
         "description": "Analysis of a product review.",
         "properties": {


### PR DESCRIPTION
Closes langchain-ai/langchain#34662

---

Raw JSON Schema examples on the structured output page did not show the top-level `title` key that LangChain expects when converting schemas for structured output. This can lead users to copy an example that later fails with an error saying `title` and `description` are required.

This updates the Python `ProviderStrategy` and `ToolStrategy` schema descriptions to call out the `title` and `description` requirement, and adds `title` to the JSON Schema examples.

Validated with `git diff --check` and a local content check confirming both examples include `title`. I could not run `make lint_prose FILES="src/oss/langchain/structured-output.mdx"` locally because this Windows environment does not have `make`, `uv`, or `vale` available on PATH.

AI-agent involvement: I used OpenAI Codex to inspect the issue, make this documentation-only change, and run the local checks above.
