### PR TITLE
docs: add GCP sandbox auth proxy docs

### DIFF
--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -249,10 +249,10 @@ GCP auth rules are different from header injection rules:
 - Set `type` to `gcp`.
 - Put credentials under `gcp.service_account_json`.
 - Set `gcp.scopes` to a non-empty list of OAuth scopes.
-- Do not set `match_hosts`, `match_paths`, or `headers`; GCP host matching is built into the proxy.
+- The proxy matches Google API hosts automatically and authenticates those requests with the configured service account.
 - Configure at most one enabled GCP auth rule per sandbox.
 
-The SDK `gcp_auth` and `gcpAuth` helpers also omit host matching because the API and proxy handle it automatically.
+The SDK `gcp_auth` and `gcpAuth` helpers build this same rule shape.
 
 ```bash
 curl -X POST "$LANGSMITH_ENDPOINT/v2/sandboxes/boxes" \
@@ -338,7 +338,7 @@ After the sandbox is ready, use Google SDKs or CLIs normally inside the sandbox 
 
 ### Use GCS mounts
 
-For GCS mounts, enable a GCP auth rule with a compatible storage OAuth scope. You do not need to list `storage.googleapis.com` or `www.googleapis.com`; the proxy matches Google API hosts automatically.
+For GCS mounts, enable a GCP auth rule with a compatible storage OAuth scope. The proxy matches the required Google API hosts automatically.
 
 Use one of these scopes for read-only mounts:
 

--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -183,7 +183,8 @@ curl -X POST "$LANGSMITH_ENDPOINT/v2/sandboxes/boxes" \
 ```python Python
 from langsmith.sandbox import (
     SandboxClient,
-    aws_auth_proxy_config,
+    aws_auth,
+    proxy_config,
     workspace_secret,
 )
 
