### PR TITLE
docs: backfill LangSmith Cloud and Fleet changelogs (2025)

### DIFF
--- a/src/langsmith/changelog.mdx
+++ b/src/langsmith/changelog.mdx
@@ -173,7 +173,11 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="February 19, 2026" rss={{ title: "2026-02-19 - Cloud update" }}>
+<Update label="February 17-21, 2026" rss={{ title: "2026-02-17 - Cloud update" }}>
+
+## Observability
+
+- The [Insights Agent](/langsmith/insights) now supports scheduled reports on daily, weekly, or custom cron intervals, so report generation runs without manual triggering. Time ranges compute dynamically, so a "last 24 hours" report always reflects the most recent window when it runs, not when you configured it.
 
 ## Datasets and experiments
 
@@ -181,15 +185,11 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="February 17, 2026" rss={{ title: "2026-02-17 - Cloud update" }}>
+<Update label="February 5-9, 2026" rss={{ title: "2026-02-05 - Cloud update" }}>
 
 ## Observability
 
-- The [Insights Agent](/langsmith/insights) now supports scheduled reports on daily, weekly, or custom cron intervals, so report generation runs without manual triggering. Time ranges compute dynamically, so a "last 24 hours" report always reflects the most recent window when it runs, not when you configured it.
-
-</Update>
-
-<Update label="February 6, 2026" rss={{ title: "2026-02-06 - Cloud update" }}>
+- [Cost tracking](/langsmith/cost-tracking) now extends beyond LLM calls. Submit custom cost metadata for any run, such as an expensive tool call, a third-party API, or a retrieval step, to monitor, debug, and optimize spend across your entire agent stack from a single dashboard.
 
 ## Tracing
 
@@ -197,27 +197,15 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="February 5, 2026" rss={{ title: "2026-02-05 - Cloud update" }}>
-
-## Observability
-
-- [Cost tracking](/langsmith/cost-tracking) now extends beyond LLM calls. Submit custom cost metadata for any run, such as an expensive tool call, a third-party API, or a retrieval step, to monitor, debug, and optimize spend across your entire agent stack from a single dashboard.
-
-</Update>
-
-<Update label="December 17, 2025" rss={{ title: "2025-12-17 - Cloud update" }}>
-
-## Annotation and human feedback
-
-- New pairwise [annotation queues](/langsmith/annotation-queues) let reviewers compare two runs side by side and choose whether option A is better, option B is better, or the two are equal across rubric items. LangSmith automatically pairs runs between two experiments and manages queues, reviewer assignments, and trace access, so you can run A/B evaluations across agents, prompts, and models, including for subjective dimensions like tone, correctness, usefulness, or style.
-
-</Update>
-
-<Update label="December 10, 2025" rss={{ title: "2025-12-10 - Cloud update" }}>
+<Update label="December 10-17, 2025" rss={{ title: "2025-12-10 - Cloud update" }}>
 
 ## Observability
 
 - LangSmith Fetch, a new command-line tool, brings LangSmith traces directly into your terminal, coding environment, or IDE. Install it with `pip install langsmith-fetch`, then retrieve traces with filters such as `--limit`, `--after`, and `--last-n-minutes`, or bulk-export traces and threads to files for analysis, scripting, or dataset creation.
+
+## Annotation and human feedback
+
+- New pairwise [annotation queues](/langsmith/annotation-queues) let reviewers compare two runs side by side and choose whether option A is better, option B is better, or the two are equal across rubric items. LangSmith automatically pairs runs between two experiments and manages queues, reviewer assignments, and trace access, so you can run A/B evaluations across agents, prompts, and models, including for subjective dimensions like tone, correctness, usefulness, or style.
 
 </Update>
 

