### PR TITLE
Fix casing of 'ReAct' on Evaluation Types

### DIFF
--- a/src/langsmith/evaluation-types.mdx
+++ b/src/langsmith/evaluation-types.mdx
@@ -24,7 +24,7 @@ _Benchmarking_ compares multiple application versions on a curated dataset to id
 
 Benchmarking requires dataset curation with gold-standard reference outputs and well-designed comparison metrics. Examples:
 - **RAG Q&A bot**: Dataset of questions and reference answers, with an LLM-as-judge evaluator checking semantic equivalence between actual and reference answers.
-- **ReACT agent**: Dataset of user requests and reference tool calls, with a heuristic evaluator verifying all expected tool calls were made.
+- **ReAct agent**: Dataset of user requests and reference tool calls, with a heuristic evaluator verifying all expected tool calls were made.
 
 ### Unit tests
 


### PR DESCRIPTION
## Overview
Changed ReACT to ReAct to be consistent with rest of docs

## Type of change

Fix typo/bug/link/formatting

## Related issues/PRs
N/A

## Checklist
N/A

## Additional notes
N/A