### PR TITLE
docs(sql-agent): stop shadowing the @tool decorator in the tools loop

### DIFF
--- a/src/code-samples/langchain/sql-agent.py
+++ b/src/code-samples/langchain/sql-agent.py
@@ -142,8 +142,9 @@ SQL Query: """.format(query=query)
 
 tools = [sql_db_list_tables, sql_db_schema, sql_db_query, sql_db_query_checker]
 
-for tool in tools:
-    print(f"{tool.name}: {tool.description}\n")
+# Use a distinct loop variable so it does not shadow the `tool` decorator.
+for t in tools:
+    print(f"{t.name}: {t.description}\n")
 # :snippet-end:
 
 # :snippet-start: sql-agent-system-prompt-py
@@ -391,8 +392,9 @@ SQL Query: """.format(query=query)
 
 tools = [sql_db_list_tables, sql_db_schema, sql_db_query, sql_db_query_checker]
 
-for tool in tools:
-    print(f"{tool.name}: {tool.description}\n")
+# Use a distinct loop variable so it does not shadow the `tool` decorator.
+for t in tools:
+    print(f"{t.name}: {t.description}\n")
 
 # Use create_agent
 system_prompt = """

--- a/src/code-samples/langgraph/langgraph-sql-agent.py
+++ b/src/code-samples/langgraph/langgraph-sql-agent.py
@@ -118,8 +118,10 @@ def sql_db_query(query: str) -> str:
 
 tools = [sql_db_list_tables, sql_db_schema, sql_db_query]
 
-for tool in tools:
-    print(f"{tool.name}: {tool.description}\n")
+# Use a distinct loop variable so it does not shadow the `tool` decorator,
+# which is reused later to wrap the query tool for human review.
+for t in tools:
+    print(f"{t.name}: {t.description}\n")
 # :snippet-end:
 
 # :snippet-start: langgraph-sql-agent-define-steps-py

--- a/src/snippets/code-samples/langgraph-sql-agent-tools-py.mdx
+++ b/src/snippets/code-samples/langgraph-sql-agent-tools-py.mdx
@@ -91,6 +91,8 @@ def sql_db_query(query: str) -> str:
 
 tools = [sql_db_list_tables, sql_db_schema, sql_db_query]
 
-for tool in tools:
-    print(f"{tool.name}: {tool.description}\n")
+# Use a distinct loop variable so it does not shadow the `tool` decorator,
+# which is reused later to wrap the query tool for human review.
+for t in tools:
+    print(f"{t.name}: {t.description}\n")
 ```

--- a/src/snippets/code-samples/sql-agent-studio-py.mdx
+++ b/src/snippets/code-samples/sql-agent-studio-py.mdx
@@ -121,8 +121,9 @@ SQL Query: """.format(query=query)
 
 tools = [sql_db_list_tables, sql_db_schema, sql_db_query, sql_db_query_checker]
 
-for tool in tools:
-    print(f"{tool.name}: {tool.description}\n")
+# Use a distinct loop variable so it does not shadow the `tool` decorator.
+for t in tools:
+    print(f"{t.name}: {t.description}\n")
 
 # Use create_agent
 system_prompt = """

--- a/src/snippets/code-samples/sql-agent-tools-py.mdx
+++ b/src/snippets/code-samples/sql-agent-tools-py.mdx
@@ -99,6 +99,7 @@ SQL Query: """.format(query=query)
 
 tools = [sql_db_list_tables, sql_db_schema, sql_db_query, sql_db_query_checker]
 
-for tool in tools:
-    print(f"{tool.name}: {tool.description}\n")
+# Use a distinct loop variable so it does not shadow the `tool` decorator.
+for t in tools:
+    print(f"{t.name}: {t.description}\n")
 ```


### PR DESCRIPTION
## Why

Fixes #4159 

The LangGraph SQL agent tutorial fails at the human-in-the-loop step with:

    TypeError: 'StructuredTool' object is not callable

The tools snippet ends with a loop that rebinds `tool` - the decorator imported
from `langchain.tools` - to a `StructuredTool`:

    tools = [sql_db_list_tables, sql_db_schema, sql_db_query]

    for tool in tools:                       # shadows the @tool decorator
        print(f"{tool.name}: {tool.description}\n")

A later cell then reuses the decorator:

    @tool(run_query_tool.name, description=..., args_schema=...)   # tool is now a StructuredTool
    def run_query_tool_with_interrupt(...): ...

Because `tool` no longer refers to the decorator, Python raises
`'StructuredTool' object is not callable`. This is independent of the Python or
`langchain` version (reproduced on 3.12 with langchain 1.3.1 / langgraph 1.2).

## What changed

Rename the loop variable so it no longer shadows the decorator:

    for t in tools:
        print(f"{t.name}: {t.description}\n")

- Fixed the source samples (`src/code-samples/langgraph/langgraph-sql-agent.py`
  and `src/code-samples/langchain/sql-agent.py`) and regenerated the affected
  snippets under `src/snippets/code-samples/`.
- Applied the same rename to the LangChain SQL agent tutorial, which contains the
  identical pattern (latent there, since it uses middleware for HITL).

## Testing

- Reproduced the exact `TypeError` on the reported package versions and confirmed
  `type(tool)` becomes `StructuredTool` after the loop.
- Verified the rename keeps `tool` as the decorator and the HITL snippet
  (`@tool(name, ...)` + `ToolNode`) runs end-to-end with no re-import needed.
- Both code samples compile; regenerated snippets match their sources.

