### PR TITLE
docs: fix standard test wording

### DIFF
--- a/src/oss/contributing/standard-tests-langchain.mdx
+++ b/src/oss/contributing/standard-tests-langchain.mdx
@@ -115,7 +115,7 @@ Both types of tests are implemented as [`pytest`](https://docs.pytest.org/en/sta
 
 Depending on your integration type, you will need to implement either or both unit and integration tests.
 
-By subclassing the standard test suite for your integration type, you get the full collection of standard tests for that type. For a test run to be successful, the a given test should pass only if the model supports the capability being tested. Otherwise, the test should be skipped.
+By subclassing the standard test suite for your integration type, you get the full collection of standard tests for that type. For a test run to be successful, a given test should pass only if the model supports the capability being tested. Otherwise, the test should be skipped.
 
 Because different integrations offer unique sets of features, most standard tests provided by LangChain are **opt-in by default** to prevent false positives. Consequently, you will need to override properties to indicate which features your integration supports - see the below example for an illustration.
 

--- a/src/oss/python/integrations/providers/yeagerai.mdx
+++ b/src/oss/python/integrations/providers/yeagerai.mdx
@@ -31,7 +31,7 @@ This will install the necessary dependencies and set up yAgents on your system. 
 
 `OPENAI_API_KEY=<your_openai_api_key_here>`
 
-We recommend using GPT-4,. However, the tool can also work with GPT-3 if the problem is broken down sufficiently.
+We recommend using GPT-4. However, the tool can also work with GPT-3 if the problem is broken down sufficiently.
 
 ### Creating and executing tools with yAgents
 yAgents makes it easy to create and execute AI-powered tools. Here's a brief overview of the process:


### PR DESCRIPTION
﻿## Overview

Fix two small wording issues in the docs:

- remove an extra article in the standard tests contributor guide
- fix punctuation in the YeagerAI provider page

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs

- GitHub issue: N/A
- Feature PR: N/A
- Linear issue: N/A
- Slack thread: N/A

## Checklist

- [x] I have read the contributing guidelines, including the language policy
- [ ] I have tested my changes locally using `docs dev` (not run; text-only wording fix)
- [ ] All code examples have been tested and work correctly (N/A; no executable examples changed)
- [x] I have used **root relative** paths for internal links (N/A; no links changed)
- [x] I have updated navigation in `src/docs.json` if needed (not needed; no navigation changes)

## Additional notes

Targeted validation:

```bash
git diff --check -- src/oss/contributing/standard-tests-langchain.mdx src/oss/python/integrations/providers/yeagerai.mdx
UV_CACHE_DIR="E:\Industry Codebases\uv-cache-docs" uvx --from codespell codespell src/oss/contributing/standard-tests-langchain.mdx src/oss/python/integrations/providers/yeagerai.mdx
rg -n "the a given|GPT-4,\." src/oss/contributing/standard-tests-langchain.mdx src/oss/python/integrations/providers/yeagerai.mdx
```

The final `rg` command returns no matches.
