### PR TITLE
docs: add Mimir integration (langchain-mimir)

### DIFF
--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -722,6 +722,14 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
+        title="Mimir"
+        href="/oss/integrations/providers/mimir"
+        icon="link"
+    >
+        Local-first, encrypted persistent-memory MCP server.
+    </Card>
+
+    <Card
         title="Metal"
         href="/oss/integrations/providers/metal"
         icon="link"

--- a/src/oss/python/integrations/providers/mimir.mdx
+++ b/src/oss/python/integrations/providers/mimir.mdx
@@ -1,0 +1,28 @@
+---
+title: "Mimir integration"
+description: "Integrate with Mimir using LangChain Python."
+---
+
+[Mimir](https://github.com/Perseus-Computing-LLC/mimir) is a local-first, encrypted, MIT-licensed persistent-memory MCP server. The `langchain-mimir` package integrates Mimir with LangChain, exposing it as tools and as a retriever so agents can store and recall memories from a local, encrypted store.
+
+## Installation and setup
+
+<CodeGroup>
+```bash pip
+pip install langchain-mimir
+```
+
+```bash uv
+uv add langchain-mimir
+```
+</CodeGroup>
+
+Mimir runs as a local `mimir` binary. Download a release from the [Mimir releases page](https://github.com/Perseus-Computing-LLC/mimir/releases), or build from source with `cargo build --release`, and put the `mimir` executable on your `PATH`.
+
+## Tools
+
+For more information on the available tools, see the [Mimir tools documentation](/oss/integrations/tools/mimir).
+
+## Retrievers
+
+For more information on the available retrievers, see the [Mimir retriever documentation](/oss/integrations/retrievers/mimir).

--- a/src/oss/python/integrations/retrievers/index.mdx
+++ b/src/oss/python/integrations/retrievers/index.mdx
@@ -59,6 +59,7 @@ The below retrievers will search over an external index (e.g., constructed from 
 <Card title="IMAP" icon="link" href="/oss/integrations/retrievers/imap" arrow="true" cta="View guide" />
 <Card title="Kinetica Vectorstore" icon="link" href="/oss/integrations/retrievers/kinetica" arrow="true" cta="View guide" />
 <Card title="LinkupSearchRetriever" icon="link" href="/oss/integrations/retrievers/linkup_search" arrow="true" cta="View guide" />
+<Card title="Mimir" icon="link" href="/oss/integrations/retrievers/mimir" arrow="true" cta="View guide" />
 <Card title="Nebius" icon="link" href="/oss/integrations/retrievers/nebius" arrow="true" cta="View guide" />
 <Card title="Nimble Extract" icon="link" href="/oss/integrations/retrievers/nimble_extract" arrow="true" cta="View guide" />
 <Card title="Nimble Search" icon="link" href="/oss/integrations/retrievers/nimble_search" arrow="true" cta="View guide" />

--- a/src/oss/python/integrations/retrievers/mimir.mdx
+++ b/src/oss/python/integrations/retrievers/mimir.mdx
@@ -1,0 +1,58 @@
+---
+title: "Mimir integration"
+description: "Integrate with the MimirRetriever retriever using LangChain Python."
+---
+
+# MimirRetriever
+
+This will help you get started with the Mimir [retriever](/oss/langchain/retrieval). `MimirRetriever` queries a local, encrypted Mimir memory store and returns matching `Document` objects. For the Mimir tools, see the [Mimir tools documentation](/oss/integrations/tools/mimir).
+
+### Integration details
+
+Bring-your-own data (index and search a local corpus of memories):
+
+| Retriever | Self-host | Cloud offering | Package |
+| :--- | :--- | :---: | :---: |
+| `MimirRetriever` | ✅ | ❌ | `langchain-mimir` |
+
+## Setup
+
+Mimir runs as a local `mimir` binary. Download a release from the [Mimir releases page](https://github.com/Perseus-Computing-LLC/mimir/releases), or build from source with `cargo build --release`, and put the `mimir` executable on your `PATH`. Alternatively, pass an absolute path to the binary through the `MimirClient` constructor.
+
+### Installation
+
+This retriever lives in the `langchain-mimir` package:
+
+```python
+pip install -qU langchain-mimir
+```
+
+## Instantiation
+
+Create a `MimirClient`, then construct the retriever:
+
+```python
+from langchain_mimir import MimirClient, MimirRetriever
+
+client = MimirClient(db_path="~/.langchain/mimir.db")
+retriever = MimirRetriever(client=client, k=5)
+```
+
+## Usage
+
+Store memories through the client, then query them with the retriever:
+
+```python
+from langchain_mimir import MimirClient, MimirRetriever
+
+client = MimirClient(db_path="~/.langchain/mimir.db")
+client.remember("The capital of France is Paris.")
+
+retriever = MimirRetriever(client=client, k=5)
+docs = retriever.invoke("What is the capital of France?")
+print(docs[0].page_content)
+```
+
+## API reference
+
+For detailed documentation of all Mimir features and configurations, head to the [langchain-mimir repository](https://github.com/Perseus-Computing-LLC/langchain-mimir).

--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -136,6 +136,7 @@ The following platforms provide access to multiple tools and services through a 
 <Card title="Lemon Agent" icon="link" href="/oss/integrations/tools/lemonai" arrow="true" cta="View guide" />
 <Card title="Linkup Search Tool" icon="link" href="/oss/integrations/tools/linkup_search" arrow="true" cta="View guide" />
 <Card title="Memgraph" icon="link" href="/oss/integrations/tools/memgraph" arrow="true" cta="View guide" />
+<Card title="Mimir" icon="link" href="/oss/integrations/tools/mimir" arrow="true" cta="View guide" />
 <Card title="Naver Search" icon="link" href="/oss/integrations/tools/naver_search" arrow="true" cta="View guide" />
 <Card title="Nia Toolkit" icon="link" href="/oss/integrations/tools/nia" arrow="true" cta="View guide" />
 <Card title="Nimble Extract" icon="link" href="/oss/integrations/tools/nimble_extract" arrow="true" cta="View guide" />

--- a/src/oss/python/integrations/tools/mimir.mdx
+++ b/src/oss/python/integrations/tools/mimir.mdx
@@ -1,0 +1,90 @@
+---
+title: "Mimir integration"
+description: "Integrate with the Mimir memory tools using LangChain Python."
+---
+
+This guide provides a quick overview for getting started with the Mimir [tools](/oss/langchain/tools). Mimir is a local-first, encrypted, MIT-licensed persistent-memory MCP server. The `langchain-mimir` package exposes Mimir as LangChain tools (`mimir_remember` and `mimir_recall`) and as a [retriever](/oss/integrations/retrievers/mimir).
+
+## Overview
+
+### Details
+
+| Class | Package | Serializable | Downloads | Version |
+| :--- | :--- | :---: | :---: | :---: |
+| `create_mimir_tools` | [`langchain-mimir`](https://pypi.org/project/langchain-mimir/) | ❌ | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain-mimir?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-mimir?style=flat-square&label=%20) |
+
+### Features
+
+- `mimir_remember`: store text in local, encrypted memory.
+- `mimir_recall`: retrieve relevant memories for a query.
+
+## Setup
+
+Mimir runs as a local `mimir` binary. Download a release from the [Mimir releases page](https://github.com/Perseus-Computing-LLC/mimir/releases), or build from source with `cargo build --release`, and put the `mimir` executable on your `PATH`. Alternatively, pass an absolute path to the binary through the `MimirClient` constructor.
+
+### Installation
+
+The Mimir tools live in the `langchain-mimir` package:
+
+<CodeGroup>
+    ```bash pip
+    pip install -U langchain-mimir
+    ```
+    ```bash uv
+    uv add langchain-mimir
+    ```
+</CodeGroup>
+
+## Instantiation
+
+Create a `MimirClient`, then build the tools with `create_mimir_tools`:
+
+```python
+from langchain_mimir import MimirClient, create_mimir_tools
+
+client = MimirClient(db_path="~/.langchain/mimir.db")
+tools = create_mimir_tools(client)  # [mimir_remember, mimir_recall]
+```
+
+If the `mimir` binary is not on your `PATH`, pass its absolute location:
+
+```python
+client = MimirClient(db_path="~/.langchain/mimir.db", mimir_binary="/usr/local/bin/mimir")
+```
+
+## Invocation
+
+### Within an agent
+
+Bind the tools to a tool-calling model so the model can store and retrieve memories:
+
+```python
+from langchain.chat_models import init_chat_model
+from langchain_mimir import MimirClient, create_mimir_tools
+
+client = MimirClient(db_path="~/.langchain/mimir.db")
+tools = create_mimir_tools(client)
+
+llm = init_chat_model("anthropic:claude-sonnet-4-6")
+llm_with_memory = llm.bind_tools(tools)
+
+response = llm_with_memory.invoke("Remember that my favorite language is Rust.")
+```
+
+### Direct client access
+
+The underlying `MimirClient` exposes `remember` and `recall` directly:
+
+```python
+from langchain_mimir import MimirClient
+
+client = MimirClient(db_path="~/.langchain/mimir.db")
+client.remember("Project deadline is July 15.", tags=["project", "deadline"])
+
+items = client.recall("when is the deadline")
+print(items[0]["text"])
+```
+
+## API reference
+
+For detailed documentation of all Mimir features and configurations, head to the [langchain-mimir repository](https://github.com/Perseus-Computing-LLC/langchain-mimir).


### PR DESCRIPTION
## Why

Adds documentation for [`langchain-mimir`](https://pypi.org/project/langchain-mimir/) ([repo](https://github.com/Perseus-Computing-LLC/langchain-mimir)), a published LangChain integration for [Mimir](https://github.com/Perseus-Computing-LLC/mimir), a local-first, encrypted, MIT-licensed persistent-memory MCP server. The package is live on PyPI (`pip install langchain-mimir`).

## What

The integration is primarily a set of tools, plus a retriever. Following the integration-authoring guide and the existing third-party patterns (e.g. Cognee), this PR adds:

- `src/oss/python/integrations/tools/mimir.mdx` — `create_mimir_tools()` (`mimir_remember` / `mimir_recall`), built from the tools `TEMPLATE.mdx`.
- `src/oss/python/integrations/retrievers/mimir.mdx` — `MimirRetriever` usage.
- `src/oss/python/integrations/providers/mimir.mdx` — provider overview linking both component pages.

Registry entries:

- Added a card to `tools/index.mdx` and `retrievers/index.mdx`.
- Added a card to `providers/all_providers.mdx`.

Setup notes cover the prerequisite local `mimir` binary (release download or `cargo build --release`, on `PATH` or via the `MimirClient` constructor). Code examples use only the package's documented API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)