### PR TITLE
fix: align GCS blob storage indentation

### DIFF
--- a/src/langsmith/self-host-blob-storage.mdx
+++ b/src/langsmith/self-host-blob-storage.mdx
@@ -28,7 +28,7 @@ Native GCS blob storage engine support (using `engine: "GCS"`) is available in H
 * Access to a valid blob storage service
 
   * [Amazon S3](https://aws.amazon.com/s3/)
-    * [Google Cloud Storage (GCS)](https://cloud.google.com/storage?hl=en)
+  * [Google Cloud Storage (GCS)](https://cloud.google.com/storage?hl=en)
   * [Azure Blob Storage](https://azure.microsoft.com/en-us/products/storage/blobs)
 
 * A bucket/directory in your blob storage to store the data. We highly recommend creating a separate bucket/directory for LangSmith data.


### PR DESCRIPTION
## Description
Fixes the nested GCS entry in self-hosted blob storage requirements so it renders alongside S3 and Azure.

## Self-Hosted Release Note pls
none

## Test Plan
- [ ] Reviewed the requirements list rendering indentation.

Made by [Open SWE](https://openswe.vercel.app/agents/8cb56d40-55b0-f570-35fd-832d3f5098da)