### PR TITLE
fix: document invite batch rate limits [closes ENT-641]

### DIFF
--- a/src/langsmith/usage-and-billing.mdx
+++ b/src/langsmith/usage-and-billing.mdx
@@ -174,7 +174,7 @@ The [`POST /runs/query`](/langsmith/smith-api/run/query-runs) endpoint has addit
 
 ### Workspace invite batch endpoint
 
-The `POST /workspaces/current/members/batch` endpoint has a limit of 2 requests per 1 second per user and 2 requests per 1 second per workspace.
+The `POST /workspaces/current/members/batch` endpoint has a limit of 2 requests per 1 second per workspace.
 
 ### Handling 429s responses in your application
 

--- a/src/langsmith/usage-and-billing.mdx
+++ b/src/langsmith/usage-and-billing.mdx
@@ -172,6 +172,10 @@ This is thrown by our application and varies by organization based on their conf
 
 The [`POST /runs/query`](/langsmith/smith-api/run/query-runs) endpoint has additional per-tenant rate limits based on query parameters. See [Query traces using the SDK](/langsmith/export-traces#rate-limits) for details.
 
+### Workspace invite batch endpoint
+
+The `POST /workspaces/current/members/batch` endpoint has a limit of 2 requests per 1 second per user and 2 requests per 1 second per workspace.
+
 ### Handling 429s responses in your application
 
 Since some 429 responses are temporary and may succeed on a successive call, if you are directly calling the LangSmith API in your application we recommend implementing retry logic with exponential backoff and jitter.

--- a/src/langsmith/usage-and-billing.mdx
+++ b/src/langsmith/usage-and-billing.mdx
@@ -174,7 +174,7 @@ The [`POST /runs/query`](/langsmith/smith-api/run/query-runs) endpoint has addit
 
 ### Workspace invite batch endpoint
 
-The `POST /workspaces/current/members/batch` endpoint has a limit of 2 requests per 1 second per workspace.
+The `POST /workspaces/current/members/batch` endpoint has a limit of 2 requests per 1 second per workspace. This limit applies to LangSmith Cloud. Self-hosted deployments do not enable this limit by default.
 
 ### Handling 429s responses in your application
 


### PR DESCRIPTION
## Description
Documents the workspace invite batch endpoint limit in LangSmith usage and billing docs. The note covers the per-workspace limit.

## Test Plan
- [x] `PATH=/tmp/vale-bin:$PATH make -C /workspace/docs lint_prose FILES="src/langsmith/usage-and-billing.mdx"`

Made by [Open SWE](https://openswe.vercel.app/agents/0710ae56-0768-dd2b-1ae3-d4a1e2c2963d)
