### PR TITLE
docs: add Agent Server changelog entry for v0.11.0rc8

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -1631,6 +1631,7 @@
                     "group": "Configure",
                     "pages": [
                       "langsmith/self-hosted-platform-features",
+                      "langsmith/self-hosted-agent-server-metrics",
                       "langsmith/agent-server-scale",
                       "langsmith/diagnostics-self-hosted"
                     ]

--- a/src/langsmith/agent-server-changelog.mdx
+++ b/src/langsmith/agent-server-changelog.mdx
@@ -15,8 +15,8 @@ rss: true
 ## v0.11.0rc8
 
 ### General Notes
-- Agent Server metrics are now emitted through the OpenTelemetry/Prometheus client.
-- **Potentially breaking** for Prometheus scrapers and dashboards: `lg_api_http_requests_latency_seconds` is now `lg_api_http_requests_latency` and reports milliseconds instead of seconds. Pool request counters now use a `_total` suffix (`lg_api_pg_pool_requests_queued_total`, `lg_api_pg_pool_requests_errors_total`). The `lg_api_pending_runs_wait_time_*` gauges are removed in favor of the `lg_api_run_queue_wait_time_1st_attempt` latency histogram.
+- Agent Server metrics are now emitted through the OpenTelemetry/Prometheus client on the dedicated Prometheus scrape endpoint (`LSD_PROM_METRICS_PORT`, default 9464). Set `LSD_PROM_METRICS_ENABLED=true` to enable the endpoint and `EXPOSE_INTERNAL_METRICS_PROMETHEUS=true` to expose the internal metrics migrated from the main API `/metrics` path. By default, the Prometheus endpoint serves only LSD Deployment UI metrics.
+- **Potentially breaking** for Prometheus scrapers and dashboards: point collectors at the OTLP Prometheus port instead of the main API `/metrics` path. `lg_api_http_requests_latency_seconds` is now `lg_api_http_requests_latency` and reports milliseconds instead of seconds. Pool request counters now use a `_total` suffix (`lg_api_pg_pool_requests_queued_total`, `lg_api_pg_pool_requests_errors_total`). The `lg_api_pending_runs_wait_time_*` gauges are removed in favor of the `lg_api_run_queue_wait_time_1st_attempt` latency histogram.
 </Update>
 
 <Update label="2026-06-25" tags={["agent-server"]}>

--- a/src/langsmith/agent-server-changelog.mdx
+++ b/src/langsmith/agent-server-changelog.mdx
@@ -11,6 +11,14 @@ rss: true
 
 [Agent Server](/langsmith/agent-server) is an API platform for creating and managing agent-based applications. It provides built-in persistence, a task queue, and supports deploying, configuring, and running assistants (agentic workflows) at scale. This changelog documents all notable updates, features, and fixes to Agent Server releases.
 
+<Update label="2026-06-30" tags={["agent-server"]}>
+## v0.11.0rc8
+
+### General Notes
+- Agent Server metrics are now emitted through the OpenTelemetry/Prometheus client.
+- **Potentially breaking** for Prometheus scrapers and dashboards: `lg_api_http_requests_latency_seconds` is now `lg_api_http_requests_latency` and reports milliseconds instead of seconds. Pool request counters now use a `_total` suffix (`lg_api_pg_pool_requests_queued_total`, `lg_api_pg_pool_requests_errors_total`). The `lg_api_pending_runs_wait_time_*` gauges are removed in favor of the `lg_api_run_queue_wait_time_1st_attempt` latency histogram.
+</Update>
+
 <Update label="2026-06-25" tags={["agent-server"]}>
 ## v0.11.0rc5
 

