### PR TITLE
Add weekly changelog assembler and coverage audit

### DIFF
--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -2,9 +2,9 @@
 """Assemble weekly LangSmith Cloud + Fleet changelog entries from fragment files.
 
 Reads per-PR changelog fragments from ``langchainplus/.changelog/`` (see that
-directory's ``README.md`` for the schema), filters to the requested surfaces and
-to entries that are ready to publish, groups them by the category map, and
-renders a Mintlify ``<Update>`` block ready to paste into
+directory's ``README.md`` for the schema), keeps the ones ready to publish,
+groups them by the category map (which also routes each component to Cloud or
+Fleet), and renders a Mintlify ``<Update>`` block ready to paste into
 ``src/langsmith/changelog.mdx``.
 
 The weekly agent (see ``.claude/skills/changelog-weekly``) runs this, reviews the
@@ -51,7 +51,6 @@ DEFAULT_FRAGMENTS_DIR = _REPO_ROOT.parent / "langchainplus" / ".changelog"
 EPPO_API_BASE = "https://eppo.cloud/api/v1"
 EPPO_TIMEOUT_SECONDS = 15
 
-VALID_SURFACES = {"cloud", "fleet", "self-hosted"}
 
 
 # --- Fragment model --------------------------------------------------------
@@ -63,9 +62,9 @@ class Fragment:
     title: str
     body: str
     components: list[str]
-    surfaces: list[str]
     flag: str | None
     status: str
+    self_hosted: bool = False
     docs_link: str = ""
     pr: str = ""
     errors: list[str] = field(default_factory=list)
@@ -109,7 +108,7 @@ def load_fragments(fragments_dir: Path) -> list[Fragment]:
 
 def _invalid(path: Path, message: str) -> Fragment:
     return Fragment(
-        path=path, title="", body="", components=[], surfaces=[], flag=None,
+        path=path, title="", body="", components=[], flag=None,
         status="", errors=[message],
     )
 
@@ -120,7 +119,7 @@ def _build_fragment(path: Path, data: dict) -> Fragment:
         title=str(data.get("title") or "").strip(),
         body=str(data.get("body") or "").strip(),
         components=list(data.get("components") or []),
-        surfaces=list(data.get("surfaces") or []),
+        self_hosted=bool(data.get("self_hosted")),
         flag=(data.get("flag") or None),
         status=str(data.get("status") or "").strip().lower(),
         docs_link=str(data.get("docs_link") or "").strip(),
@@ -132,9 +131,6 @@ def _build_fragment(path: Path, data: dict) -> Fragment:
         frag.errors.append("missing `body`")
     if not frag.components:
         frag.errors.append("missing `components`")
-    bad_surfaces = set(frag.surfaces) - VALID_SURFACES
-    if bad_surfaces:
-        frag.errors.append(f"invalid surfaces: {sorted(bad_surfaces)}")
     if frag.status not in {"ready", "held"}:
         frag.errors.append(f"invalid status: {frag.status!r} (want ready|held)")
     if frag.status == "held" and not frag.flag:
@@ -342,7 +338,6 @@ def default_week(today: dt.date) -> tuple[str, str]:
 def main(argv: list[str] | None = None) -> int:
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
     parser.add_argument("--fragments-dir", type=Path, default=DEFAULT_FRAGMENTS_DIR)
-    parser.add_argument("--surfaces", default="cloud,fleet", help="comma-separated surfaces to include")
     parser.add_argument("--week-label", default=None, help='e.g. "June 15-19, 2026"')
     parser.add_argument("--rss-date", default=None, help="ISO date for the rss title, e.g. 2026-06-15")
     parser.add_argument("--check-flag", default=None, help="debug: print Eppo JSON + rollout verdict for a flag key")
@@ -367,7 +362,6 @@ def main(argv: list[str] | None = None) -> int:
         print(f"\nis_fully_rolled_out -> {is_fully_rolled_out(flag)}", file=sys.stderr)
         return 0
 
-    want_surfaces = {s.strip() for s in args.surfaces.split(",") if s.strip()}
     fragments = load_fragments(args.fragments_dir)
     category_map = load_category_map(args.fragments_dir)
 
@@ -385,8 +379,6 @@ def main(argv: list[str] | None = None) -> int:
 
     ready, held, errored, promoted = [], [], [], []
     for frag in valid:
-        if not (set(frag.surfaces) & want_surfaces):
-            continue
         status = effective_status(frag, flag_index, bool(token))
         if status == "ready":
             ready.append(frag)
@@ -423,7 +415,7 @@ def main(argv: list[str] | None = None) -> int:
     if ready:
         print(render_update_block(ready, category_map, week_label, rss_date))
     else:
-        print("# No ready fragments for surfaces: " + ", ".join(sorted(want_surfaces)), file=sys.stderr)
+        print("# No ready fragments to render.", file=sys.stderr)
     return 0
 
 

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -176,11 +176,15 @@ def _eppo_get(path: str, token: str) -> dict | list:
 
 
 def eppo_flag_index(token: str) -> dict[str, dict]:
-    """Fetch all feature flags (with allocations) indexed by their flag key.
+    """Fetch feature flags (with allocations) indexed by their flag key.
 
     Eppo's flag-detail endpoint is keyed by numeric id, not the flag key, so we
-    list all flags once and index by ``key``. Handles either a bare list or a
-    paginated envelope.
+    list flags and index by ``key``. Accepts a bare list or an envelope.
+
+    NOTE: this reads a single page. If the API paginates and a held fragment's
+    flag is on a later page, it surfaces as "Eppo flag not found" (a loud error,
+    never a silent wrong publish). The truncation check below warns when the
+    envelope reports more flags than were returned.
     """
     payload = _eppo_get("feature-flags?include_detailed_allocations=true", token)
     if isinstance(payload, list):
