### PR TITLE
docs(deepagents): use Kimi-K2.7-Code in code examples

### DIFF
--- a/src/oss/deepagents/code/overview.mdx
+++ b/src/oss/deepagents/code/overview.mdx
@@ -39,7 +39,7 @@ Persistent memory carries context across conversations, customizable skills shap
         dcode --model anthropic:claude-opus-4-8
         dcode --model openai:gpt-5.5
         dcode --model fireworks:accounts/fireworks/models/deepseek-v4-pro
-        dcode --model baseten:moonshotai/Kimi-K2.6
+        dcode --model baseten:moonshotai/Kimi-K2.7-Code
         ```
 
         See [Model providers](/oss/deepagents/code/providers) for the full provider list, open weights options, and credential details.

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -299,11 +299,11 @@ Use the interactive switcher, or pass the model directly with `/model fireworks:
 
     ```bash Shell
     dcode --install baseten
-    BASETEN_API_KEY="your-api-key" dcode --model baseten:moonshotai/Kimi-K2.6
+    BASETEN_API_KEY="your-api-key" dcode --model baseten:moonshotai/Kimi-K2.7-Code
     ```
 </CodeGroup>
 
-Use the interactive switcher, or pass the model directly with `/model baseten:moonshotai/Kimi-K2.6`.
+Use the interactive switcher, or pass the model directly with `/model baseten:moonshotai/Kimi-K2.7-Code`.
 
 <Tip>
     If you want a provider preinstalled at the same time as the CLI itself, use `DEEPAGENTS_CODE_EXTRAS` during the initial install:


### PR DESCRIPTION
Updates the example `dcode --model` commands (overview + providers) and the inline `/model` example from `baseten:moonshotai/Kimi-K2.6` to `baseten:moonshotai/Kimi-K2.7-Code`. The generated eval category matrix snippet and its refresh script were left untouched since they reflect actual K2.6 benchmark results.

Made by [Open SWE](https://openswe.vercel.app/agents/47bd1250-8806-5acc-2a2f-ec8497332af0)