### PR TITLE
docs: add recursion_limit formula for cyclical graphs

### DIFF
--- a/src/oss/langgraph/errors/GRAPH_RECURSION_LIMIT.mdx
+++ b/src/oss/langgraph/errors/GRAPH_RECURSION_LIMIT.mdx
@@ -54,13 +54,13 @@ However, complex graphs may hit the default limit naturally.
 graph.invoke({...}, {"recursion_limit": 1000})
 ```
 
-* If you have a cyclical graph (e.g. a multi-round agent loop), the recursion limit counts **individual node executions**, not "rounds" or "iterations" of your loop. A useful formula for picking a safe value:
+* If you have a cyclical graph (e.g. a multi-round agent loop), the recursion limit counts **individual node executions**, not "rounds" or "iterations" of your loop, so it's easy to underestimate. A useful formula for picking a safe value:
 
   ```
   recursion_limit = (nodes_per_cycle × max_iterations) + buffer
   ```
 
-  For example, a debate graph with 7 nodes per round (`round_start → proponent → opponent → fact_checker → moderator → consensus → round_start`) run for 5 rounds needs at least `7 × 5 = 35` steps — well above the default of 25. Setting `recursion_limit: 100` gives comfortable headroom:
+  For example, a debate graph with 7 nodes per round (`round_start → proponent → opponent → fact_checker → moderator → consensus → round_start`) run for 5 rounds needs at least `7 × 5 = 35` steps. Setting `recursion_limit` comfortably above that gives headroom without masking a real infinite loop:
 
   ```python
   graph.invoke({...}, {"recursion_limit": 100})
@@ -74,13 +74,13 @@ graph.invoke({...}, {"recursion_limit": 1000})
 await graph.invoke({...}, { recursionLimit: 1000 });
 ```
 
-* If you have a cyclical graph (e.g. a multi-round agent loop), the recursion limit counts **individual node executions**, not "rounds" or "iterations" of your loop. A useful formula for picking a safe value:
+* If you have a cyclical graph (e.g. a multi-round agent loop), the recursion limit counts **individual node executions**, not "rounds" or "iterations" of your loop, so it's easy to underestimate. A useful formula for picking a safe value:
 
   ```
   recursionLimit = (nodesPerCycle × maxIterations) + buffer
   ```
 
-  For example, a debate graph with 7 nodes per round run for 5 rounds needs at least `7 × 5 = 35` steps — well above the default of 25. Setting `recursionLimit: 100` gives comfortable headroom:
+  For example, a debate graph with 7 nodes per round run for 5 rounds needs at least `7 × 5 = 35` steps. Setting `recursionLimit` comfortably above that gives headroom without masking a real infinite loop:
 
   ```typescript
   await graph.invoke({...}, { recursionLimit: 100 });

--- a/src/oss/langgraph/errors/GRAPH_RECURSION_LIMIT.mdx
+++ b/src/oss/langgraph/errors/GRAPH_RECURSION_LIMIT.mdx
@@ -53,6 +53,18 @@ However, complex graphs may hit the default limit naturally.
 ```python
 graph.invoke({...}, {"recursion_limit": 1000})
 ```
+
+* If you have a cyclical graph (e.g. a multi-round agent loop), the recursion limit counts **individual node executions**, not "rounds" or "iterations" of your loop. A useful formula for picking a safe value:
+
+  ```
+  recursion_limit = (nodes_per_cycle × max_iterations) + buffer
+  ```
+
+  For example, a debate graph with 7 nodes per round (`round_start → proponent → opponent → fact_checker → moderator → consensus → round_start`) run for 5 rounds needs at least `7 × 5 = 35` steps — well above the default of 25. Setting `recursion_limit: 100` gives comfortable headroom:
+
+  ```python
+  graph.invoke({...}, {"recursion_limit": 100})
+  ```
 :::
 
 :::js
@@ -61,4 +73,16 @@ graph.invoke({...}, {"recursion_limit": 1000})
 ```typescript
 await graph.invoke({...}, { recursionLimit: 1000 });
 ```
+
+* If you have a cyclical graph (e.g. a multi-round agent loop), the recursion limit counts **individual node executions**, not "rounds" or "iterations" of your loop. A useful formula for picking a safe value:
+
+  ```
+  recursionLimit = (nodesPerCycle × maxIterations) + buffer
+  ```
+
+  For example, a debate graph with 7 nodes per round run for 5 rounds needs at least `7 × 5 = 35` steps — well above the default of 25. Setting `recursionLimit: 100` gives comfortable headroom:
+
+  ```typescript
+  await graph.invoke({...}, { recursionLimit: 100 });
+  ```
 :::


### PR DESCRIPTION
The current page explains how to raise `recursion_limit` via the config object, but doesn't explain that the limit counts individual node executions rather than "rounds" or "iterations" of a cycle, and gives no way to calculate an appropriate value for a given graph.

This is a common source of confusion for anyone building cyclical/multi-round agent graphs,since it's easy to underestimate how many steps a multi-round loop actually needs.

This PR adds a short formula (`nodes_per_cycle × max_iterations + buffer`) with a worked example directly on the `GRAPH_RECURSION_LIMIT` error page, since that's where users land when they hit this error. Added to both the Python and JS tabs for parity.