### PR TITLE
Move Manage evaluators page in left nav to Set up evaluations group

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -1225,6 +1225,7 @@
                       }
                     ]
                   },
+                  "langsmith/evaluators",
                   {
                     "group": "Frameworks & integrations",
                     "pages": [
@@ -1319,7 +1320,6 @@
               {
                 "group": "Feedback",
                 "pages": [
-                  "langsmith/evaluators",
                   "langsmith/attach-user-feedback",
                   "langsmith/presigned-feedback-tokens"
                 ]


### PR DESCRIPTION
Modified docs.json, moved Managed evaluators to Set up evaluations group.

Fixes DOC-1268