### PR TITLE
docs: document tag-level SBOM verification and fetching

### DIFF
--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -247,7 +247,11 @@ cosign verify-attestation \
   docker.io/langchain/langsmith-backend:<tag>
 ```
 
-The index-level query returns one verified statement per architecture. To inspect a specific architecture's SBOM, resolve the child digests first and verify each one.
+The command returns one verified statement per architecture. A successful verification gives the same guarantees as the image signature: the attestation was produced by the stable-branch release workflow, and its claims are logged in the [Rekor](https://docs.sigstore.dev/rekor/overview/) transparency log.
+
+### Fetching SBOMs
+
+To feed an SBOM into a vulnerability scanner or SBOM management tool, extract the verified SPDX document to a file. Because the index carries one statement per architecture, resolve a single architecture's child digest first so you get one SPDX document rather than one per architecture.
 
 List the per-architecture digests for a tag:
 
@@ -256,34 +260,7 @@ docker buildx imagetools inspect --raw docker.io/langchain/langsmith-backend:<ta
   | jq -r '.manifests[] | select(.platform.os == "linux") | .digest + "  " + .platform.architecture'
 ```
 
-Verify the SBOM attestation on one of those digests:
-
-```bash
-cosign verify-attestation \
-  --type spdxjson \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp 'https://github\.com/langchain-ai/langchainplus/\.github/workflows/release_self_hosted_on_version_bump\.yaml@refs/heads/v[0-9]+-stable' \
-  docker.io/langchain/langsmith-backend@<digest>
-```
-
-A successful verification gives the same guarantees as the image signature: the attestation was produced by the stable-branch release workflow, and its claims are logged in the [Rekor](https://docs.sigstore.dev/rekor/overview/) transparency log.
-
-To extract the SPDX document itself, decode the verified attestation payload:
-
-```bash
-cosign verify-attestation \
-  --type spdxjson \
-  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-identity-regexp 'https://github\.com/langchain-ai/langchainplus/\.github/workflows/release_self_hosted_on_version_bump\.yaml@refs/heads/v[0-9]+-stable' \
-  docker.io/langchain/langsmith-backend@<digest> \
-  | jq -r '.payload' | base64 -d | jq '.predicate'
-```
-
-The decoded predicate is a standard SPDX 2.3 document listing every package in that image.
-
-### Fetching SBOMs
-
-To feed an SBOM into a vulnerability scanner or SBOM management tool, save the verified predicate to a file. Resolve a single architecture's child digest first (see above) so you get one SPDX document rather than one per architecture:
+Then verify that digest and save the decoded predicate — a standard SPDX 2.3 document listing every package in the image — to a file:
 
 ```bash
 cosign verify-attestation \

--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -235,7 +235,19 @@ cosign download attestation docker.io/langchain/langsmith-backend:<tag>
 
 ### Verifying SBOM attestations
 
-Released images also carry signed SPDX software bill of materials (SBOM) attestations, one per architecture in the image index. The attestations are attached to the per-architecture child digests rather than to the multi-architecture tag, so `cosign verify-attestation` against a bare tag reports `no matching attestations`. Resolve the child digests first, then verify each one.
+Released images also carry signed SPDX software bill of materials (SBOM) attestations, one per architecture in the image index.
+
+On `0.15.12` and later, the per-architecture SBOMs are also attached to the multi-architecture index digest, so you can verify against a bare tag directly:
+
+```bash
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'https://github\.com/langchain-ai/langchainplus/\.github/workflows/release_self_hosted_on_version_bump\.yaml@refs/heads/v[0-9]+-stable' \
+  docker.io/langchain/langsmith-backend:<tag>
+```
+
+The index-level query returns one verified statement per architecture. To inspect a specific architecture's SBOM — or to verify releases earlier than `0.15.12`, where attestations are attached only to the per-architecture child digests — resolve the child digests first and verify each one.
 
 List the per-architecture digests for a tag:
 
@@ -268,3 +280,22 @@ cosign verify-attestation \
 ```
 
 The decoded predicate is a standard SPDX 2.3 document listing every package in that image.
+
+### Fetching SBOMs
+
+To feed an SBOM into a vulnerability scanner or SBOM management tool, save the verified predicate to a file. Resolve a single architecture's child digest first (see above) so you get one SPDX document rather than one per architecture:
+
+```bash
+cosign verify-attestation \
+  --type spdxjson \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  --certificate-identity-regexp 'https://github\.com/langchain-ai/langchainplus/\.github/workflows/release_self_hosted_on_version_bump\.yaml@refs/heads/v[0-9]+-stable' \
+  docker.io/langchain/langsmith-backend@<digest> \
+  | jq -r '.payload' | base64 -d | jq '.predicate' > langsmith-backend.spdx.json
+```
+
+The resulting `langsmith-backend.spdx.json` can be passed directly to scanners such as [Grype](https://github.com/anchore/grype) (`grype sbom:langsmith-backend.spdx.json`) or [Trivy](https://trivy.dev/) (`trivy sbom langsmith-backend.spdx.json`).
+
+<Note>
+Extracting the SBOM through `cosign verify-attestation` — rather than `cosign download attestation` — ensures you only ever consume an SBOM whose signature and signing identity have been verified.
+</Note>

--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -247,7 +247,7 @@ cosign verify-attestation \
   docker.io/langchain/langsmith-backend:<tag>
 ```
 
-The index-level query returns one verified statement per architecture. To inspect a specific architecture's SBOM — or to verify releases earlier than `0.15.12`, where attestations are attached only to the per-architecture child digests — resolve the child digests first and verify each one.
+The index-level query returns one verified statement per architecture. To inspect a specific architecture's SBOM, resolve the child digests first and verify each one.
 
 List the per-architecture digests for a tag:
 
@@ -294,8 +294,8 @@ cosign verify-attestation \
   | jq -r '.payload' | base64 -d | jq '.predicate' > langsmith-backend.spdx.json
 ```
 
-The resulting `langsmith-backend.spdx.json` can be passed directly to scanners such as [Grype](https://github.com/anchore/grype) (`grype sbom:langsmith-backend.spdx.json`) or [Trivy](https://trivy.dev/) (`trivy sbom langsmith-backend.spdx.json`).
+You can pass the resulting `langsmith-backend.spdx.json` directly to scanners such as [Grype](https://github.com/anchore/grype) (`grype sbom:langsmith-backend.spdx.json`) or [Trivy](https://trivy.dev/) (`trivy sbom langsmith-backend.spdx.json`).
 
 <Note>
-Extracting the SBOM through `cosign verify-attestation` — rather than `cosign download attestation` — ensures you only ever consume an SBOM whose signature and signing identity have been verified.
+Extracting the SBOM through `cosign verify-attestation`, rather than `cosign download attestation`, ensures you only ever consume an SBOM whose signature and signing identity have been verified.
 </Note>


### PR DESCRIPTION
Follow-up to [langchain-ai/langchainplus#26199](https://github.com/langchain-ai/langchainplus/pull/26199) / [#26202](https://github.com/langchain-ai/langchainplus/pull/26202), which attached per-architecture SBOM attestations to the multi-arch **index** digest so `cosign verify-attestation` resolves against a bare tag. That shipped in `0.15.12`, but the docs still only described the older per-child-digest workaround.

## Changes to `self-host-mirroring-images.mdx`

- **Verifying SBOM attestations:** lead with the simpler tag-level `cosign verify-attestation :<tag>` command (works on `0.15.12`+), and reframe the per-child-digest flow as the path for older releases and for inspecting a single architecture's SBOM.
- **New "Fetching SBOMs" section:** how to save a *verified* SPDX document to a file for feeding into vulnerability scanners (Grype, Trivy).

## Verified against public images

All commands tested with `cosign v3.0.6` + `docker buildx` + `jq` against `docker.io/langchain/langsmith-backend`:

| Test | Image | Result |
|------|-------|--------|
| Tag-level SBOM verify | `langsmith-backend:0.15.17` | exit 0, all cosign checks pass, 2 statements (one per arch), bound to index digest |
| Version threshold (pre-fix fails at tag) | `langsmith-backend:0.15.9` | `no matching attestations` as documented |
| Pre-fix works per child digest | `langsmith-backend@<amd64>` (0.15.9) | exit 0 |
| Fetch-to-file → valid SPDX | `langsmith-backend@<amd64>` (0.15.17) | SPDX-2.3, 407 packages |
| FIPS repo | `langsmith-backend-fips:0.15.17` | exit 0, 2 statements, 413 packages |

Note: the unverified `cosign download attestation` path was intentionally **not** documented — in cosign v3 that command returns a sigstore bundle (`bundle.v0.3+json`) with the payload under `.dsseEnvelope.payload`, so the top-level `.payload` extraction does not apply, and consuming an unverified SBOM is an anti-pattern anyway.