### PR TITLE
fix: move custom Docker doc navigation

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -1457,6 +1457,7 @@
                           "langsmith/setup-app-requirements-txt",
                           "langsmith/setup-pyproject",
                           "langsmith/setup-javascript",
+                          "langsmith/custom-docker",
                           "langsmith/monorepo-support"
                         ]
                       },
@@ -2137,7 +2138,6 @@
                           "langsmith/self-host-environment-variables",
                           "langsmith/self-host-scale",
                           "langsmith/self-host-ttl",
-                          "langsmith/custom-docker",
                           "langsmith/self-host-playground-environment-settings",
                           "langsmith/self-host-ui-customization",
                           "langsmith/troubleshooting"


### PR DESCRIPTION
## Description
Moves the custom Dockerfile doc out of the LangSmith self-hosting configuration nav and into Deploy > Develop agents alongside dependency setup docs.

## Test Plan
- [x] `python -m json.tool src/docs.json`
- [x] `git diff --check`
- [x] `make broken-links`

Made by [Open SWE](https://openswe.vercel.app/agents/85512a6f-1a9e-59f5-fd46-4df695062ed1)