### PR TITLE
docs(deepagents): remove rubric criteria alias reference

### DIFF
--- a/src/oss/deepagents/code/overview.mdx
+++ b/src/oss/deepagents/code/overview.mdx
@@ -276,7 +276,7 @@ The agent uses its built-in tools, skills, and memory to help you with tasks.
         - `/agents` - Hot-swap between pre-configured agents without relaunching. See [Command reference](/oss/deepagents/code/overview#command-reference) for details
         - `/auth` - Manage stored API keys for model providers and services (such as Tavily web search). See [Provider credentials](/oss/deepagents/code/configuration#provider-credentials) for details
         - `/goal <objective>` - Draft acceptance criteria from an objective, review them inline, then run the accepted goal. Use `/goal show` to inspect the current goal and `/goal clear` to clear it
-        - `/rubric` (alias `/criteria`) - Set explicit acceptance criteria for rubric grading. Use `/rubric set <criteria>`, `/rubric next <criteria>`, `/rubric file <path>`, `/rubric show`, `/rubric clear`, or `/rubric model <provider:model>` to set the rubric grader model
+        - `/rubric` - Set explicit acceptance criteria for rubric grading. Use `/rubric set <criteria>`, `/rubric next <criteria>`, `/rubric file <path>`, `/rubric show`, `/rubric clear`, or `/rubric model <provider:model>` to set the rubric grader model
         - `/remember [context]` - Review conversation and update memory and skills. Optionally pass additional context
         - `/skill:<name> [args]` - Directly invoke a skill by name. The skill's `SKILL.md` instructions are injected into the prompt along with any arguments you provide
         - `/skill-creator [task]` - Guide for creating effective agent skills


### PR DESCRIPTION
Remove the documented `/criteria` alias from the Deep Agents Code command list so the overview matches the supported `/rubric` command surface.

## Changes
- Drops the `/criteria` alias from the `/rubric` command reference while keeping the documented rubric subcommands unchanged.

## Testing
- `make lint_prose FILES="src/oss/deepagents/code/overview.mdx"`

AI agent assisted with preparing this PR.
