### PR TITLE
Remove 'Fixes' section from changelog

### DIFF
--- a/src/langsmith/changelog.mdx
+++ b/src/langsmith/changelog.mdx
@@ -51,8 +51,6 @@ If you use self-hosted LangSmith, see the [self-hosted changelog](/langsmith/sel
 
 - [Granular billable usage](/langsmith/granular-usage) now clarifies org scoping, so you can interpret usage totals more accurately.
 
-## Fixes
-
 </Update>
 
 <Update label="June 8-12, 2026" rss={{ title: "2026-06-08 - Cloud update" }}>


### PR DESCRIPTION
Removed the 'Fixes' section from the changelog.

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
