### PR TITLE
feat(oss): update hitl pattern with custom forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,15 +8,14 @@
       "name": "docs",
       "version": "1.0.0",
       "dependencies": {
-        "@langchain/docs-sandbox": "^0.0.22"
+        "@langchain/docs-sandbox": "^0.0.23"
       }
     },
     "node_modules/@langchain/docs-sandbox": {
-      "version": "0.0.22",
-      "resolved": "https://registry.npmjs.org/@langchain/docs-sandbox/-/docs-sandbox-0.0.22.tgz",
-      "integrity": "sha512-FhDYqjbJCqq9PM0D7SD4WuYcY5qk6KWUgWidKJp1+o7TYdAunzzMnTH87eMCR4IdkfdqA1+Tm47X5LPid6n8HA==",
+      "version": "0.0.23",
+      "resolved": "https://registry.npmjs.org/@langchain/docs-sandbox/-/docs-sandbox-0.0.23.tgz",
+      "integrity": "sha512-Qr/txD/+mYKnd7J+nda5dRT1iMS88FP42mKLX8dXh3dIj017G8mKp0sNtHkd9z0mjlPNRy8hlMUhSNV+euP1lQ==",
       "peerDependencies": {
-        "@langchain/playground-preview-protocol": "workspace:*",
         "react": "^18 || ^19",
         "zod": "^4.3.6"
       }

--- a/package.json
+++ b/package.json
@@ -4,6 +4,6 @@
   "description": "Docs for the project",
   "private": true,
   "dependencies": {
-    "@langchain/docs-sandbox": "^0.0.22"
+    "@langchain/docs-sandbox": "^0.0.23"
   }
 }

