### PR TITLE
docs: add AI-agent migration prompt and consolidate SDK version requirements

### DIFF
--- a/src/langsmith/smithdb-sdk-migration.mdx
+++ b/src/langsmith/smithdb-sdk-migration.mdx
@@ -21,6 +21,40 @@ SmithDB-powered methods are now available to SDK users in eligible regions.
 | EU and other SaaS regions | Methods are available but not yet backed by SmithDB. |
 | Self-hosted | Supported starting with self-hosted version 0.16.0. |
 
+## Minimum SDK version
+
+The SmithDB-backed methods require a minimum SDK version:
+
+| Language | Package | Minimum version |
+|---|---|---|
+| Python | `langsmith` | `>=0.9.8` |
+| TypeScript | `langsmith` | `>=0.7.15` |
+| Java | `langsmith-java` | `0.1.0-beta.11` |
+| Go | `langsmith-go` | `v0.17.0` |
+
+## Migrate with an AI agent
+
+This guide is written to be fetched and applied directly by an AI coding agent. Copy the following prompt into your agent to migrate your codebase to the SmithDB-backed methods.
+
+```text
+Migrate this codebase's LangSmith SDK usage to the new SmithDB-backed methods.
+
+Fetch https://docs.langchain.com/langsmith/smithdb-sdk-migration.md and treat it
+as the source of truth for what changed, including which methods and
+parameters are affected, what replaces them, and deployment support.
+
+1. Check the installed LangSmith SDK version against the minimum version
+   required for the SmithDB-backed methods per the guide, and upgrade the
+   dependency if it does not meet that minimum.
+2. Identify every call site in this codebase that uses a method the guide
+   marks as migrated, in whichever language(s) this codebase uses.
+3. For each call site, apply the corresponding before/after change from the
+   guide, including any added, removed, or renamed parameters.
+
+If a call site or parameter is not covered by the guide, stop and ask rather
+than guessing.
+```
+
 <SmithdbMigrationRunsQuery />
 
 <SmithdbMigrationRunsRetrieve />

--- a/src/snippets/langsmith/smithdb-migration/runs-query.mdx
+++ b/src/snippets/langsmith/smithdb-migration/runs-query.mdx
@@ -617,8 +617,6 @@ Query runs from a project with optional filtering and field projection. Returns 
   <Tab title="Python">
     `runs.query` does not accept a project name directly. Resolve the project UUID with `client.aread_project()` first, then pass it as a string in `project_ids`.
 
-    <Note>Requires `langsmith>=0.9.8`.</Note>
-
 <Tabs sync={false}>
   <Tab title="Before">
     <SmithdbRunsQueryListAllBeforePy />

--- a/src/snippets/langsmith/smithdb-migration/runs-retrieve.mdx
+++ b/src/snippets/langsmith/smithdb-migration/runs-retrieve.mdx
@@ -456,8 +456,6 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
   <Tab title="Python">
     `runs.retrieve` requires two additional parameters that `read_run` did not need: `project_id` (UUID) and `start_time`. Both are required by the SmithDB storage model to locate a run efficiently. Resolve the project UUID via `client.aread_project()` first.
 
-    <Note>Requires `langsmith>=0.9.8`.</Note>
-
 <Tabs sync={false}>
   <Tab title="Before">
     <SmithdbRunsRetrieveByIdBeforePy />
@@ -528,8 +526,6 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
   <Tab title="Python">
     `read_run` returns a full run object with no selection needed. `runs.retrieve` returns only `id` by default—pass `selects=[...]` to request more.
 
-    <Note>Requires `langsmith>=0.9.8`.</Note>
-
     <Tabs sync={false}>
       <Tab title="Before">
         <SmithdbRunsRetrieveBasicBeforePy />
@@ -541,8 +537,6 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
   </Tab>
   <Tab title="TypeScript">
     `readRun` returns a full run object with no selection needed. `client.runs.retrieve` returns only `id` by default—pass `selects: [...]` to request more.
-
-    <Note>Requires `langsmith@>=0.7.15`.</Note>
 
     <Tabs sync={false}>
       <Tab title="Before">
@@ -556,8 +550,6 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
   <Tab title="Java">
     `.retrieve()` returns a full run object with no selection needed. `.retrieveV2()` returns only `id` by default—call `.addSelect(...)` for each field you need.
 
-    <Note>Requires `langsmith-java` 0.1.0-beta.11.</Note>
-
     <Tabs sync={false}>
       <Tab title="Before">
         <SmithdbRunsRetrieveBasicBeforeKt />
@@ -569,8 +561,6 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
   </Tab>
   <Tab title="Go">
     `Get` returns a full run struct with no selection needed. `GetV2` returns only `ID` by default—pass `Selects` with the fields you need.
-
-    <Note>Requires `langsmith-go` v0.17.0.</Note>
 
     <Tabs sync={false}>
       <Tab title="Before">


### PR DESCRIPTION
## Summary
- Add a "Migrate with an AI agent" section to the SmithDB SDK migration page with a copy/paste prompt clients can hand to a coding agent to perform the migration
- Add a "Minimum SDK version" section consolidating the per-language version requirements (Python `langsmith>=0.9.8`, TypeScript `langsmith>=0.7.15`, Java `langsmith-java 0.1.0-beta.11`, Go `langsmith-go v0.17.0`) that were previously scattered as inline `<Note>` callouts across the runs-query and runs-retrieve snippets
- Remove the now-redundant inline version notes from `runs-query.mdx` and `runs-retrieve.mdx`