### PR TITLE
fix: clarify agentBootstrap migration docs

### DIFF
--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -210,7 +210,7 @@ We recommend storing each key in a predefined Kubernetes secret rather than sett
     </Tabs>
 
     <Warning>
-    If you are migrating from the legacy `agentBootstrap` deployment model, disable `backend.agentBootstrap` and the old `config.agentBuilder`, `config.insights`, and `config.polly` flags. These are the flags under the `config` section, not the top-level `fleet`, `insights`, and `polly` flags shown above.
+    These migration steps apply only when upgrading to LangSmith Self-Hosted v0.15 or later. If you are on v0.13.x, continue using the legacy `backend.agentBootstrap` deployment model until you upgrade. When you migrate from the legacy `agentBootstrap` deployment model, disable `backend.agentBootstrap` and the old `config.agentBuilder`, `config.insights`, and `config.polly` flags. These are the flags under the `config` section, not the top-level `fleet`, `insights`, and `polly` flags shown above.
 
     You must also manually delete the existing Fleet, Insights, and Chat deployments through the LangSmith Deployments UI. If you did not use an external PostgreSQL database for Fleet with the legacy `agentBootstrap` model and want to preserve existing Fleet agents, contact technical support via the [Support Portal](https://support.langchain.com) before applying this configuration.
     </Warning>


### PR DESCRIPTION
## Description
Clarifies the legacy `backend.agentBootstrap` migration warning in the self-hosted full platform docs. The note now says the standalone migration path applies to LangSmith Self-Hosted v0.15+ and that v0.13.x users should keep `backend.agentBootstrap` until upgrading.

## Test Plan
- [x] `PATH="/tmp/vale-bin:$PATH" make -C /workspace/docs lint_prose FILES="src/langsmith/deploy-self-hosted-full-platform.mdx"`

Made by [Open SWE](https://openswe.vercel.app/agents/d01e4d02-addd-0e5f-f419-7b4f13d6a771)