--- a/src/oss/langchain/frontend/human-in-the-loop.mdx
+++ b/src/oss/langchain/frontend/human-in-the-loop.mdx
@@ -394,6 +394,185 @@ function MultiActionReview({
 }
 ```
 
+## Custom interrupt forms
+
+The flow above uses `humanInTheLoopMiddleware`, which wraps a tool with a
+generic approve / reject / edit / respond card. Sometimes a single set of
+buttons is not enough: booking a flight, approving a refund, and reviewing a
+social post each need a *different* form, with their own fields, validation, and
+copy. For that, raise the `interrupt()` **from inside the tool** and let the
+payload describe the exact form the UI should render. Each tool can surface a
+completely different interface.
+
+<PatternEmbed pattern="hitl-interrupt-forms" />
+
+### Describe the form in the interrupt payload
+
+`interrupt()` accepts any JSON-serializable value, so use it to carry a "card"
+that the frontend knows how to render — a form type, a title, the context the
+human is reviewing, and the fields to collect. `interrupt()` is generic over its
+input and return types — `interrupt<I, R>(value: I): R` — so you can type both
+the card you send (`InterruptCard`) and the value the user resolves with
+(`ReviewDecision`). Export those types so the frontend can import them and stay
+in sync:
+
+```ts
+import { createAgent, tool } from "langchain";
+import { interrupt } from "@langchain/langgraph";
+import { z } from "zod";
+
+export interface FormField {
+  name: string;
+  label: string;
+  type: "select" | "checkbox" | "textarea" | "currency";
+  options?: string[];
+  default?: unknown;
+}
+
+/** What the user resolves the interrupt with. */
+export interface ReviewDecision {
+  approved: boolean;
+  /** Edited / collected form values the tool should act on. */
+  values?: Record<string, unknown>;
+}
+
+/** The form spec ("card") an interrupt hands to the frontend. */
+export interface InterruptCard {
+  formType: "flight-booking" | "refund-approval" | "content-review";
+  tool: string;
+  title: string;
+  context: Record<string, unknown>;
+  fields: FormField[];
+  /** Populated by the frontend when it commits the resolved card to state. */
+  resolved?: boolean;
+  decision?: ReviewDecision;
+}
+
+const bookFlight = tool(
+  async ({ origin, destination, date, passengers }) => {
+    // Pause the tool and hand the frontend a typed form spec; the typed return
+    // is whatever the UI resolves the interrupt with.
+    const decision = interrupt<InterruptCard, ReviewDecision>({
+      formType: "flight-booking",
+      tool: "book_flight",
+      title: "Confirm flight booking",
+      context: { origin, destination, date, passengers },
+      fields: [
+        {
+          name: "seatClass",
+          label: "Seat class",
+          type: "select",
+          options: ["Economy", "Premium Economy", "Business"],
+          default: "Economy",
+        },
+        { name: "insurance", label: "Add trip insurance", type: "checkbox", default: false },
+      ],
+    });
+
+    if (!decision.approved) {
+      return `Booking cancelled. No flight from ${origin} to ${destination} was reserved.`;
+    }
+
+    // Run the real (possibly slow) work with the values the human confirmed.
+    const seatClass = String(decision.values?.seatClass ?? "Economy");
+    return `Flight booked from ${origin} to ${destination} in ${seatClass}.`;
+  },
+  {
+    name: "book_flight",
+    description: "Book a flight. Requires human confirmation of trip details.",
+    schema: z.object({
+      origin: z.string(),
+      destination: z.string(),
+      date: z.string(),
+      passengers: z.number().int().min(1),
+    }),
+  },
+);
+```
+
+Give each tool a distinct `formType` (e.g. `"refund-approval"`,
+`"content-review"`) so the frontend can switch on it and render the matching
+form.
+
+### Render a different form per tool
+
+On the client, the card arrives on `stream.interrupt.value`. Import the
+`InterruptCard` and `ReviewDecision` types from your agent module so the form
+and the payload stay in sync, switch on `formType` to pick the right form, and
+feed `fields` into your inputs:
+
+```tsx
+import { useStream } from "@langchain/react";
+import type { InterruptCard, ReviewDecision } from "./agent";
+
+function Chat() {
+  const stream = useStream<typeof myAgent>({
+    apiUrl: AGENT_URL,
+    assistantId: "hitl_interrupt_forms",
+  });
+
+  const card = stream.interrupt?.value as InterruptCard | undefined;
+
+  return (
+    <div>
+      {stream.messages.map((msg) => (
+        <Message key={msg.id} message={msg} />
+      ))}
+      {card && <InterruptForm card={card} onResolve={handleResolve} />}
+    </div>
+  );
+}
+
+// `InterruptForm` renders a flight / refund / content card based on
+// `card.formType`, collects `card.fields`, and calls `onResolve` with the
+// user's decision and edited values.
+```
+
+### Keep the card on screen with `respond(decision, { update })`
+
+When you resolve a plain interrupt, the card disappears the instant the
+interrupt clears and only the tool result comes back — so a rich review card
+would vanish mid-run. To keep it on screen, resolve the interrupt **and** commit
+a message carrying the card to state in the *same* superstep using
+@[`useStream`]'s `respond`:
+
+```tsx
+import { AIMessage } from "langchain";
+
+function handleResolve(decision: ReviewDecision) {
+  // Snapshot the card with the decision baked in so it renders read-only.
+  const resolvedCard = { ...card, resolved: true, decision };
+  const cardMessage = new AIMessage({
+    content: `Review ${decision.approved ? "approved" : "declined"}.`,
+    response_metadata: { cards: resolvedCard },
+  });
+
+  // Resume the interrupt AND push the card into state atomically. Maps to
+  // LangGraph's `Command(resume, update)`: one checkpoint, no extra state write.
+  stream.respond(decision, { update: { messages: [cardMessage] } });
+}
+```
+
+`respond(response, { update })` applies the `update` **optimistically**: the
+card paints immediately and is reconciled by id once the resumed run echoes the
+same message back. The backend never re-emits the card, so it stays rendered
+without a flicker while the (potentially slow) tool runs. Render the resolved
+card by reading it back off the message:
+
+```tsx
+{stream.messages.map((msg) => {
+  const card = (msg.response_metadata as { cards?: InterruptCard })?.cards;
+  if (card) return <InterruptForm key={msg.id} card={card} readOnly />;
+  return <Message key={msg.id} message={msg} />;
+})}
+```
+
+<Tip>
+Because the resolved card lives in the message history, it survives refreshes
+and is visible to every component reading the thread — the human's decision
+becomes part of the durable transcript, not just transient UI state.
+</Tip>
+
 ## Best practices
 
 Keep these guidelines in mind when implementing HITL workflows:

--- a/src/oss/langchain/frontend/human-in-the-loop.mdx
+++ b/src/oss/langchain/frontend/human-in-the-loop.mdx
@@ -569,7 +569,7 @@ card by reading it back off the message:
 
 <Tip>
 Because the resolved card lives in the message history, it survives refreshes
-and is visible to every component reading the thread — the human's decision
+and is visible to every component reading the thread and the human's decision
 becomes part of the durable transcript, not just transient UI state.
 </Tip>
 

--- a/src/oss/langchain/frontend/human-in-the-loop.mdx
+++ b/src/oss/langchain/frontend/human-in-the-loop.mdx
@@ -496,7 +496,7 @@ form.
 
 ### Render a different form per tool
 
-On the client, the card arrives on `stream.interrupt.value`. Import the
+On the client, the card arrives as `stream.interrupt.value`. Import the
 `InterruptCard` and `ReviewDecision` types from your agent module so the form
 and the payload stay in sync, switch on `formType` to pick the right form, and
 feed `fields` into your inputs:

--- a/src/oss/langchain/frontend/human-in-the-loop.mdx
+++ b/src/oss/langchain/frontend/human-in-the-loop.mdx
@@ -531,7 +531,7 @@ function Chat() {
 ### Keep the card on screen with `respond(decision, { update })`
 
 When you resolve a plain interrupt, the card disappears the instant the
-interrupt clears and only the tool result comes back — so a rich review card
+interrupt clears and only the tool result comes back. That means a rich review card
 would vanish mid-run. To keep it on screen, resolve the interrupt **and** commit
 a message carrying the card to state in the *same* superstep using
 @[`useStream`]'s `respond`:

--- a/src/oss/langchain/frontend/human-in-the-loop.mdx
+++ b/src/oss/langchain/frontend/human-in-the-loop.mdx
@@ -408,10 +408,10 @@ completely different interface.
 
 ### Describe the form in the interrupt payload
 
-`interrupt()` accepts any JSON-serializable value, so use it to carry a "card"
-that the frontend knows how to render — a form type, a title, the context the
+`interrupt()` accepts any JSON-serializable value, which allows you to provide a "card"
+that the frontend knows how to render, for example, a form type, a title, the context the
 human is reviewing, and the fields to collect. `interrupt()` is generic over its
-input and return types — `interrupt<I, R>(value: I): R` — so you can type both
+input and return types (`interrupt<I, R>(value: I): R`) so you can type both
 the card you send (`InterruptCard`) and the value the user resolves with
 (`ReviewDecision`). Export those types so the frontend can import them and stay
 in sync:

--- a/src/oss/langchain/frontend/human-in-the-loop.mdx
+++ b/src/oss/langchain/frontend/human-in-the-loop.mdx
@@ -396,7 +396,7 @@ function MultiActionReview({
 
 ## Custom interrupt forms
 
-The flow above uses `humanInTheLoopMiddleware`, which wraps a tool with a
+The [resume flow](#the-resume-flow) uses `humanInTheLoopMiddleware`, which wraps a tool with a
 generic approve / reject / edit / respond card. Sometimes a single set of
 buttons is not enough: booking a flight, approving a refund, and reviewing a
 social post each need a *different* form, with their own fields, validation, and

--- a/src/oss/langchain/frontend/human-in-the-loop.mdx
+++ b/src/oss/langchain/frontend/human-in-the-loop.mdx
@@ -554,7 +554,7 @@ function handleResolve(decision: ReviewDecision) {
 ```
 
 `respond(response, { update })` applies the `update` **optimistically**: the
-card paints immediately and is reconciled by id once the resumed run echoes the
+card paints immediately and is reconciled by ID once the resumed run echoes the
 same message back. The backend never re-emits the card, so it stays rendered
 without a flicker while the (potentially slow) tool runs. Render the resolved
 card by reading it back off the message:


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
This patch adds docs how one would build custom HITL forms using interrupts that describe UI forms.

## Type of change

**Type:** Update existing documentation

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
