### PR TITLE
docs(deepagents): add E2B dcode follow-ups

### DIFF
--- a/src/oss/deepagents/code/overview.mdx
+++ b/src/oss/deepagents/code/overview.mdx
@@ -170,7 +170,7 @@ dcode --startup-cmd "git diff --stat" -n "Review these changes"
         | `-y`, `--auto-approve` | Auto-approve all tool calls without prompting (disables human-in-the-loop). Toggle with `Shift+Tab` during an interactive session |
         | `-S`, `--shell-allow-list LIST` | Comma-separated shell commands to auto-approve, `'recommended'` for safe defaults, or `'all'` to allow any command. Applies to both `-n` and interactive modes |
         | `--json`               | Emit machine-readable JSON from management subcommands (`agents`, `threads`, `skills`, `update`). Output envelope: `{"schema_version": 1, "command": "...", "data": ...}` |
-        | `--sandbox TYPE`       | Remote sandbox for code execution: `none` (default), `langsmith`, `agentcore`, `modal`, `daytona`, `runloop`. LangSmith is included; AgentCore/Modal/Daytona/Runloop require extras |
+        | `--sandbox TYPE`       | Remote sandbox for code execution: `none` (default), `langsmith`, `agentcore`, `modal`, `daytona`, `runloop`, `e2b`. LangSmith is included; AgentCore/Modal/Daytona/Runloop require extras; E2B requires `langchain-e2b` installed as a package |
         | `--sandbox-id ID`      | Reuse an existing sandbox (skips creation and cleanup)      |
         | `--sandbox-snapshot-name NAME` | Sandbox snapshot name to use or create (LangSmith only) |
         | `--sandbox-setup PATH` | Path to setup script to run in sandbox after creation       |

--- a/src/oss/python/integrations/sandboxes/e2b.mdx
+++ b/src/oss/python/integrations/sandboxes/e2b.mdx
@@ -80,6 +80,10 @@ finally:
 
 `langchain-e2b` also publishes an E2B sandbox provider for [Deep Agents Code](/oss/deepagents/code/remote-sandboxes), so `dcode` can run agent tool calls inside an E2B sandbox. Install the package into the `dcode` environment, set your API key, then select the provider:
 
+<Note>
+    Using E2B with Deep Agents Code requires `dcode` 0.1.19 or newer and `langchain-e2b` 0.0.4 or newer.
+</Note>
+
 ```bash
 dcode --install langchain-e2b --package
 export E2B_API_KEY="..."


### PR DESCRIPTION
Adds the narrow E2B follow-up after #4524 was superseded by #4521.

- Adds `e2b` to the Deep Agents Code CLI overview `--sandbox` option row.
- Documents the minimum versions for using E2B with Deep Agents Code on the E2B sandbox integration page.

Validation:
- `make lint_prose FILES="src/oss/deepagents/code/overview.mdx src/oss/python/integrations/sandboxes/e2b.mdx"`

Prepared with Codex.