### PR TITLE
docs: add NVIDIA sandboxed agents resources

### DIFF
--- a/src/oss/deepagents/sandboxes.mdx
+++ b/src/oss/deepagents/sandboxes.mdx
@@ -222,7 +222,7 @@ from langsmith.sandbox import SandboxClient
 
 load_dotenv()
 
-# Can also do this with AgentCore, Daytona, E2B, Modal, Runloop, or Vercel
+# Can also do this with AgentCore, Daytona, E2B, Modal, NVIDIA OpenShell, Runloop, or Vercel
 client = SandboxClient()
 ls_sandbox = client.create_sandbox()
 backend = LangSmithSandbox(sandbox=ls_sandbox)
@@ -441,6 +441,29 @@ You can also call the backend `execute()` method directly in your application co
 
         result = backend.execute("python --version")
         print(result.output)
+        ```
+    </Tab>
+    <Tab title="NVIDIA OpenShell">
+        <CodeGroup>
+            ```bash pip
+            pip install langchain-nvidia-openshell
+            ```
+
+            ```bash uv
+            uv add langchain-nvidia-openshell
+            ```
+        </CodeGroup>
+
+        ```python
+        import openshell
+
+        from langchain_nvidia_openshell import OpenShellSandbox
+
+        with openshell.Sandbox(delete_on_exit=True) as sandbox:
+            backend = OpenShellSandbox(sandbox=sandbox)
+
+            result = backend.execute("python3 --version")
+            print(result.output)
         ```
     </Tab>
     <Tab title="Runloop">

--- a/src/oss/python/integrations/chat/nvidia_ai_endpoints.mdx
+++ b/src/oss/python/integrations/chat/nvidia_ai_endpoints.mdx
@@ -76,8 +76,8 @@ Now we can access models in the NVIDIA API Catalog. [Nemotron](https://www.nvidi
 ```python
 from langchain_nvidia_ai_endpoints import ChatNVIDIA
 
