### PR TITLE
docs: manage Tavily web-search key via `/auth` in Deep Agents Code

### DIFF
--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -54,7 +54,7 @@ Open the credential manager from any session:
 /auth
 ```
 
-The manager lists the LLM providers available in your installation, plus non-model services such as Tavily web search, and marks the ones that already have a key set. Select a provider or service to add or replace its key, or remove one you have already stored. Keys you save here persist across sessions.
+The manager lists the LLM providers available in your installation, plus non-model services such as Tavily web search, and marks the ones that already have a key set. Select a provider to add or replace its key, or remove one you have already stored. Keys you save here persist across sessions.
 
 <Accordion title="Provider row labels" icon="list-check">
     Each row shows the provider name followed by where its key comes from:

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -54,7 +54,7 @@ Open the credential manager from any session:
 /auth
 ```
 
-The manager lists the LLM providers available in your installation and marks the ones that already have a key set. Select a provider to add or replace its key, or remove one you have already stored. Keys you save here persist across sessions.
+The manager lists the LLM providers available in your installation, plus non-model services such as Tavily web search, and marks the ones that already have a key set. Select a provider or service to add or replace its key, or remove one you have already stored. Keys you save here persist across sessions.
 
 <Accordion title="Provider row labels" icon="list-check">
     Each row shows the provider name followed by where its key comes from:
@@ -80,7 +80,7 @@ The `/auth` prompt also has an optional **base URL** field. Leave it blank to us
 
 Selecting the `openai_codex` provider in `/auth` starts a browser sign-in instead of prompting for an API key, letting you use OpenAI models with a ChatGPT subscription. To re-authenticate or sign out, select `openai_codex` again. See [Sign in with ChatGPT (Codex models)](/oss/deepagents/code/providers) for the full flow.
 
