### PR TITLE
docs: add Agent Server changelog entry for v0.11.0rc5

### DIFF
--- a/src/langsmith/agent-server-changelog.mdx
+++ b/src/langsmith/agent-server-changelog.mdx
@@ -11,6 +11,13 @@ rss: true
 
 [Agent Server](/langsmith/agent-server) is an API platform for creating and managing agent-based applications. It provides built-in persistence, a task queue, and supports deploying, configuring, and running assistants (agentic workflows) at scale. This changelog documents all notable updates, features, and fixes to Agent Server releases.
 
+<Update label="2026-06-25" tags={["agent-server"]}>
+## v0.11.0rc5
+
+### Fixes
+- Fixed DeltaChannel replay for channels that migrated from a non-delta channel to DeltaChannel. The checkpointer did not correctly recognize the head seed checkpoint, which could produce incorrect reconstructed state for non-additive reducers.
+</Update>
+
 <Update label="2026-06-18" tags={["agent-server"]}>
 ## v0.11.0rc4
 


### PR DESCRIPTION
## Summary
- Added release notes for Agent Server **v0.11.0rc5** to `src/langsmith/agent-server-changelog.mdx`.
- **v0.11.0rc5** (2026-06-25): Fixed DeltaChannel replay for channels that migrated from a non-delta channel to DeltaChannel. The checkpointer did not correctly recognize the head seed checkpoint, which could produce incorrect reconstructed state for non-additive reducers ([langgraph-api#3608](https://github.com/langchain-ai/langgraph-api/pull/3608), commit [62427ea](https://github.com/langchain-ai/langgraph-api/commit/62427eae7a94d3c6ba11b3cce263e825367e5bf3)).

## Test plan
- [x] `make lint_prose FILES="src/langsmith/agent-server-changelog.mdx"` passes
- [ ] Preview changelog entry on `/langsmith/agent-server-changelog`


Made with [Cursor](https://cursor.com)