### PR TITLE
docs(langsmith): warn against distributed tracing on untrusted-facing services

### DIFF
--- a/src/langsmith/agent-server-distributed-tracing.mdx
+++ b/src/langsmith/agent-server-distributed-tracing.mdx
@@ -24,7 +24,7 @@ To opt-in to distributed tracing, both client and server need to opt in.
 To accept distributed trace context, your graph must read the trace headers from the config and set the tracing context. The headers are passed through the `configurable` field as `langsmith-trace` and `langsmith-project`.
 
 <Warning>
-Distributed-tracing headers (`langsmith-trace`, `baggage`) are consumed as trusted tracing context. Only configure your server to apply inbound trace context for deployments called by trusted, internal services. If your Agent Server receives requests directly from untrusted third parties or the public internet, do not propagate these headers into the tracing context — strip them at your gateway or proxy instead. Trusting `baggage` from an external caller lets them influence how your runs are recorded.
+Distributed-tracing headers (`langsmith-trace`, `baggage`) are consumed as trusted tracing context. Only configure your server to apply inbound trace context for deployments called by trusted, internal services. If your Agent Server receives requests directly from untrusted third parties or the public internet, do not propagate these headers into the tracing context: strip them at your gateway or proxy instead. Trusting `baggage` from an external caller lets them influence how your runs are recorded.
 </Warning>
 
 ```python

--- a/src/langsmith/agent-server-distributed-tracing.mdx
+++ b/src/langsmith/agent-server-distributed-tracing.mdx
@@ -23,6 +23,10 @@ To opt-in to distributed tracing, both client and server need to opt in.
 
 To accept distributed trace context, your graph must read the trace headers from the config and set the tracing context. The headers are passed through the `configurable` field as `langsmith-trace` and `langsmith-project`.
 
+<Warning>
+Distributed-tracing headers (`langsmith-trace`, `baggage`) are consumed as trusted tracing context. Only configure your server to apply inbound trace context for deployments called by trusted, internal services. If your Agent Server receives requests directly from untrusted third parties or the public internet, do not propagate these headers into the tracing context — strip them at your gateway or proxy instead. Trusting `baggage` from an external caller lets them influence how your runs are recorded.
+</Warning>
+
 ```python
 import contextlib
 import langsmith as ls

--- a/src/langsmith/distributed-tracing.mdx
+++ b/src/langsmith/distributed-tracing.mdx
@@ -12,6 +12,10 @@ Example client-server setup:
 * Trace starts on client
 * Continues on server
 
+<Warning>
+**Only accept distributed-tracing headers from trusted services.** The `langsmith-trace` and `baggage` headers are consumed as trusted tracing context. Do not add `TracingMiddleware` (or pass inbound request headers as the tracing `parent`) on a service that receives requests directly from untrusted third parties or the public internet. Keep distributed tracing to internal, service-to-service calls, and strip these headers from untrusted inbound requests at your gateway or proxy. Trusting `baggage` from an external caller lets them influence how your runs are recorded.
+</Warning>
+
 ## Distributed tracing in Python
 
 ```python


### PR DESCRIPTION
Adds a warning to the [Implement distributed tracing](https://docs.langchain.com/langsmith/distributed-tracing) page.

`langsmith-trace` / `baggage` headers are consumed as **trusted** tracing context. This advises users to:
- Not add `TracingMiddleware` (or pass inbound request headers as the tracing `parent`) on services that receive requests directly from untrusted third parties / the public internet.
- Keep distributed tracing to internal, service-to-service calls.
- Strip these headers from untrusted inbound requests at the gateway/proxy.

No matter how much inbound tracing context is validated, trusting `baggage` from an external caller is risky by design.