### PR TITLE
gp inheritance clarification

### DIFF
--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -453,7 +453,7 @@ An override **replaces** the default middleware instance, it is not merged with 
 
 </Note>
 
-The general-purpose subagent, which Deep Agents adds automatically, inherits the same middleware customization you pass to the main agent.
+The general-purpose subagent, which Deep Agents adds automatically, inherits overrides for its default middleware from the main agent, without carrying over middleware that's specific to the main agent.
 
 Declarative subagents defined via `subagents=` do not inherit the main agent's middleware customization. Pass the override directly in that subagent's own [`middleware`](/oss/deepagents/subagents#subagent-dictionary-based) field to apply it there; that field is matched against the subagent's own default stack, the same way `middleware=` is matched against the main agent's.
 


### PR DESCRIPTION
Clarification on how GP agents inherit the main agents default mw customization