--- a/src/langsmith/changelog.mdx
+++ b/src/langsmith/changelog.mdx
@@ -173,7 +173,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="February 17-21, 2026" rss={{ title: "2026-02-17 - Cloud update" }}>
+<Update label="February 16-20, 2026" rss={{ title: "2026-02-16 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -187,7 +187,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="February 5-9, 2026" rss={{ title: "2026-02-05 - Cloud update" }}>
+<Update label="February 2-6, 2026" rss={{ title: "2026-02-02 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -201,17 +201,23 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="December 10-17, 2025" rss={{ title: "2025-12-10 - Cloud update" }}>
+<Update label="December 15-19, 2025" rss={{ title: "2025-12-15 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Annotation and human feedback
+
+- New pairwise [annotation queues](/langsmith/annotation-queues) let reviewers compare two runs side by side and choose whether option A is better, option B is better, or the two are equal across rubric items. LangSmith automatically pairs runs between two experiments and manages queues, reviewer assignments, and trace access, so you can run A/B evaluations across agents, prompts, and models, including for subjective dimensions like tone, correctness, usefulness, or style.
+
+</Update>
+
+<Update label="December 8-12, 2025" rss={{ title: "2025-12-08 - Cloud update" }}>
 
 ## Observability and evaluations
 
 ### Tracing
 
 - LangSmith Fetch, a new command-line tool, brings LangSmith traces directly into your terminal, coding environment, or IDE. Install it with `pip install langsmith-fetch`, then retrieve traces with filters such as `--limit`, `--after`, and `--last-n-minutes`, or bulk-export traces and threads to files for analysis, scripting, or dataset creation.
-
-### Annotation and human feedback
-
-- New pairwise [annotation queues](/langsmith/annotation-queues) let reviewers compare two runs side by side and choose whether option A is better, option B is better, or the two are equal across rubric items. LangSmith automatically pairs runs between two experiments and manages queues, reviewer assignments, and trace access, so you can run A/B evaluations across agents, prompts, and models, including for subjective dimensions like tone, correctness, usefulness, or style.
 
 </Update>
 

--- a/src/langsmith/changelog.mdx
+++ b/src/langsmith/changelog.mdx
@@ -175,11 +175,13 @@ The experiments table now displays loading progress bars showing the number of r
 
 <Update label="February 17-21, 2026" rss={{ title: "2026-02-17 - Cloud update" }}>
 
-## Observability
+## Observability and evaluations
+
+### Insights
 
 - The [Insights Agent](/langsmith/insights) now supports scheduled reports on daily, weekly, or custom cron intervals, so report generation runs without manual triggering. Time ranges compute dynamically, so a "last 24 hours" report always reflects the most recent window when it runs, not when you configured it.
 
-## Datasets and experiments
+### Datasets and experiments
 
 - You can now pin any experiment as a baseline. The pinned experiment stays at the top of the [Experiments](/langsmith/compare-experiment-results) view and serves as the automatic comparison point for later runs, surfacing performance deltas across every column so improvements and regressions are immediately clear.
 
@@ -187,11 +189,13 @@ The experiments table now displays loading progress bars showing the number of r
 
 <Update label="February 5-9, 2026" rss={{ title: "2026-02-05 - Cloud update" }}>
 
-## Observability
+## Observability and evaluations
+
+### Cost tracking
 
 - [Cost tracking](/langsmith/cost-tracking) now extends beyond LLM calls. Submit custom cost metadata for any run, such as an expensive tool call, a third-party API, or a retrieval step, to monitor, debug, and optimize spend across your entire agent stack from a single dashboard.
 
-## Tracing
+### Tracing
 
 - You can now [configure which parts of a trace's inputs and outputs](/langsmith/configure-input-output-preview) appear in the tracing table, so teams working with custom trace formats can surface the most relevant fields, reduce clutter, and identify traces that need a closer look faster.
 
@@ -199,11 +203,13 @@ The experiments table now displays loading progress bars showing the number of r
 
 <Update label="December 10-17, 2025" rss={{ title: "2025-12-10 - Cloud update" }}>
 
-## Observability
+## Observability and evaluations
+
+### Tracing
 
 - LangSmith Fetch, a new command-line tool, brings LangSmith traces directly into your terminal, coding environment, or IDE. Install it with `pip install langsmith-fetch`, then retrieve traces with filters such as `--limit`, `--after`, and `--last-n-minutes`, or bulk-export traces and threads to files for analysis, scripting, or dataset creation.
 
-## Annotation and human feedback
+### Annotation and human feedback
 
 - New pairwise [annotation queues](/langsmith/annotation-queues) let reviewers compare two runs side by side and choose whether option A is better, option B is better, or the two are equal across rubric items. LangSmith automatically pairs runs between two experiments and manages queues, reviewer assignments, and trace access, so you can run A/B evaluations across agents, prompts, and models, including for subjective dimensions like tone, correctness, usefulness, or style.
 

--- a/src/langsmith/changelog.mdx
+++ b/src/langsmith/changelog.mdx
@@ -215,7 +215,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="December 2, 2025" rss={{ title: "2025-12-02 - Cloud update" }}>
+<Update label="December 1-5, 2025" rss={{ title: "2025-12-01 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -225,7 +225,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="November 17, 2025" rss={{ title: "2025-11-17 - Cloud update" }}>
+<Update label="November 17-21, 2025" rss={{ title: "2025-11-17 - Cloud update" }}>
 
 ## Admin and billing
 
@@ -235,7 +235,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="October 23, 2025" rss={{ title: "2025-10-23 - Cloud update" }}>
+<Update label="October 20-24, 2025" rss={{ title: "2025-10-20 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -249,7 +249,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="October 14-17, 2025" rss={{ title: "2025-10-14 - Cloud update" }}>
+<Update label="October 13-17, 2025" rss={{ title: "2025-10-13 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -263,7 +263,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="October 7, 2025" rss={{ title: "2025-10-07 - Cloud update" }}>
+<Update label="October 6-10, 2025" rss={{ title: "2025-10-06 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -273,7 +273,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="September 23, 2025" rss={{ title: "2025-09-23 - Cloud update" }}>
+<Update label="September 22-26, 2025" rss={{ title: "2025-09-22 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -283,7 +283,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="September 10, 2025" rss={{ title: "2025-09-10 - Cloud update" }}>
+<Update label="September 8-12, 2025" rss={{ title: "2025-09-08 - Cloud update" }}>
 
 ## Admin and billing
 
@@ -293,7 +293,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="August 27, 2025" rss={{ title: "2025-08-27 - Cloud update" }}>
+<Update label="August 25-29, 2025" rss={{ title: "2025-08-25 - Cloud update" }}>
 
 ## Deployment
 
@@ -301,7 +301,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="August 15, 2025" rss={{ title: "2025-08-15 - Cloud update" }}>
+<Update label="August 11-15, 2025" rss={{ title: "2025-08-11 - Cloud update" }}>
 
 ## Deployment
 
@@ -309,7 +309,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="July 29-31, 2025" rss={{ title: "2025-07-29 - Cloud update" }}>
+<Update label="July 28 - August 1, 2025" rss={{ title: "2025-07-28 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -323,7 +323,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="July 25, 2025" rss={{ title: "2025-07-25 - Cloud update" }}>
+<Update label="July 21-25, 2025" rss={{ title: "2025-07-21 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -333,7 +333,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="July 10, 2025" rss={{ title: "2025-07-10 - Cloud update" }}>
+<Update label="July 7-11, 2025" rss={{ title: "2025-07-07 - Cloud update" }}>
 
 ## Deployment
 
@@ -341,7 +341,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="July 1, 2025" rss={{ title: "2025-07-01 - Cloud update" }}>
+<Update label="June 30 - July 4, 2025" rss={{ title: "2025-06-30 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -357,7 +357,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="June 18, 2025" rss={{ title: "2025-06-18 - Cloud update" }}>
+<Update label="June 16-20, 2025" rss={{ title: "2025-06-16 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -371,7 +371,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="June 4, 2025" rss={{ title: "2025-06-04 - Cloud update" }}>
+<Update label="June 2-6, 2025" rss={{ title: "2025-06-02 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -381,7 +381,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="May 26, 2025" rss={{ title: "2025-05-26 - Cloud update" }}>
+<Update label="May 26-30, 2025" rss={{ title: "2025-05-26 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -391,7 +391,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="May 20-22, 2025" rss={{ title: "2025-05-20 - Cloud update" }}>
+<Update label="May 19-23, 2025" rss={{ title: "2025-05-19 - Cloud update" }}>
 
 ## Deployment
 
@@ -405,7 +405,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="May 14-16, 2025" rss={{ title: "2025-05-14 - Cloud update" }}>
+<Update label="May 12-16, 2025" rss={{ title: "2025-05-12 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -420,7 +420,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="May 8, 2025" rss={{ title: "2025-05-08 - Cloud update" }}>
+<Update label="May 5-9, 2025" rss={{ title: "2025-05-05 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -430,7 +430,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="April 22, 2025" rss={{ title: "2025-04-22 - Cloud update" }}>
+<Update label="April 21-25, 2025" rss={{ title: "2025-04-21 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -440,7 +440,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="April 1, 2025" rss={{ title: "2025-04-01 - Cloud update" }}>
+<Update label="March 31 - April 4, 2025" rss={{ title: "2025-03-31 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -450,7 +450,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="March 26-27, 2025" rss={{ title: "2025-03-26 - Cloud update" }}>
+<Update label="March 24-28, 2025" rss={{ title: "2025-03-24 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -464,7 +464,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="March 19, 2025" rss={{ title: "2025-03-19 - Cloud update" }}>
+<Update label="March 17-21, 2025" rss={{ title: "2025-03-17 - Cloud update" }}>
 
 ## Deployment
 
@@ -472,7 +472,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="March 11-16, 2025" rss={{ title: "2025-03-11 - Cloud update" }}>
+<Update label="March 10-14, 2025" rss={{ title: "2025-03-10 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -486,7 +486,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="February 25-26, 2025" rss={{ title: "2025-02-25 - Cloud update" }}>
+<Update label="February 24-28, 2025" rss={{ title: "2025-02-24 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -500,7 +500,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="February 20, 2025" rss={{ title: "2025-02-20 - Cloud update" }}>
+<Update label="February 17-21, 2025" rss={{ title: "2025-02-17 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -510,7 +510,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="February 4-8, 2025" rss={{ title: "2025-02-04 - Cloud update" }}>
+<Update label="February 3-7, 2025" rss={{ title: "2025-02-03 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -524,7 +524,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="January 30, 2025" rss={{ title: "2025-01-30 - Cloud update" }}>
+<Update label="January 27-31, 2025" rss={{ title: "2025-01-27 - Cloud update" }}>
 
 ## Observability and evaluations
 
@@ -534,7 +534,7 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
-<Update label="January 20-22, 2025" rss={{ title: "2025-01-20 - Cloud update" }}>
+<Update label="January 20-24, 2025" rss={{ title: "2025-01-20 - Cloud update" }}>
 
 ## Observability and evaluations
 

--- a/src/langsmith/changelog.mdx
+++ b/src/langsmith/changelog.mdx
@@ -215,6 +215,339 @@ The experiments table now displays loading progress bars showing the number of r
 
 </Update>
 
+<Update label="December 2, 2025" rss={{ title: "2025-12-02 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Cost tracking
+
+- [Cost tracking](/langsmith/cost-tracking) now automatically records token usage and derived costs for major model providers, and you can submit custom cost data for tools, retrieval steps, and other operations. Costs appear across trace trees, project stats, and dashboards, with an editable price map for non-standard pricing.
+
+</Update>
+
+<Update label="November 17, 2025" rss={{ title: "2025-11-17 - Cloud update" }}>
+
+## Admin and billing
+
+### Administration
+
+- LangSmith is now on the Okta Integration Network, so enterprise teams can provision and deprovision users with SCIM and configure SSO through Okta's guided setup. See the [administration overview](/langsmith/administration-overview) for access control options.
+
+</Update>
+
+<Update label="October 23, 2025" rss={{ title: "2025-10-23 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Insights
+
+- The [Insights Agent](/langsmith/insights) is now generally available for Plus and Enterprise plans. It analyzes production traces to surface usage patterns, agent behaviors, and failure modes, with usage-pattern clustering, poor-interaction analysis, and custom grouping and filtering.
+
+### Datasets and experiments
+
+- [Multi-turn evals](/langsmith/online-evaluations-multi-turn) measure end-to-end agent conversations across multiple exchanges, scoring semantic intent, semantic outcomes, and agent trajectory, including tool calls and decisions.
+
+</Update>
+
+<Update label="October 14-17, 2025" rss={{ title: "2025-10-14 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Datasets and experiments
+
+- [Dataset creation](/langsmith/manage-datasets) now infers schema automatically from uploaded CSV and JSONL files, supports adding metadata fields during upload, supports column mapping and renaming, and supports bulk additions to existing datasets from new uploads.
+
+## Deployment
+
+- LangGraph Platform is now [LangSmith Deployment](/langsmith/deployment) and LangGraph Studio is now [LangSmith Studio](/langsmith/studio). LangSmith now spans three services: Observability, Evaluation, and Deployment. Existing deployments, APIs, workflows, pricing, and contracts are unchanged, and no action is required.
+
+</Update>
+
+<Update label="October 7, 2025" rss={{ title: "2025-10-07 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Datasets and experiments
+
+- You can now write custom code [evaluators](/langsmith/evaluators) in JavaScript in addition to Python, so TypeScript teams can stay in their ecosystem end to end.
+
+</Update>
+
+<Update label="September 23, 2025" rss={{ title: "2025-09-23 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Datasets and experiments
+
+- [Composite evaluators](/langsmith/online-evaluations-composite) combine multiple evaluator scores into a single metric using a weighted average or weighted sum, with customizable weights.
+
+</Update>
+
+<Update label="September 10, 2025" rss={{ title: "2025-09-10 - Cloud update" }}>
+
+## Admin and billing
+
+### Administration
+
+- You can now create service keys at the [organization level](/langsmith/administration-overview), scoped to multiple workspaces or the entire organization, and assign roles, including custom roles, for granular permissions.
+
+</Update>
+
+<Update label="August 27, 2025" rss={{ title: "2025-08-27 - Cloud update" }}>
+
+## Deployment
+
+- [LangSmith Deployment](/langsmith/deployment) now queues revisions automatically, processing each new revision only after the current one finishes to prevent overlapping deployments and conflicts.
+
+</Update>
+
+<Update label="August 15, 2025" rss={{ title: "2025-08-15 - Cloud update" }}>
+
+## Deployment
+
+- [Studio](/langsmith/studio) now includes Trace Mode, which shows your LangSmith traces directly in Studio and supports annotating runs and adding them to datasets for evaluation.
+
+</Update>
+
+<Update label="July 29-31, 2025" rss={{ title: "2025-07-29 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Datasets and experiments
+
+- Align Evals provides a playground-like interface for iterating on [evaluator](/langsmith/evaluators) prompts and comparing human-graded scores side by side with LLM-generated scores to surface misaligned cases.
+
+## Deployment
+
+- LangSmith now links traces to the server logs in [LangSmith Deployment](/langsmith/deployment), so you can open user and system logs directly from a trace.
+
+</Update>
+
+<Update label="July 25, 2025" rss={{ title: "2025-07-25 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Tracing
+
+- [Data export](/langsmith/data-export) now supports scheduled exports of traces, so external systems such as data warehouses, monitoring platforms, and dashboards stay in sync without custom infrastructure.
+
+</Update>
+
+<Update label="July 10, 2025" rss={{ title: "2025-07-10 - Cloud update" }}>
+
+## Deployment
+
+- A new Monitoring tab shows [deployment](/langsmith/deployment) metrics, including CPU and memory usage, API request latency, and active run counts, over a customizable time range.
+
+</Update>
+
+<Update label="July 1, 2025" rss={{ title: "2025-07-01 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Datasets and experiments
+
+- You can now create custom views of [evaluation results](/langsmith/analyze-an-experiment) by breaking fields from inputs, outputs, and reference outputs into their own columns, hiding or reordering columns, and adjusting decimal precision on feedback scores.
+
+## Admin and billing
+
+### Administration
+
+- LangSmith [API keys](/langsmith/administration-overview) now support expiration dates, so you can scope access for temporary tasks or team members.
+
+</Update>
+
+<Update label="June 18, 2025" rss={{ title: "2025-06-18 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Prompts and playground
+
+- The [Playground](/langsmith/playground-model-providers) now supports calling built-in tools from OpenAI and Anthropic, such as web search and MCP, so you can verify tool selection and argument passing.
+
+## Deployment
+
+- [Studio](/langsmith/studio) now lets you run agent evaluations in the UI without code, comparing against reference outputs and grading responses with custom criteria.
+
+</Update>
+
+<Update label="June 4, 2025" rss={{ title: "2025-06-04 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Cost tracking
+
+- [Cost tracking](/langsmith/cost-tracking) now accounts for cached tokens, multiple token modalities such as text and image, and reasoning tokens, and supports tracking costs for arbitrary token types.
+
+</Update>
+
+<Update label="May 26, 2025" rss={{ title: "2025-05-26 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Prompts and playground
+
+- [Prompts](/langsmith/prompt-engineering) now support webhook triggers that sync a prompt to external systems such as GitHub, databases, or CI/CD pipelines when it is updated.
+
+</Update>
+
+<Update label="May 20-22, 2025" rss={{ title: "2025-05-20 - Cloud update" }}>
+
+## Deployment
+
+- Every agent deployed on [LangSmith](/langsmith/deployment) now exposes its own Model Context Protocol (MCP) endpoint, so the agent can be used as a tool in any client that supports streamable HTTP for MCP, with no custom code or infrastructure.
+
+## Admin and billing
+
+### Usage and billing
+
+- SaaS customers can now view monthly [usage charts](/langsmith/granular-usage) that track all billable metrics in one place.
+
+</Update>
+
+<Update label="May 14-16, 2025" rss={{ title: "2025-05-14 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Monitoring and alerting
+
+- [Agent observability](/langsmith/observability) surfaces tool calls and run stats, including the most-used tools and runs, their latency, and which generate the most errors.
+
+## Deployment
+
+- LangGraph Platform, now [LangSmith Deployment](/langsmith/deployment), reached general availability for deploying and managing long-running, stateful agents at scale, with one-click GitHub-to-production deployment, integrated memory and persistence, scalable APIs, and an agent registry across cloud, hybrid, self-hosted, and developer deployment options.
+- [Studio](/langsmith/studio) v2 runs locally without the desktop app, supports editing prompts and configuration in the UI, integrates with the Playground, and lets you download production traces to debug them locally.
+
+</Update>
+
+<Update label="May 8, 2025" rss={{ title: "2025-05-08 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Tracing
+
+- LangSmith now supports [multimodal content](/langsmith/log-multimodal-traces) for images, PDFs, and audio across the playground, annotation queues, and datasets, including attaching files to dataset examples without base64 encoding and visualizing the content in the app.
+
+</Update>
+
+<Update label="April 22, 2025" rss={{ title: "2025-04-22 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Monitoring and alerting
+
+- [Alerts](/langsmith/alerts) send real-time notifications on error rates, run latency, and feedback scores, so you can catch production failures proactively.
+
+</Update>
+
+<Update label="April 1, 2025" rss={{ title: "2025-04-01 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Prompts and playground
+
+- The [Playground](/langsmith/playground-model-providers) now lets you create datasets inline and add examples to existing datasets without leaving the Playground.
+
+</Update>
+
+<Update label="March 26-27, 2025" rss={{ title: "2025-03-26 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Tracing
+
+- LangSmith now has end-to-end native [OpenTelemetry support](/langsmith/trace-with-opentelemetry) for LangChain and LangGraph applications, including distributed tracing across microservices.
+
+### Datasets and experiments
+
+- You can now define [evaluators](/langsmith/evaluators) for datasets and tracing projects directly in the UI with no code, including LLM-as-a-judge evaluators with prebuilt templates, customizable prompts, variable mapping, scoring, and few-shot support.
+
+</Update>
+
+<Update label="March 19, 2025" rss={{ title: "2025-03-19 - Cloud update" }}>
+
+## Deployment
+
+- [Studio](/langsmith/studio) now lets you view and edit node logic in the UI by tagging configuration fields with `langgraph_nodes`, edit prompts without code changes, and sync Playground experiments back to the graph.
+
+</Update>
+
+<Update label="March 11-16, 2025" rss={{ title: "2025-03-11 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Tracing
+
+- LangSmith now supports tracing [OpenAI Agents SDK](/langsmith/trace-with-openai-agents-sdk) applications with two lines of code, for step-by-step observability of agent execution and reasoning.
+
+### Datasets and experiments
+
+- You can now rename an [experiment](/langsmith/analyze-an-experiment) in the UI, either from the Playground table header after a run or with the pencil icon in the Experiments view.
+
+</Update>
+
+<Update label="February 25-26, 2025" rss={{ title: "2025-02-25 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Datasets and experiments
+
+- You can now group [experiment results](/langsmith/analyze-an-experiment) by metadata to analyze evaluation performance across segments such as user groups or subject areas.
+
+## Fixes
+
+- A new ingest-backend service separates trace ingestion from frontend request handling, improving average request processing and high-traffic response times.
+
+</Update>
+
+<Update label="February 20, 2025" rss={{ title: "2025-02-20 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Prompts and playground
+
+- The [Playground](/langsmith/playground-model-providers) can now use workspace secrets saved in LangSmith, for consistent credential management across environments.
+
+</Update>
+
+<Update label="February 4-8, 2025" rss={{ title: "2025-02-04 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Datasets and experiments
+
+- A new [experiment view](/langsmith/analyze-an-experiment) gives each feedback key its own column and adds filtering, sorting, and a heat map to spot patterns and performance areas.
+
+## Deployment
+
+- You can now open LLM runs from [Studio](/langsmith/studio) in the LangSmith Playground for debugging, visualization, and prompt experimentation within threads.
+
+</Update>
+
+<Update label="January 30, 2025" rss={{ title: "2025-01-30 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Tracing
+
+- [Traces](/langsmith/view-traces) now include a waterfall graph that highlights latency bottlenecks and shows which components run in parallel versus sequentially.
+
+</Update>
+
+<Update label="January 20-22, 2025" rss={{ title: "2025-01-20 - Cloud update" }}>
+
+## Observability and evaluations
+
+### Prompts and playground
+
+- The [Playground](/langsmith/playground-model-providers) adds a streamlined prompt settings UI, a default model configuration, an enhanced tool management modal, and improved side-by-side comparison.
+
+### Datasets and experiments
+
+- New [Pytest and Vitest integrations](/langsmith/pytest) let you run evaluations using familiar testing frameworks, with debugging, metrics tracking, and built-in evaluation functions.
+
+</Update>
+
 </Tab>
 <Tab title="LangSmith Fleet">
 

--- a/src/snippets/langsmith/fleet-changelog.mdx
+++ b/src/snippets/langsmith/fleet-changelog.mdx
@@ -65,3 +65,11 @@
 - A central tool registry lets workspace admins connect [tools](/langsmith/fleet/tools), manage authentication, and control access across the organization.
 
 </Update>
+
+<Update label="October 29, 2025" rss={{ title: "2025-10-29 - Fleet product update" }}>
+
+## New features
+
+- LangSmith Agent Builder launched in private preview as a no-code way for non-developers to build agents, with conversational setup, built-in memory, MCP integrations, automated triggers, and subagent support. Agent Builder later became [LangSmith Fleet](/langsmith/fleet).
+
+</Update>

--- a/src/snippets/langsmith/fleet-changelog.mdx
+++ b/src/snippets/langsmith/fleet-changelog.mdx
@@ -47,7 +47,7 @@
 
 </Update>
 
-<Update label="March 19, 2026" rss={{ title: "2026-03-19 - Fleet product update" }}>
+<Update label="March 16-20, 2026" rss={{ title: "2026-03-16 - Fleet product update" }}>
 
 ## New features
 
@@ -55,7 +55,7 @@
 
 </Update>
 
-<Update label="February 18, 2026" rss={{ title: "2026-02-18 - Fleet product update" }}>
+<Update label="February 16-20, 2026" rss={{ title: "2026-02-16 - Fleet product update" }}>
 
 ## New features
 
@@ -66,7 +66,7 @@
 
 </Update>
 
-<Update label="October 29, 2025" rss={{ title: "2025-10-29 - Fleet product update" }}>
+<Update label="October 27-31, 2025" rss={{ title: "2025-10-27 - Fleet product update" }}>
 
 ## New features
 


### PR DESCRIPTION
## Why

The LangSmith Cloud and Fleet changelogs only went back to December 2025. This backfills older entries so the published changelog has full coverage of 2025, sourced from the legacy changelog at [changelog.langchain.com](https://changelog.langchain.com/feed).

This PR bundles the earlier backfill (Dec 2025–Feb 2026) with the new 2025 continuation, since neither was on `main` yet.

## What changed

**LangSmith Cloud changelog** (`src/langsmith/changelog.mdx`)
- 29 new weekly `<Update>` blocks spanning January 20, 2025 through December 2, 2025.
- Grouped by week and nested under the standard headings (Observability and evaluations, Deployment, Admin and billing, Fixes), matching the existing format.

**Fleet changelog** (`src/snippets/langsmith/fleet-changelog.mdx`)
- Added the October 29, 2025 LangSmith Agent Builder private preview entry (Fleet's predecessor).

## Scope decisions (please confirm)

- **Excluded** OSS framework releases (LangChain, LangGraph, Deep Agents, LangMem, OpenEvals, MCP adapters, etc.) and self-hosted version releases (v0.9–v0.12), consistent with the prior backfill.
- **Included** LangSmith Deployment and Studio entries as Cloud, including ones historically branded LangGraph Platform/Studio (e.g. LangGraph Platform GA, Studio v2, Trace Mode, the MCP endpoint), since the changelog already has Deployment and Studio sections. Happy to drop the platform-GA-style ones if you prefer.
- Each entry was written from the actual changelog page content (fetched per entry), not fabricated.

## Validation

- `make lint_prose` on changed files → 0 errors, 0 warnings.
- `make broken-links` → ✅ No broken links.

## AI involvement

Drafted with Claude Code: feed parsing, per-entry content fetching, and authoring. Reviewed by @laurenhiratasingh.
