### PR TITLE
chore: Update Agent ServerOpenAPI spec for API version 0.12.0

### DIFF
--- a/src/langsmith/agent-server-openapi.json
+++ b/src/langsmith/agent-server-openapi.json
@@ -1742,7 +1742,8 @@
                   "status",
                   "metadata",
                   "kwargs",
-                  "multitask_strategy"
+                  "multitask_strategy",
+                  "langsmith_session_name"
                 ]
               },
               "title": "Select",
@@ -4549,10 +4550,10 @@
             "description": "IANA timezone for the cron schedule (e.g. 'America/New_York'). Defaults to null, which is treated as UTC."
           },
           "end_time": {
-            "type": "string",
+            "type": ["string", "null"],
             "format": "date-time",
             "title": "End Time",
-            "description": "The end date to stop running the cron."
+            "description": "The end date to stop running the cron. Send null to clear a previously set end time; omit this field to leave the existing value unchanged."
           },
           "input": {
             "anyOf": [
@@ -4967,6 +4968,12 @@
             "enum": ["reject", "rollback", "interrupt", "enqueue"],
             "title": "Multitask Strategy",
             "description": "Strategy to handle concurrent runs on the same thread."
+          },
+          "langsmith_session_name": {
+            "type": "string",
+            "title": "Langsmith Session Name",
+            "description": "LangSmith tracing session (project) name for this run, when tracing is enabled at creation time.",
+            "nullable": true
           }
         },
         "type": "object",


### PR DESCRIPTION
This PR updates the OpenAPI specification for the Agent Server. Merge when convenient.

**Changes detected as of API version 0.12.0**

This update was automatically generated by the sync workflow in the langgraph-api repository.