### PR TITLE
docs(otel): document linking OTel spans to a LangSmith SDK trace

### DIFF
--- a/src/langsmith/trace-with-opentelemetry.mdx
+++ b/src/langsmith/trace-with-opentelemetry.mdx
@@ -465,7 +465,7 @@ Here is an [example](https://smith.langchain.com/public/d6d47eeb-511e-4fda-ad17-
 
 ### Link OpenTelemetry spans to a LangSmith SDK trace
 
-Native OTLP `parentSpanId` can't reference an existing LangSmith run: an OTLP span ID is 8 bytes, while LangSmith run IDs are full UUIDs. To attach an OpenTelemetry span to a run created elsewhere (for example, a LangChain-SDK run), set the `langsmith.*` attributes with the parent's full UUIDs — they override the IDs derived from the native OTLP span, so the span nests under the existing run in the same trace.
+Native OTLP `parentSpanId` can't reference an existing LangSmith run: an OTLP span ID is 8 bytes, while LangSmith run IDs are full UUIDs. To attach an OpenTelemetry span to a run created elsewhere (for example, a LangChain-SDK run), set the `langsmith.*` attributes with the parent's full UUIDs. They override the IDs derived from the native OTLP span, so the span nests under the existing run in the same trace.
 
 ```python
 import uuid

--- a/src/langsmith/trace-with-opentelemetry.mdx
+++ b/src/langsmith/trace-with-opentelemetry.mdx
@@ -463,7 +463,7 @@ You do not need to set OTEL environment variables or exporters. `configure()` wi
 
 Here is an [example](https://smith.langchain.com/public/d6d47eeb-511e-4fda-ad17-2caa7bd7150b/r) of what the resulting trace looks like in LangSmith.
 
-### Nest an OpenTelemetry span under an existing LangSmith run
+### Link OpenTelemetry spans to a LangSmith SDK trace
 
 Native OTLP `parentSpanId` can't reference an existing LangSmith run: an OTLP span ID is 8 bytes, while LangSmith run IDs are full UUIDs. To attach an OpenTelemetry span to a run created elsewhere (for example, a LangChain-SDK run), set the `langsmith.*` attributes with the parent's full UUIDs — they override the IDs derived from the native OTLP span, so the span nests under the existing run in the same trace.
 

--- a/src/langsmith/trace-with-opentelemetry.mdx
+++ b/src/langsmith/trace-with-opentelemetry.mdx
@@ -256,6 +256,10 @@ When sending traces to LangSmith via OpenTelemetry, the following attributes are
 | ------------------------------ | ---------------- | ---------------------------------------------------------------------------- |
 | `langsmith.trace.name`         | Run name         | Overrides the span name for the run                                          |
 | `langsmith.span.kind`          | [Run type](/langsmith/run-data-format#run-types) | Values: `llm`, `chain`, `tool`, `retriever`, `embedding`, `prompt`, `parser` |
+| `langsmith.trace.id`           | Trace ID         | The trace (root run) the span belongs to; set to attach to an existing trace |
+| `langsmith.span.id`            | Run ID           | This span's run ID (a UUID); overrides the ID derived from the OTLP span ID   |
+| `langsmith.span.parent_id`     | Parent run ID    | Nests the span under an existing run by its run ID                            |
+| `langsmith.span.dotted_order`  | Dotted order     | Position in the trace tree: `<parent.dotted_order>.<timestamp><span.id>`. See [`dotted_order`](https://docs.langchain.com/langsmith/run-data-format#what-is-dotted_order). |
 | `langsmith.trace.session_id`   | Session ID       | Session identifier for related traces                                        |
 | `langsmith.trace.session_name` | Session name     | Name of the session                                                          |
 | `langsmith.span.tags`          | Tags             | Custom tags attached to the span (comma-separated)                           |
@@ -458,6 +462,46 @@ You do not need to set OTEL environment variables or exporters. `configure()` wi
 </Note>
 
 Here is an [example](https://smith.langchain.com/public/d6d47eeb-511e-4fda-ad17-2caa7bd7150b/r) of what the resulting trace looks like in LangSmith.
+
+### Nest an OpenTelemetry span under an existing LangSmith run
+
+Native OTLP `parentSpanId` can't reference an existing LangSmith run: an OTLP span ID is 8 bytes, while LangSmith run IDs are full UUIDs. To attach an OpenTelemetry span to a run created elsewhere (for example, a LangChain-SDK run), set the `langsmith.*` attributes with the parent's full UUIDs — they override the IDs derived from the native OTLP span, so the span nests under the existing run in the same trace.
+
+```python
+import uuid
+from datetime import datetime, timezone
+
+from langsmith import get_current_run_tree, traceable
+from opentelemetry import trace
+
+tracer = trace.get_tracer("my-harness")
+
+
+def emit_otel_child(parent):
+    """Emit an OTel span that nests under an existing LangSmith run."""
+    child_id = uuid.uuid4()
+    start = datetime.now(timezone.utc)
+    # dotted_order = parent's dotted_order, a dot, then this span's timestamp + id
+    dotted = f"{parent.dotted_order}.{start.strftime('%Y%m%dT%H%M%S%fZ')}{child_id}"
+
+    with tracer.start_as_current_span("otel-child") as span:
+        span.set_attribute("langsmith.trace.id", str(parent.trace_id))           # same trace
+        span.set_attribute("langsmith.span.parent_id", str(parent.id))           # nest under parent
+        span.set_attribute("langsmith.span.id", str(child_id))                   # this span's run id
+        span.set_attribute("langsmith.span.dotted_order", dotted)                # position in the tree
+        span.set_attribute("langsmith.trace.session_name", parent.session_name)  # same project
+        # ... your instrumented work here ...
+
+
+@traceable
+def my_agent():
+    parent = get_current_run_tree()  # the LangSmith run to nest under
+    emit_otel_child(parent)
+```
+
+<Note>
+`langsmith.span.dotted_order` encodes the span's position in the trace tree. Build it from the parent's [`dotted_order`](https://docs.langchain.com/langsmith/run-data-format#what-is-dotted_order), a dot, then this span's timestamp followed by its `langsmith.span.id`.
+</Note>
 
 ### Add an attachment to a trace
 


### PR DESCRIPTION
## What

Documents how to link an OpenTelemetry span to an **existing LangSmith SDK trace** (nesting it under a run created via the LangChain/LangSmith SDK) using the `langsmith.*` span attributes.

- Adds the identity/linking attributes to the **Core LangSmith attributes** table — they were previously undocumented: `langsmith.trace.id`, `langsmith.span.id`, `langsmith.span.parent_id`, `langsmith.span.dotted_order` (with a link to the `dotted_order` reference).
- Adds a worked example under **Implementation examples**: "Link OpenTelemetry spans to a LangSmith SDK trace."

## Why

Native OTLP `parentSpanId` can't reference an existing LangSmith run (an OTLP span ID is 8 bytes; run IDs are full UUIDs). The supported path is to set the `langsmith.*` attributes with the parent's full UUIDs, which override the IDs derived from the native OTLP span. This was only known via support hand-offs; this documents it.

## Validation

Verified against **prod** LangSmith: created a LangChain-SDK run, emitted an OTel span with these attributes pointing at it, and confirmed the span materialized and nested under the SDK run in the same trace (parent had a normal full UUID — the case native `parentSpanId` cannot address).

## Related

- LIN-240 (OTLP spans with orphan parentSpanId)
- Companion docs PR: #4485 (documents the orphan-parent drop behavior)
