### PR TITLE
dcode: clarify `openai_codex` vs `OPENAI_API_KEY` coexistence

### DIFF
--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -155,6 +155,8 @@ DEEPAGENTS_CODE_OPENAI_API_KEY=sk-xxxx dcode -n "..."
 
 This layering exists for the common case where your machine already exports a plain provider variable for some other purpose — a shared `OPENAI_API_KEY` used by other tools, scripts, or CI — that you do not want Deep Agents Code to reuse. An app-stored key or a `DEEPAGENTS_CODE_`-prefixed variable gives Deep Agents Code its own value while leaving the unprefixed one untouched for everything else, so the two never mix.
 
+This order applies to a single provider's API key. The `openai` and `openai_codex` providers are independent: `OPENAI_API_KEY` belongs to `openai`, while `openai_codex` uses a ChatGPT sign-in, so the two never compete—the model you select decides which is used. See [Sign in with ChatGPT](/oss/deepagents/code/providers#sign-in-with-chatgpt) for how they interact, including which one a fresh launch defaults to.
+
 Each provider's API key and its endpoint (`base_url`) resolve as a pair from the same source. See [Endpoints, keys, and gateways](#endpoints-keys-and-gateways).
 
 ### Enable web search with Tavily

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -113,6 +113,12 @@ Your sign-in persists across sessions. To check your status or sign out, run `/a
     `openai_codex` is separate from `openai`. To use OpenAI models with a standard API key instead, use the regular `openai` provider (e.g. `/model openai:gpt-5.5`).
 </Note>
 
+<Warning>
+    Being signed into `openai_codex` and having an `OPENAI_API_KEY` set are not mutually exclusive—they are independent credentials for two separate providers, and the model you select decides which one is used. A Codex model (`openai_codex:...`) always authenticates with your ChatGPT sign-in and never uses `OPENAI_API_KEY`; an `openai:...` model always uses the API key.
+
+    The one place this matters is the startup default. [Environment auto-detection](#switch-models) only checks `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, and `GOOGLE_CLOUD_PROJECT`—**not** your ChatGPT sign-in. So if you have both set and no `--model`, `[models].default`, or `[models].recent`, a fresh launch defaults to `openai:gpt-5.5` (the API key), not Codex. To make Codex your default, set `[models].default = "openai_codex:<model>"` in `~/.deepagents/config.toml` or pass `--model openai_codex:<model>`.
+</Warning>
+
 :::
 
 ### Model routers and proxies
@@ -183,6 +189,8 @@ To switch models in Deep Agents Code, either:
     4. **Environment auto-detection**: falls back to the first available startup credential, checked in order: `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_API_KEY`, `GOOGLE_CLOUD_PROJECT` (Vertex AI).
 
     This startup fallback intentionally checks only those four credentials. Other supported providers (for example, Groq) are still available via `--model`, `/model`, and saved defaults (`[models].default` / `[models].recent`).
+
+    Auto-detection does **not** consider an [`openai_codex` ChatGPT sign-in](#sign-in-with-chatgpt). If you are signed into Codex but also have `OPENAI_API_KEY` set, a fresh launch with no saved default selects `openai`, not `openai_codex`. Set `[models].default = "openai_codex:<model>"` or pass `--model openai_codex:<model>` to make Codex your default.
 </Accordion>
 
 ### Which models appear in the switcher


### PR DESCRIPTION
Deep Agents Code's `openai` and `openai_codex` providers are independent, but the docs never spelled out what happens when a user has both an `OPENAI_API_KEY` set *and* a ChatGPT/Codex OAuth sign-in. This adds a `<Warning>` in the "Sign in with ChatGPT" section, a note in the model-resolution accordion, and a clarifying line in `configuration.mdx`'s key-resolution section explaining that startup auto-detection ignores the Codex sign-in, so a fresh launch defaults to `openai`, plus how to make Codex the default.

Made by [Open SWE](https://openswe.vercel.app/agents/4f27684d-e115-0894-1ac8-72a569edfddf)