### PR TITLE
docs: document E2B `dcode` sandbox provider

### DIFF
--- a/src/oss/deepagents/code/remote-sandboxes.mdx
+++ b/src/oss/deepagents/code/remote-sandboxes.mdx
@@ -215,6 +215,14 @@ A package can publish a sandbox provider under the `deepagents_code.sandbox_prov
 dcode --sandbox acme
 ```
 
+For example, [`langchain-e2b`](/oss/integrations/sandboxes/e2b) publishes an `e2b` provider. Install it as a package, set your credentials, then select it:
+
+```bash
+dcode --install langchain-e2b --package
+export E2B_API_KEY="..."
+dcode --sandbox e2b
+```
+
 If you pass a `--sandbox` name that isn't installed or declared, Deep Agents Code lists the available providers and explains how to install or configure the missing one.
 
 <Accordion title="Publishing a sandbox provider" icon="package">

--- a/src/oss/deepagents/code/remote-sandboxes.mdx
+++ b/src/oss/deepagents/code/remote-sandboxes.mdx
@@ -215,7 +215,7 @@ A package can publish a sandbox provider under the `deepagents_code.sandbox_prov
 dcode --sandbox acme
 ```
 
-For example, [`langchain-e2b`](/oss/integrations/sandboxes/e2b) publishes an `e2b` provider. Install it as a package, set your credentials, then select it:
+For example, the `langchain-e2b` package publishes an `e2b` provider (see [sandbox integrations](/oss/integrations/sandboxes)). Install it as a package, set your credentials, then select it:
 
 ```bash
 dcode --install langchain-e2b --package

--- a/src/oss/python/integrations/sandboxes/e2b.mdx
+++ b/src/oss/python/integrations/sandboxes/e2b.mdx
@@ -76,6 +76,20 @@ finally:
     e2b_sandbox.kill()
 ```
 
+## Use with Deep Agents Code
+
+`langchain-e2b` also publishes an E2B sandbox provider for [Deep Agents Code](/oss/deepagents/code/remote-sandboxes), so `dcode` can run agent tool calls inside an E2B sandbox. Install the package into the `dcode` environment, set your API key, then select the provider:
+
+```bash
+dcode --install langchain-e2b --package
+export E2B_API_KEY="..."
+dcode --sandbox e2b
+```
+
+E2B sandboxes use `/home/user` as the default working directory. To create sandboxes from a specific [E2B template](https://e2b.dev/docs/sandbox-template), set `E2B_TEMPLATE`; to change the sandbox lifetime, set `E2B_SANDBOX_TIMEOUT` (in seconds). Each variable also accepts a `DEEPAGENTS_CODE_`-prefixed form (for example, `DEEPAGENTS_CODE_E2B_API_KEY`), which takes precedence.
+
+Deep Agents Code manages the sandbox lifecycle for you, creating a sandbox on start and deleting it on exit.
+
 ## Cleanup
 
 Always kill E2B sandboxes when you are done to avoid ongoing resource usage.


### PR DESCRIPTION
Following [e2b-dev/langchain-e2b#4](https://github.com/e2b-dev/langchain-e2b/pull/4), which adds a Deep Agents Code sandbox provider entry point, this documents `dcode --sandbox e2b`. The E2B integration page gains a "Use with Deep Agents Code" section (install, credentials, `E2B_TEMPLATE` / `E2B_SANDBOX_TIMEOUT` overrides), and the remote sandboxes guide now references E2B as a concrete third-party provider example.

Made by [Open SWE](https://openswe.vercel.app/agents/9fda946d-c2ab-def8-ac1a-e702d185b553)