### PR TITLE
docs(langchain): add "Chunk documents for retrieval" guide

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -347,6 +347,7 @@
                               "oss/python/langchain/multi-agent/custom-workflow"
                             ]
                           },
+                          "oss/python/langchain/chunking",
                           "oss/python/langchain/retrieval",
                           "oss/python/langchain/long-term-memory"
                         ]
@@ -805,6 +806,7 @@
                               "oss/javascript/langchain/multi-agent/custom-workflow"
                             ]
                           },
+                          "oss/javascript/langchain/chunking",
                           "oss/javascript/langchain/retrieval",
                           "oss/javascript/langchain/long-term-memory"
                         ]

--- a/src/oss/integrations/splitters/index.mdx
+++ b/src/oss/integrations/splitters/index.mdx
@@ -46,7 +46,7 @@ description: "Integrate with text splitters using LangChain."
 There are several strategies for splitting documents, each with its own advantages.
 
 <Tip>
-    For most use cases, start with the [`RecursiveCharacterTextSplitter`](/oss/integrations/splitters/recursive_text_splitter). It provides a solid balance between keeping context intact and managing chunk size. This default strategy works well out of the box, and you should only consider adjusting it if you need to fine-tune performance for your specific application.
+    For most use cases, start with the [`RecursiveCharacterTextSplitter`](/oss/integrations/splitters/recursive_text_splitter). It provides a solid balance between keeping context intact and managing chunk size. This default strategy works well out of the box, and you should only consider adjusting it if you need to fine-tune performance for your specific application. For guidance on choosing chunk size and a splitting strategy, see [Chunk documents for retrieval](/oss/langchain/chunking).
 </Tip>
 
 ## Text structure-based

