### PR TITLE
docs(otel): document orphan-parent span drop behavior

### DIFF
--- a/src/langsmith/trace-with-opentelemetry.mdx
+++ b/src/langsmith/trace-with-opentelemetry.mdx
@@ -691,7 +691,7 @@ In distributed systems, context propagation passes trace metadata between servic
 <Warning>
 **A span whose parent is never sent to LangSmith is dropped.**
 
-The OTel endpoint is asynchronous: it accepts a batch, returns `200`, and materializes runs in the background. When a span's `parentSpanId` references a parent that LangSmith hasn't received yet, the child is buffered and linked once the parent arrives. This works regardless of order — a child can arrive before its parent, in a separate request, and still link correctly.
+The OTel endpoint is asynchronous: it accepts a batch, returns `200`, and materializes runs in the background. When a span's `parentSpanId` references a parent that LangSmith hasn't received yet, the child is buffered and linked once the parent arrives. This works regardless of order; a child can arrive before its parent, in a separate request, and still link correctly.
 
 However, if the parent span is **never** exported to LangSmith, the buffered child expires and never appears as a run — and no error is returned, since the `200` was sent before processing. This commonly happens when only part of a distributed trace reaches LangSmith: the parent is emitted by a service that exports to a different backend, or it's removed by a sampling decision.
 

--- a/src/langsmith/trace-with-opentelemetry.mdx
+++ b/src/langsmith/trace-with-opentelemetry.mdx
@@ -684,6 +684,16 @@ In distributed systems, context propagation passes trace metadata between servic
 * **Span ID**: A unique identifier for the current span
 * **Sampling Decision**: Indicates whether this trace should be sampled
 
+<Warning>
+**A span whose parent is never sent to LangSmith is dropped.**
+
+The OTel endpoint is asynchronous: it accepts a batch, returns `200`, and materializes runs in the background. When a span's `parentSpanId` references a parent that LangSmith hasn't received yet, the child is buffered and linked once the parent arrives. This works regardless of order — a child can arrive before its parent, in a separate request, and still link correctly.
+
+However, if the parent span is **never** exported to LangSmith, the buffered child expires and never appears as a run — and no error is returned, since the `200` was sent before processing. This commonly happens when only part of a distributed trace reaches LangSmith: the parent is emitted by a service that exports to a different backend, or it's removed by a sampling decision.
+
+To avoid silent loss, make sure every span you want in LangSmith has its ancestors exported to LangSmith as well, within the buffering window. On self-hosted deployments, this window is controlled by `REDIS_RUNS_EXPIRY_SECONDS` (default 12 hours).
+</Warning>
+
 #### Set up distributed tracing with LangChain
 
 To enable distributed tracing across multiple services:
