### PR TITLE
Remove Candidate Outreach from Jun 15-19 changelog (flag not GA)

### DIFF
--- a/src/snippets/langsmith/fleet-changelog.mdx
+++ b/src/snippets/langsmith/fleet-changelog.mdx
@@ -7,7 +7,7 @@
 - Fleet agents now post a notification to the originating thread, such as Slack, when they pause at a human-in-the-loop interrupt, with a link back to the agent chat.
 - You can now complete Fleet integration OAuth through your own callback URL, so headless setups can finish authentication without the LangSmith UI.
 - Agent cards now show the agent owner.
-- New first-party [templates](/langsmith/fleet/templates), Brand Copywriter, Applicant Screening, and Candidate Outreach, are available in the gallery.
+- New first-party [templates](/langsmith/fleet/templates), Brand Copywriter and Applicant Screening, are available in the gallery.
 
 ## Fixes
 


### PR DESCRIPTION
## Why
The merged June 15-19 entry (#4574) lists the Candidate Outreach Fleet template as available, but `fleet_template_candidate_outreach` is not in the confirmed-GA set (only `fleet_template_copywriting_agent` and `fleet_template_applicant_screening` were confirmed in prod). Announcing it risks pointing customers at a feature still hidden behind a rollout flag.

## What
Drops Candidate Outreach from the templates bullet. It is tracked as a `held` fragment in langchainplus#28144 and will be announced automatically when its flag is fully rolled out.

Follow-up to #4574, which merged before this flag check.

Drafted with assistance from Claude Code.