### PR TITLE
docs(langsmith): link to the deepagents Harbor guide instead of duplicating the command

### DIFF
--- a/src/langsmith/sandbox-harbor.mdx
+++ b/src/langsmith/sandbox-harbor.mdx
@@ -74,29 +74,42 @@ harbor run -d "<org/name>" \
 
 ## Run Deep Agents on LangSmith
 
-Deep Agents runs against the LangSmith environment as a custom Harbor agent. To build and run a Deep Agent, see the [Deep Agents documentation](/oss/deepagents/overview). The Harbor wrapper ships in the [`deepagents-evals` package](https://github.com/langchain-ai/deepagents/tree/main/libs/evals), which exposes `deepagents_harbor:DeepAgentsWrapper` and includes ready-made `make run-terminal-bench-*` targets. Install it in the same environment as Harbor:
+Deep Agents runs against the LangSmith environment through Harbor's built-in `langgraph` agent. To build and run a Deep Agent, see the [Deep Agents documentation](/oss/deepagents/overview). The previous `deepagents_harbor:DeepAgentsWrapper` import path is no longer available.
+
+From a checkout of [`langchain-ai/deepagents`](https://github.com/langchain-ai/deepagents), install the eval dependencies and stage the local Deep Agents packages for the LangGraph sandbox install:
 
 ```bash
-pip install "harbor[langsmith]"
-
-# From a checkout of langchain-ai/deepagents:
-pip install -e libs/evals
+cd libs/evals
+uv sync --group test
+make stage-harbor-local-deps
 ```
 
-Set your LangSmith and model credentials, then run Harbor with the wrapper:
+Set your LangSmith and model credentials, then run Harbor with the LangGraph project:
 
 ```bash
 export LANGSMITH_PROFILE=prod
 export LANGSMITH_TRACING=true
 export LANGSMITH_PROJECT=harbor-deepagents
+export LANGSMITH_API_KEY="<LANGSMITH_API_KEY>"
 export ANTHROPIC_API_KEY="<ANTHROPIC_API_KEY>"
 
-harbor run -d "terminal-bench@2.0" \
-  --agent-import-path deepagents_harbor:DeepAgentsWrapper \
+uv run harbor run \
+  --agent langgraph \
+  --agent-kwarg project_path=deepagents_harbor/langgraph_project \
+  --agent-kwarg config=langgraph.json \
+  --agent-kwarg graph=deepagent \
+  --agent-env 'ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}' \
+  --agent-env 'LANGSMITH_API_KEY=${LANGSMITH_API_KEY}' \
+  --agent-env 'LANGSMITH_TRACING=true' \
+  --dataset terminal-bench/terminal-bench-2 \
   --model anthropic:claude-opus-4-8 \
-  -e langsmith \
   -n 10 \
   -l 10 \
+  --jobs-dir harbor-jobs/terminal-bench \
+  --env langsmith \
+  --plugin langsmith \
+  --plugin-kwarg dataset_name=terminal-bench/terminal-bench-2 \
+  --plugin-kwarg experiment_name=harbor-deepagents \
   --yes \
   --ek idle_ttl_seconds=0 \
   --ek delete_after_stop_seconds=7200
@@ -106,10 +119,10 @@ Keep API keys in your shell environment rather than in a job config file.
 
 ## Use a config file
 
-Capture the same run in a Harbor job config:
+Capture the reusable job inputs in a Harbor job config:
 
 ```yaml
-jobs_dir: jobs/deepagents-langsmith
+jobs_dir: harbor-jobs/terminal-bench
 n_attempts: 1
 n_concurrent_trials: 10
 environment:
@@ -119,11 +132,18 @@ environment:
     idle_ttl_seconds: 0
     delete_after_stop_seconds: 7200
 agents:
-  - import_path: deepagents_harbor:DeepAgentsWrapper
+  - name: langgraph
     model_name: anthropic:claude-opus-4-8
+    env:
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
+      LANGSMITH_API_KEY: ${LANGSMITH_API_KEY}
+      LANGSMITH_TRACING: "true"
+    kwargs:
+      project_path: deepagents_harbor/langgraph_project
+      config: langgraph.json
+      graph: deepagent
 datasets:
-  - name: terminal-bench
-    version: "2.0"
+  - name: terminal-bench/terminal-bench-2
     n_tasks: 10
 ```
 

--- a/src/langsmith/sandbox-harbor.mdx
+++ b/src/langsmith/sandbox-harbor.mdx
@@ -74,78 +74,11 @@ harbor run -d "<org/name>" \
 
 ## Run Deep Agents on LangSmith
 
-Deep Agents runs against the LangSmith environment through Harbor's built-in `langgraph` agent. To build and run a Deep Agent, see the [Deep Agents documentation](/oss/deepagents/overview). The previous `deepagents_harbor:DeepAgentsWrapper` import path is no longer available.
+[Deep Agents](/oss/deepagents/overview) run on LangSmith sandboxes through Harbor's built-in `langgraph` agent and the `-e langsmith` environment. The full setup — staging the Deep Agents packages, the LangGraph project (`langgraph.json` with the `deepagent` graph), and the exact `harbor run` command — is maintained in the Deep Agents eval guide:
 
-From a checkout of [`langchain-ai/deepagents`](https://github.com/langchain-ai/deepagents), install the eval dependencies and stage the local Deep Agents packages for the LangGraph sandbox install:
+→ [Running Deep Agents on Harbor / Terminal Bench 2.0](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/CONTRIBUTING.md#harbor--terminal-bench-20)
 
-```bash
-cd libs/evals
-uv sync --group test
-make stage-harbor-local-deps
-```
-
-Set your LangSmith and model credentials, then run Harbor with the LangGraph project:
-
-```bash
-export LANGSMITH_PROFILE=prod
-export LANGSMITH_TRACING=true
-export LANGSMITH_PROJECT=harbor-deepagents
-export LANGSMITH_API_KEY="<LANGSMITH_API_KEY>"
-export ANTHROPIC_API_KEY="<ANTHROPIC_API_KEY>"
-
-uv run harbor run \
-  --agent langgraph \
-  --agent-kwarg project_path=deepagents_harbor/langgraph_project \
-  --agent-kwarg config=langgraph.json \
-  --agent-kwarg graph=deepagent \
-  --agent-env 'ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}' \
-  --agent-env 'LANGSMITH_API_KEY=${LANGSMITH_API_KEY}' \
-  --agent-env 'LANGSMITH_TRACING=true' \
-  --dataset terminal-bench/terminal-bench-2 \
-  --model anthropic:claude-opus-4-8 \
-  -n 10 \
-  -l 10 \
-  --jobs-dir harbor-jobs/terminal-bench \
-  --env langsmith \
-  --plugin langsmith \
-  --plugin-kwarg dataset_name=terminal-bench/terminal-bench-2 \
-  --plugin-kwarg experiment_name=harbor-deepagents \
-  --yes \
-  --ek idle_ttl_seconds=0 \
-  --ek delete_after_stop_seconds=7200
-```
-
-Keep API keys in your shell environment rather than in a job config file.
-
-## Use a config file
-
-Capture the reusable job inputs in a Harbor job config:
-
-```yaml
-jobs_dir: harbor-jobs/terminal-bench
-n_attempts: 1
-n_concurrent_trials: 10
-environment:
-  type: langsmith
-  delete: true
-  kwargs:
-    idle_ttl_seconds: 0
-    delete_after_stop_seconds: 7200
-agents:
-  - name: langgraph
-    model_name: anthropic:claude-opus-4-8
-    env:
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY}
-      LANGSMITH_API_KEY: ${LANGSMITH_API_KEY}
-      LANGSMITH_TRACING: "true"
-    kwargs:
-      project_path: deepagents_harbor/langgraph_project
-      config: langgraph.json
-      graph: deepagent
-datasets:
-  - name: terminal-bench/terminal-bench-2
-    n_tasks: 10
-```
+The LangSmith-specific options above (authentication, `-e langsmith`, and the `--ek` sandbox-lifecycle kwargs) apply to those runs as well.
 
 ## Multi-container tasks
 

--- a/src/langsmith/sandbox-harbor.mdx
+++ b/src/langsmith/sandbox-harbor.mdx
@@ -74,11 +74,11 @@ harbor run -d "<org/name>" \
 
 ## Run Deep Agents on LangSmith
 
-[Deep Agents](/oss/deepagents/overview) run on LangSmith sandboxes through Harbor's built-in `langgraph` agent and the `-e langsmith` environment. The full setup — staging the Deep Agents packages, the LangGraph project (`langgraph.json` with the `deepagent` graph), and the exact `harbor run` command — is maintained in the Deep Agents eval guide:
+[Deep Agents](/oss/deepagents/overview) run on LangSmith sandboxes through Harbor's built-in `langgraph` agent and the `-e langsmith` environment. The full setup: staging the Deep Agents packages, the LangGraph project (`langgraph.json` with the `deepagent` graph), and the exact `harbor run` command, is maintained in the Deep Agents eval guide:
 
 → [Running Deep Agents on Harbor / Terminal Bench 2.0](https://github.com/langchain-ai/deepagents/blob/main/libs/evals/CONTRIBUTING.md#harbor--terminal-bench-20)
 
-The LangSmith-specific options above (authentication, `-e langsmith`, and the `--ek` sandbox-lifecycle kwargs) apply to those runs as well.
+The [LangSmith-specific options](#configure-the-sandbox-environment) (authentication, `-e langsmith`, and the `--ek` sandbox-lifecycle kwargs) apply to those runs as well.
 
 ## Multi-container tasks
 


### PR DESCRIPTION
Replaces the duplicated Harbor Deep Agents command (and the job-config YAML) on the LangSmith sandbox page with a short, LangSmith-framed pointer to the canonical guide in `langchain-ai/deepagents` (`libs/evals/CONTRIBUTING.md`).

## Why

The previous version inlined the full `harbor run` invocation and a job-config example. That command drifts out of sync with the deepagents repo — it already broke once (the removed `deepagents_harbor:DeepAgentsWrapper` import path). Keeping the runnable command in exactly one place (the deepagents eval guide) prevents that drift. The LangSmith docs keep only the LangSmith-specific framing (auth, `-e langsmith`, `--ek` sandbox-lifecycle kwargs), which already live in the sections above.

## Depends on

The linked guide must actually run. langchain-ai/deepagents#4292 fixes the Deep Agents Harbor flow end-to-end (partners staging, `UV_PRERELEASE=allow`, hello-world target) and updates `CONTRIBUTING.md`. Merge that first.

## Validation

- `make lint_prose FILES="src/langsmith/sandbox-harbor.mdx"` → 0 errors, 0 warnings
- `git diff --check` clean

Made by [Open SWE](https://openswe.vercel.app/agents/cedcd9cc-ab73-1705-2500-bac81e8189fe)
