### PR TITLE
docs: use read_project/aread_project in SmithDB migration guide

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ dependencies = [
     "langchain-quickjs>=0.3.2",
     "langgraph>=1.2.5",
     "langgraph-checkpoint-sqlite>=3.1.0",
-    "langsmith>=0.9.6",
+    "langsmith>=0.9.8",
 ]
 
 

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-boolean-filters-after.ts
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-boolean-filters-after.ts
@@ -8,9 +8,7 @@ const filterStr =
   'and(gt(start_time, "2023-07-15T12:34:56Z"),' +
   ' or(neq(status, "error"),' +
   '    and(eq(feedback_key, "Correctness"), eq(feedback_score, 0.0))))';
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs = client.runs.query({
   project_ids: [project.id],
   filter: filterStr,

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-boolean-filters.py
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-boolean-filters.py
@@ -26,8 +26,7 @@ async def main():
         ' or(neq(status, "error"),'
         '    and(eq(feedback_key, "Correctness"), eq(feedback_score, 0.0))))'
     )
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(project_ids=[str(project.id)], filter=filter_str)
 
 

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-fetch-by-id-after.ts
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-fetch-by-id-after.ts
@@ -4,9 +4,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs = client.runs.query({
   project_ids: [project.id],
   ids: ["<run-id-1>", "<run-id-2>"],

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-fetch-by-id.py
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-fetch-by-id.py
@@ -16,8 +16,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(
         project_ids=[str(project.id)],
         ids=["<run-id-1>", "<run-id-2>"],

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-filter-errors-after.ts
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-filter-errors-after.ts
@@ -4,9 +4,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs = client.runs.query({
   project_ids: [project.id],
   has_error: true,

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-filter-errors.py
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-filter-errors.py
@@ -16,8 +16,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(project_ids=[str(project.id)], has_error=True)
 
 

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-filter-metadata-after.ts
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-filter-metadata-after.ts
@@ -5,9 +5,7 @@ import { Client } from "langsmith";
 
 const client = new Client();
 const filterStr = 'and(eq(metadata_key, "user_id"), eq(metadata_value, "u_123"))';
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs = client.runs.query({
   project_ids: [project.id],
   filter: filterStr,

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-filter-metadata.py
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-filter-metadata.py
@@ -18,8 +18,7 @@ from langsmith import Client
 async def main():
     client = Client()
     filter_str = 'and(eq(metadata_key, "user_id"), eq(metadata_value, "u_123"))'
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(project_ids=[str(project.id)], filter=filter_str)
 
 

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-filter-root-after.ts
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-filter-root-after.ts
@@ -4,9 +4,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs = client.runs.query({
   project_ids: [project.id],
   is_root: true,

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-filter-root.py
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-filter-root.py
@@ -16,8 +16,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(project_ids=[str(project.id)], is_root=True)
 
 

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-filter-time-range-after.ts
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-filter-time-range-after.ts
@@ -4,9 +4,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
 const runs = client.runs.query({
   project_ids: [project.id],

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-filter-time-range.py
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-filter-time-range.py
@@ -23,8 +23,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(
         project_ids=[str(project.id)],
         min_start_time=datetime.now() - timedelta(days=1),

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-list-all-after.ts
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-list-all-after.ts
@@ -4,8 +4,6 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs = client.runs.query({ project_ids: [project.id] });
 // :snippet-end:

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-list-all.py
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-list-all.py
@@ -16,8 +16,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(project_ids=[str(project.id)])
 
 

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-pagination-after.ts
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-pagination-after.ts
@@ -4,9 +4,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs: unknown[] = [];
 for await (const run of client.runs.query({
   project_ids: [project.id],

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-pagination.py
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-pagination.py
@@ -16,8 +16,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = []
     async for run in client.runs.query(
         project_ids=[str(project.id)],

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-scoped-filters-after.ts
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-scoped-filters-after.ts
@@ -4,9 +4,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs = client.runs.query({
   project_ids: [project.id],
   filter: 'eq(name, "RetrieveDocs")',

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-scoped-filters.py
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-scoped-filters.py
@@ -21,8 +21,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(
         project_ids=[str(project.id)],
         filter='eq(name, "RetrieveDocs")',

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-selecting-fields-after.ts
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-selecting-fields-after.ts
@@ -4,9 +4,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 // must explicitly list every field needed; default returns only id
 for await (const run of client.runs.query({
   project_ids: [project.id],

--- a/src/code-samples/langsmith/smithdb-migration/runs-query-selecting-fields.py
+++ b/src/code-samples/langsmith/smithdb-migration/runs-query-selecting-fields.py
@@ -22,8 +22,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     # must explicitly list every field needed; default returns only id
     async for run in client.runs.query(
         project_ids=[str(project.id)],

--- a/src/code-samples/langsmith/smithdb-migration/runs-retrieve-basic.py
+++ b/src/code-samples/langsmith/smithdb-migration/runs-retrieve-basic.py
@@ -10,9 +10,8 @@ async def find_run(project_id: str):
 async def get_project_id():
     from langsmith import Client as AsyncClient
     client = AsyncClient()
-    async for project in client.projects.list(name="default", limit=1):
-        return project.id
-    return None
+    project = await client.aread_project(project_name="default")
+    return project.id
 
 # :snippet-start: runs-retrieve-basic-before-py
 # :codegroup-tab: Before
@@ -37,8 +36,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     run_id = "<run-id>"
     start_time = "2026-06-01T12:00:00Z"
     # :remove-start:

--- a/src/code-samples/langsmith/smithdb-migration/runs-retrieve-by-id-after.ts
+++ b/src/code-samples/langsmith/smithdb-migration/runs-retrieve-by-id-after.ts
@@ -13,8 +13,7 @@ async function findRun(projectId: string) {
 import { Client } from "langsmith";
 
 const client = new Client();
-const projectPage = await client.projects.list({ name: "default", limit: 1 });
-const project = projectPage.getPaginatedItems()[0];
+const project = await client.readProject({ projectName: "default" });
 let runId = "<run-id>";
 let startTime = "2026-06-01T12:00:00Z";
 // :remove-start:

--- a/src/code-samples/langsmith/smithdb-migration/runs-retrieve-by-id.py
+++ b/src/code-samples/langsmith/smithdb-migration/runs-retrieve-by-id.py
@@ -10,9 +10,8 @@ async def find_run(project_id: str):
 async def get_project_id():
     from langsmith import Client as AsyncClient
     client = AsyncClient()
-    async for project in client.projects.list(name="default", limit=1):
-        return project.id
-    return None
+    project = await client.aread_project(project_name="default")
+    return project.id
 
 # :snippet-start: runs-retrieve-by-id-before-py
 # :codegroup-tab: Before
@@ -36,8 +35,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     run_id = "<run-id>"
     start_time="2026-06-01T12:00:00Z"
     # :remove-start:

--- a/src/snippets/code-samples/smithdb-migration/runs-query-boolean-filters-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-boolean-filters-after-js.mdx
@@ -6,9 +6,7 @@ const filterStr =
   'and(gt(start_time, "2023-07-15T12:34:56Z"),' +
   ' or(neq(status, "error"),' +
   '    and(eq(feedback_key, "Correctness"), eq(feedback_score, 0.0))))';
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs = client.runs.query({
   project_ids: [project.id],
   filter: filterStr,

--- a/src/snippets/code-samples/smithdb-migration/runs-query-boolean-filters-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-boolean-filters-after-py.mdx
@@ -11,8 +11,7 @@ async def main():
         ' or(neq(status, "error"),'
         '    and(eq(feedback_key, "Correctness"), eq(feedback_score, 0.0))))'
     )
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(project_ids=[str(project.id)], filter=filter_str)
 
 

--- a/src/snippets/code-samples/smithdb-migration/runs-query-fetch-by-id-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-fetch-by-id-after-js.mdx
@@ -2,9 +2,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs = client.runs.query({
   project_ids: [project.id],
   ids: ["<run-id-1>", "<run-id-2>"],

--- a/src/snippets/code-samples/smithdb-migration/runs-query-fetch-by-id-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-fetch-by-id-after-py.mdx
@@ -6,8 +6,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(
         project_ids=[str(project.id)],
         ids=["<run-id-1>", "<run-id-2>"],

--- a/src/snippets/code-samples/smithdb-migration/runs-query-filter-errors-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-filter-errors-after-js.mdx
@@ -2,9 +2,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs = client.runs.query({
   project_ids: [project.id],
   has_error: true,

--- a/src/snippets/code-samples/smithdb-migration/runs-query-filter-errors-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-filter-errors-after-py.mdx
@@ -6,8 +6,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(project_ids=[str(project.id)], has_error=True)
 
 

--- a/src/snippets/code-samples/smithdb-migration/runs-query-filter-metadata-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-filter-metadata-after-js.mdx
@@ -3,9 +3,7 @@ import { Client } from "langsmith";
 
 const client = new Client();
 const filterStr = 'and(eq(metadata_key, "user_id"), eq(metadata_value, "u_123"))';
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs = client.runs.query({
   project_ids: [project.id],
   filter: filterStr,

--- a/src/snippets/code-samples/smithdb-migration/runs-query-filter-metadata-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-filter-metadata-after-py.mdx
@@ -7,8 +7,7 @@ from langsmith import Client
 async def main():
     client = Client()
     filter_str = 'and(eq(metadata_key, "user_id"), eq(metadata_value, "u_123"))'
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(project_ids=[str(project.id)], filter=filter_str)
 
 

--- a/src/snippets/code-samples/smithdb-migration/runs-query-filter-root-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-filter-root-after-js.mdx
@@ -2,9 +2,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs = client.runs.query({
   project_ids: [project.id],
   is_root: true,

--- a/src/snippets/code-samples/smithdb-migration/runs-query-filter-root-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-filter-root-after-py.mdx
@@ -6,8 +6,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(project_ids=[str(project.id)], is_root=True)
 
 

--- a/src/snippets/code-samples/smithdb-migration/runs-query-filter-time-range-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-filter-time-range-after-js.mdx
@@ -2,9 +2,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const oneDayAgo = new Date(Date.now() - 24 * 60 * 60 * 1000);
 const runs = client.runs.query({
   project_ids: [project.id],

--- a/src/snippets/code-samples/smithdb-migration/runs-query-filter-time-range-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-filter-time-range-after-py.mdx
@@ -7,8 +7,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(
         project_ids=[str(project.id)],
         min_start_time=datetime.now() - timedelta(days=1),

--- a/src/snippets/code-samples/smithdb-migration/runs-query-list-all-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-list-all-after-js.mdx
@@ -2,8 +2,6 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs = client.runs.query({ project_ids: [project.id] });
 ```

--- a/src/snippets/code-samples/smithdb-migration/runs-query-list-all-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-list-all-after-py.mdx
@@ -6,8 +6,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(project_ids=[str(project.id)])
 
 

--- a/src/snippets/code-samples/smithdb-migration/runs-query-pagination-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-pagination-after-js.mdx
@@ -2,9 +2,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs: unknown[] = [];
 for await (const run of client.runs.query({
   project_ids: [project.id],

--- a/src/snippets/code-samples/smithdb-migration/runs-query-pagination-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-pagination-after-py.mdx
@@ -6,8 +6,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = []
     async for run in client.runs.query(
         project_ids=[str(project.id)],

--- a/src/snippets/code-samples/smithdb-migration/runs-query-scoped-filters-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-scoped-filters-after-js.mdx
@@ -2,9 +2,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 const runs = client.runs.query({
   project_ids: [project.id],
   filter: 'eq(name, "RetrieveDocs")',

--- a/src/snippets/code-samples/smithdb-migration/runs-query-scoped-filters-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-scoped-filters-after-py.mdx
@@ -6,8 +6,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     runs = client.runs.query(
         project_ids=[str(project.id)],
         filter='eq(name, "RetrieveDocs")',

--- a/src/snippets/code-samples/smithdb-migration/runs-query-selecting-fields-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-selecting-fields-after-js.mdx
@@ -2,9 +2,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const project = await client.projects
-  .list({ name: "default", limit: 1 })
-  .then((page) => page.getPaginatedItems()[0]);
+const project = await client.readProject({ projectName: "default" });
 // must explicitly list every field needed; default returns only id
 for await (const run of client.runs.query({
   project_ids: [project.id],

--- a/src/snippets/code-samples/smithdb-migration/runs-query-selecting-fields-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-selecting-fields-after-py.mdx
@@ -6,8 +6,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     # must explicitly list every field needed; default returns only id
     async for run in client.runs.query(
         project_ids=[str(project.id)],

--- a/src/snippets/code-samples/smithdb-migration/runs-retrieve-basic-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-retrieve-basic-after-py.mdx
@@ -6,8 +6,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     run_id = "<run-id>"
     start_time = "2026-06-01T12:00:00Z"
     run = await client.runs.retrieve(

--- a/src/snippets/code-samples/smithdb-migration/runs-retrieve-by-id-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-retrieve-by-id-after-js.mdx
@@ -2,8 +2,7 @@
 import { Client } from "langsmith";
 
 const client = new Client();
-const projectPage = await client.projects.list({ name: "default", limit: 1 });
-const project = projectPage.getPaginatedItems()[0];
+const project = await client.readProject({ projectName: "default" });
 let runId = "<run-id>";
 let startTime = "2026-06-01T12:00:00Z";
 await client.runs.retrieve(runId, {

--- a/src/snippets/code-samples/smithdb-migration/runs-retrieve-by-id-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-retrieve-by-id-after-py.mdx
@@ -6,8 +6,7 @@ from langsmith import Client
 
 async def main():
     client = Client()
-    async for project in client.projects.list(name="default", limit=1):
-        break
+    project = await client.aread_project(project_name="default")
     run_id = "<run-id>"
     start_time="2026-06-01T12:00:00Z"
     run = await client.runs.retrieve(

--- a/src/snippets/langsmith/smithdb-migration/runs-query.mdx
+++ b/src/snippets/langsmith/smithdb-migration/runs-query.mdx
@@ -140,7 +140,7 @@ Query runs from a project with optional filtering and field projection. Returns 
 <Tabs>
   <Tab title="Python">
     <Warning>
-    `project_name` is not supported in `runs.query`. Pass `project_ids` with the project UUID instead. To look up a UUID by name, use `client.projects.list(name="my-project", limit=1)`.
+    `project_name` is not supported in `runs.query`. Pass `project_ids` with the project UUID instead. To look up a UUID by name, use `client.read_project(project_name="my-project")`, or `await client.aread_project(project_name="my-project")` in async code.
     </Warning>
 
     <Warning>
@@ -172,7 +172,7 @@ Query runs from a project with optional filtering and field projection. Returns 
   </Tab>
   <Tab title="TypeScript">
     <Warning>
-    `projectName` is not supported in `client.runs.query`. Pass `project_ids` with the project UUID instead. To look up a UUID by name, use `client.projects.list({ name: "my-project", limit: 1 })`.
+    `projectName` is not supported in `client.runs.query`. Pass `project_ids` with the project UUID instead. To look up a UUID by name, use `client.readProject({ projectName: "my-project" })`.
     </Warning>
 
     <Warning>
@@ -615,7 +615,9 @@ Query runs from a project with optional filtering and field projection. Returns 
 
 <Tabs>
   <Tab title="Python">
-    `runs.query` does not accept a project name directly. Resolve the project UUID with `client.projects.list()` first, then pass it as a string in `project_ids`.
+    `runs.query` does not accept a project name directly. Resolve the project UUID with `client.aread_project()` first, then pass it as a string in `project_ids`.
+
+    <Note>Requires `langsmith>=0.9.8`.</Note>
 
 <Tabs sync={false}>
   <Tab title="Before">
@@ -628,7 +630,7 @@ Query runs from a project with optional filtering and field projection. Returns 
 
   </Tab>
   <Tab title="TypeScript">
-    `client.runs.query` does not accept a project name directly. Resolve the project UUID with `client.projects.list()` first, then pass it as a string in `project_ids`.
+    `client.runs.query` does not accept a project name directly. Resolve the project UUID with `client.readProject()` first, then pass it as a string in `project_ids`.
 
 <Tabs sync={false}>
   <Tab title="Before">

--- a/src/snippets/langsmith/smithdb-migration/runs-retrieve.mdx
+++ b/src/snippets/langsmith/smithdb-migration/runs-retrieve.mdx
@@ -454,7 +454,9 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
 
 <Tabs>
   <Tab title="Python">
-    `runs.retrieve` requires two additional parameters that `read_run` did not need: `project_id` (UUID) and `start_time`. Both are required by the SmithDB storage model to locate a run efficiently. Resolve the project UUID via `client.projects.list()` first.
+    `runs.retrieve` requires two additional parameters that `read_run` did not need: `project_id` (UUID) and `start_time`. Both are required by the SmithDB storage model to locate a run efficiently. Resolve the project UUID via `client.aread_project()` first.
+
+    <Note>Requires `langsmith>=0.9.8`.</Note>
 
 <Tabs sync={false}>
   <Tab title="Before">
@@ -467,7 +469,7 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
 
   </Tab>
   <Tab title="TypeScript">
-    `client.runs.retrieve` requires two additional parameters that `readRun` did not need: `project_id` (UUID) and `start_time`. Both are required by the SmithDB storage model to locate a run efficiently. Resolve the project UUID via `client.projects.list()` first.
+    `client.runs.retrieve` requires two additional parameters that `readRun` did not need: `project_id` (UUID) and `start_time`. Both are required by the SmithDB storage model to locate a run efficiently. Resolve the project UUID via `client.readProject()` first.
 
 <Tabs sync={false}>
   <Tab title="Before">
@@ -526,7 +528,7 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
   <Tab title="Python">
     `read_run` returns a full run object with no selection needed. `runs.retrieve` returns only `id` by default—pass `selects=[...]` to request more.
 
-    <Note>Requires `langsmith>=0.9.6`.</Note>
+    <Note>Requires `langsmith>=0.9.8`.</Note>
 
     <Tabs sync={false}>
       <Tab title="Before">

--- a/uv.lock
+++ b/uv.lock
@@ -707,7 +707,7 @@ requires-dist = [
     { name = "langgraph", specifier = ">=1.2.5" },
     { name = "langgraph-checkpoint-postgres" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=3.1.0" },
-    { name = "langsmith", specifier = ">=0.9.6" },
+    { name = "langsmith", specifier = ">=0.9.8" },
     { name = "markdownify", specifier = ">=0.13.0" },
     { name = "nbconvert", specifier = ">=7.17.1" },
     { name = "nbformat", specifier = ">=5.0.0" },
@@ -1378,7 +1378,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.9.6"
+version = "0.9.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1396,9 +1396,9 @@ dependencies = [
     { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/dc/ca2ab3b74f3a5a2089aee1483e86b6aa7ae15fba96f73866a16e31356319/langsmith-0.9.6.tar.gz", hash = "sha256:1df590a40352b2f40a36229d90e2ef6af276a0bc9f1e44a87b829f879eed2130", size = 4714803, upload-time = "2026-07-02T11:14:30.636Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0c/68/8d8471233ee0cd82c2af946d76f80a01aeb8bb04160c392c1229fddf5d3d/langsmith-0.9.8.tar.gz", hash = "sha256:8c3d6a6d5246a3ea6d439b726d59edefba31dfb251de9eedb256119bbea4439e", size = 4710812, upload-time = "2026-07-06T19:06:10.866Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bf/8f/6e8f1f3e12be9848993c297c879f63f225361eb594f8343ff42c2b26c6fd/langsmith-0.9.6-py3-none-any.whl", hash = "sha256:c5e5f2425dcb8fe363b9e1fa87a9cb9cf5631389bf7e168aa4f325f580ca284c", size = 660131, upload-time = "2026-07-02T11:14:28.552Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/67/a85caaa99117bbc988a0df7faa39e7f68344361854638d86bcce0ffe3619/langsmith-0.9.8-py3-none-any.whl", hash = "sha256:098da9fc6c184284f17913cb813a41e28c5ab1508e90bd50db40c28166681017", size = 671148, upload-time = "2026-07-06T19:06:08.911Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Replace the `client.projects.list()`-based project UUID lookup in the SmithDB SDK migration guide's Python and TypeScript examples with the single-project lookup methods: `client.read_project()` / `client.aread_project()` (Python) and `client.readProject()` (TypeScript).
- Bump the pinned `langsmith` dependency to `>=0.9.8` (first release containing `aread_project`) in `pyproject.toml`/`uv.lock`, and add matching `Requires langsmith>=0.9.8` version-added notes next to each Python example that now calls `aread_project`.