### PR TITLE
docs(langsmith): list tool-server and trigger-server FIPS images

### DIFF
--- a/src/langsmith/self-host-fips.mdx
+++ b/src/langsmith/self-host-fips.mdx
@@ -25,6 +25,8 @@ Every LangChain-authored image has a `-fips` counterpart published at the same t
 | `langchain/langsmith-playground` | `langchain/langsmith-playground-fips` |
 | `langchain/hosted-langserve-backend` | `langchain/hosted-langserve-backend-fips` |
 | `langchain/langgraph-operator` | `langchain/langgraph-operator-fips` |
+| `langchain/agent-builder-tool-server` | `langchain/agent-builder-tool-server-fips` |
+| `langchain/agent-builder-trigger-server` | `langchain/agent-builder-trigger-server-fips` |
 
 PostgreSQL, Redis, and ClickHouse are not published as FIPS variants by LangChain. If your deployment requires FIPS for these components, bring your own FIPS-mode service and connect via [external Postgres](/langsmith/self-host-external-postgres), [external Redis](/langsmith/self-host-external-redis), or [external ClickHouse](/langsmith/self-host-external-clickhouse).
 


### PR DESCRIPTION
The FIPS-compliant images table on the self-host FIPS page was missing two published `-fips` images: `agent-builder-tool-server-fips` and `agent-builder-trigger-server-fips`.

Both are built and published alongside the other `-fips` images (`build_services.yaml` build matrix + `release_self_hosted_on_version_bump.yaml` retag matrix in langchainplus) and are genuinely Full-FIPS (pure-Python images on the Chainguard FIPS base — crypto links the validated OpenSSL provider). They were simply absent from this table.

This adds the two rows. No other claims on the page are changed.