@@ -191,9 +192,13 @@ client = SandboxClient()
 
 client.create_sandbox(
     name="aws-sandbox",
-    proxy_config=aws_auth_proxy_config(
-        access_key_id=workspace_secret("AWS_ACCESS_KEY_ID"),
-        secret_access_key=workspace_secret("AWS_SECRET_ACCESS_KEY"),
+    proxy_config=proxy_config(
+        rules=[
+            aws_auth(
+                access_key_id=workspace_secret("AWS_ACCESS_KEY_ID"),
+                secret_access_key=workspace_secret("AWS_SECRET_ACCESS_KEY"),
+            )
+        ]
     ),
 )
 ```
@@ -201,7 +206,8 @@ client.create_sandbox(
 ```ts TypeScript
 import {
   SandboxClient,
-  awsAuthProxyConfig,
+  awsAuth,
+  proxyConfig,
   workspaceSecret,
 } from "langsmith/sandbox";
 
@@ -209,9 +215,13 @@ const client = new SandboxClient();
 
 await client.createSandbox({
   name: "aws-sandbox",
-  proxyConfig: awsAuthProxyConfig({
-    accessKeyId: workspaceSecret("AWS_ACCESS_KEY_ID"),
-    secretAccessKey: workspaceSecret("AWS_SECRET_ACCESS_KEY"),
+  proxyConfig: proxyConfig({
+    rules: [
+      awsAuth({
+        accessKeyId: workspaceSecret("AWS_ACCESS_KEY_ID"),
+        secretAccessKey: workspaceSecret("AWS_SECRET_ACCESS_KEY"),
+      }),
+    ],
   }),
 });
 ```
@@ -237,12 +247,14 @@ Do not set real service account JSON as a sandbox environment variable. Configur
 GCP auth rules are different from header injection rules:
 
 - Set `type` to `gcp`.
-- Set `match_hosts` to exact hosts or wildcard suffixes under `googleapis.com`, such as `storage.googleapis.com`, `www.googleapis.com`, or `*.googleapis.com`.
+- When sending raw `proxy_config`, set `match_hosts` to exact hosts or wildcard suffixes under `googleapis.com`, such as `storage.googleapis.com`, `www.googleapis.com`, or `*.googleapis.com`.
 - Do not set `match_paths`; GCP rules use host-only matching.
 - Do not set `headers`; GCP rules authenticate requests and cannot inject headers.
 - Put credentials under `gcp.service_account_json`.
 - Set `gcp.scopes` to a non-empty list of OAuth scopes.
 - Configure at most one enabled GCP auth rule per sandbox.
+
+The SDK `gcp_auth` and `gcpAuth` helpers set `match_hosts` for GCS by default. Pass `match_hosts` or `matchHosts` only when your sandbox needs to authenticate requests to other Google API hosts.
 
 ```bash
 curl -X POST "$LANGSMITH_ENDPOINT/v2/sandboxes/boxes" \
@@ -281,61 +293,48 @@ curl -X POST "$LANGSMITH_ENDPOINT/v2/sandboxes/boxes" \
 <CodeGroup>
 
 ```python Python
-from langsmith.sandbox import SandboxClient
+from langsmith.sandbox import (
+    SandboxClient,
+    gcp_auth,
+    proxy_config,
+    workspace_secret,
+)
 
 client = SandboxClient()
 
 client.create_sandbox(
     name="gcp-sandbox",
-    proxy_config={
-        "rules": [
-            {
-                "name": "gcp",
-                "type": "gcp",
-                "enabled": True,
-                "match_hosts": [
-                    "storage.googleapis.com",
-                    "www.googleapis.com",
-                ],
-                "gcp": {
-                    "service_account_json": {
-                        "type": "workspace_secret",
-                        "value": "{GCP_SERVICE_ACCOUNT_JSON}",
-                    },
-                    "scopes": [
-                        "https://www.googleapis.com/auth/devstorage.read_only"
-                    ],
-                },
-            }
+    proxy_config=proxy_config(
+        rules=[
+            gcp_auth(
+                service_account_json=workspace_secret("GCP_SERVICE_ACCOUNT_JSON"),
+                scopes=["https://www.googleapis.com/auth/devstorage.read_only"],
+            )
         ]
-    },
+    ),
 )
 ```
 
 ```ts TypeScript
-import { SandboxClient } from "langsmith/sandbox";
+import {
+  SandboxClient,
+  gcpAuth,
+  proxyConfig,
+  workspaceSecret,
+} from "langsmith/sandbox";
 
 const client = new SandboxClient();
 
 await client.createSandbox({
   name: "gcp-sandbox",
-  proxyConfig: {
+  proxyConfig: proxyConfig({
     rules: [
-      {
-        name: "gcp",
-        type: "gcp",
-        enabled: true,
-        match_hosts: ["storage.googleapis.com", "www.googleapis.com"],
-        gcp: {
-          service_account_json: {
-            type: "workspace_secret",
-            value: "{GCP_SERVICE_ACCOUNT_JSON}",
-          },
-          scopes: ["https://www.googleapis.com/auth/devstorage.read_only"],
-        },
-      },
+      gcpAuth({
+        serviceAccountJson: workspaceSecret("GCP_SERVICE_ACCOUNT_JSON"),
+        scopes: ["https://www.googleapis.com/auth/devstorage.read_only"],
+      }),
     ],
-  },
+  }),
 });
 ```
 
@@ -345,7 +344,7 @@ After the sandbox is ready, use Google SDKs or CLIs normally inside the sandbox 
 
 ### Use GCS mounts
 
-For GCS mounts, the GCP rule must cover both `storage.googleapis.com` and `www.googleapis.com`.
+For GCS mounts, the GCP rule must cover both `storage.googleapis.com` and `www.googleapis.com`. The SDK GCP auth helpers include these hosts by default.
 
 Use one of these scopes for read-only mounts:
 

--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -236,7 +236,7 @@ AWS auth proxy rules currently support access key ID and secret access key crede
 
 ## Authenticate GCP requests
 
-Use a GCP auth rule when sandbox code needs to call Google APIs with Google SDKs or CLIs. The proxy keeps the service account JSON outside the sandbox, then authenticates supported outbound HTTPS requests to matching `googleapis.com` hosts.
+Use a GCP auth rule when sandbox code needs to call Google APIs with Google SDKs or CLIs. The proxy keeps the service account JSON outside the sandbox, then authenticates supported outbound HTTPS requests to Google API hosts matched by the sandbox proxy.
 
 This is useful when agent code needs to inspect GCS objects or call another Google API without exposing service account JSON in sandbox files, environment variables, shell history, or logs. The sandbox receives compatibility credentials so SDK credential detection works, while the proxy authenticates the outbound request with the configured service account.
 
@@ -247,14 +247,12 @@ Do not set real service account JSON as a sandbox environment variable. Configur
 GCP auth rules are different from header injection rules:
 
 - Set `type` to `gcp`.
-- When sending raw `proxy_config`, set `match_hosts` to exact hosts or wildcard suffixes under `googleapis.com`, such as `storage.googleapis.com`, `www.googleapis.com`, or `*.googleapis.com`.
-- Do not set `match_paths`; GCP rules use host-only matching.
-- Do not set `headers`; GCP rules authenticate requests and cannot inject headers.
 - Put credentials under `gcp.service_account_json`.
 - Set `gcp.scopes` to a non-empty list of OAuth scopes.
+- Do not set `match_hosts`, `match_paths`, or `headers`; GCP host matching is built into the proxy.
 - Configure at most one enabled GCP auth rule per sandbox.
 
-The SDK `gcp_auth` and `gcpAuth` helpers set `match_hosts` for GCS by default. Pass `match_hosts` or `matchHosts` only when your sandbox needs to authenticate requests to other Google API hosts.
+The SDK `gcp_auth` and `gcpAuth` helpers also omit host matching because the API and proxy handle it automatically.
 
 ```bash
 curl -X POST "$LANGSMITH_ENDPOINT/v2/sandboxes/boxes" \
@@ -269,10 +267,6 @@ curl -X POST "$LANGSMITH_ENDPOINT/v2/sandboxes/boxes" \
           "name": "gcp",
           "type": "gcp",
           "enabled": true,
-          "match_hosts": [
-            "storage.googleapis.com",
-            "www.googleapis.com"
-          ],
           "gcp": {
             "service_account_json": {
               "type": "workspace_secret",
@@ -340,11 +334,11 @@ await client.createSandbox({
 
 </CodeGroup>
 
-After the sandbox is ready, use Google SDKs or CLIs normally inside the sandbox for requests to the matching `googleapis.com` hosts. The SDK or CLI can discover the compatibility credentials, and the proxy applies the real GCP authentication without exposing service account JSON inside the sandbox.
+After the sandbox is ready, use Google SDKs or CLIs normally inside the sandbox for supported Google API requests. The SDK or CLI can discover the compatibility credentials, and the proxy applies the real GCP authentication without exposing service account JSON inside the sandbox.
 
 ### Use GCS mounts
 
-For GCS mounts, the GCP rule must cover both `storage.googleapis.com` and `www.googleapis.com`. The SDK GCP auth helpers include these hosts by default.
+For GCS mounts, enable a GCP auth rule with a compatible storage OAuth scope. You do not need to list `storage.googleapis.com` or `www.googleapis.com`; the proxy matches Google API hosts automatically.
 
 Use one of these scopes for read-only mounts:
 

--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -336,21 +336,6 @@ await client.createSandbox({
 
 After the sandbox is ready, use Google SDKs or CLIs normally inside the sandbox for supported Google API requests. The SDK or CLI can discover the compatibility credentials, and the proxy applies the real GCP authentication without exposing service account JSON inside the sandbox.
 
-### Use GCS mounts
-
-For GCS mounts, enable a GCP auth rule with a compatible storage OAuth scope. The proxy matches the required Google API hosts automatically.
-
-Use one of these scopes for read-only mounts:
-
-- `https://www.googleapis.com/auth/devstorage.read_only`
-- `https://www.googleapis.com/auth/devstorage.read_write`
-- `https://www.googleapis.com/auth/cloud-platform`
-
-Use one of these scopes for read/write mounts:
-
-- `https://www.googleapis.com/auth/devstorage.read_write`
-- `https://www.googleapis.com/auth/cloud-platform`
-
 ## Single API example
 
 Create a sandbox that automatically injects an OpenAI API key into outbound requests:

--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -224,6 +224,140 @@ After the sandbox is ready, use AWS SDKs or CLIs normally inside the sandbox. Th
 AWS auth proxy rules currently support access key ID and secret access key credentials. They do not include a session token or assume-role configuration.
 </Note>
 
+## Authenticate GCP requests
+
+Use a GCP auth rule when sandbox code needs to call Google APIs with Google SDKs or CLIs. The proxy keeps the service account JSON outside the sandbox, then authenticates supported outbound HTTPS requests to matching `googleapis.com` hosts.
+
+This is useful when agent code needs to inspect GCS objects or call another Google API without exposing service account JSON in sandbox files, environment variables, shell history, or logs. The sandbox receives compatibility credentials so SDK credential detection works, while the proxy authenticates the outbound request with the configured service account.
+
+<Warning>
+Do not set real service account JSON as a sandbox environment variable. Configure it as a `workspace_secret` or `opaque` proxy value. Plaintext GCP credential values are rejected.
+</Warning>
+
+GCP auth rules are different from header injection rules:
+
+- Set `type` to `gcp`.
+- Set `match_hosts` to exact hosts or wildcard suffixes under `googleapis.com`, such as `storage.googleapis.com`, `www.googleapis.com`, or `*.googleapis.com`.
+- Do not set `match_paths`; GCP rules use host-only matching.
+- Do not set `headers`; GCP rules authenticate requests and cannot inject headers.
+- Put credentials under `gcp.service_account_json`.
+- Set `gcp.scopes` to a non-empty list of OAuth scopes.
+- Configure at most one enabled GCP auth rule per sandbox.
+
+```bash
+curl -X POST "$LANGSMITH_ENDPOINT/v2/sandboxes/boxes" \
+  -H "x-api-key: $LANGSMITH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "gcp-sandbox",
+    "wait_for_ready": true,
+    "proxy_config": {
+      "rules": [
+        {
+          "name": "gcp",
+          "type": "gcp",
+          "enabled": true,
+          "match_hosts": [
+            "storage.googleapis.com",
+            "www.googleapis.com"
+          ],
+          "gcp": {
+            "service_account_json": {
+              "type": "workspace_secret",
+              "value": "{GCP_SERVICE_ACCOUNT_JSON}"
+            },
+            "scopes": [
+              "https://www.googleapis.com/auth/devstorage.read_only"
+            ]
+          }
+        }
+      ]
+    }
+  }'
+```
+
+### Configure GCP auth via SDK
+
+<CodeGroup>
+
+```python Python
+from langsmith.sandbox import SandboxClient
+
+client = SandboxClient()
+
+client.create_sandbox(
+    name="gcp-sandbox",
+    proxy_config={
+        "rules": [
+            {
+                "name": "gcp",
+                "type": "gcp",
+                "enabled": True,
+                "match_hosts": [
+                    "storage.googleapis.com",
+                    "www.googleapis.com",
+                ],
+                "gcp": {
+                    "service_account_json": {
+                        "type": "workspace_secret",
+                        "value": "{GCP_SERVICE_ACCOUNT_JSON}",
+                    },
+                    "scopes": [
+                        "https://www.googleapis.com/auth/devstorage.read_only"
+                    ],
+                },
+            }
+        ]
+    },
+)
+```
+
+```ts TypeScript
+import { SandboxClient } from "langsmith/sandbox";
+
+const client = new SandboxClient();
+
+await client.createSandbox({
+  name: "gcp-sandbox",
+  proxyConfig: {
+    rules: [
+      {
+        name: "gcp",
+        type: "gcp",
+        enabled: true,
+        match_hosts: ["storage.googleapis.com", "www.googleapis.com"],
+        gcp: {
+          service_account_json: {
+            type: "workspace_secret",
+            value: "{GCP_SERVICE_ACCOUNT_JSON}",
+          },
+          scopes: ["https://www.googleapis.com/auth/devstorage.read_only"],
+        },
+      },
+    ],
+  },
+});
+```
+
+</CodeGroup>
+
+After the sandbox is ready, use Google SDKs or CLIs normally inside the sandbox for requests to the matching `googleapis.com` hosts. The SDK or CLI can discover the compatibility credentials, and the proxy applies the real GCP authentication without exposing service account JSON inside the sandbox.
+
+### Use GCS mounts
+
+For GCS mounts, the GCP rule must cover both `storage.googleapis.com` and `www.googleapis.com`.
+
+Use one of these scopes for read-only mounts:
+
+- `https://www.googleapis.com/auth/devstorage.read_only`
+- `https://www.googleapis.com/auth/devstorage.read_write`
+- `https://www.googleapis.com/auth/cloud-platform`
+
+Use one of these scopes for read/write mounts:
+
+- `https://www.googleapis.com/auth/devstorage.read_write`
+- `https://www.googleapis.com/auth/cloud-platform`
+
 ## Single API example
 
 Create a sandbox that automatically injects an OpenAI API key into outbound requests:

--- a/src/langsmith/sandbox-cli.mdx
+++ b/src/langsmith/sandbox-cli.mdx
@@ -152,7 +152,7 @@ Use `--proxy-config @proxy.json` on `create` or `update` to configure the sandbo
 
 For more on proxy rules, see [Sandbox auth proxy](/langsmith/sandbox-auth-proxy).
 
-To authenticate Google API requests from a sandbox, add a GCP auth rule to the same `proxy.json`. Raw GCP rules use `type: "gcp"`, host-only `match_hosts` under `googleapis.com`, and a `workspace_secret` or `opaque` `gcp.service_account_json`; see [Authenticate GCP requests](/langsmith/sandbox-auth-proxy#authenticate-gcp-requests).
+To authenticate Google API requests from a sandbox, add a GCP auth rule to the same `proxy.json`. Raw GCP rules use `type: "gcp"` with a `workspace_secret` or `opaque` `gcp.service_account_json`; do not set `match_hosts` because Google API host matching is handled by the sandbox proxy. See [Authenticate GCP requests](/langsmith/sandbox-auth-proxy#authenticate-gcp-requests).
 
 ## Run commands
 

--- a/src/langsmith/sandbox-cli.mdx
+++ b/src/langsmith/sandbox-cli.mdx
@@ -152,7 +152,7 @@ Use `--proxy-config @proxy.json` on `create` or `update` to configure the sandbo
 
 For more on proxy rules, see [Sandbox auth proxy](/langsmith/sandbox-auth-proxy).
 
-To authenticate Google API requests from a sandbox, add a GCP auth rule to the same `proxy.json`. GCP rules use `type: "gcp"`, host-only `match_hosts` under `googleapis.com`, and a `workspace_secret` or `opaque` `gcp.service_account_json`; see [Authenticate GCP requests](/langsmith/sandbox-auth-proxy#authenticate-gcp-requests).
+To authenticate Google API requests from a sandbox, add a GCP auth rule to the same `proxy.json`. Raw GCP rules use `type: "gcp"`, host-only `match_hosts` under `googleapis.com`, and a `workspace_secret` or `opaque` `gcp.service_account_json`; see [Authenticate GCP requests](/langsmith/sandbox-auth-proxy#authenticate-gcp-requests).
 
 ## Run commands
 

--- a/src/langsmith/sandbox-cli.mdx
+++ b/src/langsmith/sandbox-cli.mdx
@@ -152,8 +152,6 @@ Use `--proxy-config @proxy.json` on `create` or `update` to configure the sandbo
 
 For more on proxy rules, see [Sandbox auth proxy](/langsmith/sandbox-auth-proxy).
 
-To authenticate Google API requests from a sandbox, add a GCP auth rule to the same `proxy.json`. Raw GCP rules use `type: "gcp"` with a `workspace_secret` or `opaque` `gcp.service_account_json`; Google API host matching is handled by the sandbox proxy. See [Authenticate GCP requests](/langsmith/sandbox-auth-proxy#authenticate-gcp-requests).
-
 ## Run commands
 
 Use `sandbox exec` for one-off commands:

--- a/src/langsmith/sandbox-cli.mdx
+++ b/src/langsmith/sandbox-cli.mdx
@@ -152,6 +152,8 @@ Use `--proxy-config @proxy.json` on `create` or `update` to configure the sandbo
 
 For more on proxy rules, see [Sandbox auth proxy](/langsmith/sandbox-auth-proxy).
 
+To authenticate Google API requests from a sandbox, add a GCP auth rule to the same `proxy.json`. GCP rules use `type: "gcp"`, host-only `match_hosts` under `googleapis.com`, and a `workspace_secret` or `opaque` `gcp.service_account_json`; see [Authenticate GCP requests](/langsmith/sandbox-auth-proxy#authenticate-gcp-requests).
+
 ## Run commands
 
 Use `sandbox exec` for one-off commands:

--- a/src/langsmith/sandbox-cli.mdx
+++ b/src/langsmith/sandbox-cli.mdx
@@ -152,7 +152,7 @@ Use `--proxy-config @proxy.json` on `create` or `update` to configure the sandbo
 
 For more on proxy rules, see [Sandbox auth proxy](/langsmith/sandbox-auth-proxy).
 
-To authenticate Google API requests from a sandbox, add a GCP auth rule to the same `proxy.json`. Raw GCP rules use `type: "gcp"` with a `workspace_secret` or `opaque` `gcp.service_account_json`; do not set `match_hosts` because Google API host matching is handled by the sandbox proxy. See [Authenticate GCP requests](/langsmith/sandbox-auth-proxy#authenticate-gcp-requests).
+To authenticate Google API requests from a sandbox, add a GCP auth rule to the same `proxy.json`. Raw GCP rules use `type: "gcp"` with a `workspace_secret` or `opaque` `gcp.service_account_json`; Google API host matching is handled by the sandbox proxy. See [Authenticate GCP requests](/langsmith/sandbox-auth-proxy#authenticate-gcp-requests).
 
 ## Run commands
 


### PR DESCRIPTION
## Overview
Adds documentation for GCP sandbox auth proxy rules, including raw API configuration, SDK helper examples, service account secret handling, OAuth scopes, automatic Google API host matching, and GCS mount scope requirements.

The GCP examples present the valid rule shape directly: `type: "gcp"` with `gcp.service_account_json` and `gcp.scopes`. Host matching is handled by the sandbox API/proxy.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- GitHub issue:
- Feature PR:
- Linear issue:
- Slack thread:

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
Validation run:
- `git diff --check`
- `uv run --group test codespell src/langsmith/sandbox-auth-proxy.mdx src/langsmith/sandbox-cli.mdx`
- `make lint_prose FILES="src/langsmith/sandbox-auth-proxy.mdx src/langsmith/sandbox-cli.mdx"`
- `make dev` reached `preview ready` at `http://localhost:3000`
- `go test ./sandboxes -run 'TestValidateProxyConfig_GCPRules|TestBuildProxyConfigPayloadBytes_GCPRule'`
- `uv run python -m pytest tests/unit_tests/sandbox/test_proxy_config.py -q`
- `npm test -- --runTestsByPath src/tests/sandbox.test.ts --runInBand`
- reviewed `src/docs.json`; no navigation update was needed because this edits existing pages only

The code examples checkbox remains unchecked because credentialed LangSmith/GCP end-to-end execution was not run locally.
