### PR TITLE
fix(groq): replace deprecated llama-3.3-70b-versatile in examples

### DIFF
--- a/src/oss/javascript/integrations/chat/groq.mdx
+++ b/src/oss/javascript/integrations/chat/groq.mdx
@@ -69,7 +69,7 @@ Now we can instantiate our model object and generate chat completions:
 import { ChatGroq } from "@langchain/groq"
 
 const llm = new ChatGroq({
-    model: "llama-3.3-70b-versatile",
+    model: "openai/gpt-oss-120b",
     temperature: 0,
     maxTokens: undefined,
     maxRetries: 2,

--- a/src/oss/javascript/integrations/chat/index.mdx
+++ b/src/oss/javascript/integrations/chat/index.mdx
@@ -177,7 +177,7 @@ description: "Integrate with chat models using LangChain JavaScript."
         import { ChatGroq } from "@langchain/groq";
 
         const model = new ChatGroq({
-        model: "llama-3.3-70b-versatile",
+        model: "openai/gpt-oss-120b",
         temperature: 0
         });
         ```


### PR DESCRIPTION
Groq is deprecating `llama-3.3-70b-versatile` (shutdown 08/16/26, per [Groq's deprecation notice](https://console.groq.com/docs/deprecations#august-16-2026-llama318binstant-and-llama3370bversatile)). Updates the Groq chat integration examples (JS) to the recommended replacement `openai/gpt-oss-120b`. Same-named models from other providers (Cerebras, OCI, Cloudflare, etc.) are left untouched since the deprecation is Groq-specific.

Made by [Open SWE](https://openswe.vercel.app/agents/22845b4e-674d-346e-c594-612a8cbcedbd)