### PR TITLE
docs: document API key auth for the LangSmith Remote MCP

### DIFF
--- a/src/langsmith/langsmith-remote-mcp.mdx
+++ b/src/langsmith/langsmith-remote-mcp.mdx
@@ -1,11 +1,11 @@
 ---
 title: LangSmith Remote MCP
-description: Connect MCP-compatible clients to LangSmith over OAuth, no API key or header configuration required.
+description: Connect MCP-compatible clients to LangSmith over OAuth, or authenticate programmatic clients with a LangSmith API key.
 ---
 
 import SaasRegionUrls from '/snippets/langsmith/saas-region-urls.mdx';
 
-The LangSmith Remote MCP is a [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) server hosted by LangSmith. It exposes the same tools as the [standalone LangSmith MCP Server](/langsmith/langsmith-mcp-server) (conversation history, prompts, runs and traces, datasets, experiments, billing) but with OAuth-based authentication, so MCP-compatible clients connect directly without an API key, a separate deployment, or any header configuration.
+The LangSmith Remote MCP is a [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP) server hosted by LangSmith. It exposes the same tools as the [standalone LangSmith MCP Server](/langsmith/langsmith-mcp-server) (conversation history, prompts, runs and traces, datasets, experiments, billing) without a separate deployment. Interactive MCP clients connect over OAuth with no API key or header configuration; programmatic clients can authenticate with a LangSmith API key via the `X-Api-Key` header.
 
 The Remote MCP is available on all LangSmith Cloud regions and on [self-hosted LangSmith](/langsmith/self-hosted) deployments running v0.15 or later. Self-hosted deployments on earlier versions should continue to use the [standalone LangSmith MCP Server](/langsmith/langsmith-mcp-server).
 
@@ -24,7 +24,11 @@ The server discovers the rest of its OAuth metadata via [RFC 8414](https://datat
 
 ## Authentication
 
-Authentication uses OAuth 2.1 with [Dynamic Client Registration (RFC 7591)](https://datatracker.ietf.org/doc/html/rfc7591). Compatible MCP clients register themselves automatically on first use—there is no client ID to provision and no API key to manage.
+The Remote MCP supports two authentication methods. Use **OAuth** for interactive MCP clients (Claude Code, Cursor, and similar), and an **API key** for programmatic or headless clients that can't complete a browser-based login.
+
+### OAuth
+
+OAuth 2.1 with [Dynamic Client Registration (RFC 7591)](https://datatracker.ietf.org/doc/html/rfc7591) is the default for interactive clients. Compatible MCP clients register themselves automatically on first use—there is no client ID to provision and no API key to manage.
 
 After registration:
 
@@ -34,6 +38,16 @@ After registration:
 4. The access token is automatically refreshed by the client when it expires.
 
 The session is scoped to your LangSmith user and workspace permissions—calls through the MCP server can only view what your account is permitted to view.
+
+### API key
+
+Send a [LangSmith API key](/langsmith/create-account-api-key) in the `X-Api-Key` header on every request. This suits backend services, scripts, and SDKs—for example, the [AI SDK](#ai-sdk)—where the interactive OAuth flow isn't practical.
+
+Requests are authorized as the user that owns the API key, scoped to that key's workspace and permissions—the same authorization the key has elsewhere in the LangSmith API. Tools that accept a `workspace_id` argument can target a specific workspace; otherwise the key's own workspace is used.
+
+<Note>
+The `X-Api-Key` header is specific to the Remote MCP. The [standalone LangSmith MCP Server](/langsmith/langsmith-mcp-server) uses a different header, `LANGSMITH-API-KEY`.
+</Note>
 
 ## Quickstart
 
@@ -97,9 +111,29 @@ Add to your Cursor `mcp.json`:
 
 Cursor will prompt you to complete the OAuth flow on first use.
 
+### AI SDK
+
+For programmatic use from the [AI SDK](https://ai-sdk.dev/), authenticate with an API key via the `X-Api-Key` header and the built-in `http` (Streamable HTTP) transport:
+
+```ts
+import { createMCPClient } from "@ai-sdk/mcp";
+
+const client = await createMCPClient({
+  transport: {
+    type: "http",
+    url: "https://api.smith.langchain.com/mcp",
+    headers: { "X-Api-Key": process.env.LANGSMITH_API_KEY! },
+  },
+});
+
+const tools = await client.tools();
+```
+
+Pass `tools` directly to `streamText` or `generateText`. The Remote MCP is stateless and responds with JSON over the standard Streamable HTTP transport, so the built-in transport works as-is—you don't need a custom transport.
+
 ### Other clients
 
-Any MCP client supporting the [Streamable HTTP transport](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/transports/#streamable-http) and OAuth 2.1 with dynamic client registration can connect with just the URL above.
+Any MCP client supporting the [Streamable HTTP transport](https://spec.modelcontextprotocol.io/specification/2025-03-26/basic/transports/#streamable-http) can connect with just the URL above—using OAuth 2.1 with dynamic client registration, or a LangSmith API key in the `X-Api-Key` header.
 
 ## Known client incompatibilities
 

--- a/src/langsmith/langsmith-remote-mcp.mdx
+++ b/src/langsmith/langsmith-remote-mcp.mdx
@@ -41,7 +41,7 @@ The session is scoped to your LangSmith user and workspace permissions—calls t
 
 ### API key
 
-Send a [LangSmith API key](/langsmith/create-account-api-key) in the `X-Api-Key` header on every request. This suits backend services, scripts, and SDKs—for example, the [AI SDK](#ai-sdk)—where the interactive OAuth flow isn't practical.
+Send a [LangSmith API key](/langsmith/create-account-api-key) in the `X-Api-Key` header on every request. This suits backend services, scripts, and SDKs, for example, the [AI SDK](#ai-sdk), where the interactive OAuth flow is not practical.
 
 Requests are authorized as the user that owns the API key, scoped to that key's workspace and permissions—the same authorization the key has elsewhere in the LangSmith API. Tools that accept a `workspace_id` argument can target a specific workspace; otherwise the key's own workspace is used.
 


### PR DESCRIPTION
The LangSmith Remote MCP now accepts a LangSmith API key via the `X-Api-Key` header, in addition to the existing OAuth path. The docs previously stated OAuth was the only option ("no API key required"), which is no longer accurate and was tripping up users connecting programmatic clients (e.g. the AI SDK).

Changes to `langsmith-remote-mcp.mdx`:
- Reframe the intro + page description: OAuth for interactive clients, API key for programmatic/headless clients.
- Split **Authentication** into **OAuth** and **API key** subsections. The API-key section documents the `X-Api-Key` header, the key's workspace/permission scoping, and a note that this differs from the standalone server's `LANGSMITH-API-KEY` header (a common point of confusion).
- Add an **AI SDK** quickstart with a verified `@ai-sdk/mcp` snippet using the built-in `http` transport.
- Note in **Other clients** that either OAuth or an API key works.

Verified the documented config end-to-end against prod: `POST /mcp` with `X-Api-Key` returns a valid `initialize`/`tools/list`, and `@ai-sdk/mcp`'s built-in `http` transport connects and lists all 20 tools.

## Test Plan
- [ ] Preview renders: Authentication shows OAuth + API key subsections, AI SDK code block, and the `#ai-sdk` anchor link resolves.