### PR TITLE
docs: fix Scrapeless example domain typo

### DIFF
--- a/src/oss/python/integrations/tools/scrapeless_crawl.mdx
+++ b/src/oss/python/integrations/tools/scrapeless_crawl.mdx
@@ -130,12 +130,12 @@ from langchain_scrapeless import ScrapelessCrawlerCrawlTool
 tool = ScrapelessCrawlerCrawlTool()
 
 # Advanced usage
-result = tool.invoke({"url": "https://exmaple.com", "limit": 4})
+result = tool.invoke({"url": "https://example.com", "limit": 4})
 print(result)
 ```
 
 ```python
-{'success': True, 'status': 'completed', 'completed': 1, 'total': 1, 'data': [{'markdown': '# Well hello there.\n\nWelcome to exmaple.com.\n\nChances are you got here by mistake (example.com, anyone?)', 'metadata': {'scrapeId': '547b2478-a41a-4a17-8015-8db378ee455f', 'sourceURL': 'https://exmaple.com', 'url': 'https://exmaple.com', 'statusCode': 200}}]}
+{'success': True, 'status': 'completed', 'completed': 1, 'total': 1, 'data': [{'markdown': '# Example Domain\n\nThis domain is for use in illustrative examples in documents. You may use this\ndomain in literature without prior coordination or asking for permission.\n\n[More information...](https://www.iana.org/domains/example)', 'metadata': {'scrapeId': '547b2478-a41a-4a17-8015-8db378ee455f', 'sourceURL': 'https://example.com', 'url': 'https://example.com', 'statusCode': 200}}]}
 ```
 
 #### Use within an agent
@@ -228,7 +228,7 @@ tool = ScrapelessCrawlerScrapeTool()
 
 result = tool.invoke(
     {
-        "urls": ["https://exmaple.com", "https://www.scrapeless.com/en"],
+        "urls": ["https://example.com", "https://www.scrapeless.com/en"],
         "formats": ["markdown"],
     }
 )

--- a/src/oss/python/integrations/tools/scrapeless_universal_scraping.mdx
+++ b/src/oss/python/integrations/tools/scrapeless_universal_scraping.mdx
@@ -164,15 +164,14 @@ from langchain_scrapeless import ScrapelessUniversalScrapingTool
 
 tool = ScrapelessUniversalScrapingTool()
 
-result = tool.invoke({"url": "https://exmaple.com", "response_type": "markdown"})
+result = tool.invoke({"url": "https://example.com", "response_type": "markdown"})
 print(result)
 ```
 
 ```text
-# Well hello there.
+# Example Domain
 
-Welcome to exmaple.com.
-Chances are you got here by mistake (example.com, anyone?)
+This domain is for use in illustrative examples in documents.
 ```
 
 ### Use within an agent


### PR DESCRIPTION
## Summary

- fix `exmaple.com` typos in Scrapeless tool examples
- update the shown sample output so the URL and response are consistent with `example.com`
- keep the change scoped to documentation only

## Validation

- `git diff --check origin/main...HEAD`
- `uv run --no-project --with codespell -- codespell src/oss/python/integrations/tools/scrapeless_crawl.mdx src/oss/python/integrations/tools/scrapeless_universal_scraping.mdx`
- `rg -n exmaple src/oss/python/integrations/tools/scrapeless_crawl.mdx src/oss/python/integrations/tools/scrapeless_universal_scraping.mdx` returned no matches