@@ -190,6 +194,13 @@ def eppo_flag_index(token: str) -> dict[str, dict]:
             payload.get("flags") or payload.get("data")
             or payload.get("results") or payload.get("items") or []
         )
+        total = payload.get("total_count") or payload.get("total") or payload.get("count")
+        if isinstance(total, int) and total > len(items):
+            print(
+                f"WARNING: Eppo returned {len(items)} of {total} flags (paginated); "
+                f"some held fragments may falsely report 'flag not found'.",
+                file=sys.stderr,
+            )
     return {f["key"]: f for f in items if isinstance(f, dict) and f.get("key")}
 
 
@@ -226,7 +237,8 @@ def is_fully_rolled_out(flag_json: dict) -> bool:
         if alloc.get("targeting_rules"):
             continue  # only covers targeted tenants; not the general population
         # First catch-all allocation reached: it decides what everyone else gets.
-        if alloc.get("percent_exposure", 1) != 1:
+        # Eppo expresses full exposure as the fraction 1; tolerate 100 (percent).
+        if alloc.get("percent_exposure", 1) not in (1, 100):
             return False  # partial traffic exposure
         served = [w for w in alloc.get("variation_weight", []) if w.get("weight", 0) > 0]
         if len(served) != 1:

--- a/scripts/assemble_changelog.py
+++ b/scripts/assemble_changelog.py
@@ -1,0 +1,426 @@
+#!/usr/bin/env python3
+"""Assemble weekly LangSmith Cloud + Fleet changelog entries from fragment files.
+
+Reads per-PR changelog fragments from ``langchainplus/.changelog/`` (see that
+directory's ``README.md`` for the schema), filters to the requested surfaces and
+to entries that are ready to publish, groups them by the category map, and
+renders a Mintlify ``<Update>`` block ready to paste into
+``src/langsmith/changelog.mdx``.
+
+The weekly agent (see ``.claude/skills/changelog-weekly``) runs this, reviews the
+rendered block, and opens a docs PR for human approval.
+
+Readiness:
+  - ``status: ready``            -> always included.
+  - ``status: held`` + ``flag``  -> included only if the Eppo flag is fully
+                                    rolled out (requires ``EPPO_API_KEY``).
+  - ``status: held`` + no token  -> excluded, and reported so a human can flip it.
+
+Usage:
+  uv run python scripts/assemble_changelog.py                  # dry-run, print block
+  uv run python scripts/assemble_changelog.py --week-label "June 15-19, 2026"
+  uv run python scripts/assemble_changelog.py --check-flag my-eppo-flag-key   # debug Eppo
+  uv run python scripts/assemble_changelog.py --promote       # flip rolled-out held -> ready
+
+Eppo access: set ``EPPO_API_KEY`` in the environment (never pass it on the CLI or
+commit it). The script only ever issues read (GET) requests to eppo.cloud.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import yaml
+
+# --- Constants -------------------------------------------------------------
+
+# docs and langchainplus are sibling checkouts (~/gh/docs, ~/gh/langchainplus).
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_FRAGMENTS_DIR = _REPO_ROOT.parent / "langchainplus" / ".changelog"
+
+# Eppo REST API. Domain is hardcoded (allowlist of one) and HTTPS-only per
+# our SSRF guidance; never read the base URL from user input.
+EPPO_API_BASE = "https://eppo.cloud/api/v1"
+EPPO_TIMEOUT_SECONDS = 15
+
+VALID_SURFACES = {"cloud", "fleet", "self-hosted"}
+
+
+# --- Fragment model --------------------------------------------------------
+
+
+@dataclass
+class Fragment:
+    path: Path
+    title: str
+    body: str
+    components: list[str]
+    surfaces: list[str]
+    flag: str | None
+    status: str
+    docs_link: str = ""
+    pr: str = ""
+    errors: list[str] = field(default_factory=list)
+
+
+def _require_within(root: Path, candidate: Path) -> Path:
+    """Resolve ``candidate`` and confirm it stays inside ``root``.
+
+    Guards against path traversal / symlink escapes when iterating fragments.
+    """
+    resolved = candidate.resolve()
+    root_resolved = root.resolve()
+    if root_resolved not in resolved.parents and resolved != root_resolved:
+        raise ValueError(f"Refusing to read path outside {root_resolved}: {resolved}")
+    return resolved
+
+
+def load_fragments(fragments_dir: Path) -> list[Fragment]:
+    """Load and validate every ``*.yaml`` fragment directly in ``fragments_dir``.
+
+    Files in ``published/`` and names starting with ``_`` or ``TEMPLATE`` are
+    skipped.
+    """
+    if not fragments_dir.is_dir():
+        raise SystemExit(f"Fragments directory not found: {fragments_dir}")
+
+    fragments: list[Fragment] = []
+    for entry in sorted(fragments_dir.glob("*.yaml")):
+        name = entry.name
+        if name.startswith(("_", "TEMPLATE")):
+            continue
+        path = _require_within(fragments_dir, entry)
+        try:
+            data = yaml.safe_load(path.read_text()) or {}
+        except yaml.YAMLError as exc:
+            fragments.append(_invalid(path, f"YAML parse error: {exc}"))
+            continue
+        fragments.append(_build_fragment(path, data))
+    return fragments
+
+
+def _invalid(path: Path, message: str) -> Fragment:
+    return Fragment(
+        path=path, title="", body="", components=[], surfaces=[], flag=None,
+        status="", errors=[message],
+    )
+
+
+def _build_fragment(path: Path, data: dict) -> Fragment:
+    frag = Fragment(
+        path=path,
+        title=str(data.get("title") or "").strip(),
+        body=str(data.get("body") or "").strip(),
+        components=list(data.get("components") or []),
+        surfaces=list(data.get("surfaces") or []),
+        flag=(data.get("flag") or None),
+        status=str(data.get("status") or "").strip().lower(),
+        docs_link=str(data.get("docs_link") or "").strip(),
+        pr=str(data.get("pr") or "").strip(),
+    )
+    if not frag.title:
+        frag.errors.append("missing `title`")
+    if not frag.body:
+        frag.errors.append("missing `body`")
+    if not frag.components:
+        frag.errors.append("missing `components`")
+    bad_surfaces = set(frag.surfaces) - VALID_SURFACES
+    if bad_surfaces:
+        frag.errors.append(f"invalid surfaces: {sorted(bad_surfaces)}")
+    if frag.status not in {"ready", "held"}:
+        frag.errors.append(f"invalid status: {frag.status!r} (want ready|held)")
+    if frag.status == "held" and not frag.flag:
+        frag.errors.append("status is held but no flag set")
+    return frag
+
+
+# --- Category map ----------------------------------------------------------
+
+
+def load_category_map(fragments_dir: Path) -> dict[str, dict]:
+    path = fragments_dir / "_category-map.yaml"
+    if not path.is_file():
+        raise SystemExit(f"Category map not found: {path}")
+    data = yaml.safe_load(path.read_text()) or {}
+    return data.get("components", {})
+
+
+def categorize(frag: Fragment, category_map: dict[str, dict]) -> tuple[str, str | None]:
+    """Return (section, group) from the first component present in the map."""
+    for comp in frag.components:
+        if comp in category_map:
+            entry = category_map[comp]
+            return entry["section"], entry.get("group")
+    return "Other", None
+
+
+# --- Eppo rollout check ----------------------------------------------------
+
+
+def _eppo_get(path: str, token: str) -> dict | list:
+    """GET a path under the Eppo REST API base (HTTPS + allowlisted domain)."""
+    url = f"{EPPO_API_BASE}/{path.lstrip('/')}"
+    if not url.startswith("https://eppo.cloud/"):  # belt-and-suspenders SSRF guard
+        raise ValueError("Eppo URL failed allowlist check")
+    req = urllib.request.Request(url, headers={"X-Eppo-Token": token})
+    with urllib.request.urlopen(req, timeout=EPPO_TIMEOUT_SECONDS) as resp:
+        return json.loads(resp.read().decode())
+
+
+def eppo_flag_index(token: str) -> dict[str, dict]:
+    """Fetch all feature flags (with allocations) indexed by their flag key.
+
+    Eppo's flag-detail endpoint is keyed by numeric id, not the flag key, so we
+    list all flags once and index by ``key``. Handles either a bare list or a
+    paginated envelope.
+    """
+    payload = _eppo_get("feature-flags?include_detailed_allocations=true", token)
+    if isinstance(payload, list):
+        items = payload
+    else:
+        items = (
+            payload.get("flags") or payload.get("data")
+            or payload.get("results") or payload.get("items") or []
+        )
+    return {f["key"]: f for f in items if isinstance(f, dict) and f.get("key")}
+
+
+def is_fully_rolled_out(flag_json: dict) -> bool:
+    """Return True when the flag serves one variant to the whole production audience.
+
+    Eppo models each environment as a waterfall of allocations (top-level
+    ``allocations``, tagged by ``environment_id``). Allocations with
+    ``targeting_rules`` only cover the tenants they match; users who match none
+    fall through to the first allocation with no targeting rules (the catch-all,
+    usually ``is_default``). That catch-all decides what the general population
+    gets, so it is the signal for "shipped to everyone".
+
+    Fully rolled out := the production environment is active AND its first
+    no-targeting allocation has full traffic exposure and assigns 100% weight to
+    a single variation. For BOOLEAN flags that variation must be ``"true"`` (a
+    catch-all serving ``"false"`` means the feature is off for everyone).
+    """
+    prod = next((e for e in flag_json.get("environments", []) if e.get("is_production")), None)
+    if prod is None or not prod.get("active"):
+        return False
+    prod_id = prod.get("id")
+
+    is_boolean = flag_json.get("variation_type") == "BOOLEAN"
+    on_variation_ids = {
+        v["id"] for v in flag_json.get("variations", []) if v.get("variant_key") == "true"
+    }
+
+    prod_allocations = [
+        a for a in flag_json.get("allocations", [])
+        if a.get("environment_id") == prod_id and not a.get("archived_at")
+    ]
+    for alloc in prod_allocations:
+        if alloc.get("targeting_rules"):
+            continue  # only covers targeted tenants; not the general population
+        # First catch-all allocation reached: it decides what everyone else gets.
+        if alloc.get("percent_exposure", 1) != 1:
+            return False  # partial traffic exposure
+        served = [w for w in alloc.get("variation_weight", []) if w.get("weight", 0) > 0]
+        if len(served) != 1:
+            return False  # split across variants (experiment), not a uniform rollout
+        if is_boolean and served[0].get("variation_id") not in on_variation_ids:
+            return False  # catch-all serves "false" -> off for everyone
+        return True
+    return False  # no catch-all -> only targeted tenants get the feature
+
+
+def effective_status(frag: Fragment, flag_index: dict[str, dict], have_token: bool) -> str:
+    """Resolve held entries against Eppo. Returns 'ready', 'held', or 'error'."""
+    if frag.status == "ready":
+        return "ready"
+    if frag.status == "held":
+        if not frag.flag or not have_token:
+            return "held"
+        flag = flag_index.get(frag.flag)
+        if flag is None:
+            frag.errors.append(f"Eppo flag not found: {frag.flag!r}")
+            return "error"
+        return "ready" if is_fully_rolled_out(flag) else "held"
+    return "error"
+
+
+# --- Rendering -------------------------------------------------------------
+
+
+def render_bullet(frag: Fragment) -> str:
+    text = frag.body
+    if frag.docs_link and "](" not in text:
+        sep = " " if text.endswith(".") else ". "
+        text = f"{text}{sep}[Learn more]({frag.docs_link})."
+    return f"- {text}"
+
+
+def render_update_block(
+    fragments: list[Fragment],
+    category_map: dict[str, dict],
+    week_label: str,
+    rss_date: str,
+) -> str:
+    """Render ready fragments into a single Mintlify ``<Update>`` block.
+
+    Sections and groups follow the order they appear in the category map.
+    """
+    section_order = []
+    for entry in category_map.values():
+        if entry["section"] not in section_order:
+            section_order.append(entry["section"])
+    section_order.append("Other")
+
+    # section -> group(or None) -> [bullets], preserving insertion order.
+    buckets: dict[str, dict[str | None, list[str]]] = {}
+    for frag in fragments:
+        section, group = categorize(frag, category_map)
+        buckets.setdefault(section, {}).setdefault(group, []).append(render_bullet(frag))
+
+    lines = [
+        f'<Update label="{week_label}" rss={{{{ title: "{rss_date} - LangSmith Cloud update" }}}}>',
+        "",
+    ]
+    for section in section_order:
+        if section not in buckets:
+            continue
+        lines.append(f"## {section}")
+        lines.append("")
+        groups = buckets[section]
+        # Render the ungrouped bullets first, then named groups.
+        if None in groups:
+            lines.extend(groups[None])
+            lines.append("")
+        for group, bullets in groups.items():
+            if group is None:
+                continue
+            lines.append(f"### {group}")
+            lines.append("")
+            lines.extend(bullets)
+            lines.append("")
+    lines.append("</Update>")
+    return "\n".join(lines)
+
+
+# --- Week helpers ----------------------------------------------------------
+
+
+def default_week(today: dt.date) -> tuple[str, str]:
+    """Return (label, rss_date) for the Mon-Fri week containing ``today``."""
+    monday = today - dt.timedelta(days=today.weekday())
+    friday = monday + dt.timedelta(days=4)
+    if monday.month == friday.month:
+        label = f"{monday.strftime('%B')} {monday.day}-{friday.day}, {friday.year}"
+    else:
+        label = f"{monday.strftime('%B %-d')} - {friday.strftime('%B %-d')}, {friday.year}"
+    return label, monday.isoformat()
+
+
+# --- CLI -------------------------------------------------------------------
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--fragments-dir", type=Path, default=DEFAULT_FRAGMENTS_DIR)
+    parser.add_argument("--surfaces", default="cloud,fleet", help="comma-separated surfaces to include")
+    parser.add_argument("--week-label", default=None, help='e.g. "June 15-19, 2026"')
+    parser.add_argument("--rss-date", default=None, help="ISO date for the rss title, e.g. 2026-06-15")
+    parser.add_argument("--check-flag", default=None, help="debug: print Eppo JSON + rollout verdict for a flag key")
+    parser.add_argument("--promote", action="store_true", help="flip rolled-out held fragments to status: ready in place")
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("EPPO_API_KEY")
+
+    # Debug mode: inspect one flag so the rollout predicate can be verified.
+    if args.check_flag:
+        if not token:
+            print("EPPO_API_KEY not set", file=sys.stderr)
+            return 2
+        index = eppo_flag_index(token)
+        flag = index.get(args.check_flag)
+        if flag is None:
+            print(f"Flag {args.check_flag!r} not found. Available keys (first 30):", file=sys.stderr)
+            for key in list(index)[:30]:
+                print(f"  - {key}", file=sys.stderr)
+            return 1
+        print(json.dumps(flag, indent=2))
+        print(f"\nis_fully_rolled_out -> {is_fully_rolled_out(flag)}", file=sys.stderr)
+        return 0
+
+    want_surfaces = {s.strip() for s in args.surfaces.split(",") if s.strip()}
+    fragments = load_fragments(args.fragments_dir)
+    category_map = load_category_map(args.fragments_dir)
+
+    invalid = [f for f in fragments if f.errors]
+    valid = [f for f in fragments if not f.errors]
+
+    # Fetch the Eppo flag index once if a token is available and any held
+    # fragment needs resolving.
+    flag_index: dict[str, dict] = {}
+    if token and any(f.status == "held" and f.flag for f in valid):
+        try:
+            flag_index = eppo_flag_index(token)
+        except (urllib.error.URLError, ValueError) as exc:
+            print(f"WARNING: could not fetch Eppo flags ({exc}); held entries stay held", file=sys.stderr)
+
+    ready, held, errored, promoted = [], [], [], []
+    for frag in valid:
+        if not (set(frag.surfaces) & want_surfaces):
+            continue
+        status = effective_status(frag, flag_index, bool(token))
+        if status == "ready":
+            ready.append(frag)
+            if args.promote and frag.status == "held":
+                _flip_to_ready(frag)
+                promoted.append(frag)
+        elif status == "held":
+            held.append(frag)
+        else:
+            errored.append(frag)
+
+    if not args.week_label or not args.rss_date:
+        label, rss = default_week(dt.date.today())
+        week_label = args.week_label or label
+        rss_date = args.rss_date or rss
+    else:
+        week_label, rss_date = args.week_label, args.rss_date
+
+    # Report to stderr so stdout stays a clean, paste-able MDX block.
+    def report(tag: str, items: list[Fragment]) -> None:
+        if items:
+            print(f"\n# {tag} ({len(items)}):", file=sys.stderr)
+            for f in items:
+                detail = f" — {'; '.join(f.errors)}" if f.errors else ""
+                print(f"  - {f.path.name}: {f.title or '(no title)'}{detail}", file=sys.stderr)
+
+    report("READY (rendered below)", ready)
+    report("HELD (flag not fully rolled out)", held)
+    report("ERROR (Eppo lookup failed)", errored)
+    report("INVALID fragments (skipped)", invalid)
+    if promoted:
+        print(f"\n# PROMOTED held -> ready in place ({len(promoted)})", file=sys.stderr)
+
+    if ready:
+        print(render_update_block(ready, category_map, week_label, rss_date))
+    else:
+        print("# No ready fragments for surfaces: " + ", ".join(sorted(want_surfaces)), file=sys.stderr)
+    return 0
+
+
+def _flip_to_ready(frag: Fragment) -> None:
+    """Rewrite the fragment's status field to ready, preserving the rest."""
+    data = yaml.safe_load(frag.path.read_text()) or {}
+    data["status"] = "ready"
+    frag.path.write_text(yaml.safe_dump(data, sort_keys=False))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_changelog_coverage.py
+++ b/scripts/audit_changelog_coverage.py
@@ -49,9 +49,12 @@ DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
 TYPE_RE = re.compile(r"^(feat|fix)(\([^)]*\))?!?:", re.IGNORECASE)
 INTERNAL_SCOPE_RE = re.compile(
     r"^(feat|fix)\((sandbox-host|sandbox-router|v21proxy|v21shadow|e2e|stlc|"
-    r"langdev|ci|smith-go|smith-sdks|messages)\)",
+    r"langdev|ci|smith-go|smith-sdks|messages|issuebench)\)",
     re.IGNORECASE,
 )