--- a/src/oss/langchain/chunking.mdx
+++ b/src/oss/langchain/chunking.mdx
@@ -1,0 +1,223 @@
+---
+title: Chunk documents for retrieval
+description: Choose a chunking strategy for RAG in LangChain, including recursive and token-based splitting, structure-aware and semantic chunking, small-to-big retrieval, and chunk metadata.
+---
+
+Chunking splits your source documents into smaller pieces before you embed and index them. Chunk boundaries decide what a retriever can return: a chunk that mixes several topics dilutes its embedding, and a chunk that splits one idea across two pieces hides context from the model. Chunking is one of the largest factors in [RAG](/oss/langchain/retrieval) quality, and one of the least obvious to tune.
+
+This guide covers how to choose and tune a chunking strategy. For the mechanics of each splitter, see the [text splitter integrations](/oss/integrations/splitters). The examples assume `docs` is a list of loaded @[Document] objects, as produced in [Build a RAG agent](/oss/langchain/rag).
+
+<Tip>
+Chunking choices are empirical. Trace and score them with [LangSmith](https://smith.langchain.com): the [RAG evaluation tutorial](/langsmith/evaluate-rag-tutorial) shows how to measure retrieval and answer quality on a dataset, so you can compare strategies instead of guessing.
+</Tip>
+
+## Balance chunk size and overlap
+
+Chunk size trades precision against context, and there is no universal best value. It depends on your documents, your embedding model, and the questions you expect.
+
+- **Small chunks** produce focused embeddings and precise matches, but a single chunk may lack the surrounding context the model needs to answer.
+- **Large chunks** carry more context per chunk, but their embeddings blur together multiple topics, which makes them harder to match and spends more tokens per retrieved chunk.
+
+Chunk overlap repeats a portion of text between adjacent chunks so that an idea split at a boundary still appears whole in at least one chunk. A common starting point is an overlap of 10% to 20% of the chunk size.
+
+| If retrieval | Adjust |
+|--------------|--------|
+| Returns fragments that lack context to answer | Increase chunk size or overlap |
+| Returns long chunks padded with irrelevant text | Decrease chunk size |
+| Cuts related ideas across two chunks | Increase overlap, or split on structure |
+
+Treat these as starting points and confirm them by [evaluating your chunking](#evaluate-your-chunking).
+
+## Start with recursive character splitting
+
+Start with @[RecursiveCharacterTextSplitter]. It splits on a descending list of separators (paragraphs, then sentences, then words), which keeps semantically related text together whenever it fits within the target size. This is the recommended default for generic text.
+
+:::python
+```python
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+splitter = RecursiveCharacterTextSplitter(
+    chunk_size=1000,  # target chunk size (characters)
+    chunk_overlap=200,  # overlap between adjacent chunks (characters)
+)
+chunks = splitter.split_documents(docs)
+```
+:::
+
+:::js
+```typescript
+import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
+
+const splitter = new RecursiveCharacterTextSplitter({
+  chunkSize: 1000, // target chunk size (characters)
+  chunkOverlap: 200, // overlap between adjacent chunks (characters)
+});
+const chunks = await splitter.splitDocuments(docs);
+```
+:::
+
+## Size chunks by tokens
+
+Character count is a proxy for what actually matters: embedding models have a token limit and bill by the token. Sizing chunks by tokens keeps each chunk within the model's limit and makes cost predictable. Use a token-based splitter when a chunk must fit a specific model, or when you want to control token cost directly.
+
+:::python
+```python
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+splitter = RecursiveCharacterTextSplitter.from_tiktoken_encoder(
+    encoding_name="cl100k_base",
+    chunk_size=256,  # target chunk size (tokens)
+    chunk_overlap=32,  # overlap (tokens)
+)
+chunks = splitter.split_documents(docs)
+```
+:::
+
+:::js
+```typescript
+import { TokenTextSplitter } from "@langchain/textsplitters";
+
+const splitter = new TokenTextSplitter({
+  encodingName: "cl100k_base",
+  chunkSize: 256, // target chunk size (tokens)
+  chunkOverlap: 32, // overlap (tokens)
+});
+const chunks = await splitter.splitDocuments(docs);
+```
+:::
+
+<Note>
+The `cl100k_base` encoding is the tokenizer used by several OpenAI models. Other providers tokenize differently, so token counts are approximate across models. Choose the encoding that matches your embedding model when exact limits matter.
+</Note>
+
+## Split on document structure
+
+When a document has structure, such as Markdown, HTML, or source code, split along that structure. Structural boundaries keep related content together, and they let you capture the structure itself as metadata.
+
+:::python
+Markdown files are organized by headers. [`MarkdownHeaderTextSplitter`](/oss/integrations/splitters/markdown_header_metadata_splitter) splits on the headers you specify and records each header in the chunk's metadata, which you can later use to [filter retrieval](/oss/langchain/retrieval):
+
+```python
+from langchain_text_splitters import MarkdownHeaderTextSplitter
+
+headers_to_split_on = [
+    ("#", "Header 1"),
+    ("##", "Header 2"),
+    ("###", "Header 3"),
+]
+splitter = MarkdownHeaderTextSplitter(headers_to_split_on)
+chunks = splitter.split_text(markdown_text)
+# Each chunk's metadata includes the headers that contain it.
+```
+
+Split source code along its own boundaries (functions, classes, and blocks) with `from_language`:
+
+```python
+from langchain_text_splitters import Language, RecursiveCharacterTextSplitter
+
+splitter = RecursiveCharacterTextSplitter.from_language(
+    language=Language.PYTHON,
+    chunk_size=500,
+    chunk_overlap=0,
+)
+chunks = splitter.create_documents([source_code])
+```
+
+For HTML and JSON splitters, see the [text splitter integrations](/oss/integrations/splitters).
+:::
+
+:::js
+Split source code along its own boundaries (functions, classes, and blocks) with `fromLanguage`:
+
+```typescript
+import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
+
+const splitter = RecursiveCharacterTextSplitter.fromLanguage("js", {
+  chunkSize: 500,
+  chunkOverlap: 0,
+});
+const chunks = await splitter.createDocuments([sourceCode]);
+```
+
+For Markdown and other structure-aware splitters, see the [text splitter integrations](/oss/integrations/splitters).
+:::
+
+## Chunk by meaning
+
+Semantic chunking places boundaries where the topic shifts rather than at a fixed size. It compares the embeddings of adjacent sentences and starts a new chunk when their similarity drops, which produces more coherent chunks for prose that lacks clear structure. The tradeoff is cost: it embeds the document while splitting it.
+
+:::python
+Semantic chunking is available through the `SemanticChunker` class in the [`langchain-experimental`](https://pypi.org/project/langchain-experimental/) package. Consider it when fixed-size splitting cuts across ideas and structure-aware splitting does not apply.
+:::
+
+:::js
+Semantic chunking is currently available in Python through the `langchain-experimental` package. In TypeScript, prefer recursive or structure-aware splitting.
+:::
+
+## Retrieve more context than you embed
+
+Small chunks match precisely, but they can leave out the surrounding context a model needs to answer. The small-to-big pattern separates the two concerns: embed and index small chunks for accurate matching, then return the larger passage that contains the matched chunk to the model.
+
+To implement it, store a reference to the parent passage in each small chunk's metadata. After retrieval, look up and return the parent passage instead of the matched chunk. The `ParentDocumentRetriever` helper implements this pattern and lives in the [`langchain-classic`](https://pypi.org/project/langchain-classic/) package.
+
+## Attach metadata to chunks
+
+Metadata on each chunk enables filtering and citation at retrieval time. Carry the source, the section, and the chunk's position so you can scope searches and attribute answers.
+
+:::python
+Set `add_start_index=True` to record where each chunk begins in the source document. Metadata from the source `Document` carries through to its chunks, and you can add custom fields:
+
+```python
+from langchain_text_splitters import RecursiveCharacterTextSplitter
+
+splitter = RecursiveCharacterTextSplitter(
+    chunk_size=1000,
+    chunk_overlap=200,
+    add_start_index=True,  # record each chunk's start offset in metadata
+)
+chunks = splitter.split_documents(docs)
+# chunks[0].metadata includes "start_index" plus any metadata from the source document.
+```
+
+Structure-aware splitters add their own metadata, such as the Markdown headers that contain each chunk. Use these fields to [filter retrieval](/oss/langchain/retrieval).
+:::
+
+:::js
+Metadata from each source `Document` carries through to its chunks. Add custom fields to the source documents before splitting so every chunk inherits them:
+
+```typescript
+import { Document } from "@langchain/core/documents";
+
+const docs = [
+  new Document({
+    pageContent: text,
+    metadata: { source: "handbook.md", section: "onboarding" },
+  }),
+];
+const chunks = await splitter.splitDocuments(docs);
+// Each chunk keeps the source and section metadata for filtering.
+```
+:::
+
+## Choose a strategy
+
+Match the strategy to your document type, then tune size and overlap by measuring.
+
+| Document type | Strategy |
+|---------------|----------|
+| Prose without clear structure | [Recursive character splitting](#start-with-recursive-character-splitting), or [semantic chunking](#chunk-by-meaning) |
+| Markdown or HTML | [Split on document structure](#split-on-document-structure) and keep headers as metadata |
+| Source code | [Language-aware splitting](#split-on-document-structure) |
+| Matches that need surrounding context | [Retrieve more context than you embed](#retrieve-more-context-than-you-embed) |
+| Strict model token limits or cost constraints | [Size chunks by tokens](#size-chunks-by-tokens) |
+
+## Evaluate your chunking
+
+No chunking strategy is correct in the abstract; the right one is the one that retrieves the right context for your queries. Vary chunk size, overlap, and strategy, re-index, then compare retrieval and answer quality on a fixed dataset. See [Evaluate a RAG application](/langsmith/evaluate-rag-tutorial) to set up the dataset and evaluators.
+
+## See also
+
+- [Retrieval](/oss/langchain/retrieval): concepts and RAG architectures
+- [Build a RAG agent](/oss/langchain/rag): loading, indexing, and querying documents
+- [Text splitter integrations](/oss/integrations/splitters): the full catalog of splitters
+- [Evaluate a RAG application](/langsmith/evaluate-rag-tutorial): measure retrieval and answer quality

--- a/src/oss/langchain/rag.mdx
+++ b/src/oss/langchain/rag.mdx
@@ -527,6 +527,7 @@ Now that you have implemented a simple RAG application via @[`createAgent`], you
 :::
 
 - [Evaluate a RAG application](/langsmith/evaluate-rag-tutorial) with LangSmith datasets and evaluators
+- [Chunk documents for retrieval](/oss/langchain/chunking) to improve retrieval quality
 - [Stream](/oss/langchain/streaming) tokens and other information for responsive user experiences
 - Add [conversational memory](/oss/langchain/short-term-memory) to support multi-turn interactions
 - Add [long-term memory](/oss/langchain/long-term-memory) to support memory across conversational threads


### PR DESCRIPTION
## Summary

Adds a new guide, **Chunk documents for retrieval**, covering how to choose and
tune a chunking strategy for RAG: balancing chunk size and overlap, recursive and
token-based splitting, structure-aware and semantic chunking, small-to-big
retrieval, and chunk metadata. Closes #4722 

## Motivation

Every RAG tutorial in the docs hardcodes chunk parameters without explaining them:
`Build a RAG agent` and `Semantic search` both use `chunk_size=1000,
chunk_overlap=200` with no rationale, and the agentic-RAG tutorial uses `500/50`.
Chunking is one of the largest factors in retrieval quality and one of the least
guided steps, so users are left guessing.

The existing `text splitter integrations` page catalogs *which* splitters exist and
*how* to call them. This guide is deliberately complementary: it covers *how to
decide* (size, overlap, strategy, and how to measure the result), and links to the
integrations page for the mechanics rather than duplicating it.

## What's included

- New page: `src/oss/langchain/chunking.mdx` (Python + JS via `:::python`/`:::js`).
- Nav: added to the LangChain → **Advanced usage** group in `src/docs.json` (both
  Python and JavaScript), immediately before `retrieval` so the indexing step reads
  ahead of the retrieval step.
- Discoverability cross-links (part of the issue scope):
  - `src/oss/integrations/splitters/index.mdx`: Tip now points to the new guide.
  - `src/oss/langchain/rag.mdx`: added a Next steps entry.

## Design decisions

- **Written for LangChain v1.** Splitter examples use `langchain-text-splitters`
  (`RecursiveCharacterTextSplitter`, `from_tiktoken_encoder`/`TokenTextSplitter`,
  `MarkdownHeaderTextSplitter`, `Language.from_language`) with verified idioms.
- **Semantic chunking is described conceptually, not with a code sample.**
  `SemanticChunker` lives in `langchain-experimental` and is not documented
  elsewhere in this repo, so the guide points to the package rather than shipping an
  unverified snippet.
- **Small-to-big is presented as a pattern.** `ParentDocumentRetriever` moved to
  `langchain-classic` in v1, so the guide teaches the pattern and names the helper
  rather than centering a legacy class.
- **No link to the "Improve retrieval quality" guide (#<ISSUE_1_NUMBER>)** since it
  is not yet on `main`. Once both land, a one-line follow-up can cross-link the two
  (chunk metadata → metadata filtering).

## Validation

- `docs.json` validated as JSON.
- Prose checked against the error-level Vale rules (`MinAlertLevel = error`).
- All internal links verified to resolve for both Python and JavaScript renders;
  language-specific links are scoped inside the matching fence.
- Section anchors in the summary tables match their headings.