-`/auth` only manages **LLM provider** credentials. Tool credentials such as `TAVILY_API_KEY` (web search) and `LANGSMITH_API_KEY` (tracing) are read from the environment instead — [set them in `~/.deepagents/.env` or your shell](#environment-variables).
+`/auth` manages **LLM provider** credentials and the **Tavily web-search key**, which is listed as a non-model service. A Tavily key entered here is stored alongside your provider keys and activates web search on the next launch — see [Enable web search with Tavily](#enable-web-search-with-tavily). Other tool credentials such as `LANGSMITH_API_KEY` (tracing) are read from the environment instead — [set them in `~/.deepagents/.env` or your shell](#environment-variables).
 
 ### Manage credentials from the shell (`dcode auth`)
 
@@ -159,27 +159,45 @@ Each provider's API key and its endpoint (`base_url`) resolve as a pair from the
 
 ### Enable web search with Tavily
 
-The built-in `web_search` tool uses [Tavily](https://tavily.com). Deep Agents Code shows a "Web search disabled — `TAVILY_API_KEY` is not set" notification on startup until you provide a key. Unlike model provider keys, Tavily is **not** managed by `/auth`; it is read directly from the environment.
+The built-in `web_search` tool uses [Tavily](https://tavily.com). Deep Agents Code shows a "Web search disabled" notification on startup until you provide a key. You can store the key in the [`/auth`](#use-%2Fauth-recommended) credential manager, where Tavily appears as a non-model service, or set the `TAVILY_API_KEY` environment variable.
 
-<Steps>
-    <Step title="Get a key">
-        Sign up at [tavily.com](https://tavily.com) and copy the key (it starts with `tvly-`). The free tier is sufficient for most Deep Agents Code usage.
-    </Step>
+<Note>
+    Web search is wired up when the agent server starts, so a newly added Tavily key activates `web_search` on the **next launch** rather than mid-session. The "Web search disabled" notification confirms this when you save a key from it.
+</Note>
 
-    <Step title="Add it to your environment">
-        Add the key to `~/.deepagents/.env` so every session picks it up:
+<Tabs>
+    <Tab title="Use /auth (recommended)">
+        Get a key from [tavily.com](https://tavily.com) (it starts with `tvly-`; the free tier is sufficient for most Deep Agents Code usage), then store it in the credential manager:
 
-        ```bash title="~/.deepagents/.env"
-        TAVILY_API_KEY=tvly-...
+        ```txt
+        /auth
         ```
 
-        Shell exports take precedence over `.env` values (see [Loading order and precedence](#loading-order-and-precedence)). To scope a key to Deep Agents Code only without affecting other tools that read `TAVILY_API_KEY`, use the [`DEEPAGENTS_CODE_` prefix](#deepagents_code_-prefix): `DEEPAGENTS_CODE_TAVILY_API_KEY=tvly-...`.
-    </Step>
+        Select **Tavily** from the list and paste the key. You can also reach this prompt directly from the "Web search disabled" notification by choosing **Enter API key**. The key is stored alongside your provider keys and bridged to `TAVILY_API_KEY` at startup, so it takes effect on the next launch without exporting anything.
+    </Tab>
 
-    <Step title="Reload or restart">
-        In an existing session, run `/reload` to re-read `.env` files. On the next launch, the "Web search disabled" notification goes away and the agent can call `web_search`.
-    </Step>
-</Steps>
+    <Tab title="Set an environment variable">
+        <Steps>
+            <Step title="Get a key">
+                Sign up at [tavily.com](https://tavily.com) and copy the key (it starts with `tvly-`). The free tier is sufficient for most Deep Agents Code usage.
+            </Step>
+
+            <Step title="Add it to your environment">
+                Add the key to `~/.deepagents/.env` so every session picks it up:
+
+                ```bash title="~/.deepagents/.env"
+                TAVILY_API_KEY=tvly-...
+                ```
+
+                Shell exports take precedence over `.env` values (see [Loading order and precedence](#loading-order-and-precedence)). To scope a key to Deep Agents Code only without affecting other tools that read `TAVILY_API_KEY`, use the [`DEEPAGENTS_CODE_` prefix](#deepagents_code_-prefix): `DEEPAGENTS_CODE_TAVILY_API_KEY=tvly-...`.
+            </Step>
+
+            <Step title="Reload or restart">
+                In an existing session, run `/reload` to re-read `.env` files. On the next launch, the "Web search disabled" notification goes away and the agent can call `web_search`.
+            </Step>
+        </Steps>
+    </Tab>
+</Tabs>
 
 ---
 

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -80,7 +80,7 @@ The `/auth` prompt also has an optional **base URL** field. Leave it blank to us
 
 Selecting the `openai_codex` provider in `/auth` starts a browser sign-in instead of prompting for an API key, letting you use OpenAI models with a ChatGPT subscription. To re-authenticate or sign out, select `openai_codex` again. See [Sign in with ChatGPT (Codex models)](/oss/deepagents/code/providers) for the full flow.
 
-`/auth` manages **LLM provider** credentials and the **Tavily web-search key**, which is listed as a non-model service. A Tavily key entered here is stored alongside your provider keys and activates web search on the next launch — see [Enable web search with Tavily](#enable-web-search-with-tavily). Other tool credentials such as `LANGSMITH_API_KEY` (tracing) are read from the environment instead — [set them in `~/.deepagents/.env` or your shell](#environment-variables).
+`/auth` manages **LLM provider** credentials and the **Tavily web-search key**. A Tavily key entered here is stored alongside your provider keys and activates web search on the next launch — see [Enable web search with Tavily](#enable-web-search-with-tavily). Other tool credentials such as `LANGSMITH_API_KEY` (tracing) are read from the environment instead — [set them in `~/.deepagents/.env` or your shell](#environment-variables).
 
 ### Manage credentials from the shell (`dcode auth`)
 

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -170,7 +170,7 @@ The built-in `web_search` tool uses [Tavily](https://tavily.com). Deep Agents Co
         /auth
         ```
 
-        Select **Tavily** from the list and paste the key. You can also reach this prompt directly from the "Web search disabled" notification by choosing **Enter API key**. The key is stored alongside your provider keys and bridged to `TAVILY_API_KEY` at startup, so it takes effect on the next launch without exporting anything.
+        Select **Tavily** from the list and paste the key. You can also reach this prompt directly from the "Web search disabled" notification by choosing **Enter API key**.
     </Tab>
 
     <Tab title="Set an environment variable">

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -161,9 +161,6 @@ Each provider's API key and its endpoint (`base_url`) resolve as a pair from the
 
 The built-in `web_search` tool uses [Tavily](https://tavily.com). Deep Agents Code shows a "Web search disabled" notification on startup until you provide a key. You can store the key in the [`/auth`](#use-%2Fauth-recommended) credential manager, where Tavily appears as a non-model service, or set the `TAVILY_API_KEY` environment variable.
 
-<Note>
-    Web search is wired up when the agent server starts, so a newly added Tavily key activates `web_search` on the **next launch** rather than mid-session. The "Web search disabled" notification confirms this when you save a key from it.
-</Note>
 
 <Tabs>
     <Tab title="Use /auth (recommended)">

--- a/src/oss/deepagents/code/overview.mdx
+++ b/src/oss/deepagents/code/overview.mdx
@@ -27,7 +27,7 @@ Persistent memory carries context across conversations, customizable skills shap
         Use the `/auth` command to connect with a provider. See [Providers](/oss/deepagents/code/providers) for the full list and credential details.
 
         <Note>
-            Web search uses [Tavily](https://tavily.com) and requires `TAVILY_API_KEY`. See [Enable web search](/oss/deepagents/code/configuration#enable-web-search-with-tavily).
+            Web search uses [Tavily](https://tavily.com). Add a key from `/auth` or set `TAVILY_API_KEY`. See [Enable web search](/oss/deepagents/code/configuration#enable-web-search-with-tavily).
         </Note>
     </Step>
 
@@ -240,7 +240,7 @@ The agent uses its built-in tools, skills, and memory to help you with tasks.
 
         - `/model` - Switch models or open the interactive model selector.
         - `/agents` - Hot-swap between pre-configured agents without relaunching. See [Command reference](/oss/deepagents/code/overview#command-reference) for details
-        - `/auth` - Manage stored API keys for model providers. See [Provider credentials](/oss/deepagents/code/configuration#provider-credentials) for details
+        - `/auth` - Manage stored API keys for model providers and services (such as Tavily web search). See [Provider credentials](/oss/deepagents/code/configuration#provider-credentials) for details
         - `/remember [context]` - Review conversation and update memory and skills. Optionally pass additional context
         - `/skill:<name> [args]` - Directly invoke a skill by name. The skill's `SKILL.md` instructions are injected into the prompt along with any arguments you provide
         - `/skill-creator [task]` - Guide for creating effective agent skills


### PR DESCRIPTION
[deepagents#4062](https://github.com/langchain-ai/deepagents/pull/4062) surfaced Tavily in the Deep Agents Code `/auth` credential manager as a non-model service. The docs still said Tavily was env-var only and not managed by `/auth`. This updates the configuration and overview pages to document the `/auth` path alongside `TAVILY_API_KEY`, and notes that a newly added key activates web search on the next launch.

Made by [Open SWE](https://openswe.vercel.app/agents/e7cba2e6-9cc6-1ffd-ebf0-b9bfa4292406)