### PR TITLE
docs: use stream.subagents for named sub-agents in JS event-streaming…

### DIFF
--- a/src/oss/langchain/event-streaming.mdx
+++ b/src/oss/langchain/event-streaming.mdx
@@ -240,9 +240,9 @@ await Promise.all([
 
 ## Streaming sub-agents
 
+:::python
 When a `create_agent` call invokes another named `create_agent` (via a wrapping tool, typically), the inner agent's events flow at a nested namespace. The `name=` you pass to `create_agent` identifies that inner agent in the stream, so you can filter and label per agent.
 
-:::python
 Named sub-agents surface on the dedicated `stream.subagents` projection. Each handle exposes the inner agent's own `.messages`, `.values`, `.tool_calls`, and `.output`, plus `.name` (the `name=` you passed) and `.cause` (the tool call that dispatched the sub-agent). Because only named `create_agent` runs appear here, you don't need to filter plain subgraphs out.
 
 ```py
@@ -289,7 +289,9 @@ for subagent in stream.subagents:
 :::
 
 :::js
-Named sub-agents surface on the dedicated `stream.subagents` projection. Each handle exposes the inner agent's own `.messages`, `.values`, `.toolCalls`, and `.output`, plus `.name` (the `name=` you passed) and `.cause` (the tool call that dispatched the sub-agent). Because only named `create_agent` runs appear here, you don't need to filter plain subgraphs out.
+When a `createAgent` call invokes another named `createAgent` (via a wrapping tool, typically), the inner agent's events flow at a nested namespace. The `name` you pass to `createAgent` identifies that inner agent in the stream, so you can filter and label per agent.
+
+Named sub-agents surface on the dedicated `stream.subagents` projection. Each handle exposes the inner agent's own `.messages`, `.toolCalls`, and `.output`, plus `.name` (the `name=` you passed), `.cause` (the tool call that dispatched the sub-agent), and nested `.subagents`. Because only named `createAgent` runs appear here, you don't need to filter plain subgraphs out.
 
 ```ts
 import { createAgent, tool } from "langchain";
@@ -347,7 +349,7 @@ Plain `StateGraph` subgraphs invoked from a tool also surface on `stream.subgrap
 :::
 
 :::js
-`stream.subagents` is the focused view of named `create_agent` sub-agents, while `stream.subgraphs` covers every nested graph. Use whichever matches your UI.
+`stream.subagents` is the focused view of named `createAgent` sub-agents, while `stream.subgraphs` covers every nested graph. Use whichever matches your UI.
 :::
 
 ## State and final output

--- a/src/oss/langchain/event-streaming.mdx
+++ b/src/oss/langchain/event-streaming.mdx
@@ -289,7 +289,7 @@ for subagent in stream.subagents:
 :::
 
 :::js
-Named sub-agents surface as handles on `stream.subgraphs`, alongside any plain subgraphs. Each handle exposes the inner agent's `.messages`, `.values`, `.toolCalls`, and `.output`; filter on `subagent.name` (the `name=` you passed) to act on a specific agent.
+Named sub-agents surface on the dedicated `stream.subagents` projection. Each handle exposes the inner agent's own `.messages`, `.values`, `.toolCalls`, and `.output`, plus `.name` (the `name=` you passed) and `.cause` (the tool call that dispatched the sub-agent). Because only named `create_agent` runs appear here, you don't need to filter plain subgraphs out.
 
 ```ts
 import { createAgent, tool } from "langchain";
@@ -327,8 +327,7 @@ const stream = await supervisor.streamEvents(
   { version: "v3" }
 );
 
-for await (const subagent of stream.subgraphs) {
-  if (subagent.name !== "weather_agent") continue;
+for await (const subagent of stream.subagents) {
   process.stdout.write(`${subagent.name}: `);
   for await (const message of subagent.messages) {
     for await (const token of message.text) {
@@ -337,6 +336,7 @@ for await (const subagent of stream.subgraphs) {
   }
   process.stdout.write("\n");
 }
+//Output: "weather_agent: The weather in Boston is sunny!"
 ```
 :::
 
@@ -347,7 +347,7 @@ Plain `StateGraph` subgraphs invoked from a tool also surface on `stream.subgrap
 :::
 
 :::js
-Named sub-agents share the `stream.subgraphs` projection with plain subgraphs; the filter you write into your loop is what separates them.
+`stream.subagents` is the focused view of named `create_agent` sub-agents, while `stream.subgraphs` covers every nested graph. Use whichever matches your UI.
 :::
 
 ## State and final output


### PR DESCRIPTION
## Overview

The "Streaming sub-agents" JS example in `src/oss/langchain/event-streaming.mdx`
iterates `stream.subgraphs` and filters on
`subagent.name === "weather_agent"`, but `SubgraphRunStream.name` is the
graph node name (`agent`, `tools`, `model_request`), not the `name=` value
passed to `createAgent` — so the filter discards every handle and the
example prints nothing. The Python tab already uses the dedicated
`stream.subagents` projection, so the two tabs were also inconsistent.

This switches the JS example to `stream.subagents`, drops the now-redundant
name filter, and updates the surrounding prose to match the Python tab.
No changes to the Python tab, the "What you can stream" tables, or any
code outside the "Streaming sub-agents" section.

## Type of change

**Type:** Update existing documentation

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the `https://docs.langchain.com/oss/python/contributing/overview#language-policy`
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the `https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml`

## Additional notes

Verified against `langchain@1.5.2` / `@langchain/langgraph@1.4.6`:

- **Before**: no output — `stream.subgraphs` yields three handles named
  `model_request` / `tools` / `model_request`, none match the filter.
- **After**: prints `weather_agent: The weather in New York is always sunny!`.

`stream.subagents` is a native projection that scans `lc_agent_name`
metadata and surfaces only nested `createAgent` runs
([langchainjs `agents/transformers/subagent.ts`](https://github.com/langchain-ai/langchainjs/blob/main/libs/langchain/src/agents/transformers/subagent.ts)).