### PR TITLE
chore: clarify self-host upgrade path

### DIFF
--- a/src/langsmith/self-host-upgrades.mdx
+++ b/src/langsmith/self-host-upgrades.mdx
@@ -46,6 +46,10 @@ langchain/langsmith     0.10.9          0.10.29         Helm chart to deploy the
 
 Choose the version you want to upgrade to (generally the latest version is recommended) and note the version number:
 
+<Note>
+If your installation is more than one major version behind the latest chart, upgrade one major version at a time. Do not skip major versions. Repeat this upgrade procedure for each intervening major version before upgrading to the latest supported version.
+</Note>
+
 ```bash
 helm upgrade <release-name> langchain/langsmith --version <version> --values <path-to-values-file> --wait --debug
 ```


### PR DESCRIPTION
## Description
Clarifies the self-hosted LangSmith upgrade guide so customers know to move across major versions incrementally instead of skipping major versions.

## Self-Hosted Release Note
Documented one-major-version-at-a-time upgrades for self-hosted deployments.

## Test Plan
- [x] `make lint_prose FILES="src/langsmith/self-host-upgrades.mdx"`

Made by [Open SWE](https://openswe.vercel.app/agents/59203efa-1177-b2a4-30c2-512ad123b5a1)