### PR TITLE
docs: add deepagents v0.7.0 alpha changelog entry

### DIFF
--- a/src/oss/python/releases/changelog.mdx
+++ b/src/oss/python/releases/changelog.mdx
@@ -18,7 +18,9 @@ rss: true
     - **[Override a default middleware instance](/oss/deepagents/customization#override-a-default-middleware-instance)**: A `middleware=` (or subagent `middleware`) instance whose `.name` matches a default now replaces that default in place, instead of erroring on duplicate middleware.
     - **[Restrict filesystem tools](/oss/deepagents/overview#virtual-filesystem-access)**: `FilesystemMiddleware` now accepts a `tools` allowlist to expose only a subset of the built-in filesystem tools to the model, building on the middleware-override behavior above.
 
-    Python only — the `deepagents` JS SDK has not adopted these changes yet.
+<Note> 
+The above changes are available only in the `deepagents` Python SDK.
+</Note>
 </Update>
 <Update label="May 12, 2026" tags={["deepagents"]} rss={{ title: "May 12, 2026 - langchain" }}>
     ## `deepagents` v0.6.0

--- a/src/oss/python/releases/changelog.mdx
+++ b/src/oss/python/releases/changelog.mdx
@@ -10,6 +10,16 @@ rss: true
 </Callout>
 
 
+<Update label="Jul 7, 2026" tags={["deepagents"]} rss={{ title: "Jul 7, 2026 - deepagents" }}>
+    ## `deepagents` v0.7.0
+
+    - **New [`delete`](/oss/deepagents/tools#built-in-harness-tools) filesystem tool**: Delete a file, or recursively delete a directory and its contents. Backends that don't support deletion have the tool automatically hidden from the model.
+    - **`write_file` now overwrites existing files**: `write_file` used to error if the target file already existed. It now overwrites it — use `edit_file` for targeted changes to an existing file.
+    - **[Override a default middleware instance](/oss/deepagents/customization#override-a-default-middleware-instance)**: A `middleware=` (or subagent `middleware`) instance whose `.name` matches a default now replaces that default in place, instead of erroring on duplicate middleware.
+    - **[Restrict filesystem tools](/oss/deepagents/overview#virtual-filesystem-access)**: `FilesystemMiddleware` now accepts a `tools` allowlist to expose only a subset of the built-in filesystem tools to the model, building on the middleware-override behavior above.
+
+    Python only — the `deepagents` JS SDK has not adopted these changes yet.
+</Update>
 <Update label="May 12, 2026" tags={["deepagents"]} rss={{ title: "May 12, 2026 - langchain" }}>
     ## `deepagents` v0.6.0
 


### PR DESCRIPTION
## Description

Adds a single consolidated changelog entry for the `deepagents` 0.7.0 alpha releases, covering the `delete` filesystem tool, `write_file` overwrite behavior, default middleware override by name, and the `FilesystemMiddleware` tools allowlist (already documented in #4746, #4680, #4701). Individual alpha versions (a1, a2, ...) are not called out separately.

## Test Plan
- [ ] `npx markdownlint-cli src/oss/python/releases/changelog.mdx` — no new lint errors introduced by this change

_Opened collaboratively by Nishitha Madhu and open-swe_