### PR TITLE
docs: update sandbox AWS availability

### DIFF
--- a/src/langsmith/sandboxes.mdx
+++ b/src/langsmith/sandboxes.mdx
@@ -17,7 +17,7 @@ From the [LangSmith homepage](https://smith.langchain.com), select **Sandboxes**
 | GCP US (`smith.langchain.com`) | Generally available |
 | GCP EU (`eu.smith.langchain.com`) | Generally available |
 | GCP APAC (`apac.smith.langchain.com`) | Generally available |
-| AWS US (`aws.smith.langchain.com`) | In development |
+| AWS US (`aws.smith.langchain.com`) | Generally available |
 
 ## Get started
 


### PR DESCRIPTION
## Overview
Updates the LangSmith Sandboxes environment availability table to mark AWS US SaaS (`aws.smith.langchain.com`) as generally available.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- GitHub issue: N/A
- Feature PR: N/A

- Linear issue: N/A
- Slack thread: N/A

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
Validation:
- `git diff --check`
- `/Users/danielkneipp/.local/share/mise/installs/vale/3.12.0/vale --glob='!**/node_modules/**' src/langsmith/sandboxes.mdx`
- Pre-commit and pre-push hooks: Vale prose lint passed

`docs dev` was not run for this one-line status-only MDX update. No code examples were changed.