@@ -757,13 +767,3 @@ def service_b_endpoint():
 if __name__ == "__main__":
     app.run(port=5000)
 ```
-
-<Warning>
-**Spans whose parent is never sent to LangSmith are dropped.**
-
-The OTel endpoint is asynchronous: it accepts a batch, returns `200`, and materializes runs in the background. When a span's `parentSpanId` references a parent that LangSmith hasn't received yet, the child is buffered and linked once the parent arrives. This works regardless of order — a child can arrive before its parent, in a separate request, and still link correctly.
-
-However, if the parent span is **never** exported to LangSmith, the buffered child expires and never appears as a run — no error is returned, since the `200` was sent before processing. This can happen when only part of a distributed trace is exported to LangSmith (for example, the parent is emitted by a service that exports to a different backend, or is removed by sampling).
-
-To avoid silent loss, ensure that every span you want in LangSmith has its ancestors exported to LangSmith as well, within the buffering window. On self-hosted deployments, this window is controlled by `REDIS_RUNS_EXPIRY_SECONDS` (default 12 hours).
-</Warning>

--- a/src/langsmith/trace-with-opentelemetry.mdx
+++ b/src/langsmith/trace-with-opentelemetry.mdx
@@ -693,9 +693,9 @@ In distributed systems, context propagation passes trace metadata between servic
 
 The OTel endpoint is asynchronous: it accepts a batch, returns `200`, and materializes runs in the background. When a span's `parentSpanId` references a parent that LangSmith hasn't received yet, the child is buffered and linked once the parent arrives. This works regardless of order; a child can arrive before its parent, in a separate request, and still link correctly.
 
-However, if the parent span is **never** exported to LangSmith, the buffered child expires and never appears as a run — and no error is returned, since the `200` was sent before processing. This commonly happens when only part of a distributed trace reaches LangSmith: the parent is emitted by a service that exports to a different backend, or it's removed by a sampling decision.
+However, if the parent span is **never** exported to LangSmith, the buffered child expires and never appears as a run. LangSmith will not return an error, because the `200` was sent before processing. This commonly happens when only part of a distributed trace reaches LangSmith: the parent is emitted by a service that exports to a different backend, or it's removed by a sampling decision.
 
-To avoid silent loss, make sure every span you want in LangSmith has its ancestors exported to LangSmith as well, within the buffering window. On self-hosted deployments, this window is controlled by `REDIS_RUNS_EXPIRY_SECONDS` (default 12 hours).
+To avoid silent loss, make sure every span you want in LangSmith also has its ancestors exported to LangSmith within the buffering window. On self-hosted deployments, this window is controlled by `REDIS_RUNS_EXPIRY_SECONDS` (default 12 hours).
 </Warning>
 
 #### Set up distributed tracing with LangChain

--- a/src/langsmith/trace-with-opentelemetry.mdx
+++ b/src/langsmith/trace-with-opentelemetry.mdx
@@ -178,6 +178,10 @@ For non-LangChain applications or custom instrumentation, you can trace your app
 
 4. View the trace in your LangSmith dashboard ([example](https://smith.langchain.com/public/4f2890b1-f105-44aa-a6cf-c777dcc27a37/r)).
 
+<Note>
+If your spans reference a parent from another service or process, see [Context propagation in distributed tracing](#context-propagation-in-distributed-tracing) for how parent–child linking works and when a span can be dropped.
+</Note>
+
 ## Send traces to an alternate provider
 
 While LangSmith is the default destination for OpenTelemetry traces, you can also configure OpenTelemetry to send traces to other observability platforms.

--- a/src/langsmith/trace-with-opentelemetry.mdx
+++ b/src/langsmith/trace-with-opentelemetry.mdx
@@ -757,3 +757,13 @@ def service_b_endpoint():
 if __name__ == "__main__":
     app.run(port=5000)
 ```
+
+<Warning>
+**Spans whose parent is never sent to LangSmith are dropped.**
+
+The OTel endpoint is asynchronous: it accepts a batch, returns `200`, and materializes runs in the background. When a span's `parentSpanId` references a parent that LangSmith hasn't received yet, the child is buffered and linked once the parent arrives. This works regardless of order — a child can arrive before its parent, in a separate request, and still link correctly.
+
+However, if the parent span is **never** exported to LangSmith, the buffered child expires and never appears as a run — no error is returned, since the `200` was sent before processing. This can happen when only part of a distributed trace is exported to LangSmith (for example, the parent is emitted by a service that exports to a different backend, or is removed by sampling).
+
+To avoid silent loss, ensure that every span you want in LangSmith has its ancestors exported to LangSmith as well, within the buffering window. On self-hosted deployments, this window is controlled by `REDIS_RUNS_EXPIRY_SECONDS` (default 12 hours).
+</Warning>


### PR DESCRIPTION
## What

Documents the OTel ingest behavior where a span whose `parentSpanId` references a parent that is **never exported to LangSmith** is silently dropped after the ingestion buffer TTL.

Adds a `<Warning>` to the *Distributed tracing with LangChain and OpenTelemetry* section of `trace-with-opentelemetry.mdx`, covering:

- The endpoint is async (returns `200`, materializes runs in the background).
- A child whose parent hasn't arrived yet is **buffered and linked once the parent arrives** — order-independent, works across separate requests.
- If the parent is **never** sent to LangSmith, the buffered child expires and never appears — no error, since the `200` was already returned.
- Common causes (partial/mixed-backend instrumentation, sampling) and how to avoid it (export ancestors too; self-hosted window via `REDIS_RUNS_EXPIRY_SECONDS`, default 12h).

## Why

Customers hitting this (e.g. cross-process OTel tracing) currently have no way to self-diagnose — the request returns `200` and the span just doesn't show up. This documents the current behavior until the proper fix lands.

## Related

- Bug: LIN-240 (OTLP spans with orphan parentSpanId silently dropped)
- Feature follow-up: LIN-385 (materialize orphan-parent spans as standalone runs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)