### PR TITLE
docs: group backfilled LangSmith changelog entries into weekly blocks

### DIFF
--- a/src/langsmith/changelog.mdx
+++ b/src/langsmith/changelog.mdx
@@ -173,7 +173,11 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="February 19, 2026" rss={{ title: "2026-02-19 - Cloud update" }}>
+<Update label="February 17-21, 2026" rss={{ title: "2026-02-17 - Cloud update" }}>
+
+## Observability
+
+- The [Insights Agent](/langsmith/insights) now supports scheduled reports on daily, weekly, or custom cron intervals, so report generation runs without manual triggering. Time ranges compute dynamically, so a "last 24 hours" report always reflects the most recent window when it runs, not when you configured it.
 
 ## Datasets and experiments
 
@@ -181,15 +185,11 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="February 17, 2026" rss={{ title: "2026-02-17 - Cloud update" }}>
+<Update label="February 5-9, 2026" rss={{ title: "2026-02-05 - Cloud update" }}>
 
 ## Observability
 
-- The [Insights Agent](/langsmith/insights) now supports scheduled reports on daily, weekly, or custom cron intervals, so report generation runs without manual triggering. Time ranges compute dynamically, so a "last 24 hours" report always reflects the most recent window when it runs, not when you configured it.
-
-</Update>
-
-<Update label="February 6, 2026" rss={{ title: "2026-02-06 - Cloud update" }}>
+- [Cost tracking](/langsmith/cost-tracking) now extends beyond LLM calls. Submit custom cost metadata for any run, such as an expensive tool call, a third-party API, or a retrieval step, to monitor, debug, and optimize spend across your entire agent stack from a single dashboard.
 
 ## Tracing
 
@@ -197,27 +197,15 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="February 5, 2026" rss={{ title: "2026-02-05 - Cloud update" }}>
-
-## Observability
-
-- [Cost tracking](/langsmith/cost-tracking) now extends beyond LLM calls. Submit custom cost metadata for any run, such as an expensive tool call, a third-party API, or a retrieval step, to monitor, debug, and optimize spend across your entire agent stack from a single dashboard.
-
-</Update>
-
-<Update label="December 17, 2025" rss={{ title: "2025-12-17 - Cloud update" }}>
-
-## Annotation and human feedback
-
-- New pairwise [annotation queues](/langsmith/annotation-queues) let reviewers compare two runs side by side and choose whether option A is better, option B is better, or the two are equal across rubric items. LangSmith automatically pairs runs between two experiments and manages queues, reviewer assignments, and trace access, so you can run A/B evaluations across agents, prompts, and models, including for subjective dimensions like tone, correctness, usefulness, or style.
-
-</Update>
-
-<Update label="December 10, 2025" rss={{ title: "2025-12-10 - Cloud update" }}>
+<Update label="December 10-17, 2025" rss={{ title: "2025-12-10 - Cloud update" }}>
 
 ## Observability
 
 - LangSmith Fetch, a new command-line tool, brings LangSmith traces directly into your terminal, coding environment, or IDE. Install it with `pip install langsmith-fetch`, then retrieve traces with filters such as `--limit`, `--after`, and `--last-n-minutes`, or bulk-export traces and threads to files for analysis, scripting, or dataset creation.
+
+## Annotation and human feedback
+
+- New pairwise [annotation queues](/langsmith/annotation-queues) let reviewers compare two runs side by side and choose whether option A is better, option B is better, or the two are equal across rubric items. LangSmith automatically pairs runs between two experiments and manages queues, reviewer assignments, and trace access, so you can run A/B evaluations across agents, prompts, and models, including for subjective dimensions like tone, correctness, usefulness, or style.
 
 </Update>
 

--- a/src/langsmith/changelog.mdx
+++ b/src/langsmith/changelog.mdx
@@ -175,11 +175,13 @@ The experiments table now displays loading progress bars showing the number of r
 
 <Update label="February 17-21, 2026" rss={{ title: "2026-02-17 - Cloud update" }}>
 
-## Observability
+## Observability and evaluations
+
+### Insights
 
 - The [Insights Agent](/langsmith/insights) now supports scheduled reports on daily, weekly, or custom cron intervals, so report generation runs without manual triggering. Time ranges compute dynamically, so a "last 24 hours" report always reflects the most recent window when it runs, not when you configured it.
 
-## Datasets and experiments
+### Datasets and experiments
 
 - You can now pin any experiment as a baseline. The pinned experiment stays at the top of the [Experiments](/langsmith/compare-experiment-results) view and serves as the automatic comparison point for later runs, surfacing performance deltas across every column so improvements and regressions are immediately clear.
 
@@ -187,11 +189,13 @@ The experiments table now displays loading progress bars showing the number of r
 
 <Update label="February 5-9, 2026" rss={{ title: "2026-02-05 - Cloud update" }}>
 
-## Observability
+## Observability and evaluations
+
+### Cost tracking
 
 - [Cost tracking](/langsmith/cost-tracking) now extends beyond LLM calls. Submit custom cost metadata for any run, such as an expensive tool call, a third-party API, or a retrieval step, to monitor, debug, and optimize spend across your entire agent stack from a single dashboard.
 
-## Tracing
+### Tracing
 
 - You can now [configure which parts of a trace's inputs and outputs](/langsmith/configure-input-output-preview) appear in the tracing table, so teams working with custom trace formats can surface the most relevant fields, reduce clutter, and identify traces that need a closer look faster.
 
@@ -199,11 +203,13 @@ The experiments table now displays loading progress bars showing the number of r
 
 <Update label="December 10-17, 2025" rss={{ title: "2025-12-10 - Cloud update" }}>
 
-## Observability
+## Observability and evaluations
+
+### Tracing
 
 - LangSmith Fetch, a new command-line tool, brings LangSmith traces directly into your terminal, coding environment, or IDE. Install it with `pip install langsmith-fetch`, then retrieve traces with filters such as `--limit`, `--after`, and `--last-n-minutes`, or bulk-export traces and threads to files for analysis, scripting, or dataset creation.
 
-## Annotation and human feedback
+### Annotation and human feedback
 
 - New pairwise [annotation queues](/langsmith/annotation-queues) let reviewers compare two runs side by side and choose whether option A is better, option B is better, or the two are equal across rubric items. LangSmith automatically pairs runs between two experiments and manages queues, reviewer assignments, and trace access, so you can run A/B evaluations across agents, prompts, and models, including for subjective dimensions like tone, correctness, usefulness, or style.
 


### PR DESCRIPTION
## Why

The legacy LangSmith Cloud changelog entries (Dec 2025–Feb 2026) were backfilled as individual single-date `<Update>` blocks. This refines them to match the weekly cadence and heading structure used by the rest of the changelog.

## What

- **Group into weekly blocks**: the six single-date entries become three weekly `<Update>` blocks — December 10-17, 2025; February 5-9, 2026; February 17-21, 2026.
- **Standard heading structure**: each block now nests its entries under a single `## Observability and evaluations` umbrella with `###` subsections (Insights, Cost tracking, Tracing, Datasets and experiments, Annotation and human feedback), matching the existing June blocks. No flat duplicate top-level headings remain.

Content and links are unchanged from the backfill — only the grouping and heading structure changed. The Fleet changelog is left as-is per request.

## Notes

- The `February 17-21, 2026` label covers the entries dated Feb 17 and Feb 19; happy to relabel if a different range is preferred.
- `make lint_prose` passes clean; a duplicate-heading scan confirms no repeated heading within any block.

AI agent disclosure: drafted with Claude Code, reviewed by @laurenhirata.