### PR TITLE
docs: fix integration page guidance in CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -284,14 +284,16 @@ Before writing or updating model references, verify current model IDs against th
 
 **Add a new integration page (Python):**
 
-1. Create `src/oss/python/integrations/<provider>/<component>.mdx`
-2. Add to `src/docs.json` under Open source → Python dropdown → Integrations tab
+1. Create `src/oss/python/integrations/<component>/<provider>.mdx`
+2. Add the page to the component's index page (`src/oss/python/integrations/<component>/index.mdx`); only edit `src/docs.json` when creating a brand-new component group
 3. Use description format: `"Integrate with the ClassName type using LangChain Python."`
+4. If the provider has an overview page at `src/oss/python/integrations/providers/<provider>.mdx`, add or update a section there linking to the new page (`/oss/integrations/<component>/<provider>`)
 
 **Add a new integration page (TypeScript):**
 
-1. Create `src/oss/javascript/integrations/<provider>/<component>.mdx`
-2. Add to `src/docs.json` under Open source → TypeScript dropdown → Integrations tab
+1. Create `src/oss/javascript/integrations/<component>/<provider>.mdx`
+2. Add the page to the component's index page (`src/oss/javascript/integrations/<component>/index.mdx`); only edit `src/docs.json` when creating a brand-new component group
+3. If the provider has an overview page at `src/oss/javascript/integrations/providers/<provider>.mdx`, add or update a section there linking to the new page (`/oss/integrations/<component>/<provider>`)
 
 **Add a reusable snippet:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -284,14 +284,16 @@ Before writing or updating model references, verify current model IDs against th
 
 **Add a new integration page (Python):**
 
-1. Create `src/oss/python/integrations/<provider>/<component>.mdx`
-2. Add to `src/docs.json` under Open source → Python dropdown → Integrations tab
+1. Create `src/oss/python/integrations/<component>/<provider>.mdx`
+2. Add the page to the component's index page (`src/oss/python/integrations/<component>/index.mdx`); only edit `src/docs.json` when creating a brand-new component group
 3. Use description format: `"Integrate with the ClassName type using LangChain Python."`
+4. If the provider has an overview page at `src/oss/python/integrations/providers/<provider>.mdx`, add or update a section there linking to the new page (`/oss/integrations/<component>/<provider>`)
 
 **Add a new integration page (TypeScript):**
 
-1. Create `src/oss/javascript/integrations/<provider>/<component>.mdx`
-2. Add to `src/docs.json` under Open source → TypeScript dropdown → Integrations tab
+1. Create `src/oss/javascript/integrations/<component>/<provider>.mdx`
+2. Add the page to the component's index page (`src/oss/javascript/integrations/<component>/index.mdx`); only edit `src/docs.json` when creating a brand-new component group
+3. If the provider has an overview page at `src/oss/javascript/integrations/providers/<provider>.mdx`, add or update a section there linking to the new page (`/oss/integrations/<component>/<provider>`)
 
 **Add a reusable snippet:**
 


### PR DESCRIPTION
## Why

A Slack thread flagged errors in the **"Add a new integration page"** workflow under `### Common workflows` in `CLAUDE.md` / `AGENTS.md` (kept byte-identical). Contributors and agents follow this guidance when adding integration pages, so the inaccuracies send them to the wrong path and skip a step.

## Changes

Corrects the Python and TypeScript workflows in both files:

1. **Path ordering** — integration pages live at `integrations/<component>/<provider>.mdx` (e.g. `vectorstores/redis.mdx`), not `<provider>/<component>`. The guidance had it inverted.
2. **Step 2 repoint** — leaf integration pages are registered on the component's `index.mdx` listing, not in `src/docs.json` (which only lists `<component>/index` pages). Step 2 now points there, noting `docs.json` is only edited when creating a brand-new component group.
3. **Provider-page step** — adds a step to update the provider overview page (`integrations/providers/<provider>.mdx`) to link to the new page when one exists.

All three were verified against the repo: the RedisVectorStore page at `src/oss/python/integrations/vectorstores/redis.mdx` is registered via `vectorstores/index.mdx` and never touched `docs.json` or the provider page.

## Notes

- `CLAUDE.md` and `AGENTS.md` remain byte-identical (repo convention).
- `make lint_prose FILES="CLAUDE.md AGENTS.md"` passes (0 errors/warnings).

## AI involvement

Authored with Claude Code (Opus 4.8); a human reviewed the diff before opening this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)