### PR TITLE
docs(langsmith): fix neq(error, null) filter examples

### DIFF
--- a/src/langsmith/export-traces.mdx
+++ b/src/langsmith/export-traces.mdx
@@ -393,22 +393,22 @@ RunQueryParams runs = RunQueryParams.builder()
 ```
 
 </CodeGroup>
-### List all runs that have "error" not equal to null
+### List all runs where status is not "error"
 
 <CodeGroup>
 
 ```python Python
-client.list_runs(project_name="<your_project>", filter='neq(error, null)')
+client.list_runs(project_name="<your_project>", filter='neq(status, "error")')
 ```
 
 ```typescript TypeScript
-client.listRuns({projectName: "<your_project>", filter: 'neq(error, null)'})
+client.listRuns({projectName: "<your_project>", filter: 'neq(status, "error")'})
 ```
 
 ```java Java
 RunQueryParams runs = RunQueryParams.builder()
     .addSession("<your_project>")
-    .filter("neq(error, null)")
+    .filter("neq(status, \"error\")")
     .build();
 ```
 
@@ -477,28 +477,28 @@ RunQueryParams runs = RunQueryParams.builder()
 
 </CodeGroup>
 
-### List all runs that started after a specific timestamp and either have "error" not equal to null or a "Correctness" feedback score equal to 0
+### List all runs that started after a specific timestamp and either have a non-error status or a "Correctness" feedback score equal to 0
 
 <CodeGroup>
 
 ```python Python
 client.list_runs(
   project_name="<your_project>",
-  filter='and(gt(start_time, "2023-07-15T12:34:56Z"), or(neq(error, null), and(eq(feedback_key, "Correctness"), eq(feedback_score, 0.0))))'
+  filter='and(gt(start_time, "2023-07-15T12:34:56Z"), or(neq(status, "error"), and(eq(feedback_key, "Correctness"), eq(feedback_score, 0.0))))'
 )
 ```
 
 ```typescript TypeScript
 client.listRuns({
   projectName: "<your_project>",
-  filter: 'and(gt(start_time, "2023-07-15T12:34:56Z"), or(neq(error, null), and(eq(feedback_key, "Correctness"), eq(feedback_score, 0.0))))'
+  filter: 'and(gt(start_time, "2023-07-15T12:34:56Z"), or(neq(status, "error"), and(eq(feedback_key, "Correctness"), eq(feedback_score, 0.0))))'
 })
 ```
 
 ```java Java
 RunQueryParams runs = RunQueryParams.builder()
     .addSession("<your_project>")
-    .filter("and(gt(start_time, \"2023-07-15T12:34:56Z\"), or(neq(error, null), and(eq(feedback_key, \"Correctness\"), eq(feedback_score, 0.0))))")
+    .filter("and(gt(start_time, \"2023-07-15T12:34:56Z\"), or(neq(status, \"error\"), and(eq(feedback_key, \"Correctness\"), eq(feedback_score, 0.0))))")
     .build();
 ```
 


### PR DESCRIPTION
Fixes `neq(error, null)` filter examples in the export-traces page, which are rejected by both v1 and v2 APIs. Replaces them with `neq(status, "error")`.

Fixes LSDK-249.