### PR TITLE
docs(integrations): fix Text Embeddings Inference guide for langchain-huggingface URL rejection

### DIFF
--- a/src/oss/python/integrations/embeddings/huggingfacehub.mdx
+++ b/src/oss/python/integrations/embeddings/huggingfacehub.mdx
@@ -8,7 +8,7 @@ LangChain supports three ways to use Hugging Face embedding models:
 
 - **Local inference** via `HuggingFaceEmbeddings`: downloads the model and runs it in-process with [Sentence Transformers](https://sbert.net).
 - **Inference Providers and dedicated Inference Endpoints** via `HuggingFaceEndpointEmbeddings`: serverless or dedicated hosted inference through Hugging Face.
-- **Self-hosted at scale** via [Text Embeddings Inference (TEI)](/oss/integrations/embeddings/text_embeddings_inference): Hugging Face's production inference server, pointed at by `HuggingFaceEndpointEmbeddings`.
+- **Self-hosted at scale** via [Text Embeddings Inference (TEI)](/oss/integrations/embeddings/text_embeddings_inference): Hugging Face's production inference server, consumed through its OpenAI-compatible API with `OpenAIEmbeddings`.
 
 All three use the same `Embeddings` interface, so you can start local and graduate to a hosted or self-hosted deployment without changing the rest of your application.
 

--- a/src/oss/python/integrations/embeddings/huggingfacehub.mdx
+++ b/src/oss/python/integrations/embeddings/huggingfacehub.mdx
@@ -8,9 +8,9 @@ LangChain supports three ways to use Hugging Face embedding models:
 
 - **Local inference** via `HuggingFaceEmbeddings`: downloads the model and runs it in-process with [Sentence Transformers](https://sbert.net).
 - **Inference Providers and dedicated Inference Endpoints** via `HuggingFaceEndpointEmbeddings`: serverless or dedicated hosted inference through Hugging Face.
-- **Self-hosted at scale** via [Text Embeddings Inference (TEI)](/oss/integrations/embeddings/text_embeddings_inference): Hugging Face's production inference server, consumed through its OpenAI-compatible API with `OpenAIEmbeddings`.
+- **Self-hosted at scale** via [Text Embeddings Inference (TEI)](/oss/integrations/embeddings/text_embeddings_inference): Hugging Face's production inference server. Point `OpenAIEmbeddings` from `langchain-openai` at TEI's OpenAI-compatible API.
 
-All three use the same `Embeddings` interface, so you can start local and graduate to a hosted or self-hosted deployment without changing the rest of your application.
+Local and hosted paths use `langchain-huggingface`. Self-hosted TEI uses `langchain-openai`. All three expose the same `Embeddings` interface, so you can start local and graduate to a hosted or self-hosted deployment without changing the rest of your application.
 
 ## Setup
 

--- a/src/oss/python/integrations/embeddings/index.mdx
+++ b/src/oss/python/integrations/embeddings/index.mdx
@@ -82,7 +82,7 @@ In practice, most teams converge on one of four patterns:
 3. Local, open-source, specialist: a fine-tuned model targeting your specific domain, language, or task. Starting from a strong open base (e.g. `BAAI/bge-m3`) and fine-tuning on even a few thousand in-domain query/document pairs often beats hosted flagships on retrieval accuracy for that domain.
 4. Self-hosted at production scale: the same open models (base or fine-tuned) served via [Text Embeddings Inference (TEI)](https://github.com/huggingface/text-embeddings-inference) or Ollama. Gives you the economics of local inference with the horizontal scaling and API ergonomics of a hosted provider.
 
-LangChain treats all four the same: you instantiate an `Embeddings` subclass and hand it to your vector store or retriever. Patterns (2) and (3) use `HuggingFaceEmbeddings`; pattern (4) uses `HuggingFaceEndpointEmbeddings` or `OllamaEmbeddings`.
+LangChain treats all four the same: you instantiate an `Embeddings` subclass and hand it to your vector store or retriever. Patterns (2) and (3) use `HuggingFaceEmbeddings`; pattern (4) uses `OpenAIEmbeddings` against TEI's OpenAI-compatible endpoint, or `OllamaEmbeddings`.
 
 ### Factors to weigh
 

--- a/src/oss/python/integrations/embeddings/sentence_transformers.mdx
+++ b/src/oss/python/integrations/embeddings/sentence_transformers.mdx
@@ -84,7 +84,7 @@ Using the right prompts at indexing and query time typically gives a meaningful 
 
 ## Deploy for production
 
-For serving Sentence Transformers models at scale, use [Text Embeddings Inference (TEI)](/oss/integrations/embeddings/text_embeddings_inference), a dedicated inference server from Hugging Face with batching, GPU support, and OpenAI-compatible APIs. Point LangChain at a TEI deployment via `HuggingFaceEndpointEmbeddings`: see the [main Hugging Face embeddings guide](/oss/integrations/embeddings/huggingfacehub).
+For serving Sentence Transformers models at scale, use [Text Embeddings Inference (TEI)](/oss/integrations/embeddings/text_embeddings_inference), a dedicated inference server from Hugging Face with batching, GPU support, and OpenAI-compatible APIs. Point LangChain at a TEI deployment via `OpenAIEmbeddings`: see the [TEI integration guide](/oss/integrations/embeddings/text_embeddings_inference).
 
 ## Reranking
 

--- a/src/oss/python/integrations/embeddings/text_embeddings_inference.mdx
+++ b/src/oss/python/integrations/embeddings/text_embeddings_inference.mdx
@@ -10,7 +10,7 @@ description: "Integrate with the Text embeddings inference embedding model using
 TEI serves an OpenAI-compatible `/v1/embeddings` endpoint, so you can consume a TEI deployment from LangChain with `OpenAIEmbeddings` from the `langchain-openai` package.
 
 <Note>
-Earlier versions of this guide used `HuggingFaceEndpointEmbeddings(model="http://localhost:8080")`. `langchain-huggingface` no longer accepts a URL for `model` and raises `model must be a HuggingFace repo ID, not a URL`. Point `OpenAIEmbeddings` at the TEI server instead, as shown below.
+Earlier versions of this guide used `HuggingFaceEndpointEmbeddings(model="http://localhost:8080")`. `langchain-huggingface` no longer accepts a URL for `model` and raises `` `model` must be a HuggingFace repo ID, not a URL. ``. Point `OpenAIEmbeddings` at the TEI server instead, as shown below.
 </Note>
 
 ## Setup

--- a/src/oss/python/integrations/embeddings/text_embeddings_inference.mdx
+++ b/src/oss/python/integrations/embeddings/text_embeddings_inference.mdx
@@ -7,55 +7,70 @@ description: "Integrate with the Text embeddings inference embedding model using
 > text embeddings and sequence classification models. `TEI` enables high-performance extraction for the most popular models,
 >including `FlagEmbedding`, `Ember`, `GTE` and `E5`.
 
-To use it within langchain, first install `huggingface-hub`.
+TEI serves an OpenAI-compatible `/v1/embeddings` endpoint, so you can consume a TEI deployment from LangChain with `OpenAIEmbeddings` from the `langchain-openai` package.
 
-```python
-pip install -U huggingface-hub
+<Note>
+Earlier versions of this guide used `HuggingFaceEndpointEmbeddings(model="http://localhost:8080")`. `langchain-huggingface` no longer accepts a URL for `model` and raises `model must be a HuggingFace repo ID, not a URL`. Point `OpenAIEmbeddings` at the TEI server instead, as shown below.
+</Note>
+
+## Setup
+
+Install `langchain-openai`:
+
+```shell
+pip install -qU langchain-openai
 ```
 
-Then expose an embedding model using TEI. For instance, using Docker, you can serve `BAAI/bge-large-en-v1.5` as follows:
+## Deploy a model with TEI
+
+Expose an embedding model using TEI. For instance, using Docker, you can serve `sentence-transformers/all-MiniLM-L6-v2` as follows:
 
 ```bash
-model=BAAI/bge-large-en-v1.5
-revision=refs/pr/5
-volume=$PWD/data # share a volume with the Docker container to avoid downloading weights every run
+model=sentence-transformers/all-MiniLM-L6-v2
+volume=$PWD/data  # share a volume with the Docker container to avoid downloading weights every run
 
-docker run --gpus all -p 8080:80 -v $volume:/data --pull always ghcr.io/huggingface/text-embeddings-inference:0.6 --model-id $model --revision $revision
+docker run --gpus all -p 8080:80 -v $volume:/data --pull always ghcr.io/huggingface/text-embeddings-inference:cuda-1.9 --model-id $model
 ```
 
-Specifics on Docker usage might vary with the underlying hardware. For example, to serve the model on Intel Gaudi/Gaudi2 hardware, refer to the [tei-gaudi repository](https://github.com/huggingface/tei-gaudi) for the relevant docker run command.
+To serve on CPU-only hardware, use the `cpu-1.9` image and drop the `--gpus all` flag. Docker usage varies with the underlying hardware. For example, to serve the model on Intel Gaudi/Gaudi2 hardware, refer to the [tei-gaudi repository](https://github.com/huggingface/tei-gaudi) for the relevant docker run command.
 
-Finally, instantiate the client and embed your texts.
+## Embed text
+
+Instantiate `OpenAIEmbeddings` against the TEI server:
 
 ```python
-from langchain_huggingface.embeddings import HuggingFaceEndpointEmbeddings
+from langchain_openai import OpenAIEmbeddings
+
+embeddings = OpenAIEmbeddings(
+    model="sentence-transformers/all-MiniLM-L6-v2",
+    base_url="http://localhost:8080/v1",
+    api_key="unused",  # TEI does not require authentication by default
+    check_embedding_ctx_length=False,  # send raw text; TEI tokenizes server-side
+)
 ```
 
-```python
-embeddings = HuggingFaceEndpointEmbeddings(model="http://localhost:8080")
-```
+<Note>
+Set `check_embedding_ctx_length=False`. Without it, `OpenAIEmbeddings` tokenizes input with `tiktoken` and sends token IDs, which TEI does not accept. The flag sends raw text instead. If you start TEI with an API key, pass the same value as `api_key`.
+</Note>
+
+Then embed your texts:
 
 ```python
 text = "What is deep learning?"
-```
 
-```python
 query_result = embeddings.embed_query(text)
 query_result[:3]
 ```
 
 ```text
-[0.018113142, 0.00302585, -0.049911194]
+[-0.077851, -0.033281, 0.019743]
 ```
 
 ```python
 doc_result = embeddings.embed_documents([text])
-```
-
-```python
 doc_result[0][:3]
 ```
 
 ```text
-[0.018113142, 0.00302585, -0.049911194]
+[-0.077851, -0.033281, 0.019743]
 ```

--- a/src/oss/python/integrations/providers/huggingface.mdx
+++ b/src/oss/python/integrations/providers/huggingface.mdx
@@ -76,7 +76,7 @@ from langchain_huggingface import HuggingFaceEndpointEmbeddings
 
 ### Text Embeddings Inference (TEI)
 
-For self-hosted production serving of Sentence Transformers models, Hugging Face publishes [Text Embeddings Inference](https://github.com/huggingface/text-embeddings-inference), a dedicated inference server with batching and GPU support. Point LangChain at a TEI deployment via `HuggingFaceEndpointEmbeddings` or see the dedicated [TEI integration guide](/oss/integrations/embeddings/text_embeddings_inference).
+For self-hosted production serving of Sentence Transformers models, Hugging Face publishes [Text Embeddings Inference](https://github.com/huggingface/text-embeddings-inference), a dedicated inference server with batching and GPU support. TEI exposes an OpenAI-compatible API, so point LangChain at a TEI deployment via `OpenAIEmbeddings`. See the dedicated [TEI integration guide](/oss/integrations/embeddings/text_embeddings_inference).
 
 ### BGE embedding models
 


### PR DESCRIPTION
## Why

Fixes #4323

`langchain-huggingface` (via langchain-ai/langchain#36831) added a validator that rejects
URLs in `HuggingFaceEndpointEmbeddings(model=...)`. The Text Embeddings Inference (TEI)
guide still instructs users to pass a self-hosted URL:

    embeddings = HuggingFaceEndpointEmbeddings(model="http://localhost:8080")

On current releases this raises:

    ValidationError: `model` must be a HuggingFace repo ID, not a URL.

The wrapper now always builds its own Hugging Face-hosted `InferenceClient` and exposes no
`base_url`/`endpoint_url` parameter, so it can no longer target a self-hosted TEI server.

## What changed

TEI exposes an OpenAI-compatible `/v1/embeddings` endpoint, so the guide now points
`OpenAIEmbeddings` (from `langchain-openai`) at the TEI server. This matches the
`OpenAIEmbeddings` docstring pattern for OpenAI-compatible servers (OpenRouter, Ollama,
vLLM), including `check_embedding_ctx_length=False`:

    from langchain_openai import OpenAIEmbeddings

    embeddings = OpenAIEmbeddings(
        model="sentence-transformers/all-MiniLM-L6-v2",
        base_url="http://localhost:8080/v1",
        api_key="unused",                  # TEI needs no auth by default
        check_embedding_ctx_length=False,  # send raw text; TEI tokenizes server-side
    )

- Rewrote `embeddings/text_embeddings_inference.mdx`: OpenAI-compatible snippet, a migration
  note quoting the error, and a note on why `check_embedding_ctx_length=False` is required.
- Corrected four cross-references that still routed TEI through `HuggingFaceEndpointEmbeddings`
  (`huggingfacehub.mdx`, `sentence_transformers.mdx`, `providers/huggingface.mdx`,
  `embeddings/index.mdx`).
- Clarified on the Hugging Face embeddings page that local/hosted paths use
  `langchain-huggingface`, while self-hosted TEI uses `langchain-openai`.
- Refreshed the Docker command to current image tags (`cuda-1.9` / `cpu-1.9`) and dropped the
  stale `--revision refs/pr/5`; fixed a `python`→`shell` code-fence label on the pip command.

## Testing

- Reproduced the exact error on `langchain-huggingface==1.2.2` / `pydantic 2.13.4`.
- Ran a real TEI container (`text-embeddings-inference:cpu-1.9`, `all-MiniLM-L6-v2`) and
  confirmed the new snippet returns correct 384-dim normalized embeddings. The example output
  in the doc is the actual result from that run.
- Verified that omitting `check_embedding_ctx_length=False` makes the OpenAI client send
  token IDs, which TEI rejects - hence the note.