### PR TITLE
fix: add docs on native slack alerts

### DIFF
--- a/src/langsmith/alerts.mdx
+++ b/src/langsmith/alerts.mdx
@@ -17,7 +17,7 @@ Effective observability in LLM applications requires proactive detection of fail
 Alerts in LangSmith are project-scoped, requiring separate configuration for each monitored project.
 
 <Tip>
-Alerts can [route](#step-4-configure-notification-channel) to PagerDuty, Dynatrace, or any HTTP endpoint via webhook. The **Webhook** tab includes [example recipes](#example-recipes) for sending alerts to Slack, Microsoft Teams, and email.
+Alerts can [route](#step-4-configure-notification-channel) to Slack, PagerDuty, Dynatrace, or any HTTP endpoint via webhook. The **Webhook** tab includes [example recipes](#example-recipes) for Microsoft Teams, email, and Slack on self-hosted deployments.
 </Tip>
 
 Follow these steps to configure an alert.
@@ -68,11 +68,38 @@ You can preview alert behavior over a historical time window to understand how m
 
 ## Step 4: Configure notification channel
 
-<Tip>
-The **Webhook** tab includes [example recipes](#example-recipes) for sending alerts to Slack, Microsoft Teams, and email.
-</Tip>
-
 <Tabs>
+  <Tab title="Slack">
+    Send alert notifications directly to a Slack channel using LangSmith's native Slack integration. No custom webhook or Slack app configuration required.
+
+    <Note>
+    The native Slack notification type is available on LangSmith Cloud only. For self-hosted deployments, use the [webhook Slack recipe](#example-recipes) in the **Webhook** tab instead.
+    </Note>
+
+    **Prerequisites**
+
+    - A Slack workspace connected to your LangSmith organization. If you haven't connected one yet, LangSmith will prompt you to do so inline when you configure this notification type.
+
+    ### 1. Configure the Slack notification
+
+    1. In the **Notification Settings** section of your alert setup, select **Slack**.
+    2. Click the channel selector. If no Slack workspace is linked yet, click **Connect Slack** and complete the OAuth flow to authorize LangSmith.
+    3. Add the `@LangSmith` app to the channel you want to receive notifications in. The app must be a member of the channel — type `/invite @LangSmith` in the channel to add it.
+    4. Select the workspace and channel from the dropdown. Click the refresh icon if the channel does not appear immediately.
+    5. Click **Save** to save the notification configuration.
+
+    ### 2. Test the integration
+
+    Click **Send Test Notification** to verify that LangSmith can reach the channel. Check the channel for the test message.
+
+    ### Notification format
+
+    When an alert triggers, LangSmith posts a structured Slack message that includes:
+
+    - **Headline**: The alert name and your LangSmith workspace name.
+    - **Detail line**: The metric attribute, triggered value, comparison operator, configured threshold, aggregation method, and time window — for example: `Total Cost: $12.50 ≥ $5.00 · avg · 30 min`.
+    - **Action buttons**: **View Alert** (links to the alert preview in LangSmith) and **View Runs** (links to the filtered runs that triggered the alert).
+  </Tab>
   <Tab title="PagerDuty">
     Configure PagerDuty as a notification channel using PagerDuty's [Events API v2](https://developer.pagerduty.com/docs/events-api-v2-overview). This integration allows critical LLM application issues to trigger PagerDuty incidents, enabling rapid response through your established incident management workflow.
 


### PR DESCRIPTION
## Overview
we did not have any docs on our new native slack alert functionality

## Checklist
- [X] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [X] I have tested my changes locally using `docs dev`
- [X] All code examples have been tested and work correctly
- [X] I have used **root relative** paths for internal links
- [X] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)
