### PR TITLE
fix: update sandbox private registry docs

### DIFF
--- a/src/langsmith/sandbox-snapshots.mdx
+++ b/src/langsmith/sandbox-snapshots.mdx
@@ -48,20 +48,16 @@ console.log(snapshot.id);
 
 ### Private registries
 
-Pass registry credentials (or a pre-registered `registry_id` / `registryId`) to pull from a private registry.
+Register the private registry first, then pass its `registry_id` / `registryId` to pull from it.
 
 <CodeGroup>
 
 ```python Python
-import os
-
 snapshot = client.create_snapshot(
     "internal-python",
     docker_image="registry.example.com/internal/python:3.12",
     fs_capacity_bytes=2 * 1024**3,
-    registry_url="https://registry.example.com",
-    registry_username="me",
-    registry_password=os.environ["REGISTRY_PASSWORD"],
+    registry_id="550e8400-e29b-41d4-a716-446655440000",
     timeout=600,
 )
 ```
@@ -72,9 +68,7 @@ const snapshot = await client.createSnapshot(
   "registry.example.com/internal/python:3.12",
   2_147_483_648,
   {
-    registryUrl: "https://registry.example.com",
-    registryUsername: "me",
-    registryPassword: process.env.REGISTRY_PASSWORD,
+    registryId: "550e8400-e29b-41d4-a716-446655440000",
     timeout: 600,
   },
 );

--- a/src/langsmith/sandbox-snapshots.mdx
+++ b/src/langsmith/sandbox-snapshots.mdx
@@ -53,22 +53,43 @@ Register the private registry first, then pass its `registry_id` / `registryId` 
 <CodeGroup>
 
 ```python Python
+import os
+
+registry = client.create_registry(
+    "internal-registry",
+    url="https://registry.example.com",
+    username="me",
+    password=os.environ["REGISTRY_PASSWORD"],
+)
+
 snapshot = client.create_snapshot(
     "internal-python",
     docker_image="registry.example.com/internal/python:3.12",
     fs_capacity_bytes=2 * 1024**3,
-    registry_id="550e8400-e29b-41d4-a716-446655440000",
+    registry_id=registry.id,
     timeout=600,
 )
 ```
 
 ```ts TypeScript
+const registryPassword = process.env.REGISTRY_PASSWORD;
+if (!registryPassword) {
+  throw new Error("REGISTRY_PASSWORD is required");
+}
+
+const registry = await client.createRegistry(
+  "internal-registry",
+  "https://registry.example.com",
+  "me",
+  registryPassword,
+);
+
 const snapshot = await client.createSnapshot(
   "internal-python",
   "registry.example.com/internal/python:3.12",
   2_147_483_648,
   {
-    registryId: "550e8400-e29b-41d4-a716-446655440000",
+    registryId: registry.id,
     timeout: 600,
   },
 );


### PR DESCRIPTION
## Description
Update the sandbox snapshot private registry examples to create a registry with SDK helpers, then use the returned registry ID for snapshot creation instead of unsupported inline snapshot credentials.

## Test Plan
- [x] `git diff --check`
- [ ] `make lint_prose FILES=src/langsmith/sandbox-snapshots.mdx` was not run because Vale is not installed in the sandbox.

Made by [Open SWE](https://openswe.vercel.app/agents/d22cdfb4-6120-dde5-1c66-307e27c4d982)