### PR TITLE
docs: fix MariaDB provider wording

### DIFF
--- a/src/oss/python/integrations/providers/mariadb.mdx
+++ b/src/oss/python/integrations/providers/mariadb.mdx
@@ -1,10 +1,10 @@
 ---
-title: "Mariadb integrations"
-description: "Integrate with Mariadb using LangChain Python."
+title: "MariaDB integrations"
+description: "Integrate with MariaDB using LangChain Python."
 ---
 
 This page covers how to use the [MariaDB](https://github.com/mariadb/) ecosystem within LangChain.
-It is broken into two parts: installation and setup, and then references to specific PGVector wrappers.
+It is broken into two parts: installation and setup, and then references to specific MariaDB wrappers.
 
 ## Installation
 - Install c/c connector

--- a/src/oss/python/integrations/vectorstores/google_vertex_ai_vector_search.mdx
+++ b/src/oss/python/integrations/vectorstores/google_vertex_ai_vector_search.mdx
@@ -514,10 +514,10 @@ my_index_endpoint.deployed_indexes
 NOTE : If you have existing Index and Endpoints, you can load them using below code
 
 ```python
-# TODO : replace 1234567890123456789 with your acutial index ID
+# TODO : replace 1234567890123456789 with your actual index ID
 my_index = aiplatform.MatchingEngineIndex("1234567890123456789")
 
-# TODO : replace 1234567890123456789 with your acutial endpoint ID
+# TODO : replace 1234567890123456789 with your actual endpoint ID
 my_index_endpoint = aiplatform.MatchingEngineIndexEndpoint("1234567890123456789")
 ```
 


### PR DESCRIPTION
﻿## Overview

Fixes #4728.

This corrects copied wording on the MariaDB provider page:

- uses the official `MariaDB` casing in the title and description
- replaces the incorrect "PGVector wrappers" reference with "MariaDB wrappers"
- fixes two `acutial` typos in the Google Vertex AI Vector Search guide found during the same pass

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs

- GitHub issue: Fixes #4728
- Feature PR: N/A

## Checklist

- [x] I have read the contributing guidelines, including the language policy
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

No code examples, internal links, or navigation entries changed. I did not run `docs dev` because this is a text-only fix and the local machine has very limited C: drive space; instead I ran targeted checks:

```bash
rg -n "PGVector wrappers|acutial|Mariadb integrations|Integrate with Mariadb" src/oss/python/integrations/providers/mariadb.mdx src/oss/python/integrations/vectorstores/google_vertex_ai_vector_search.mdx
git diff --check
UV_CACHE_DIR="E:\Industry Codebases\uv-cache-docs" uvx --from codespell codespell src/oss/python/integrations/providers/mariadb.mdx src/oss/python/integrations/vectorstores/google_vertex_ai_vector_search.mdx
```
