### PR TITLE
docs(sandbox): document registry creation via client.registries

### DIFF
--- a/src/langsmith/sandbox-cli.mdx
+++ b/src/langsmith/sandbox-cli.mdx
@@ -58,14 +58,12 @@ langsmith sandbox snapshot build my-snapshot \
   --wait
 ```
 
-For private registries, pass registry credentials from environment variables:
+For private images, create a registry first (see [Private registries](/langsmith/sandbox-snapshots#private-registries)), then pass its id with `--registry-id`:
 
 ```bash
 langsmith sandbox snapshot build internal-python \
   --docker-image registry.example.com/internal/python:3.12 \
-  --registry-url https://registry.example.com \
-  --registry-username "$REGISTRY_USERNAME" \
-  --registry-password "$REGISTRY_PASSWORD" \
+  --registry-id "$REGISTRY_ID" \
   --wait
 ```
 

--- a/src/langsmith/sandbox-snapshots.mdx
+++ b/src/langsmith/sandbox-snapshots.mdx
@@ -48,39 +48,51 @@ console.log(snapshot.id);
 
 ### Private registries
 
-Pass registry credentials (or a pre-registered `registry_id` / `registryId`) to pull from a private registry.
+To pull from a private registry, create a registry once with its credentials, then reference it by id when building a snapshot. Registries persist, so reuse one across snapshots.
 
 <CodeGroup>
 
 ```python Python
 import os
 
+registry = client.registries.create(
+    name="internal",
+    url="registry.example.com",
+    username="me",
+    password=os.environ["REGISTRY_PASSWORD"],
+)
+
 snapshot = client.create_snapshot(
     "internal-python",
     docker_image="registry.example.com/internal/python:3.12",
     fs_capacity_bytes=2 * 1024**3,
-    registry_url="https://registry.example.com",
-    registry_username="me",
-    registry_password=os.environ["REGISTRY_PASSWORD"],
+    registry_id=registry.id,
     timeout=600,
 )
 ```
 
 ```ts TypeScript
+const registry = await client.registries.create({
+  name: "internal",
+  url: "registry.example.com",
+  username: "me",
+  password: process.env.REGISTRY_PASSWORD,
+});
+
 const snapshot = await client.createSnapshot(
   "internal-python",
   "registry.example.com/internal/python:3.12",
   2_147_483_648,
   {
-    registryUrl: "https://registry.example.com",
-    registryUsername: "me",
-    registryPassword: process.env.REGISTRY_PASSWORD,
+    registryId: registry.id,
     timeout: 600,
   },
 );
 ```
 
 </CodeGroup>
+
+List, inspect, update, and delete registries with `client.registries.list()`, `client.registries.retrieve(name)`, `client.registries.update(name, ...)`, and `client.registries.delete(name)`.
 
 ## Build a snapshot from a Dockerfile
 


### PR DESCRIPTION
## Why

Snapshot creation no longer accepts inline registry credentials. The `registry_url` / `registry_username` / `registry_password` options (and the CLI `--registry-url/--registry-username/--registry-password` flags) were removed in favor of first-class registries referenced by id. The current docs still show the removed options, so anyone copying them hits an error.

## What

- **`sandbox-snapshots.mdx`**: replace the inline-credential example with creating a registry via `client.registries.create(...)` and passing its id as `registry_id` (Python) / `registryId` (TypeScript). Add a line covering `list` / `retrieve` / `update` / `delete`.
- **`sandbox-cli.mdx`**: replace the removed registry-credential flags with `--registry-id`, linking to the snapshots page for creating a registry.

Both examples use the same `SandboxClient` the docs already show — the `registries` accessor is added in langchain-ai/langsmith-sdk#3087.

## Dependency — do not merge before the SDK ships

`client.registries` / `client.registries` ships in langchain-ai/langsmith-sdk#3087. Keep this PR as a draft until that PR is merged and released, otherwise the docs describe an API users cannot call yet. A version-added `<Note>` should be added once the target `langsmith` release is known.

## Test plan

- `make lint_prose` clean on both files (0 errors, 0 warnings).
- Code examples verified against the live API (dev) via `client.registries` create → retrieve → list → delete.

Authored with the assistance of an AI agent.
