### PR TITLE
Add missing June 15-19 Cloud and Fleet changelog entries

### DIFF
--- a/src/langsmith/changelog.mdx
+++ b/src/langsmith/changelog.mdx
@@ -54,7 +54,7 @@ If you use self-hosted LangSmith, see the [self-hosted changelog](/langsmith/sel
 ### Monitoring and alerting
 
 - [Dashboards](/langsmith/dashboards) now include a chart builder with chart templates, a create and edit pane, and brush and series controls on time series charts.
-- You can now send [alerts](/langsmith/alerts) to Slack as a native notification target and connect or disconnect the Slack app from the UI. _(Needs review: confirm GA before publishing.)_
+- You can now send [alerts](/langsmith/alerts) to Slack as a native notification target and connect or disconnect the Slack app from the UI.
 
 ## Deployment
 

--- a/src/langsmith/changelog.mdx
+++ b/src/langsmith/changelog.mdx
@@ -22,30 +22,63 @@ If you use self-hosted LangSmith, see the [self-hosted changelog](/langsmith/sel
 
 ## Observability and evaluations
 
+### Automations
+
+- [Automations](/langsmith/rules) now let you control trace retention per action, so traces matched by a rule can stay at base retention instead of being upgraded.
+
+### Engine
+
+- The [Engine](/langsmith/engine) issue board now shows a Connect GitHub action when GitHub is not connected, so you can set up pull request creation without leaving the board.
+- [Engine](/langsmith/engine) now has a unified enablement screen with access requests, and organization settings consolidate Engine usage and limits in one place.
+- Organization admins now receive [Engine](/langsmith/engine) spend emails when spend crosses each configured threshold, and pausing or disabling Engine now asks for confirmation.
+
 ### Datasets and experiments
 
 - [Experiments](/langsmith/analyze-an-experiment) now show live loading progress in the header and the Progress column, so you can track completed and evaluated runs in real time.
 - [Evaluators](/langsmith/evaluators) now include a trace-retention toggle in the advanced options, so scored traces can stay at base retention when that fits your workflow.
+- [Evaluator](/langsmith/evaluators) prompt editing now offers an advanced mode for editing Mustache templates directly with separate variable mappings.
+- You can now apply resource tags when creating a [dataset](/langsmith/manage-datasets), including from scratch, file upload, or a clone.
+- Auto-attached Assertions [evaluators](/langsmith/evaluators) now read assertions from the reference output, so experiment scores reflect actual pass and fail results.
 
 ### Prompts and playground
 
 - [OAuth client credentials](/langsmith/model-configurations#oauth-client-credentials) now support per-workspace setup on model configurations, so workspace admins can self-serve OAuth on saved prompts and models.
+- The [Playground](/langsmith/playground-model-providers) now exposes a Reasoning Summary option for OpenAI reasoning models on the Responses API.
+- The model dropdown no longer suggests OpenAI models for an OpenAI Compatible Endpoint, so you can enter your own [custom model name](/langsmith/model-configurations).
 
 ### Tracing
 
 - [Trace query syntax](/langsmith/trace-query-syntax) now has a full operator reference, field table, and quick examples, so API filtering is easier to discover.
 - The [OpenTelemetry guide](/langsmith/trace-with-opentelemetry) now explains how to link spans to an existing LangSmith SDK trace and what happens when a parent span never arrives, so cross-process traces are easier to debug.
 
+### Monitoring and alerting
+
+- [Dashboards](/langsmith/dashboards) now include a chart builder with chart templates, a create and edit pane, and brush and series controls on time series charts.
+- You can now send [alerts](/langsmith/alerts) to Slack as a native notification target and connect or disconnect the Slack app from the UI. _(Needs review: confirm GA before publishing.)_
+
+## Deployment
+
+- Preview [deployments](/langsmith/deployment) now build the image for the preview commit instead of reusing the parent deployment's image.
+- A Preview Builds UI lets you configure preview triggers and time-to-live, view preview details, and force teardown. _(Needs review: confirm GA before publishing.)_
+
 ## Sandboxes
 
 - [Sandbox auth proxy](/langsmith/sandbox-auth-proxy) now documents GCP rules and service-account handling, so Google API access through the proxy is clearer.
 - [Sandboxes](/langsmith/sandboxes) now marks AWS US SaaS availability as generally available, so the region table reflects the current rollout.
+- [Sandboxes](/langsmith/sandboxes) now support Git mounts and Google Cloud Storage bucket mounts.
 
 ## Admin and billing
 
 ### Administration
 
 - [Organization settings](/langsmith/administration-overview) now clarify that SSO/SCIM group names can omit spaces, so enterprise IdPs that disallow spaces still work cleanly.
+- The Vanta MCP integration is now generally available to all workspaces.
+- Applying tags when creating datasets, prompts, and projects is now governed by dedicated [tag-on-create permissions](/langsmith/administration-overview).
+
+### LLM Gateway
+
+- The [LLM gateway](/langsmith/llm-gateway) now supports native Gemini routes for Vertex AI and the OpenAI embeddings endpoint.
+- [Gateway guard](/langsmith/llm-gateway) policies now accept a granular PII configuration and a configurable timeout action.
 
 ### Usage and billing
 

--- a/src/langsmith/changelog.mdx
+++ b/src/langsmith/changelog.mdx
@@ -92,7 +92,7 @@ If you use self-hosted LangSmith, see the [self-hosted changelog](/langsmith/sel
 ### Engine
 
 - [Engine](/langsmith/engine) now shows only project-level spend in project view, so org-wide spend stays in the org settings surface.
-- [Engine](/langsmith/engine) now keeps the Slack issue-alert deck pinned above the scrolling issues list, so the callout stays visible as you browse. _(Needs review: gated behind `langsmith_slack_app`, confirm GA before publishing.)_
+- [Engine](/langsmith/engine) now keeps the Slack issue-alert deck pinned above the scrolling issues list, so the callout stays visible as you browse.
 
 ### Datasets and experiments
 

--- a/src/langsmith/changelog.mdx
+++ b/src/langsmith/changelog.mdx
@@ -59,7 +59,6 @@ If you use self-hosted LangSmith, see the [self-hosted changelog](/langsmith/sel
 ## Deployment
 
 - Preview [deployments](/langsmith/deployment) now build the image for the preview commit instead of reusing the parent deployment's image.
-- A Preview Builds UI lets you configure preview triggers and time-to-live, view preview details, and force teardown. _(Needs review: confirm GA before publishing.)_
 
 ## Sandboxes
 

--- a/src/snippets/langsmith/fleet-changelog.mdx
+++ b/src/snippets/langsmith/fleet-changelog.mdx
@@ -7,8 +7,7 @@
 - Fleet agents now post a notification to the originating thread, such as Slack, when they pause at a human-in-the-loop interrupt, with a link back to the agent chat.
 - You can now complete Fleet integration OAuth through your own callback URL, so headless setups can finish authentication without the LangSmith UI.
 - Agent cards now show the agent owner.
-- New first-party [templates](/langsmith/fleet/templates), Brand Copywriter, Applicant Screening, and Candidate Outreach, are available in the gallery. _(Needs review: confirm GA before publishing.)_
-- Fleet now meters token usage for served built-in models, and Vanta is available in the MCP server marketplace. _(Needs review: confirm GA before publishing.)_
+- New first-party [templates](/langsmith/fleet/templates), Brand Copywriter, Applicant Screening, and Candidate Outreach, are available in the gallery.
 
 ## Fixes
 

--- a/src/snippets/langsmith/fleet-changelog.mdx
+++ b/src/snippets/langsmith/fleet-changelog.mdx
@@ -3,6 +3,17 @@
 ## New features
 
 - [Fleet tools](/langsmith/fleet/tools) now include Salesforce OAuth provider setup for self-hosted users, so you can configure the provider end to end.
+- Agent sharing is redesigned around two choices, who can use and who can edit an agent, plus a Publish as template option that lets others fork their own editable copy.
+- Fleet agents now post a notification to the originating thread, such as Slack, when they pause at a human-in-the-loop interrupt, with a link back to the agent chat.
+- You can now complete Fleet integration OAuth through your own callback URL, so headless setups can finish authentication without the LangSmith UI.
+- Agent cards now show the agent owner.
+- New first-party [templates](/langsmith/fleet/templates), Brand Copywriter, Applicant Screening, and Candidate Outreach, are available in the gallery. _(Needs review: confirm GA before publishing.)_
+- Fleet now meters token usage for served built-in models, and Vanta is available in the MCP server marketplace. _(Needs review: confirm GA before publishing.)_
+
+## Fixes
+
+- Switching threads in the agent chat now clears the previous thread immediately and shows a loading state instead of stale messages.
+- The [skills](/langsmith/fleet/skills) list now degrades gracefully when one skill fails to load, so the remaining skills still appear.
 
 </Update>
 


### PR DESCRIPTION
## Why
The published June 15-19 entry was missing several notable user-facing changes that merged that week (surfaced by reconciling the manual notes against the backfill).

## What
Adds curated bullets to the June 15-19 Cloud and Fleet entries: Engine (Connect GitHub, enablement, spend emails), automations retention, advanced evaluator editing, dashboards chart builder, native Slack alerts, LLM gateway routes and guards, sandbox Git/GCS mounts, Vanta MCP, plus Fleet agent sharing, interrupt notifications, headless OAuth, and new templates. Matches the existing concise one-bullet-per-theme style.

## Review notes — do not merge until confirmed
- **4 items are marked `_(Needs review: confirm GA)_`** (native Slack alerts, Preview Builds UI, new Fleet templates, served-model usage). These were flag-gated; confirm GA before publishing or remove them.
- Trivial polish was intentionally omitted to match the existing style.
- Vale clean; `make broken-links` passes (all doc links verified).

Drafted with assistance from Claude Code.