### PR TITLE
docs: simplify SmithDB context copy on SDK migration page

### DIFF
--- a/src/langsmith/smithdb-sdk-migration.mdx
+++ b/src/langsmith/smithdb-sdk-migration.mdx
@@ -11,7 +11,7 @@ import SmithdbMigrationRunsRetrieve from '/snippets/langsmith/smithdb-migration/
 
 In May 2026, we released [SmithDB](https://www.langchain.com/blog/introducing-smithdb?utm_source=docs), a new observability database built for modern AI agents. SmithDB delivers industry-leading performance across every key observability workload, making core LangSmith experiences dramatically faster.
 
-SmithDB-powered methods are now available to SDK users.
+SmithDB-powered methods are now available to SDK users in eligible regions.
 
 ## Deployment support
 

--- a/src/langsmith/smithdb-sdk-migration.mdx
+++ b/src/langsmith/smithdb-sdk-migration.mdx
@@ -9,9 +9,9 @@ import SmithdbMigrationRunsRetrieve from '/snippets/langsmith/smithdb-migration/
 
 ## Context
 
-In May 2026, we released [SmithDB](https://www.langchain.com/blog/introducing-smithdb?utm_source=docs), a new observability database built for modern AI agents. Agent traces have grown dramatically in complexity: hundreds of nested spans, multi-modal content, and spans that remain open for hours. General-purpose databases were never designed to handle these patterns at scale. SmithDB addresses this directly, built in Rust on Apache DataFusion and Vortex with purpose-built support for the query patterns that matter most for agent observability: random access, interactive filtering, full-text search, and tree-aware trace reconstruction.
+In May 2026, we released [SmithDB](https://www.langchain.com/blog/introducing-smithdb?utm_source=docs), a new observability database built for modern AI agents. SmithDB delivers industry-leading performance across every key observability workload, making core LangSmith experiences dramatically faster.
 
-SmithDB-powered methods are now available to all SDK users.
+SmithDB-powered methods are now available to SDK users.
 
 ## Deployment support
 


### PR DESCRIPTION
## Summary

Simplify intro