### PR TITLE
fix: update support query docs

### DIFF
--- a/src/langsmith/script-running-pg-support-queries.mdx
+++ b/src/langsmith/script-running-pg-support-queries.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Run support queries against PostgreSQL
 
 This Helm repository contains queries to produce output that the LangSmith UI does not currently support directly (e.g. obtaining trace counts for multiple organizations in a single query).
 
-This command takes a postgres connection string that contains an embedded name and password (which can be passed in from a call to a secrets manager) and executes a query from an input file. In the example below, we are using the `pg_get_trace_counts_daily.sql` input file in the `support_queries/postgres` directory.
+This command takes a PostgreSQL connection string that contains an embedded name and password (which can be passed in from a call to a secrets manager) and executes a query from an input file. The following example uses the `pg_get_historic_trace_counts_daily.sql` input file in the `support_queries/postgres` directory.
 
 ## Prerequisites
 
@@ -50,7 +50,7 @@ sh run_support_query_pg.sh <postgres_url> --input path/to/query.sql
 For example, if you are using the bundled version with port-forwarding, the command might look like:
 
 ```bash
-sh run_support_query_pg.sh "postgres://postgres:postgres@localhost:5432/postgres" --input support_queries/pg_get_trace_counts_daily.sql
+sh run_support_query_pg.sh "postgres://postgres:postgres@localhost:5432/postgres" --input support_queries/postgres/pg_get_historic_trace_counts_daily.sql
 ```
 
 which will output the count of daily traces by workspace ID and organization ID. To extract this to a file add the flag `--output path/to/file.csv`

--- a/src/langsmith/self-host-organization-charts.mdx
+++ b/src/langsmith/self-host-organization-charts.mdx
@@ -40,7 +40,7 @@ For installations using offline keys or when you need more detailed export capab
 
 ```bash
 sh run_support_query_pg.sh "postgres://postgres:postgres@localhost:5432/postgres" \
-  --input support_queries/pg_get_trace_counts_daily.sql \
+  --input support_queries/postgres/pg_get_historic_trace_counts_daily.sql \
   --output trace_counts.csv
 ```
 


### PR DESCRIPTION
## Description
Updates LangSmith docs to reference the existing `pg_get_historic_trace_counts_daily.sql` PostgreSQL support query and include the `support_queries/postgres` path used by the Helm repository.

## Test Plan
- [x] `PATH="/tmp/bin:$PATH" make -C /workspace/docs lint_prose FILES="src/langsmith/script-running-pg-support-queries.mdx src/langsmith/self-host-organization-charts.mdx"`
- [x] Confirmed no remaining `pg_get_trace_counts_daily.sql` references under `src/langsmith`.

Made by [Open SWE](https://openswe.vercel.app/agents/cedbd22f-bf7c-4fa5-52e4-a0f99dc7845e)