### PR TITLE
docs(langsmith): consolidate API rate limits into usage-and-billing

### DIFF
--- a/src/langsmith/export-traces.mdx
+++ b/src/langsmith/export-traces.mdx
@@ -1118,27 +1118,4 @@ df.head()
 
 ## Rate limits
 
-The [`POST /runs/query`](/langsmith/smith-api/run/query-runs) endpoint ([`list_runs`](https://reference.langchain.com/python/langsmith/client/Client/list_runs) in Python, [`listRuns`](https://reference.langchain.com/javascript/langsmith/client/Client/listRuns) in JavaScript) has per-tenant rate limits that vary based on query parameters:
-
-| **Query type** | **Limit** | **Window** |
-|---|---|---|
-| Short time window (≤ 7 days) | 10 requests | 10 seconds |
-| Large time window (> 7 days) | 3 requests | 10 seconds |
-| Full-text search, short time window (≤ 7 days) | 3 requests | 10 seconds |
-| Full-text search, large time window (> 7 days) | 1 request | 10 seconds |
-| Select `child_run_ids`, short time window (≤ 7 days) | 3 requests | 10 seconds |
-| Select `child_run_ids`, large time window (> 7 days) | 1 request | 10 seconds |
-
-The time window is determined by `end_time - start_time`. If `end_time` is not provided, LangSmith will use the current time. Queries without a `start_time` are treated as large time window queries.
-
-### Best practices
-
-To avoid hitting rate limits and reduce query time, especially for runs with large inputs/outputs:
-
-- **Set `start_time`**: omitting it triggers the large time window rate limit tier (3 requests per 10 seconds instead of 10). Use a window of 7 days or less when possible.
-- **Use `select`**: by default all fields are returned. Specifying only the fields you need (e.g., `select=["inputs", "outputs"]`) substantially reduces response size and query time, especially for runs with large inputs/outputs.
-- **Set `limit`**: cap the number of results if you don't need to paginate through everything.
-- **Avoid full-text search**: `filter='search("...")'` has the strictest rate limits; use structured filters (e.g., `eq()`, `has()`) when possible.
-- **Avoid selecting `child_run_ids`**: this also triggers a stricter rate limit tier.
-
-When you exceed these limits, the API returns a `429 Too Many Requests` response. For general rate limit information, refer to [Administration overview](/langsmith/usage-and-billing#rate-limits).
+The [`POST /runs/query`](/langsmith/smith-api/run/query-runs) endpoint has per-tenant rate limits based on query parameters. See [Run query endpoint rate limits](/langsmith/usage-and-billing#run-query-endpoint) for the full table and best practices.

--- a/src/langsmith/usage-and-billing.mdx
+++ b/src/langsmith/usage-and-billing.mdx
@@ -170,7 +170,51 @@ This is thrown by our application and varies by organization based on their conf
 
 ### Run query endpoint
 
-The [`POST /runs/query`](/langsmith/smith-api/run/query-runs) endpoint has additional per-tenant rate limits based on query parameters. See [Query traces using the SDK](/langsmith/export-traces#rate-limits) for details.
+LangSmith exposes two versions of the run query endpoint with different rate limit profiles.
+
+**v2 (recommended):** `POST /v2/runs/query` ([`list_runs`](https://reference.langchain.com/python/langsmith/client/Client/list_runs) in Python, [`listRuns`](https://reference.langchain.com/javascript/langsmith/client/Client/listRuns) in JavaScript) is backed by SmithDB and has a flat limit with no query-parameter tiers:
+
+| **Limit** | **Window** |
+|---|---|
+| 300 requests | 10 seconds |
+
+**v1:** `POST /runs/query` has per-tenant rate limits that vary based on query parameters:
+
+| **Query type** | **Limit** | **Window** |
+|---|---|---|
+| Short time window (≤ 7 days) | 10 requests | 10 seconds |
+| Large time window (> 7 days) | 3 requests | 10 seconds |
+| Full-text search, short time window (≤ 7 days) | 3 requests | 10 seconds |
+| Full-text search, large time window (> 7 days) | 1 request | 10 seconds |
+| Select `child_run_ids`, short time window (≤ 7 days) | 3 requests | 10 seconds |
+| Select `child_run_ids`, large time window (> 7 days) | 1 request | 10 seconds |
+
+The time window is determined by `end_time - start_time`. If `end_time` is not provided, LangSmith will use the current time. Queries without a `start_time` are treated as large time window queries.
+
+To avoid hitting v1 rate limits and reduce query time:
+
+- **Set `start_time`**: omitting it triggers the large time window tier (3 requests per 10 seconds instead of 10). Use a window of 7 days or less when possible.
+- **Use `select`**: by default all fields are returned. Specifying only the fields you need (e.g., `select=["inputs", "outputs"]`) substantially reduces response size and query time.
+- **Set `limit`**: cap the number of results if you don't need to paginate through everything.
+- **Avoid full-text search**: `filter='search("...")'` has the strictest rate limits; use structured filters (e.g., `eq()`, `has()`) when possible.
+- **Avoid selecting `child_run_ids`**: this also triggers a stricter rate limit tier.
+
+### Run stats endpoint
+
+The [`POST /runs/stats`](/langsmith/smith-api/run/get-run-stats) endpoint has per-tenant rate limits that vary based on the query time window:
+
+| **Query type** | **Limit** | **Window** |
+|---|---|---|
+| Short time window (≤ 30 days) | 10 requests | 10 seconds |
+| Large time window (> 30 days) | 3 requests | 10 seconds |
+| No `start_time` | 1 request | 10 seconds |
+
+The time window is determined by `end_time - start_time`. Queries without a `start_time` are subject to the strictest limit.
+
+To avoid hitting rate limits:
+
+- **Set `start_time`**: use a window of 30 days or less when possible.
+- **Avoid open-ended queries**: always provide a `start_time` to stay in the less-restrictive tier.
 
 ### Handling 429s responses in your application
 


### PR DESCRIPTION
## Summary

- Expands `usage-and-billing#rate-limits` to inline all endpoint-specific rate limit tables, replacing the cross-reference to `export-traces`
- Adds new **`/runs/stats`** rate limits section (tiered by time window: ≤30d / >30d / no `start_time`)
- Adds **`POST /v2/runs/query`** flat limit (300 req/10s, SmithDB-backed, no query-parameter tiers) alongside the existing v1 tiered table
- Reduces `export-traces#rate-limits` to a single sentence + link to the canonical page

Related: langchain-ai/langchainplus#28424 (runs/stats limits), langchain-ai/deployments#31891 (v2 runs/query LB limits)

## Test plan

- [ ] Review rendered output at `usage-and-billing#run-query-endpoint` and `usage-and-billing#run-stats-endpoint`
- [ ] Confirm `export-traces#rate-limits` cross-reference resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)