+# Self-hosted/BYOC/provisioning work has no scope to filter on but is out of
+# scope for the Cloud/Fleet changelog. Matched anywhere in the title.
+TITLE_INTERNAL_RE = re.compile(r"\b(byoc|data[ -]plane|provisioning)\b", re.IGNORECASE)
 PR_NUM_RE = re.compile(r"#(\d+)\s*$")
 
 
@@ -102,7 +105,11 @@ def fetch_merged_prs(since: dt.date, until: dt.date) -> list[dict]:
 
 
 def is_user_facing(title: str) -> bool:
-    return bool(TYPE_RE.match(title)) and not INTERNAL_SCOPE_RE.match(title)
+    return (
+        bool(TYPE_RE.match(title))
+        and not INTERNAL_SCOPE_RE.match(title)
+        and not TITLE_INTERNAL_RE.search(title)
+    )
 
 
 def covered_pr_numbers(fragments_dir: Path) -> set[int]:
@@ -132,10 +139,10 @@ def load_ignore(path: Path | None) -> set[int]:
     if not path:
         return set()
     nums: set[int] = set()
-    for line in path.read_text().splitlines():
-        line = line.split("#", 1)[0].strip() if not line.strip().startswith("#") else ""
-        if line.isdigit():
-            nums.add(int(line))
+    for raw in path.read_text().splitlines():
+        token = raw.split("#", 1)[0].strip()  # drop inline/full-line comments
+        if token.isdigit():
+            nums.add(int(token))
     return nums
 
 