-# Nemotron 3 Nano — efficient reasoning and agentic tasks
-llm = ChatNVIDIA(model="nvidia/nemotron-3-super-120b-a12b")
+# Nemotron 3 Ultra - frontier reasoning and agentic workflows
+llm = ChatNVIDIA(model="nvidia/nemotron-3-ultra-550b-a55b")
 ```
 
 Any other model from the API Catalog can be used by passing its model ID:
@@ -144,7 +144,7 @@ The following code connects to locally hosted NIM Microservices.
 from langchain_nvidia_ai_endpoints import ChatNVIDIA, NVIDIAEmbeddings, NVIDIARerank
 
 # Connect to a chat NIM running at localhost:8000, specifying a model
-llm = ChatNVIDIA(base_url="http://localhost:8000/v1", model="nvidia/nemotron-3-super-120b-a12b")
+llm = ChatNVIDIA(base_url="http://localhost:8000/v1", model="nvidia/nemotron-3-ultra-550b-a55b")
 
 # Connect to an embedding NIM running at localhost:8080
 embedder = NVIDIAEmbeddings(base_url="http://localhost:8080/v1")
@@ -218,7 +218,7 @@ prompt = ChatPromptTemplate.from_messages(
         ("user", "{input}"),
     ]
 )
-chain = prompt | ChatNVIDIA(model="nvidia/nemotron-3-super-120b-a12b") | StrOutputParser()
+chain = prompt | ChatNVIDIA(model="nvidia/nemotron-3-ultra-550b-a55b") | StrOutputParser()
 
 for txt in chain.stream({"input": "What are the key considerations when designing a multi-agent RAG system?"}):
     print(txt, end="")
@@ -236,7 +236,7 @@ from langchain_nvidia_ai_endpoints import ChatNVIDIA
 prompt = ChatPromptTemplate.from_messages(
     [("system", "You are a helpful AI assistant named Fred."), ("user", "{input}")]
 )
-chain = prompt | ChatNVIDIA(model="nvidia/nemotron-3-super-120b-a12b") | StrOutputParser()
+chain = prompt | ChatNVIDIA(model="nvidia/nemotron-3-ultra-550b-a55b") | StrOutputParser()
 
 for txt in chain.stream({"input": "What's your name?"}):
     print(txt, end="")
@@ -371,7 +371,7 @@ def get_session_history(session_id: str) -> InMemoryChatMessageHistory:
 
 
 chat = ChatNVIDIA(
-    model="nvidia/nemotron-3-super-120b-a12b",
+    model="nvidia/nemotron-3-ultra-550b-a55b",
     temperature=0.1,
     max_tokens=100,
     top_p=1.0,
@@ -580,6 +580,9 @@ For detailed documentation of all `ChatNVIDIA` features and configurations head 
 - [Overview of NeMo Retriever Reranking NIM](https://docs.nvidia.com/nim/nemo-retriever/text-reranking/latest/overview.html)
 - [`NVIDIAEmbeddings` Model for RAG Workflows](/oss/integrations/embeddings/nvidia_ai_endpoints)
 - [NVIDIA Provider Page](/oss/integrations/providers/nvidia)
+- [Sandboxed agents with NVIDIA OpenShell](/oss/integrations/providers/nvidia#sandboxed-agents-with-openshell)
+- [Deep Agent harness profiles for Nemotron 3 Ultra](/oss/integrations/providers/nvidia#deep-agent-harness-profiles-for-nemotron-3-ultra)
+- [Post-training agent workflows](/oss/integrations/providers/nvidia#post-training-agent-workflows)
 - [NVIDIA Dynamo](https://developer.nvidia.com/dynamo) — open-source inference framework
 - [Dynamo Quickstart Guide](https://docs.nvidia.com/dynamo/latest/getting-started/quickstart) — get a local deployment running
 - [KV Cache-Aware Routing](https://docs.nvidia.com/dynamo/latest/user-guides/kv-cache-aware-routing) — how the Smart Router works

--- a/src/oss/python/integrations/chat/nvidia_ai_endpoints.mdx
+++ b/src/oss/python/integrations/chat/nvidia_ai_endpoints.mdx
@@ -581,7 +581,6 @@ For detailed documentation of all `ChatNVIDIA` features and configurations head 
 - [`NVIDIAEmbeddings` Model for RAG Workflows](/oss/integrations/embeddings/nvidia_ai_endpoints)
 - [NVIDIA Provider Page](/oss/integrations/providers/nvidia)
 - [Sandboxed agents with NVIDIA OpenShell](/oss/integrations/providers/nvidia#sandboxed-agents-with-openshell)
-- [Deep Agent harness profiles for Nemotron 3 Ultra](/oss/integrations/providers/nvidia#deep-agent-harness-profiles-for-nemotron-3-ultra)
 - [Post-training agent workflows](/oss/integrations/providers/nvidia#post-training-agent-workflows)
 - [NVIDIA Dynamo](https://developer.nvidia.com/dynamo) — open-source inference framework
 - [Dynamo Quickstart Guide](https://docs.nvidia.com/dynamo/latest/getting-started/quickstart) — get a local deployment running

--- a/src/oss/python/integrations/providers/nvidia.mdx
+++ b/src/oss/python/integrations/providers/nvidia.mdx
@@ -3,12 +3,15 @@ title: "NVIDIA"
 description: "Integrate with NVIDIA using LangChain Python."
 ---
 
-LangChain and NVIDIA have partnered to accelerate agents through four mechanisms:
+LangChain and NVIDIA have partnered across the agent stack:
 
 1. [Components](#components)
-2. [LangGraph acceleration primitives](#accelerate-langgraph-with-nvidia)
-3. [NeMo Agent Toolkit optimizations](#nemo-agent-toolkit-optimizations-with-langsmith-telemetry)
-4. [Full Stack blueprints](#full-stack-blueprints)
+2. [Sandboxed agents with OpenShell](#sandboxed-agents-with-openshell)
+3. [Deep Agent harness profiles for Nemotron 3 Ultra](#deep-agent-harness-profiles-for-nemotron-3-ultra)
+4. [LangGraph acceleration primitives](#accelerate-langgraph-with-nvidia)
+5. [NeMo Agent Toolkit optimizations](#nemo-agent-toolkit-optimizations-with-langsmith-telemetry)
+6. [Post-training agent workflows](#post-training-agent-workflows)
+7. [Full Stack blueprints](#full-stack-blueprints)
 
 ## Components
 
@@ -64,8 +67,8 @@ else:
 ```python
 from langchain_nvidia_ai_endpoints import ChatNVIDIA
 
