### PR TITLE
docs(contributing): require release notes for user-facing PRs

### DIFF
--- a/src/oss/contributing/overview.mdx
+++ b/src/oss/contributing/overview.mdx
@@ -128,6 +128,7 @@ The following requirements must be met for all external pull requests:
 
 * The pull request must link to an issue or discussion where a solution has been approved by a maintainer, and the contributor must be assigned to that issue before opening the PR.
 * The pull request must fill in the repository's pull request template.
+* Pull requests for net new features or behavior-changing bugfixes should include a `## Release note` section that states the user-visible change in release-note-ready language.
 
 Maintainers reserve the right to close PRs without comment if these requirements are not met. **We will close pull requests and issues that appear to be low-effort spam.**
 


### PR DESCRIPTION
Adds release note guidance to the contributing overview so contributors know when a user-visible change needs release-note-ready language in the PR body.