### PR TITLE
docs(deepagents): replace lifecycle language tabs with fences

### DIFF
--- a/src/oss/deepagents/sandboxes.mdx
+++ b/src/oss/deepagents/sandboxes.mdx
@@ -139,18 +139,13 @@ Each conversation gets its own sandbox. The first run creates it; follow-up turn
 When users can return after idle time, configure a TTL on the sandbox so the provider deletes or archives idle environments automatically.
 </Tip>
 
-<Tabs>
-    <Tab title="Python">
-
-<SandboxLifecycleFactoryThreadPy />
-
-    </Tab>
-    <Tab title="TypeScript">
-
+:::js
 <SandboxLifecycleFactoryThreadTs />
+:::
 
-    </Tab>
-</Tabs>
+:::python
+<SandboxLifecycleFactoryThreadPy />
+:::
 
 ### Assistant-scoped
 
@@ -160,18 +155,13 @@ Every thread on the same assistant reuses one sandbox. Files, installed packages
 Assistant-scoped sandboxes accumulate in-sandbox state over time. Configure a TTL with your sandbox provider, use snapshots to reset periodically, or implement cleanup logic so disk and memory do not grow without bound.
 </Warning>
 
-<Tabs>
-    <Tab title="Python">
-
-<SandboxLifecycleFactoryAssistantPy />
-
-    </Tab>
-    <Tab title="TypeScript">
-
+:::js
 <SandboxLifecycleFactoryAssistantTs />
+:::
 
-    </Tab>
-</Tabs>
+:::python
+<SandboxLifecycleFactoryAssistantPy />
+:::
 
 For manual create, execute, and teardown outside a graph factory, see [Basic usage](#basic-usage) and [sandbox integrations](/oss/integrations/sandboxes) for provider-specific APIs.
 


### PR DESCRIPTION
Fixes DOC-1301

## Summary
- Replaces Python/TypeScript `<Tabs>` with `:::js` and `:::python` language fences in the thread-scoped and assistant-scoped lifecycle sections on the Deep Agents sandboxes page.
- Aligns those sections with the Basic usage pattern so the build pipeline generates separate Python and TypeScript pages instead of in-page language tabs.