-# Nemotron 3 Super — efficient reasoning and agentic tasks
-llm = ChatNVIDIA(model="nvidia/nemotron-3-super-120b-a12b")
+# Nemotron 3 Ultra - frontier reasoning and agentic workflows
+llm = ChatNVIDIA(model="nvidia/nemotron-3-ultra-550b-a55b")
 result = llm.invoke("Plan a three-step research workflow for competitive analysis.")
 print(result.content)
 ```
@@ -82,7 +85,7 @@ from langchain_nvidia_ai_endpoints import ChatNVIDIADynamo
 
 llm = ChatNVIDIADynamo(
     base_url="http://localhost:8099/v1",
-    model="nvidia/nemotron-3-super-120b-a12b",
+    model="nvidia/nemotron-3-ultra-550b-a55b",
     osl=512,             # expected output sequence length (tokens)
     iat=250,             # expected inter-arrival time (ms)
     latency_sensitivity=1.0,
@@ -147,7 +150,7 @@ When you are ready to deploy your AI application, you can self-host models with 
 from langchain_nvidia_ai_endpoints import ChatNVIDIA, NVIDIAEmbeddings, NVIDIARerank
 
 # connect to a chat NIM running at localhost:8000, specifying a model
-llm = ChatNVIDIA(base_url="http://localhost:8000/v1", model="nvidia/nemotron-3-super-120b-a12b")
+llm = ChatNVIDIA(base_url="http://localhost:8000/v1", model="nvidia/nemotron-3-ultra-550b-a55b")
 
 # connect to an embedding NIM running at localhost:8080
 embedder = NVIDIAEmbeddings(base_url="http://localhost:8080/v1")
@@ -155,6 +158,43 @@ embedder = NVIDIAEmbeddings(base_url="http://localhost:8080/v1")
 # connect to a reranking NIM running at localhost:2016
 ranker = NVIDIARerank(base_url="http://localhost:2016/v1")
 ```