--- a/src/langsmith/deploy-to-self-hosted-overview.mdx
+++ b/src/langsmith/deploy-to-self-hosted-overview.mdx
@@ -16,7 +16,7 @@ Self-hosted deployments require an [Enterprise plan](https://www.langchain.com/p
 
 ## Topologies
 
-LangSmith supports three self-hosted topologies that trade off setup complexity against control-plane features. Reference pages for [platform features](/langsmith/self-hosted-platform-features) and [diagnostics](/langsmith/diagnostics-self-hosted) apply to all three.
+LangSmith supports three self-hosted topologies that trade off setup complexity against control-plane features. Reference pages for [platform features](/langsmith/self-hosted-platform-features), [Agent Server metrics](/langsmith/self-hosted-agent-server-metrics), and [diagnostics](/langsmith/diagnostics-self-hosted) apply to all three.
 
 <CardGroup cols={2}>
 
@@ -34,6 +34,10 @@ The lightest option—Agent Server containers (API + queue workers) with your ow
 
 <Card title="Platform features" icon="list-check" href="/langsmith/self-hosted-platform-features">
 Reference for self-hosted-only platform behavior: custom Postgres and Redis, listeners, and resource customization.
+</Card>
+
+<Card title="Agent Server metrics" icon="chart-line" href="/langsmith/self-hosted-agent-server-metrics">
+Prometheus and Datadog export for Agent Server, including Deployment UI metrics and internal metrics.
 </Card>
 
 <Card title="Diagnostics" icon="stethoscope" href="/langsmith/diagnostics-self-hosted">

--- a/src/langsmith/self-hosted-agent-server-metrics.mdx
+++ b/src/langsmith/self-hosted-agent-server-metrics.mdx
@@ -1,0 +1,147 @@
+---
+title: Agent Server metrics
+sidebarTitle: Agent Server metrics
+icon: "chart-line"
+description: Reference for Agent Server OpenTelemetry metrics on self-hosted deployments, including Deployment UI metrics, internal metrics, and Datadog export.
+---
+
+The [Agent Server](/langsmith/agent-server) emits metrics through an OpenTelemetry (OTel) client. Metrics use the `lg_api_` name prefix by default (override with `METRIC_PREFIX`).
+
+On self-hosted deployments, use this page to choose a scrape or push backend, enable the metric sets you need, and look up Prometheus names when building dashboards or alerts.
+
+## Metric backends
+
+Agent Server splits metrics into two sets:
+
+- **Deployment UI metrics**: Surfaced in the LangSmith Deployment UI and exposed on the Agent Server Prometheus scrape endpoint (`GET /metrics`, `format=prometheus`) by default.
+- **Internal metrics**: Operational and debugging metrics used by LangChain operators. Sent to Datadog when configured. On Prometheus, internal metrics appear only when you opt in.
+
+| Backend | Default metric set | Enable |
+|---------|-------------------|--------|
+| **Prometheus** (scrape `GET /metrics`) | Deployment UI metrics only | Always available when the OTel Prometheus exporter is installed |
+| **Prometheus** (all metrics) | Deployment UI + internal metrics | Set `EXPOSE_INTERNAL_METRICS_PROMETHEUS=true` |
+| **Datadog** (OTLP push) | Internal metrics only | Set `LSD_DD_API_KEY` (or `CUSTOM_LSD_DD_API_KEY`). Metrics push to `https://{LSD_DD_ENDPOINT}/v1/metrics` (default endpoint: `otlp.us5.datadoghq.com`). |
+
+Prometheus and Datadog can run at the same time. Prometheus receives the Deployment UI set (or the full set when `EXPOSE_INTERNAL_METRICS_PROMETHEUS=true` is set). Datadog receives the internal complement so UI metrics are not duplicated in both backends.
+
+<Note>
+Every metric has a tier (`CRITICAL`, `INFO`, `DEBUG`, or `DEEP_DEBUG`). Deployment UI metrics bypass `METRIC_MAX_EMITTING_TIER` filtering and always emit, regardless of tier. Internal metrics respect the tier gate and are omitted when their tier exceeds the configured maximum.
+</Note>
+
+## Metric tiers
+
+Each metric is assigned a tier that controls whether internal metrics are recorded:
+
+| Tier | Value | Purpose |
+|------|-------|---------|
+| **CRITICAL** | `1` | Core health and failure signals. Always recorded when internal metrics are enabled, including on `dev` / `dev_free` deployments. |
+| **INFO** | `2` | Operational detail for production monitoring. Default ceiling in production (`METRIC_MAX_EMITTING_TIER=2`). |
+| **DEBUG** | `3` | Deeper diagnostics for troubleshooting. Omitted unless you raise `METRIC_MAX_EMITTING_TIER`. |
+| **DEEP_DEBUG** | `4` | Verbose diagnostics. Omitted unless you raise `METRIC_MAX_EMITTING_TIER`. |
+
+Set `METRIC_MAX_EMITTING_TIER` to the highest tier you want recorded for internal metrics. Deployment UI metrics ignore this setting and always emit.
+
+## Configure export
+
+### Prometheus
+
+To scrape Deployment UI metrics:
+
+1. Point your Prometheus collector at the Agent Server `/metrics` endpoint (for example, `https://<agent-server-host>/metrics`).
+2. Use the default `format=prometheus` query parameter (or omit it).
+
+To also expose internal metrics on the same endpoint, set:
+
+```bash
+EXPOSE_INTERNAL_METRICS_PROMETHEUS=true
+```
+
+Record-time tier filtering still applies: internal metrics above `METRIC_MAX_EMITTING_TIER` are not recorded and never appear on either backend.
+
+### Datadog
+
+To push internal metrics to Datadog instead of (or alongside) Prometheus:
+
+1. Set `LSD_DD_API_KEY` to your Datadog API key. `DATADOG_METRICS_ENABLED` turns on automatically when the key is present.
+2. Optionally set `LSD_DD_ENDPOINT` (default: `otlp.us5.datadoghq.com`) or the legacy alias `CUSTOM_LSD_DD_API_KEY` / `CUSTOM_LSD_DD_ENDPOINT`.
+
+Datadog receives only internal metrics. Continue scraping `/metrics` for Deployment UI metrics in Prometheus or Grafana.
+
+### Optional tuning
+
+- **`METRIC_PREFIX`**: Prefix for all metric names (default: `lg_api_`).
+- **`METRIC_MAX_EMITTING_TIER`**: Highest metric tier to record for internal metrics. Defaults to `2` (INFO) in production and `1` (CRITICAL) in `dev` / `dev_free` deployments. Tiers are `1` CRITICAL, `2` INFO, `3` DEBUG, `4` DEEP_DEBUG.
+
+## Deployment UI metrics
+
+These metrics have `lsd_web_metric=true`. They appear on the Prometheus `/metrics` scrape by default and power the LangSmith Deployment UI. Tier values are listed for reference; these metrics always emit regardless of `METRIC_MAX_EMITTING_TIER`.
+
+| Name | Type | Tier | Description |
+|------|------|------|-------------|
+| `lg_api_http_requests_total` | Counter | INFO | Total HTTP requests to the Agent Server. |
+| `lg_api_http_requests_latency` | Histogram (milliseconds) | INFO | HTTP request latency. |
+| `lg_api_run_queue_wait_time_1st_attempt` | Histogram (milliseconds) | INFO | Time jobs spend waiting in the queue before first processing. |
+| `lg_api_num_pending_runs` | Gauge | INFO | Runs currently pending. On Postgres backends, the Go core is the source; on in-memory backends, the Python collector emits this gauge. |
+| `lg_api_num_running_runs` | Gauge | INFO | Runs currently running. Same runtime split as `lg_api_num_pending_runs`. |
+| `lg_api_workers_max` | Gauge | CRITICAL | Maximum worker capacity. Emitted by the Python collector on in-memory runtimes; the Go core emits this on Postgres. |
+| `lg_api_workers_active` | Gauge | CRITICAL | Workers currently executing runs. |
+| `lg_api_workers_available` | Gauge | CRITICAL | Workers available to accept new runs. |
+| `lg_api_pg_pool_max` | Gauge | CRITICAL | Maximum Postgres connection pool size. |
+| `lg_api_pg_pool_size` | Gauge | CRITICAL | Connections currently managed by the Postgres pool (idle, in use, or being prepared). |
+| `lg_api_pg_pool_available` | Gauge | INFO | Idle connections in the Postgres pool. |
+| `lg_api_pg_pool_requests_queued_total` | Counter | CRITICAL | Postgres connection requests queued because a connection was not immediately available. The OTel Prometheus exporter appends `_total` to counter names. |
+| `lg_api_pg_pool_requests_errors_total` | Counter | CRITICAL | Postgres connection request errors (timeouts, queue full, and similar failures). |
+| `lg_api_redis_pool_max` | Gauge | INFO | Maximum Redis connection pool size. |
+| `lg_api_redis_pool_size` | Gauge | INFO | Redis connections currently in use. |
+| `lg_api_redis_pool_available` | Gauge | INFO | Idle connections in the Redis pool. |
+
+## Internal metrics
+
+These metrics have `lsd_web_metric=false`. By default they are exported to Datadog when `LSD_DD_API_KEY` is set. Set `EXPOSE_INTERNAL_METRICS_PROMETHEUS=true` to include them on the Prometheus `/metrics` scrape. Internal metrics at or below `METRIC_MAX_EMITTING_TIER` are recorded; higher-tier metrics are omitted.
+
+### Run lifecycle
+
+| Name | Type | Tier | Description |
+|------|------|------|-------------|
+| `lg_api_run_attempt_started_counter` | Counter | CRITICAL | Run execution attempts started. |
+| `lg_api_run_success_counter` | Counter | CRITICAL | Runs completed successfully. |
+| `lg_api_run_canceled_by_request_counter` | Counter | CRITICAL | Runs canceled by an explicit cancel request. |
+| `lg_api_run_failed_retriable_counter` | Counter | CRITICAL | Runs failed with a retriable error. |
+| `lg_api_run_failed_after_retry_counter` | Counter | CRITICAL | Runs that failed after exhausting retries. |
+| `lg_api_run_exceed_max_attempts_at_start_counter` | Counter | CRITICAL | Runs rejected at start because max attempts were already exceeded. |
+| `lg_api_run_abandoned_by_shutdown_counter` | Counter | CRITICAL | Runs abandoned during server shutdown. |
+| `lg_api_run_set_status_error_counter` | Counter | CRITICAL | Errors while updating run status. |
+| `lg_api_failed_to_fetch_runs_counter` | Counter | CRITICAL | Failures fetching runs from the queue. |
+| `lg_api_run_execution_latency` | Histogram (milliseconds) | INFO | End-to-end run execution latency. |
+| `lg_api_run_queue_wait_time_retry_attempt` | Histogram (milliseconds) | INFO | Queue wait time on retry attempts (after the first). |
+
+### Streaming and protocol v2
+
+| Name | Type | Tier | Description |
+|------|------|------|-------------|
+| `lg_api_streaming_data_loss_counter` | Counter | CRITICAL | Streaming data loss events. |
+| `lg_api_stream_publish_latency` | Histogram (milliseconds) | INFO | Latency publishing stream chunks. |
+| `lg_api_stream_data_size_bytes` | Histogram | DEBUG | Size of published stream payloads in bytes. |
+| `lg_api_protocol_v2_buffer_evicted_counter` | Counter | INFO | Event Streaming v2 replay buffer evictions. |
+| `lg_api_protocol_v2_event_emitted_counter` | Counter | DEBUG | Event Streaming v2 events emitted. |
+| `lg_api_protocol_v2_resume_gap_counter` | Counter | INFO | Event Streaming v2 resume gaps detected during replay. |
+| `lg_api_protocol_v2_transport_send_failure_counter` | Counter | INFO | Event Streaming v2 transport send failures. |
+| `lg_api_protocol_v2_buffer_size` | Gauge | DEBUG | Current Event Streaming v2 replay buffer occupancy per run. Tune `LSD_PROTOCOL_V2_BUFFER_SIZE` when this approaches the limit. |
+| `lg_api_protocol_v2_replayed_events` | Histogram | DEBUG | Number of events replayed on Event Streaming v2 reconnect. |
+
+### Server and infrastructure
+
+| Name | Type | Tier | Description |
+|------|------|------|-------------|
+| `lg_api_server_started_counter` | Counter | INFO | Server start events. |
+| `lg_api_server_requested_to_stop_counter` | Counter | INFO | Graceful shutdown requests received. |
+| `lg_api_server_stopped_counter` | Counter | INFO | Server stop events. |
+| `lg_api_graph_recursion_limit_error_counter` | Counter | INFO | Graph recursion limit errors. |
+| `lg_api_publish_queue_availability` | Gauge | CRITICAL | Redis publish queue availability signal. |
+
+## See also
+
+- [Self-hosted overview](/langsmith/deploy-to-self-hosted-overview)
+- [Configure Agent Server for scale](/langsmith/agent-server-scale)
+- [Troubleshooting for self-hosted deployments](/langsmith/diagnostics-self-hosted)
+- [Agent Server changelog](/langsmith/agent-server-changelog)

--- a/src/langsmith/self-hosted-agent-server-metrics.mdx
+++ b/src/langsmith/self-hosted-agent-server-metrics.mdx
@@ -16,17 +16,13 @@ Agent Server splits metrics into two sets:
 - **Deployment UI metrics**: Surfaced in the LangSmith Deployment UI and exposed on the Agent Server Prometheus scrape endpoint (`GET /metrics`, `format=prometheus`) by default.
 - **Internal metrics**: Operational and debugging metrics used by LangChain operators. Sent to Datadog when configured. On Prometheus, internal metrics appear only when you opt in.
 
-| Backend | Default metric set | Enable |
-|---------|-------------------|--------|
-| **Prometheus** (scrape `GET /metrics`) | Deployment UI metrics only | Always available when the OTel Prometheus exporter is installed |
-| **Prometheus** (all metrics) | Deployment UI + internal metrics | Set `EXPOSE_INTERNAL_METRICS_PROMETHEUS=true` |
+| Backend | Metric set | Enable |
+|---------|------------|--------|
+| **Prometheus** (scrape `GET /metrics`) | Deployment UI metrics by default. Set `EXPOSE_INTERNAL_METRICS_PROMETHEUS=true` to also expose internal metrics on the same endpoint. | Available when the OTel Prometheus exporter is installed |
 | **Datadog** (OTLP push) | Internal metrics only | Set `LSD_DD_API_KEY` (or `CUSTOM_LSD_DD_API_KEY`). Metrics push to `https://{LSD_DD_ENDPOINT}/v1/metrics` (default endpoint: `otlp.us5.datadoghq.com`). |
 
-Prometheus and Datadog can run at the same time. Prometheus receives the Deployment UI set (or the full set when `EXPOSE_INTERNAL_METRICS_PROMETHEUS=true` is set). Datadog receives the internal complement so UI metrics are not duplicated in both backends.
+Prometheus and Datadog can run at the same time. Datadog receives the internal complement so UI metrics are not duplicated in both backends.
 
-<Note>
-Every metric has a tier (`CRITICAL`, `INFO`, `DEBUG`, or `DEEP_DEBUG`). Deployment UI metrics bypass `METRIC_MAX_EMITTING_TIER` filtering and always emit, regardless of tier. Internal metrics respect the tier gate and are omitted when their tier exceeds the configured maximum.
-</Note>
 
 ## Metric tiers
 
@@ -56,8 +52,6 @@ To also expose internal metrics on the same endpoint, set:
 EXPOSE_INTERNAL_METRICS_PROMETHEUS=true
 ```
 
-Record-time tier filtering still applies: internal metrics above `METRIC_MAX_EMITTING_TIER` are not recorded and never appear on either backend.
-
 ### Datadog
 
 To push internal metrics to Datadog instead of (or alongside) Prometheus:
@@ -66,11 +60,6 @@ To push internal metrics to Datadog instead of (or alongside) Prometheus:
 2. Optionally set `LSD_DD_ENDPOINT` (default: `otlp.us5.datadoghq.com`) or the legacy alias `CUSTOM_LSD_DD_API_KEY` / `CUSTOM_LSD_DD_ENDPOINT`.
 
 Datadog receives only internal metrics. Continue scraping `/metrics` for Deployment UI metrics in Prometheus or Grafana.
-
-### Optional tuning
-
-- **`METRIC_PREFIX`**: Prefix for all metric names (default: `lg_api_`).
-- **`METRIC_MAX_EMITTING_TIER`**: Highest metric tier to record for internal metrics. Defaults to `2` (INFO) in production and `1` (CRITICAL) in `dev` / `dev_free` deployments. Tiers are `1` CRITICAL, `2` INFO, `3` DEBUG, `4` DEEP_DEBUG.
 
 ## Deployment UI metrics
 


### PR DESCRIPTION
## Summary
- Added release notes for Agent Server **v0.11.0rc8** to `src/langsmith/agent-server-changelog.mdx`.
- **v0.11.0rc8** (2026-06-30): Migrated Agent Server metrics to the OpenTelemetry/Prometheus client, with renamed Prometheus metric names and units for HTTP latency, pool counters, and run-queue wait time ([langgraph-api#3602](https://github.com/langchain-ai/langgraph-api/pull/3602), backport of [#3502](https://github.com/langchain-ai/langgraph-api/pull/3502), commit [70232b5](https://github.com/langchain-ai/langgraph-api/commit/70232b513cc17b31468099d1a82dbfaef143615e)).

## Test plan
- [x] `make lint_prose FILES="src/langsmith/agent-server-changelog.mdx"` passes
- [ ] Preview changelog entry on `/langsmith/agent-server-changelog`


Made with [Cursor](https://cursor.com)