### PR TITLE
docs: note write_file overwrite behavior [deepagents PR #4109]

### DIFF
--- a/src/oss/deepagents/overview.mdx
+++ b/src/oss/deepagents/overview.mdx
@@ -298,7 +298,7 @@ The backends support the following file system operations:
 
 :::python
 <Note>
-  `write_file` overwrites a file if it already exists, as of `deepagents>=0.7.0a2`. On earlier versions, `write_file` errors instead — use `edit_file` to modify an existing file.
+  `write_file` overwrites a file if it already exists, as of `deepagents>=0.7.0a2`. On earlier versions, `write_file` errors instead. Use `edit_file` to modify an existing file.
 </Note>
 :::
 

--- a/src/oss/deepagents/overview.mdx
+++ b/src/oss/deepagents/overview.mdx
@@ -290,11 +290,17 @@ The backends support the following file system operations:
 | ---- | ----------- |
 | `ls` | List files in a directory with metadata (size, modified time) |
 | `read_file` | Read file contents with line numbers, supports offset/limit for large files. Also supports returning multimodal content blocks for non-text files (images, video, audio, and documents). See supported extensions below. |
-| `write_file` | Create new files |
+| `write_file` | Create a new file, or overwrite an existing one |
 | `edit_file` | Perform exact string replacements in files (with global replace mode) |
 | `glob` | Find files matching patterns (e.g., `**/*.py`) |
 | `grep` | Search file contents with multiple output modes (files only, content with context, or counts) |
 | `execute` | Run shell commands in the environment (available with [sandbox backends](/oss/deepagents/sandboxes) only) |
+
+:::python
+<Note>
+  `write_file` overwrites a file if it already exists, as of `deepagents>=0.7.0a2`. On earlier versions, `write_file` errors instead — use `edit_file` to modify an existing file.
+</Note>
+:::
 
 <Accordion title="Supported multimodal file extensions">
 

--- a/src/oss/deepagents/tools.mdx
+++ b/src/oss/deepagents/tools.mdx
@@ -78,13 +78,19 @@ In addition to the tools you provide, every Deep Agent comes with a built-in set
 | ---- | ----------- |
 | `ls` | List files in a directory |
 | `read_file` | Read file contents (with pagination and multimodal support) |
-| `write_file` | Create new files |
+| `write_file` | Create a new file, or overwrite an existing one |
 | `edit_file` | Perform exact string replacements in files |
 | `glob` | Find files matching a glob pattern |
 | `grep` | Search file contents |
 | `execute` | Run shell commands (sandbox backends only) |
 | `task` | Spawn a subagent to handle a delegated task |
 | `write_todos` | Manage a structured todo list |
+
+:::python
+<Note>
+  `write_file` overwrites a file if it already exists, as of `deepagents>=0.7.0a2`. On earlier versions, `write_file` errors instead — use `edit_file` to modify an existing file.
+</Note>
+:::
 
 For a full breakdown of what each built-in tool does, see [Harness overview](/oss/deepagents/overview#execution-environment).
 

--- a/src/oss/deepagents/tools.mdx
+++ b/src/oss/deepagents/tools.mdx
@@ -88,7 +88,7 @@ In addition to the tools you provide, every Deep Agent comes with a built-in set
 
 :::python
 <Note>
-  `write_file` overwrites a file if it already exists, as of `deepagents>=0.7.0a2`. On earlier versions, `write_file` errors instead — use `edit_file` to modify an existing file.
+  `write_file` overwrites a file if it already exists, as of `deepagents>=0.7.0a2`. On earlier versions, `write_file` errors instead. Use `edit_file` to modify an existing file.
 </Note>
 :::
 


### PR DESCRIPTION
## Description

Depends on: langchain-ai/deepagents#4109

`write_file` now overwrites an existing file instead of erroring. Updates the built-in tool tables in the harness overview and tools pages, and adds a callout that this behavior requires `deepagents>=0.7.0a2` (Python only for no,  the JS package still errors on overwrite).

## Test Plan
- [x] `npx markdownlint-cli src/oss/deepagents/tools.mdx src/oss/deepagents/overview.mdx` — no new lint errors introduced by this change

_Opened collaboratively by Nishitha Madhu and open-swe_