### PR TITLE
Improve the TypeScript Script in the short term memory docs

### DIFF
--- a/src/oss/langchain/short-term-memory.mdx
+++ b/src/oss/langchain/short-term-memory.mdx
@@ -752,6 +752,7 @@ import * as z from "zod";
 
 const CustomState = new StateSchema({
   userId: z.string().optional(),
+  userName: z.string().optional(),
 });
 
 const updateUserInfo = tool(
@@ -779,8 +780,8 @@ const updateUserInfo = tool(
 );
 
 const greet = tool(
-  async (_, config) => {
-    const userName = config.context?.userName;
+  async (_, config: ToolRuntime<typeof CustomState.State>) => {
+    const userName = config.state.userName;
     return `Hello ${userName}!`;
   },
   {
@@ -802,7 +803,7 @@ const result = await agent.invoke({
 });
 
 console.log(result.messages.at(-1)?.content);
-// Output: "Hello! I’m here to help — what would you like to do today?"
+// Output: "Hello John Smith! It's great to meet you. How can I help you today?"
 ```
 :::
 


### PR DESCRIPTION
This section aims to guide developers on writing short-term memory from tools. The recommended approach is to write to state within the `update_user_info` tool and then read it in the `greet` tool. The current error in `greet` tool is using `config.context?.userName`, which cannot access the value set by `update_user_info` tool; the correct way is to retrieve it from state: `config.state.userName`.

## Overview
Improve the TypeScript script in the "Write short-term memory from tools" section of the short-term memory document

## Type of change

**Type:** Update existing documentation

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