+
+
+## Sandboxed Agents with OpenShell
+
+[OpenShell](https://github.com/NVIDIA/OpenShell) gives LangChain agents a policy-governed Linux sandbox for code execution, file access, process permissions, and network egress. This is useful for deep agents that need to inspect data, write code, run commands, or use tools against local resources while keeping the execution environment isolated from the host.
+
+For LangChain applications, the [`langchain-nvidia-openshell`](https://github.com/langchain-ai/langchain-nvidia/tree/main/libs/openshell) package adapts OpenShell to the Deep Agents sandbox interface. The agent can run on the host with `ChatNVIDIA`, while tool execution is dispatched into an OpenShell sandbox through the `OpenShellSandbox` backend.
+
+Resources:
+
+- [LangChain NVIDIA samples](https://github.com/langchain-samples/langchain-nvidia-samples) includes runnable NVIDIA examples, including an OpenShell incident-analysis agent.
+- [OpenShell Deep Agent](https://github.com/langchain-ai/openshell-deepagent) is a reference coding agent that runs inside an OpenShell sandbox, orchestrated by Deep Agents and powered by NVIDIA Nemotron.
+- [`langchain-nvidia-openshell`](https://github.com/langchain-ai/langchain-nvidia/tree/main/libs/openshell) provides the Python adapter, setup notes, policy guidance, and notebook walkthroughs for sandboxed Deep Agents.
+
+```python
+import openshell
+from deepagents import create_deep_agent
+from langchain_nvidia_ai_endpoints import ChatNVIDIA
+from langchain_nvidia_openshell import OpenShellSandbox
+
+with openshell.Sandbox() as sandbox:
+    backend = OpenShellSandbox(sandbox=sandbox)
+    agent = create_deep_agent(
+        model=ChatNVIDIA(model="nvidia/nemotron-3-ultra-550b-a55b"),
+        system_prompt="You are a careful coding agent.",
+        backend=backend,
+    )
+```
+
+
+## Deep Agent Harness Profiles for Nemotron 3 Ultra
+
+Deep Agents include harness profiles that tune the agent loop around specific model behavior. A Nemotron 3 Ultra profile adds a behavior-shaping system prompt suffix plus middleware for common long-running-agent failure modes, including empty tool-message normalization, `read_file` continuation notices, and one retry for filesystem tool failures.
+
+The profile is registered per model key for `nvidia/nemotron-3-ultra-550b-a55b`, rather than provider-wide, so other NVIDIA catalog models are unchanged. It covers both `ChatNVIDIA` instances and `init_chat_model("nvidia:...")` usage, and also maps Nemotron 3 Ultra variants served by Fireworks, Baseten, and OpenRouter.
+
+See the Deep Agents PR that added the profile: [langchain-ai/deepagents#4192](https://github.com/langchain-ai/deepagents/pull/4192/changes/9cde96141156d804bf9d3f468af15466cdb78e64#top).
 
 
 ## Accelerate LangGraph with NVIDIA
@@ -228,6 +268,12 @@ The NVIDIA NeMo Agent Toolkit is an open-source AI toolkit for building, profili
 
 - [Optimize LangChain with NeMo Agent Toolkit and LangSmith](https://github.com/NVIDIA/NeMo-Agent-Toolkit/blob/develop/docs/source/run-workflows/observe/observe-workflow-with-langsmith.md)
 
+## Post-training Agent Workflows
+
+NVIDIA NeMo Gym provides post-training workflows for agentic systems, including examples that pair LangGraph agents with Responses API-style training data and evaluation loops. Use these workflows when you want to improve agent behavior after initial prompting and harness tuning, especially for tool-use and multi-step reasoning tasks.
+
+- [NeMo Gym LangGraph agent example](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/langgraph_agent)
+
 ## Full Stack Blueprints
 
 NVIDIA and LangChain have collaborated on [full stack examples](https://github.com/langchain-ai/deepagents/tree/main/examples) showing how all these components are combined for two enterprise use cases, with focus on production readiness:
@@ -240,6 +286,10 @@ NVIDIA and LangChain have collaborated on [full stack examples](https://github.c
 - [`langchain-nvidia-ai-endpoints` package README](https://github.com/langchain-ai/langchain-nvidia/blob/main/libs/ai-endpoints/README.md)
 - [`langchain-nvidia-langgraph` package](https://github.com/langchain-ai/langchain-nvidia/tree/main/libs/langgraph)
 - [Nemotron model family](https://www.nvidia.com/en-us/ai-data-science/foundation-models/nemotron/)
+- [`langchain-nvidia-openshell` package](https://github.com/langchain-ai/langchain-nvidia/tree/main/libs/openshell)
+- [LangChain NVIDIA samples](https://github.com/langchain-samples/langchain-nvidia-samples)
+- [OpenShell Deep Agent](https://github.com/langchain-ai/openshell-deepagent)
+- [NeMo Gym LangGraph agent example](https://github.com/NVIDIA-NeMo/Gym/tree/main/responses_api_agents/langgraph_agent)
 - [Overview of NVIDIA NIM for Large Language Models (LLMs)](https://docs.nvidia.com/nim/large-language-models/latest/introduction.html)
 - [Overview of NeMo Retriever Embedding NIM](https://docs.nvidia.com/nim/nemo-retriever/text-embedding/latest/overview.html)
 - [Overview of NeMo Retriever Reranking NIM](https://docs.nvidia.com/nim/nemo-retriever/text-reranking/latest/overview.html)

--- a/src/oss/python/integrations/providers/nvidia.mdx
+++ b/src/oss/python/integrations/providers/nvidia.mdx
@@ -188,15 +188,6 @@ with openshell.Sandbox() as sandbox:
 ```
 
 
-## Deep Agent Harness Profiles for Nemotron 3 Ultra
-
-Deep Agents include harness profiles that tune the agent loop around specific model behavior. A Nemotron 3 Ultra profile adds a behavior-shaping system prompt suffix plus middleware for common long-running-agent failure modes, including empty tool-message normalization, `read_file` continuation notices, and one retry for filesystem tool failures.
-
-The profile is registered per model key for `nvidia/nemotron-3-ultra-550b-a55b`, rather than provider-wide, so other NVIDIA catalog models are unchanged. It covers both `ChatNVIDIA` instances and `init_chat_model("nvidia:...")` usage, and also maps Nemotron 3 Ultra variants served by Fireworks, Baseten, and OpenRouter.
-
-See the Deep Agents PR that added the profile: [langchain-ai/deepagents#4192](https://github.com/langchain-ai/deepagents/pull/4192/changes/9cde96141156d804bf9d3f468af15466cdb78e64#top).
-
-
 ## Accelerate LangGraph with NVIDIA
 
 The `langchain-nvidia-langgraph` package provides NVIDIA-optimized execution strategies for LangGraph graphs. It offers two complementary optimizations applied at compile time:

--- a/src/oss/python/integrations/providers/nvidia.mdx
+++ b/src/oss/python/integrations/providers/nvidia.mdx
@@ -7,11 +7,10 @@ LangChain and NVIDIA have partnered across the agent stack:
 
 1. [Components](#components)
 2. [Sandboxed agents with OpenShell](#sandboxed-agents-with-openshell)
-3. [Deep Agent harness profiles for Nemotron 3 Ultra](#deep-agent-harness-profiles-for-nemotron-3-ultra)
-4. [LangGraph acceleration primitives](#accelerate-langgraph-with-nvidia)
-5. [NeMo Agent Toolkit optimizations](#nemo-agent-toolkit-optimizations-with-langsmith-telemetry)
-6. [Post-training agent workflows](#post-training-agent-workflows)
-7. [Full Stack blueprints](#full-stack-blueprints)
+3. [LangGraph acceleration primitives](#accelerate-langgraph-with-nvidia)
+4. [NeMo Agent Toolkit optimizations](#nemo-agent-toolkit-optimizations-with-langsmith-telemetry)
+5. [Post-training agent workflows](#post-training-agent-workflows)
+6. [Full Stack blueprints](#full-stack-blueprints)
 
 ## Components
 

--- a/src/oss/python/integrations/sandboxes/index.mdx
+++ b/src/oss/python/integrations/sandboxes/index.mdx
@@ -36,6 +36,10 @@ Sandboxes provide isolated execution environments for running agent-generated co
         <span className="font-semibold">Modal</span>
     </a>
 
+    <a href="/oss/integrations/providers/nvidia#sandboxed-agents-with-openshell" className="flex items-center justify-center gap-1.5 p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 no-underline">
+        <span className="font-semibold">NVIDIA OpenShell</span>
+    </a>
+
     <a href="/oss/integrations/sandboxes/runloop" className="flex items-center justify-center gap-1.5 p-2 rounded-lg border border-gray-200 dark:border-gray-700 hover:border-gray-300 dark:hover:border-gray-600 no-underline">
         <img className="block dark:hidden w-5 h-5" src="/images/providers/light/runloop.svg" alt="" />
         <img className="hidden dark:block w-5 h-5" src="/images/providers/dark/runloop.svg" alt="" />
@@ -49,4 +53,4 @@ Sandboxes provide isolated execution environments for running agent-generated co
     </a>
 </div>
 
-If you'd like to contribute a sandbox, see [Implement a sandbox integration](/oss/contributing/implement-langchain#sandboxes).
+If you'd like to contribute a sandbox, see [Implement a sandbox integration](/oss/contributing/implement-langchain).


### PR DESCRIPTION
## Overview

Updates NVIDIA-related documentation across the OSS Python integrations and Deep Agents docs:

- Switches NVIDIA provider and ChatNVIDIA examples from Nemotron 3 Super to Nemotron 3 Ultra.
- Adds sandboxed agent guidance for NVIDIA OpenShell, including links to the NVIDIA samples repo, OpenShell Deep Agent example, and LangChain NVIDIA OpenShell package.
- Lists NVIDIA OpenShell on the sandbox integrations index and adds an NVIDIA OpenShell provider tab to the Deep Agents sandboxes page.
- Cross-promotes sandboxed agents and post-training workflows from the ChatNVIDIA page.
- Removes a stale `#sandboxes` anchor from the sandbox contribution link.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: N/A
- Feature PR: https://github.com/langchain-ai/deepagents/pull/4192, https://github.com/langchain-ai/langchain-nvidia/pull/330
- Linear issue: N/A
- Slack thread: N/A

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

Validation performed:

- `git diff --check`
- Verified all unique external URLs in `src/oss/python/integrations/providers/nvidia.mdx` return HTTP 200.
- Verified all in-page anchors match local headings.
- Verified internal `/oss/...` links resolve to source files, including `#use-with-nvidia-dynamo` and `#sandboxed-agents-with-openshell`.
- Verified all links in `src/oss/python/integrations/sandboxes/index.mdx` resolve to source files/anchors.
- Verified the new ChatNVIDIA related-topic links resolve to NVIDIA provider page anchors.
- No `src/docs.json` changes were needed because this PR updates existing pages and an existing integrations index.

The OpenShell code snippets were source-checked against the current LangChain NVIDIA OpenShell README, but not executed locally.
