### PR TITLE
docs: drop 0.15.12 version qualifier from SBOM tag-level verify

### DIFF
--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -237,7 +237,7 @@ cosign download attestation docker.io/langchain/langsmith-backend:<tag>
 
 Released images also carry signed SPDX software bill of materials (SBOM) attestations, one per architecture in the image index.
 
-On `0.15.12` and later, the per-architecture SBOMs are also attached to the multi-architecture index digest, so you can verify against a bare tag directly:
+The per-architecture SBOMs are also attached to the multi-architecture index digest, so you can verify against a bare tag directly:
 
 ```bash
 cosign verify-attestation \


### PR DESCRIPTION
Follow-up to #4679. That PR removed the "earlier than `0.15.12`" fallback explanation from the *Verifying SBOM attestations* section but left the "On `0.15.12` and later" qualifier on the tag-level verify sentence, so the doc named a version threshold without explaining what happens before it.

Since the section no longer documents pre-fix behavior, this drops the qualifier and states tag-level verification plainly.

Trade-off (accepted): a customer on a pre-`0.15.12` image who follows the tag-level command will get `no matching attestations` for the `spdxjson` predicate, without the doc explaining why. This affects only the small window of images released between the start of the `0.15` line and when SBOMs began attaching to the index digest.