--- a/scripts/audit_changelog_coverage.py
+++ b/scripts/audit_changelog_coverage.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""Reconciliation audit: find user-facing merged PRs with no changelog fragment.
+
+Lists merged PRs in langchain-ai/langchainplus over a CONTIGUOUS date window
+(covering weekends, so Friday/weekend merges never fall between weekly runs),
+filters to user-facing ``feat``/``fix`` changes, and reports any that have no
+corresponding ``.changelog`` fragment. This is the backstop that guarantees no
+user-facing PR silently slips out of the Cloud/Fleet changelog.
+
+It errs toward over-reporting: a borderline PR is flagged for a human to
+disposition rather than dropped. Dispositioned PRs (for example, ones written
+into the changelog by hand during the transition) go in ``--ignore-file`` so
+they are not re-flagged.
+
+Usage:
+  uv run python scripts/audit_changelog_coverage.py --since 2026-06-06 --until 2026-06-22
+  uv run python scripts/audit_changelog_coverage.py            # default: last 14 days
+  uv run python scripts/audit_changelog_coverage.py --ignore-file dispositioned.txt
+
+Requires the `gh` CLI, authenticated for langchain-ai/langchainplus (read-only).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+DEFAULT_FRAGMENTS_DIR = _REPO_ROOT.parent / "langchainplus" / ".changelog"
+REPO = "langchain-ai/langchainplus"
+
+GH_TIMEOUT_SECONDS = 90
+GH_PAGE_LIMIT = 1000          # gh search hard cap; we sub-window to stay under it.
+SUBWINDOW_DAYS = 7            # query at most a week at a time to avoid truncation.
+
+DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+# Only feat/fix are candidate user-facing changes (docs/refactor/perf/chore/ci/
+# test/build/revert are excluded by type). Within feat/fix, drop scopes that are
+# clearly internal/infra. Kept deliberately SHORT so the audit over-reports
+# rather than hiding a real gap.
+TYPE_RE = re.compile(r"^(feat|fix)(\([^)]*\))?!?:", re.IGNORECASE)
+INTERNAL_SCOPE_RE = re.compile(
+    r"^(feat|fix)\((sandbox-host|sandbox-router|v21proxy|v21shadow|e2e|stlc|"
+    r"langdev|ci|smith-go|smith-sdks|messages)\)",
+    re.IGNORECASE,
+)
+PR_NUM_RE = re.compile(r"#(\d+)\s*$")
+
+
+def _validate_date(value: str) -> str:
+    if not DATE_RE.match(value):
+        raise SystemExit(f"Invalid date {value!r}; expected YYYY-MM-DD")
+    return value
+
+
+def _subwindows(since: dt.date, until: dt.date) -> list[tuple[dt.date, dt.date]]:
+    """Split [since, until] into contiguous chunks of at most SUBWINDOW_DAYS."""
+    if since > until:
+        raise SystemExit(f"--since ({since}) is after --until ({until})")
+    out = []
+    start = since
+    while start <= until:
+        end = min(start + dt.timedelta(days=SUBWINDOW_DAYS - 1), until)
+        out.append((start, end))
+        start = end + dt.timedelta(days=1)
+    return out
+
+
+def fetch_merged_prs(since: dt.date, until: dt.date) -> list[dict]:
+    """Fetch merged PRs across the window, sub-windowing to avoid the page cap."""
+    prs: dict[int, dict] = {}
+    for start, end in _subwindows(since, until):
+        argv = [
+            "gh", "search", "prs", "--repo", REPO, "--merged",
+            "--merged-at", f"{start.isoformat()}..{end.isoformat()}",
+            "--limit", str(GH_PAGE_LIMIT),
+            "--json", "number,title,url",
+        ]
+        result = subprocess.run(
+            argv, capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS, check=False,
+        )
+        if result.returncode != 0:
+            raise SystemExit(f"gh failed for {start}..{end}: {result.stderr.strip()}")
+        batch = json.loads(result.stdout or "[]")
+        if len(batch) >= GH_PAGE_LIMIT:
+            print(
+                f"WARNING: {start}..{end} hit the {GH_PAGE_LIMIT}-result cap; "
+                f"narrow SUBWINDOW_DAYS to avoid missing PRs.",
+                file=sys.stderr,
+            )
+        for pr in batch:
+            prs[pr["number"]] = pr
+    return list(prs.values())
+
+
+def is_user_facing(title: str) -> bool:
+    return bool(TYPE_RE.match(title)) and not INTERNAL_SCOPE_RE.match(title)
+
+
+def covered_pr_numbers(fragments_dir: Path) -> set[int]:
+    """PR numbers referenced by any fragment (active or already published)."""
+    root = fragments_dir.resolve()
+    covered: set[int] = set()
+    for sub in (root, root / "published"):
+        if not sub.is_dir():
+            continue
+        for path in sub.glob("*.yaml"):
+            resolved = path.resolve()
+            if root not in resolved.parents:  # path-traversal guard
+                continue
+            if resolved.name.startswith(("_", "TEMPLATE")):
+                continue
+            try:
+                data = yaml.safe_load(resolved.read_text()) or {}
+            except yaml.YAMLError:
+                continue
+            m = PR_NUM_RE.search(str(data.get("pr", "")))
+            if m:
+                covered.add(int(m.group(1)))
+    return covered
+
+
+def load_ignore(path: Path | None) -> set[int]:
+    if not path:
+        return set()
+    nums: set[int] = set()
+    for line in path.read_text().splitlines():
+        line = line.split("#", 1)[0].strip() if not line.strip().startswith("#") else ""
+        if line.isdigit():
+            nums.add(int(line))
+    return nums
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--since", type=_validate_date, default=None, help="YYYY-MM-DD (default: 14 days ago)")
+    parser.add_argument("--until", type=_validate_date, default=None, help="YYYY-MM-DD (default: today)")
+    parser.add_argument("--fragments-dir", type=Path, default=DEFAULT_FRAGMENTS_DIR)
+    parser.add_argument("--ignore-file", type=Path, default=None, help="newline list of PR numbers to skip")
+    args = parser.parse_args(argv)
+
+    today = dt.date.today()
+    until = dt.date.fromisoformat(args.until) if args.until else today
+    since = dt.date.fromisoformat(args.since) if args.since else until - dt.timedelta(days=14)
+
+    prs = fetch_merged_prs(since, until)
+    covered = covered_pr_numbers(args.fragments_dir)
+    ignored = load_ignore(args.ignore_file)
+
+    candidates = [p for p in prs if is_user_facing(p["title"])]
+    uncovered = [
+        p for p in candidates
+        if p["number"] not in covered and p["number"] not in ignored
+    ]
+    uncovered.sort(key=lambda p: p["number"], reverse=True)
+
+    print(
+        f"# Audit {since}..{until} (contiguous, includes weekends)\n"
+        f"# merged PRs: {len(prs)} | user-facing feat/fix: {len(candidates)} | "
+        f"covered by a fragment: {sum(1 for p in candidates if p['number'] in covered)} | "
+        f"ignored: {sum(1 for p in candidates if p['number'] in ignored)}\n"
+        f"# UNCOVERED (no fragment, needs disposition): {len(uncovered)}",
+        file=sys.stderr,
+    )
+    for p in uncovered:
+        print(f"{p['number']}\t{p['title']}\t{p['url']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/audit_changelog_coverage.py
+++ b/scripts/audit_changelog_coverage.py
@@ -135,6 +135,26 @@ def covered_pr_numbers(fragments_dir: Path) -> set[int]:
     return covered
 
 
+def pr_added_fragment(pr_number: int) -> bool:
+    """True if the PR's own diff adds or touches a .changelog/*.yaml fragment.
+
+    This is the primary (going-forward) coverage signal: a fragment authored in
+    the same PR as the change needs no `pr:` field. The `pr:` field is only the
+    fallback for fragments added separately from their source PR (e.g. backfills).
+    """
+    argv = ["gh", "pr", "view", str(pr_number), "--repo", REPO, "--json", "files"]
+    result = subprocess.run(
+        argv, capture_output=True, text=True, timeout=GH_TIMEOUT_SECONDS, check=False
+    )
+    if result.returncode != 0:
+        return False
+    files = json.loads(result.stdout or "{}").get("files", [])
+    return any(
+        f.get("path", "").startswith(".changelog/") and f.get("path", "").endswith(".yaml")
+        for f in files
+    )
+
+
 def load_ignore(path: Path | None) -> set[int]:
     if not path:
         return set()
@@ -163,6 +183,12 @@ def main(argv: list[str] | None = None) -> int:
     ignored = load_ignore(args.ignore_file)
 
     candidates = [p for p in prs if is_user_facing(p["title"])]
+    # Going-forward coverage: a PR that added a fragment in its own diff is
+    # covered without a `pr:` field. Only check candidates not already covered
+    # (by a fragment's pr: field) or dispositioned, to limit gh calls.
+    for p in candidates:
+        if p["number"] not in covered and p["number"] not in ignored and pr_added_fragment(p["number"]):
+            covered.add(p["number"])
     uncovered = [
         p for p in candidates
         if p["number"] not in covered and p["number"] not in ignored

--- a/scripts/changelog_audit_ignore.txt
+++ b/scripts/changelog_audit_ignore.txt
@@ -1,0 +1,116 @@
+# PR numbers already dispositioned for the changelog coverage audit.
+# These were reviewed during the June 15-19 backfill and judged NOT user-facing
+# (internal/infra/refactor/security-hardening/test). The audit skips them.
+# Add a PR number here once you have decided it does not need a changelog entry.
+# Lines starting with # are comments.
+
+# --- backfill 2026-06-19 exclusions (chunk aa) ---
+27987
+27978
+27959
+27947
+27913
+27907
+27906
+27893
+27874
+27857
+27837
+27835
+27827
+27808
+27797
+27768
+27759
+27753
+27749
+27747
+27736
+# --- chunk ab ---
+27730
+27726
+27723
+27715
+27710
+27709
+27706
+27687
+27682
+27681
+27678
+27677
+27664
+27663
+27651
+27643
+27638
+27637
+27603
+27601
+# --- chunk ac ---
+27600
+27595
+27592
+27589
+27586
+27573
+27568
+27559
+27558
+27536
+27543
+27526
+27528
+27515
+27512
+27507
+27496
+27474
+27472
+27471
+27468
+27466
+# --- recovery pass 2026-06-19 (internal/infra/byoc/issuebench/smithdb; #27864 dup of #27791) ---
+27993
+27992
+27981
+27975
+27949
+27939
+27891
+27864
+27845
+27840
+27812
+27800
+27796
+27787
+27786
+27780
+27762
+27720
+27718
+27702
+27670
+27516
+27513
+27505
+27426
+27314
+# --- chunk ad ---
+27457
+27453
+27444
+27443
+27438
+27427
+27415
+27390
+27322
+27305
+27286
+27257
+27186
+26971
+26910
+26835


### PR DESCRIPTION
## Why
Tooling for the fragment-based Cloud/Fleet changelog: generate the weekly entry from `.changelog` fragments, and guarantee no user-facing PR slips through.

## What
- `scripts/assemble_changelog.py`: reads langchainplus `.changelog` fragments, filters by surface and readiness, resolves Eppo flag rollout (held → ready once a flag is fully rolled out), and renders the Mintlify `<Update>` block. Verified against the live Eppo API.
- `scripts/audit_changelog_coverage.py`: lists merged langchainplus PRs over a contiguous, weekend-inclusive window and flags any user-facing `feat`/`fix` with no fragment. Sub-windows queries to avoid the gh 1000-result cap.
- `scripts/changelog_audit_ignore.txt`: dispositioned (not-user-facing) PRs the audit skips.

Read-only against the Eppo API and `gh`; `EPPO_API_KEY` is read from the environment / the docs repo Actions secret.

Drafted with assistance from Claude Code.