### PR TITLE
docs(engine): document Slack notifications for LangSmith Engine

### DIFF
--- a/src/langsmith/engine-webhooks.mdx
+++ b/src/langsmith/engine-webhooks.mdx
@@ -8,6 +8,10 @@ Forward LangSmith-detected agent issues into your incident-management, paging, o
 
 To configure webhook subscriptions, open the **Engine Settings** panel on the **Engine** tab of a tracing project. See [Configure the LangSmith Engine](/langsmith/engine#configure-the-langsmith-engine).
 
+<Note>
+A destination can deliver to a webhook URL or, instead, to a **Slack channel**—both use the same event types and minimum-priority filtering described on this page. Slack destinations post through LangSmith's managed Slack app rather than sending the JSON payload below, so the signing secret and custom headers do not apply to them. To set up Slack delivery, see [Notify a Slack channel](/langsmith/engine#notify-a-slack-channel). The rest of this page is the reference for **webhook URL** destinations.
+</Note>
+
 ## Delivery
 
 LangSmith sends a `POST` request with a JSON body to your webhook URL. The request uses `Content-Type: application/json` and includes any custom headers you attached to the subscription.

--- a/src/langsmith/engine-webhooks.mdx
+++ b/src/langsmith/engine-webhooks.mdx
@@ -9,7 +9,9 @@ Forward LangSmith-detected agent issues into your incident-management, paging, o
 To configure webhook subscriptions, open the **Engine Settings** panel on the **Engine** tab of a tracing project. See [Configure the LangSmith Engine](/langsmith/engine#configure-the-langsmith-engine).
 
 <Note>
-A destination can deliver to a webhook URL or, instead, to a **Slack channel**—both use the same event types and minimum-priority filtering described on this page. Slack destinations post through LangSmith's managed Slack app rather than sending the JSON payload below, so the signing secret and custom headers do not apply to them. To set up Slack delivery, see [Notify a Slack channel](/langsmith/engine#notify-a-slack-channel). The rest of this page is the reference for **webhook URL** destinations.
+A destination delivers to either a webhook URL or a **Slack channel**. Both use the same [event types](#event-types) and [minimum-priority filtering](#severity-filtering) described on this page. Slack destinations post through LangSmith's managed Slack app instead of sending the [JSON payload](#event-envelope) below, so the [signing secret](#signing-secret) and [custom headers](#custom-headers) do not apply.
+
+To set up Slack delivery, see [Notify a Slack channel](/langsmith/engine#notify-a-slack-channel). The rest of this page documents **webhook URL** destinations.
 </Note>
 
 ## Delivery

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -186,21 +186,21 @@ langsmith project issues list --project <project-name>
 
 ## Get notified about new issues
 
-LangSmith Engine can notify you when it opens a new issue, links new traces to an existing issue, or fails to complete a run. You can deliver these notifications to a **Slack channel**, an **HTTP webhook endpoint**, or both. Each destination has its own event types and minimum priority, so you can route urgent issues to a paging webhook while sending everything to a Slack channel.
+LangSmith Engine can notify you when it opens a new issue, links a new trace to an existing issue, or fails to complete a run. Deliver these notifications to a **Slack channel**, an **HTTP webhook endpoint**, or both. Each destination has its own event types and minimum priority level, so you can route urgent issues to a paging webhook while sending every issue to a Slack channel.
 
-Manage notification destinations from the **Engine Settings** panel: open the **Engine** tab for a tracing project, click the **Engine settings** gear icon, and click **Add destination**.
+Manage notification destinations from the **Engine Settings** panel: open the **Engine** tab for a tracing project, click the **Engine settings** gear icon, and under **Notifications** click **+ Add destination**.
 
 ### Notify a Slack channel
 
 <Steps>
   <Step title="Connect a Slack workspace">
-    Connecting a workspace is an organization-level action done once per workspace. In the [LangSmith console](https://smith.langchain.com), open **Settings**, go to your organization's **General** settings, and under **Slack** click **Connect Slack**. Authorize the LangSmith app in Slack. You need the `organization:manage` permission to connect or disconnect a workspace, and you can connect more than one workspace to an organization.
+    Connecting a Slack workspace is an organization-level action you perform once, not per project. Connecting or disconnecting a workspace requires the `organization:manage` permission. In the [LangSmith console](https://smith.langchain.com), open **Settings**, go to your organization's **General** settings, and under **Slack** click **Connect Slack**. Authorize the LangSmith app in Slack. You can connect more than one Slack workspace to an organization.
   </Step>
   <Step title="Add a Slack destination">
-    On the **Engine** tab of a tracing project, click the **Engine settings** gear icon, then click **Add destination**. Set **Deliver to** to **Slack** and choose the workspace and channel under **Channel**.
+    On the **Engine** tab of a tracing project, click the **Engine settings** gear icon, then click **Add destination**. Set the **Deliver to** field to **Slack**, then choose the workspace and channel under **Channel**.
   </Step>
   <Step title="Choose events and priority">
-    Under **Notify when**, select which [event types](/langsmith/engine-webhooks#event-types) should post a message. Under **Minimum priority**, choose the lowest [severity](/langsmith/engine-webhooks#severity-filtering) that should notify the channel. Click **Add destination** to save.
+    Under **Notify when**, select which [event types](/langsmith/engine-webhooks#event-types) post a message to the channel. Under **Minimum priority**, choose the lowest [severity](/langsmith/engine-webhooks#severity-filtering) that triggers a notification. Click **Add destination** to save.
   </Step>
 </Steps>
 
@@ -210,7 +210,7 @@ Each Slack message includes the issue title, description, and severity, a **View
 
 ### Send to a webhook
 
-To forward Engine events to your own incident-management, paging, or chat tooling, add a destination with **Deliver to** set to **Webhook** and provide a URL (and optional custom headers). Webhook deliveries are signed so you can verify their authenticity. For the full event payload reference, signing-secret verification, and delivery semantics, see [Engine webhook events](/langsmith/engine-webhooks).
+To forward Engine events to your own incident-management, paging, or chat tooling, add a destination and set the **Deliver to** field to **Webhook**. Enter a URL and, optionally, custom headers. Webhook deliveries are signed so you can verify their authenticity. For the full event payload reference, signing-secret verification, and delivery semantics, see [Engine webhook events](/langsmith/engine-webhooks).
 
 ## Configure the LangSmith Engine
 
@@ -223,6 +223,6 @@ Within a tracing project, click the **Engine settings** gear icon on the **Engin
 - **Agent Overview**: Edit your agent overview document to keep LangSmith Engine's understanding of your project accurate as your application evolves.
 - **Priorities**: Areas the LangSmith Engine should pay extra attention to when scanning traces. Changes take effect on the next scan.
 - **Code repository**: Update the connected GitHub repository or subfolder.
-- **Notifications**: Add Slack channel or webhook destinations to be notified when new issues are found at different priority levels. See [Get notified about new issues](#get-notified-about-new-issues).
+- **Notifications**: Add Slack channel or webhook destinations that receive a notification when LangSmith Engine detects a new issue. Set a minimum priority level per destination to control which issues trigger a notification. See [Get notified about new issues](#get-notified-about-new-issues).
 - **Pause Engine**: The LangSmith Engine scans your traces every 6 hours by default. Click **Pause** to suspend scanning or **Resume** to resume scanning.
 - **Delete all issues**: This action cannot be undone. All issues and settings will be permanently removed.

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -90,7 +90,7 @@ To monitor usage, you can view your organization's monthly LCU spend on the **En
     Under **What matters most to you?**, select categories to prioritize for your review (for example, **Tool Call Failures** or **Latency**). Click **+ Add something specific** to describe a custom concern. You can update **Priorities** at any time from the [**Engine settings**](#configure-the-langsmith-engine).
   </Step>
   <Step title="Start analyzing">
-    Click **Start Analyzing**. LangSmith Engine can take up to 20 minutes to analyze your project’s traces and begin making suggestions. While you wait, you can configure webhooks in the [settings panel](#configure-the-langsmith-engine) to be notified when issues of different priority levels are found.
+    Click **Start Analyzing**. LangSmith Engine can take up to 20 minutes to analyze your project’s traces and begin making suggestions. While you wait, you can [set up notifications](#get-notified-about-new-issues) in the settings panel to be alerted in Slack or via webhook when issues of different priority levels are found.
   </Step>
   <Step title="Review the agent overview document">
     Before surfacing issues, LangSmith Engine generates an agent overview document describing your project's purpose, architecture, and key metrics based on your traces. Review and edit the document, then click **Accept & Continue** to proceed. If the overview is inaccurate, edit it before continuing, since the LangSmith Engine uses it as context for all analysis, so accuracy here affects the quality of detected issues. You can update it at any time from the [**Engine settings**](#configure-the-langsmith-engine).
@@ -184,6 +184,34 @@ You can list issues programmatically using the [LangSmith CLI](/langsmith/cli).
 langsmith project issues list --project <project-name>
 ```
 
+## Get notified about new issues
+
+LangSmith Engine can notify you when it opens a new issue, links new traces to an existing issue, or fails to complete a run. You can deliver these notifications to a **Slack channel**, an **HTTP webhook endpoint**, or both. Each destination has its own event types and minimum priority, so you can route urgent issues to a paging webhook while sending everything to a Slack channel.
+
+Manage notification destinations from the **Engine Settings** panel: open the **Engine** tab for a tracing project, click the **Engine settings** gear icon, and click **Add destination**.
+
+### Notify a Slack channel
+
+<Steps>
+  <Step title="Connect a Slack workspace">
+    Connecting a workspace is an organization-level action done once per workspace. In the [LangSmith console](https://smith.langchain.com), open **Settings**, go to your organization's **General** settings, and under **Slack** click **Connect Slack**. Authorize the LangSmith app in Slack. You need the `organization:manage` permission to connect or disconnect a workspace, and you can connect more than one workspace to an organization.
+  </Step>
+  <Step title="Add a Slack destination">
+    On the **Engine** tab of a tracing project, click the **Engine settings** gear icon, then click **Add destination**. Set **Deliver to** to **Slack** and choose the workspace and channel under **Channel**.
+  </Step>
+  <Step title="Choose events and priority">
+    Under **Notify when**, select which [event types](/langsmith/engine-webhooks#event-types) should post a message. Under **Minimum priority**, choose the lowest [severity](/langsmith/engine-webhooks#severity-filtering) that should notify the channel. Click **Add destination** to save.
+  </Step>
+</Steps>
+
+LangSmith automatically joins the public channel you select. To post to a private channel, invite the LangSmith app to that channel in Slack first.
+
+Each Slack message includes the issue title, description, and severity, a **View issue** link back to LangSmith, and (for issue events) a chart of the issue's recurrence over time. If a workspace's connection becomes invalid—for example, the app is removed from Slack—its destinations stop delivering until you reconnect it from your organization's **General** settings.
+
+### Send to a webhook
+
+To forward Engine events to your own incident-management, paging, or chat tooling, add a destination with **Deliver to** set to **Webhook** and provide a URL (and optional custom headers). Webhook deliveries are signed so you can verify their authenticity. For the full event payload reference, signing-secret verification, and delivery semantics, see [Engine webhook events](/langsmith/engine-webhooks).
+
 ## Configure the LangSmith Engine
 
 <Note>
@@ -195,6 +223,6 @@ Within a tracing project, click the **Engine settings** gear icon on the **Engin
 - **Agent Overview**: Edit your agent overview document to keep LangSmith Engine's understanding of your project accurate as your application evolves.
 - **Priorities**: Areas the LangSmith Engine should pay extra attention to when scanning traces. Changes take effect on the next scan.
 - **Code repository**: Update the connected GitHub repository or subfolder.
-- **Webhooks**: Configure webhooks to be notified when new issues are found at different priority levels. See [Engine webhook events](/langsmith/engine-webhooks) for the event payload reference.
+- **Notifications**: Add Slack channel or webhook destinations to be notified when new issues are found at different priority levels. See [Get notified about new issues](#get-notified-about-new-issues).
 - **Pause Engine**: The LangSmith Engine scans your traces every 6 hours by default. Click **Pause** to suspend scanning or **Resume** to resume scanning.
 - **Delete all issues**: This action cannot be undone. All issues and settings will be permanently removed.


### PR DESCRIPTION
## Overview

Engine can deliver issue notifications to a **Slack channel** or a **webhook URL**, but only the webhook path was documented. This adds Slack notification docs.

- **`engine.mdx`** — new **"Get notified about new issues"** section: connect a Slack workspace (org **General** settings, `organization:manage`), add a Slack destination via **Engine Settings → Add destination → Deliver to: Slack**, choose events/minimum priority, plus public-vs-private channel behavior and message contents (severity headline, **View issue** link, recurrence chart). Also updates the setup step and the Configure-panel bullet ("Webhooks" → "Notifications").
- **`engine-webhooks.mdx`** — a `<Note>` clarifying a destination can deliver to Slack instead of a URL, sharing the same event-type/severity filtering, and that the signing secret and custom headers don't apply to Slack.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- GitHub issue:
- Feature PR:
- Linear issue:
- Slack thread:

## Checklist
- [x] I have read the contributing guidelines, including the language policy
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed (no new page — not needed)

## Additional notes

> [!IMPORTANT]
> The Slack UI is gated behind the `langsmith_slack_app` Eppo rollout flag and is rolling out region by region. If the feature is not yet GA everywhere, consider holding this PR or adding a "Beta" note before publishing.

Source of truth verified against `smith-go/slack/`, `smith-go/tracer_session_issues_agent_webhooks/` (incl. `slack_render.go`), and the `smith-frontend` Engine webhook editor / org Slack settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)