### PR TITLE
docs: update evaluator SDK Python async examples

### DIFF
--- a/src/langsmith/evaluators.mdx
+++ b/src/langsmith/evaluators.mdx
@@ -60,24 +60,31 @@ You can also add an evaluator directly from a [tracing project](/langsmith/obser
 Use the LangSmith SDK to create evaluators programmatically. The SDK is available for [Python](/langsmith/smith-python-sdk) and [TypeScript](/langsmith/smith-js-ts-sdk). Evaluators created through the SDK appear in the **Evaluators** table alongside those created in the UI.
 
 <Note>
-Managing evaluators through the SDK requires `langsmith>=0.9.8` (Python, PyPI) or `langsmith>=0.7.16` (TypeScript, npm).
+Managing evaluators through the SDK requires `langsmith>=0.9.8` (Python, PyPI) or `langsmith>=0.7.16` (TypeScript, npm). In the current Python SDK, `Client().evaluators` methods are async, so call them with `await` inside an async function.
 </Note>
 
 <CodeGroup>
 ```python Python
+import asyncio
+
 from langsmith import Client
 
-client = Client()
 
-created = client.evaluators.create(
-    name="Correctness evaluator",
-    type="code",
-    code_evaluator={
-        "code": "def perform_eval(run, example):\n    return {'score': 1}",
-        "language": "python",
-    },
-)
-print("Created evaluator:", created.evaluator.id)
+async def main():
+    client = Client()
+
+    created = await client.evaluators.create(
+        name="Correctness evaluator",
+        type="code",
+        code_evaluator={
+            "code": "def perform_eval(run, example):\n    return {'score': 1}",
+            "language": "python",
+        },
+    )
+    print("Created evaluator:", created.evaluator.id)
+
+
+asyncio.run(main())
 ```
 ```typescript TypeScript
 import { Client } from "langsmith";

--- a/src/langsmith/evaluators.mdx
+++ b/src/langsmith/evaluators.mdx
@@ -60,7 +60,7 @@ You can also add an evaluator directly from a [tracing project](/langsmith/obser
 Use the LangSmith SDK to create evaluators programmatically. The SDK is available for [Python](/langsmith/smith-python-sdk) and [TypeScript](/langsmith/smith-js-ts-sdk). Evaluators created through the SDK appear in the **Evaluators** table alongside those created in the UI.
 
 <Note>
-Managing evaluators through the SDK requires `langsmith>=0.9.8` (Python, PyPI) or `langsmith>=0.7.16` (TypeScript, npm). In the current Python SDK, `Client().evaluators` methods are async, so call them with `await` inside an async function.
+Managing evaluators through the SDK requires `langsmith>=0.9.8` (Python, PyPI) or `langsmith>=0.7.16` (TypeScript, npm).
 </Note>
 
 <CodeGroup>

--- a/src/langsmith/manage-evaluators-sdk.mdx
+++ b/src/langsmith/manage-evaluators-sdk.mdx
@@ -21,7 +21,7 @@ For installation and setup, refer to the [Python SDK documentation](https://refe
 
 The examples on this page initialize the client with no arguments, so it reads the `LANGSMITH_API_KEY` and `LANGSMITH_ENDPOINT` environment variables. Configure your [API key](/langsmith/create-account-api-key) through environment variables rather than hardcoding it.
 
-In the following examples, replace placeholders such as `<evaluator-uuid>` with the corresponding information from LangSmith.
+In the following examples, replace placeholders such as `<evaluator-uuid>` with the corresponding information from LangSmith. All Python async examples on this page assume they run inside `async def main(): ... asyncio.run(main())`, as shown in the create a code evaluator example.
 
 ## Create an evaluator
 
@@ -81,20 +81,31 @@ The prompt must be a structured prompt (type `StructuredPrompt`). A `StructuredP
 
 <CodeGroup>
 ```python Python
-created = await client.evaluators.create(
-    name="LLM judge",
-    type="llm",
-    llm_evaluator={
-        "prompt_repo_handle": "<prompt-repo-handle>",
-        "commit_hash_or_tag": "<commit-hash-or-tag>",
-        "variable_mapping": {
-            "input": "inputs.question",
-            "output": "outputs.answer",
-            "reference": "reference.answer",
+import asyncio
+
+from langsmith import Client
+
+
+async def main():
+    client = Client()
+
+    created = await client.evaluators.create(
+        name="LLM judge",
+        type="llm",
+        llm_evaluator={
+            "prompt_repo_handle": "<prompt-repo-handle>",
+            "commit_hash_or_tag": "<commit-hash-or-tag>",
+            "variable_mapping": {
+                "input": "inputs.question",
+                "output": "outputs.answer",
+                "reference": "reference.answer",
+            },
         },
-    },
-)
-evaluator_id = created.evaluator.id
+    )
+    evaluator_id = created.evaluator.id
+
+
+asyncio.run(main())
 ```
 ```typescript TypeScript
 const created = await client.evaluators.create({
@@ -156,11 +167,23 @@ Fetch a single evaluator by its ID to read its configuration, including its name
 
 <CodeGroup>
 ```python Python
-evaluator = await client.evaluators.retrieve(evaluator_id)
-print(evaluator.name)
-print(evaluator.type)
-print(evaluator.feedback_keys)
-print(evaluator.run_rules)
+import asyncio
+
+from langsmith import Client
+
+
+async def main():
+    client = Client()
+    evaluator_id = "<evaluator-uuid>"
+
+    evaluator = await client.evaluators.retrieve(evaluator_id)
+    print(evaluator.name)
+    print(evaluator.type)
+    print(evaluator.feedback_keys)
+    print(evaluator.run_rules)
+
+
+asyncio.run(main())
 ```
 ```typescript TypeScript
 const evaluator = await client.evaluators.retrieve(evaluatorId);
@@ -177,30 +200,41 @@ Pass the field that matches the evaluator type: `code_evaluator` for a code eval
 
 <CodeGroup>
 ```python Python
-# Update a code evaluator
-code_evaluator_id = "<code-evaluator-uuid>"
+import asyncio
 
-updated = await client.evaluators.update(
-    code_evaluator_id,
-    name="Updated correctness evaluator",
-    code_evaluator={
-        "code": "def perform_eval(run, example):\n    return {'score': 0.8}",
-        "language": "python",
-    },
-)
-print(updated.evaluator.name if updated.evaluator else None)
+from langsmith import Client
 
-# Update the name and prompt of an LLM-as-a-judge evaluator
-llm_evaluator_id = "<llm-evaluator-uuid>"
 
-await client.evaluators.update(
-    llm_evaluator_id,
-    name="Updated LLM judge",
-    llm_evaluator={
-        "prompt_repo_handle": "<prompt-repo-handle>",
-        "commit_hash_or_tag": "<commit-hash-or-tag>",
-    },
-)
+async def main():
+    client = Client()
+
+    # Update a code evaluator
+    code_evaluator_id = "<code-evaluator-uuid>"
+
+    updated = await client.evaluators.update(
+        code_evaluator_id,
+        name="Updated correctness evaluator",
+        code_evaluator={
+            "code": "def perform_eval(run, example):\n    return {'score': 0.8}",
+            "language": "python",
+        },
+    )
+    print(updated.evaluator.name if updated.evaluator else None)
+
+    # Update the name and prompt of an LLM-as-a-judge evaluator
+    llm_evaluator_id = "<llm-evaluator-uuid>"
+
+    await client.evaluators.update(
+        llm_evaluator_id,
+        name="Updated LLM judge",
+        llm_evaluator={
+            "prompt_repo_handle": "<prompt-repo-handle>",
+            "commit_hash_or_tag": "<commit-hash-or-tag>",
+        },
+    )
+
+
+asyncio.run(main())
 ```
 ```typescript TypeScript
 // Update a code evaluator
@@ -241,21 +275,31 @@ These settings take effect on the next evaluation run, not when you call `update
 
 <CodeGroup>
 ```python Python
-llm_evaluator_id = "<llm-evaluator-uuid>"
+import asyncio
 
-await client.evaluators.update(
-    llm_evaluator_id,
-    llm_evaluator={
-        "prompt_repo_handle": "<prompt-repo-handle>",
-        "commit_hash_or_tag": "<commit-hash-or-tag>",
-        "variable_mapping": {
-            "input": "inputs.question",
-            "output": "outputs.answer",
+from langsmith import Client
+
+
+async def main():
+    client = Client()
+    llm_evaluator_id = "<llm-evaluator-uuid>"
+
+    await client.evaluators.update(
+        llm_evaluator_id,
+        llm_evaluator={
+            "prompt_repo_handle": "<prompt-repo-handle>",
+            "commit_hash_or_tag": "<commit-hash-or-tag>",
+            "variable_mapping": {
+                "input": "inputs.question",
+                "output": "outputs.answer",
+            },
+            "use_corrections_dataset": True,
+            "num_few_shot_examples": 3,
         },
-        "use_corrections_dataset": True,
-        "num_few_shot_examples": 3,
-    },
-)
+    )
+
+
+asyncio.run(main())
 ```
 ```typescript TypeScript
 const llmEvaluatorId = "<llm-evaluator-uuid>";
@@ -281,33 +325,44 @@ Filter by name, type, feedback key, attached resource, or tag value, and sort or
 
 <CodeGroup>
 ```python Python
-# Read a single page of results
-page = await client.evaluators.list(
-    name_contains="correctness",
-    type="code",
-    limit=10,
-)
-for evaluator in page.evaluators:
-    print(evaluator.id, evaluator.name, evaluator.type)
+import asyncio
 
-# Collect every match into a list
-evaluators = [
-    evaluator
-    async for evaluator in client.evaluators.list(feedback_key="correctness", limit=20)
-]
+from langsmith import Client
 
-# Filter, sort, and paginate
-page = await client.evaluators.list(
-    feedback_key="correctness",
-    name_contains="judge",
-    resource_id=["<project-or-dataset-uuid>"],
-    tag_value_id=["<tag-value-uuid>"],
-    type="llm",
-    sort_by="updated_at",  # "created_at" (default) or "updated_at"
-    sort_by_desc=False,
-    limit=20,
-    offset=0,
-)
+
+async def main():
+    client = Client()
+
+    # Read a single page of results
+    page = await client.evaluators.list(
+        name_contains="correctness",
+        type="code",
+        limit=10,
+    )
+    for evaluator in page.evaluators:
+        print(evaluator.id, evaluator.name, evaluator.type)
+
+    # Collect every match into a list
+    evaluators = [
+        evaluator
+        async for evaluator in client.evaluators.list(feedback_key="correctness", limit=20)
+    ]
+
+    # Filter, sort, and paginate
+    page = await client.evaluators.list(
+        feedback_key="correctness",
+        name_contains="judge",
+        resource_id=["<project-or-dataset-uuid>"],
+        tag_value_id=["<tag-value-uuid>"],
+        type="llm",
+        sort_by="updated_at",  # "created_at" (default) or "updated_at"
+        sort_by_desc=False,
+        limit=20,
+        offset=0,
+    )
+
+
+asyncio.run(main())
 ```
 ```typescript TypeScript
 // Read a single page of results
@@ -359,46 +414,56 @@ Pass exactly one of `group_by`, `evaluator_id`, `session_id` (the LangSmith trac
 
 <CodeGroup>
 ```python Python
-evaluator_uuid = "<evaluator-uuid>"
-start_date = "<period-start-date>" # for example, "2026-06-29"
+import asyncio
 
-# Spend for a single evaluator
-spend = await client.evaluators.spend(
-    period_start=start_date,
-    evaluator_id=evaluator_uuid,
-)
-for group in spend.groups or []:
-    print(group.evaluator_name, group.total_spend_usd, group.total_trace_count)
+from langsmith import Client
 
-# Group spend by evaluator
-spend_by_evaluator = await client.evaluators.spend(
-    period_start=start_date,
-    group_by="evaluator",
-    type="llm",
-)
-print("Group by evaluator")
-for group in spend_by_evaluator.groups or []:
-    print(group.evaluator_name, group.total_spend_usd, group.total_trace_count)
 
-# Group spend by resource
-spend_by_resource = await client.evaluators.spend(
-    period_start=start_date,
-    group_by="resource",
-    type="llm",
-)
-print("Group by resource")
-for group in spend_by_resource.groups or []:
-    print(group.session_name, group.dataset_name, group.total_spend_usd, group.total_trace_count)
+async def main():
+    client = Client()
+    evaluator_uuid = "<evaluator-uuid>"
+    start_date = "<period-start-date>" # for example, "2026-06-29"
 
-# Group spend by run_rule
-spend_by_run_rule = await client.evaluators.spend(
-    period_start=start_date,
-    group_by="run_rule",
-    type="llm",
-)
-print("Group by run_rule")
-for group in spend_by_run_rule.groups or []:
-    print(group.run_rule_name, group.total_spend_usd, group.total_trace_count)
+    # Spend for a single evaluator
+    spend = await client.evaluators.spend(
+        period_start=start_date,
+        evaluator_id=evaluator_uuid,
+    )
+    for group in spend.groups or []:
+        print(group.evaluator_name, group.total_spend_usd, group.total_trace_count)
+
+    # Group spend by evaluator
+    spend_by_evaluator = await client.evaluators.spend(
+        period_start=start_date,
+        group_by="evaluator",
+        type="llm",
+    )
+    print("Group by evaluator")
+    for group in spend_by_evaluator.groups or []:
+        print(group.evaluator_name, group.total_spend_usd, group.total_trace_count)
+
+    # Group spend by resource
+    spend_by_resource = await client.evaluators.spend(
+        period_start=start_date,
+        group_by="resource",
+        type="llm",
+    )
+    print("Group by resource")
+    for group in spend_by_resource.groups or []:
+        print(group.session_name, group.dataset_name, group.total_spend_usd, group.total_trace_count)
+
+    # Group spend by run_rule
+    spend_by_run_rule = await client.evaluators.spend(
+        period_start=start_date,
+        group_by="run_rule",
+        type="llm",
+    )
+    print("Group by run_rule")
+    for group in spend_by_run_rule.groups or []:
+        print(group.run_rule_name, group.total_spend_usd, group.total_trace_count)
+
+
+asyncio.run(main())
 ```
 ```typescript TypeScript
 const evaluatorUUID = "<evaluator-uuid>";
@@ -454,12 +519,22 @@ You cannot delete an evaluator while it is attached to a tracing project or data
 
 <CodeGroup>
 ```python Python
-evaluator_id = "<evaluator-uuid>"
+import asyncio
 
-await client.evaluators.delete(
-    evaluator_id,
-    delete_run_rules=True, # run rules referencing the evaluator are deleted first
-)
+from langsmith import Client
+
+
+async def main():
+    client = Client()
+    evaluator_id = "<evaluator-uuid>"
+
+    await client.evaluators.delete(
+        evaluator_id,
+        delete_run_rules=True, # run rules referencing the evaluator are deleted first
+    )
+
+
+asyncio.run(main())
 ```
 ```typescript TypeScript
 const evaluatorId = "<evaluator-uuid>";

--- a/src/langsmith/manage-evaluators-sdk.mdx
+++ b/src/langsmith/manage-evaluators-sdk.mdx
@@ -21,8 +21,6 @@ For installation and setup, refer to the [Python SDK documentation](https://refe
 
 The examples on this page initialize the client with no arguments, so it reads the `LANGSMITH_API_KEY` and `LANGSMITH_ENDPOINT` environment variables. Configure your [API key](/langsmith/create-account-api-key) through environment variables rather than hardcoding it.
 
-In the current Python SDK, `Client().evaluators` methods are async, so call them with `await` inside an async function, such as `asyncio.run(main())`.
-
 In the following examples, replace placeholders such as `<evaluator-uuid>` with the corresponding information from LangSmith.
 
 ## Create an evaluator

--- a/src/langsmith/manage-evaluators-sdk.mdx
+++ b/src/langsmith/manage-evaluators-sdk.mdx
@@ -21,6 +21,8 @@ For installation and setup, refer to the [Python SDK documentation](https://refe
 
 The examples on this page initialize the client with no arguments, so it reads the `LANGSMITH_API_KEY` and `LANGSMITH_ENDPOINT` environment variables. Configure your [API key](/langsmith/create-account-api-key) through environment variables rather than hardcoding it.
 
+In the current Python SDK, `Client().evaluators` methods are async, so call them with `await` inside an async function, such as `asyncio.run(main())`.
+
 In the following examples, replace placeholders such as `<evaluator-uuid>` with the corresponding information from LangSmith.
 
 ## Create an evaluator
@@ -31,20 +33,27 @@ A code evaluator scores each run or example with a function that you define.
 
 <CodeGroup>
 ```python Python
+import asyncio
+
 from langsmith import Client
 
-client = Client()
 
-created = client.evaluators.create(
-    name="Correctness evaluator",
-    type="code",
-    code_evaluator={
-        "code": "def perform_eval(run, example):\n    return {'score': 1}",
-        "language": "python",
-    },
-)
-evaluator_id = created.evaluator.id
-print("Created evaluator:", evaluator_id)
+async def main():
+    client = Client()
+
+    created = await client.evaluators.create(
+        name="Correctness evaluator",
+        type="code",
+        code_evaluator={
+            "code": "def perform_eval(run, example):\n    return {'score': 1}",
+            "language": "python",
+        },
+    )
+    evaluator_id = created.evaluator.id
+    print("Created evaluator:", evaluator_id)
+
+
+asyncio.run(main())
 ```
 ```typescript TypeScript
 import { Client } from "langsmith";
@@ -74,7 +83,7 @@ The prompt must be a structured prompt (type `StructuredPrompt`). A `StructuredP
 
 <CodeGroup>
 ```python Python
-created = client.evaluators.create(
+created = await client.evaluators.create(
     name="LLM judge",
     type="llm",
     llm_evaluator={
@@ -149,7 +158,7 @@ Fetch a single evaluator by its ID to read its configuration, including its name
 
 <CodeGroup>
 ```python Python
-evaluator = client.evaluators.retrieve(evaluator_id)
+evaluator = await client.evaluators.retrieve(evaluator_id)
 print(evaluator.name)
 print(evaluator.type)
 print(evaluator.feedback_keys)
@@ -173,7 +182,7 @@ Pass the field that matches the evaluator type: `code_evaluator` for a code eval
 # Update a code evaluator
 code_evaluator_id = "<code-evaluator-uuid>"
 
-updated = client.evaluators.update(
+updated = await client.evaluators.update(
     code_evaluator_id,
     name="Updated correctness evaluator",
     code_evaluator={
@@ -186,7 +195,7 @@ print(updated.evaluator.name if updated.evaluator else None)
 # Update the name and prompt of an LLM-as-a-judge evaluator
 llm_evaluator_id = "<llm-evaluator-uuid>"
 
-client.evaluators.update(
+await client.evaluators.update(
     llm_evaluator_id,
     name="Updated LLM judge",
     llm_evaluator={
@@ -236,7 +245,7 @@ These settings take effect on the next evaluation run, not when you call `update
 ```python Python
 llm_evaluator_id = "<llm-evaluator-uuid>"
 
-client.evaluators.update(
+await client.evaluators.update(
     llm_evaluator_id,
     llm_evaluator={
         "prompt_repo_handle": "<prompt-repo-handle>",
@@ -275,7 +284,7 @@ Filter by name, type, feedback key, attached resource, or tag value, and sort or
 <CodeGroup>
 ```python Python
 # Read a single page of results
-page = client.evaluators.list(
+page = await client.evaluators.list(
     name_contains="correctness",
     type="code",
     limit=10,
@@ -284,12 +293,13 @@ for evaluator in page.evaluators:
     print(evaluator.id, evaluator.name, evaluator.type)
 
 # Collect every match into a list
-evaluators = list(
-    client.evaluators.list(feedback_key="correctness", limit=20)
-)
+evaluators = [
+    evaluator
+    async for evaluator in client.evaluators.list(feedback_key="correctness", limit=20)
+]
 
 # Filter, sort, and paginate
-evaluators = client.evaluators.list(
+page = await client.evaluators.list(
     feedback_key="correctness",
     name_contains="judge",
     resource_id=["<project-or-dataset-uuid>"],
@@ -355,7 +365,7 @@ evaluator_uuid = "<evaluator-uuid>"
 start_date = "<period-start-date>" # for example, "2026-06-29"
 
 # Spend for a single evaluator
-spend = client.evaluators.spend(
+spend = await client.evaluators.spend(
     period_start=start_date,
     evaluator_id=evaluator_uuid,
 )
@@ -363,7 +373,7 @@ for group in spend.groups or []:
     print(group.evaluator_name, group.total_spend_usd, group.total_trace_count)
 
 # Group spend by evaluator
-spend_by_evaluator = client.evaluators.spend(
+spend_by_evaluator = await client.evaluators.spend(
     period_start=start_date,
     group_by="evaluator",
     type="llm",
@@ -373,7 +383,7 @@ for group in spend_by_evaluator.groups or []:
     print(group.evaluator_name, group.total_spend_usd, group.total_trace_count)
 
 # Group spend by resource
-spend_by_resource = client.evaluators.spend(
+spend_by_resource = await client.evaluators.spend(
     period_start=start_date,
     group_by="resource",
     type="llm",
@@ -383,7 +393,7 @@ for group in spend_by_resource.groups or []:
     print(group.session_name, group.dataset_name, group.total_spend_usd, group.total_trace_count)
 
 # Group spend by run_rule
-spend_by_run_rule = client.evaluators.spend(
+spend_by_run_rule = await client.evaluators.spend(
     period_start=start_date,
     group_by="run_rule",
     type="llm",
@@ -448,7 +458,7 @@ You cannot delete an evaluator while it is attached to a tracing project or data
 ```python Python
 evaluator_id = "<evaluator-uuid>"
 
-client.evaluators.delete(
+await client.evaluators.delete(
     evaluator_id,
     delete_run_rules=True, # run rules referencing the evaluator are deleted first
 )


### PR DESCRIPTION
## Summary
- Update Python evaluator SDK examples to use `await` with `Client().evaluators` methods.
- Add notes clarifying that current Python evaluator methods are async and should run inside an async function.
- Adjust list examples to await a page or async-iterate the paginator.

## Test plan
- `git diff --check`


Made with [Cursor](https://cursor.com)