### PR TITLE
docs: replace EOL Bedrock Claude model ID in code examples

### DIFF
--- a/src/oss/javascript/integrations/chat/bedrock_converse.mdx
+++ b/src/oss/javascript/integrations/chat/bedrock_converse.mdx
@@ -74,7 +74,7 @@ There are a few different ways to authenticate with AWS - the below examples rel
 import { ChatBedrockConverse } from "@langchain/aws";
 
 const llm = new ChatBedrockConverse({
-  model: "anthropic.claude-3-5-sonnet-20240620-v1:0",
+  model: "us.anthropic.claude-sonnet-4-6",
   region: process.env.BEDROCK_AWS_REGION,
   credentials: {
     accessKeyId: process.env.BEDROCK_AWS_ACCESS_KEY_ID!,

--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -309,7 +309,7 @@ Start by creating a simple agent that can answer questions and call tools. The a
         return f"It's always sunny in {city}!"
 
     agent = create_agent(
-        model="anthropic.claude-3-5-sonnet-20240620-v1:0",
+        model="us.anthropic.claude-sonnet-4-6",
         model_provider="bedrock_converse",
         tools=[get_weather],
         system_prompt="You are a helpful assistant",
@@ -852,7 +852,7 @@ Along the way you will explore the following concepts:
             from langchain.chat_models import init_chat_model
 
             model = init_chat_model(
-                "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                "us.anthropic.claude-sonnet-4-6",
                 model_provider="bedrock_converse",
                 temperature=0.5,
                 timeout=300,

--- a/src/oss/python/integrations/chat/bedrock.mdx
+++ b/src/oss/python/integrations/chat/bedrock.mdx
@@ -80,7 +80,7 @@ Now we can instantiate our model object and generate chat completions:
 from langchain_aws import ChatBedrockConverse
 
 llm = ChatBedrockConverse(
-    model_id="anthropic.claude-3-5-sonnet-20240620-v1:0",
+    model_id="us.anthropic.claude-sonnet-4-6",
     # region_name=...,
     # aws_access_key_id=...,
     # aws_secret_access_key=...,
@@ -106,7 +106,7 @@ ai_msg
 ```
 
 ```text
-AIMessage(content="J'adore la programmation.", additional_kwargs={}, response_metadata={'ResponseMetadata': {'RequestId': 'b07d1630-06f2-44b1-82bf-e82538dd2215', 'HTTPStatusCode': 200, 'HTTPHeaders': {'date': 'Wed, 16 Apr 2025 19:35:34 GMT', 'content-type': 'application/json', 'content-length': '206', 'connection': 'keep-alive', 'x-amzn-requestid': 'b07d1630-06f2-44b1-82bf-e82538dd2215'}, 'RetryAttempts': 0}, 'stopReason': 'end_turn', 'metrics': {'latencyMs': [488]}, 'model_name': 'anthropic.claude-3-5-sonnet-20240620-v1:0'}, id='run-d09ed928-146a-4336-b1fd-b63c9e623494-0', usage_metadata={'input_tokens': 29, 'output_tokens': 11, 'total_tokens': 40, 'input_token_details': {'cache_creation': 0, 'cache_read': 0}})
+AIMessage(content="J'adore la programmation.", additional_kwargs={}, response_metadata={'ResponseMetadata': {'RequestId': 'b07d1630-06f2-44b1-82bf-e82538dd2215', 'HTTPStatusCode': 200, 'HTTPHeaders': {'date': 'Wed, 16 Apr 2025 19:35:34 GMT', 'content-type': 'application/json', 'content-length': '206', 'connection': 'keep-alive', 'x-amzn-requestid': 'b07d1630-06f2-44b1-82bf-e82538dd2215'}, 'RetryAttempts': 0}, 'stopReason': 'end_turn', 'metrics': {'latencyMs': [488]}, 'model_name': 'us.anthropic.claude-sonnet-4-6'}, id='run-d09ed928-146a-4336-b1fd-b63c9e623494-0', usage_metadata={'input_tokens': 29, 'output_tokens': 11, 'total_tokens': 40, 'input_token_details': {'cache_creation': 0, 'cache_read': 0}})
 ```
 
 ```python

--- a/src/oss/python/integrations/vectorstores/teradata.mdx
+++ b/src/oss/python/integrations/vectorstores/teradata.mdx
@@ -258,7 +258,7 @@ from langchain.chat_models import init_chat_model
 
 #Example: Simple RAG chain
 # Initialize the chat model
-llm = init_chat_model("anthropic.claude-3-5-sonnet-20240620-v1:0",
+llm = init_chat_model("us.anthropic.claude-sonnet-4-6",
                       model_provider="bedrock_converse",
                       region_name="<ENTER REGION>",
                       aws_access_key_id = "<ENTER AWS ACCESS KEY>" ,

--- a/src/snippets/chat-model-tabs.mdx
+++ b/src/snippets/chat-model-tabs.mdx
@@ -124,14 +124,14 @@
             # https://docs.aws.amazon.com/bedrock/latest/userguide/getting-started.html
 
             model = init_chat_model(
-                "anthropic.claude-3-5-sonnet-20240620-v1:0",
+                "us.anthropic.claude-sonnet-4-6",
                 model_provider="bedrock_converse",
             )
             ```
             ```python Model Class
             from langchain_aws import ChatBedrock
 
-            model = ChatBedrock(model="anthropic.claude-3-5-sonnet-20240620-v1:0")
+            model = ChatBedrock(model="us.anthropic.claude-sonnet-4-6")
             ```
         </CodeGroup>
     </Tab>


### PR DESCRIPTION
Several code examples instantiate Bedrock models with
`anthropic.claude-3-5-sonnet-20240620-v1:0`, which has reached end of life —
users copying these examples get an invalid-model error. Affected pages: the
LangChain quickstart, the shared chat-model-tabs snippet (used by multiple
pages), the Python Bedrock and Teradata integration pages, and the JS
`ChatBedrockConverse` page.

This replaces the EOL ID with the `us.anthropic.claude-sonnet-4-6`
cross-region inference profile, matching the replacement convention used in
#4448 (which covers the same fix for `overview.mdx` and is intentionally not
duplicated here).

First-party (non-Bedrock) stale model IDs in `stripe.mdx`, `use-graph-api.mdx`,
and `observability-studio.mdx` are left for a follow-up, as they take a
different replacement ID.
