### PR TITLE
docs: document Engine issue categories

### DIFF
--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -124,6 +124,18 @@ Click any issue to display its details in the right panel.
 
 If no issues appear after setup completes, LangSmith Engine found no recurring patterns in the analyzed traces. Try checking back after more traces have been collected.
 
+## Understand issue categories
+
+LangSmith Engine looks for recurring patterns across traces, then groups related evidence into issues. The categories below describe the kinds of issues Engine can surface, but issue titles and descriptions stay specific to the traces in your project.
+
+- **Safety and policy**: Sensitive data exposure, user attempts to bypass guardrails, or off-topic responses that drift outside the agent's intended purpose.
+- **Answer quality**: Hallucinated facts, flawed plans, incomplete answers, or responses that solve the wrong problem.
+- **Tool and capability use**: Wrong tool selection, incorrect tool arguments, missing awareness of available capabilities, or legitimate gaps where the requested capability does not exist yet.
+- **Execution reliability**: Tool errors treated as successful results, repeated failed retries, looping behavior, or responses cut off before completion.
+- **Trace and context quality**: Excessive context growth, missing metadata, unclear run names, missing model information, or other instrumentation gaps that make traces harder to evaluate and monitor.
+
+Use priority categories during setup to tell Engine which areas matter most for the project. Engine can still surface other recurring issue types when the trace evidence supports them.
+
 ## Review an issue
 
 Click any issue in the list to open its detail panel. At the top, a diagnosis describes the problem and its impact.


### PR DESCRIPTION
## Description
Adds a concise Engine issue categories section to the LangSmith Engine docs. The grouping is based on the issues-agent taxonomy while avoiding per-category implementation detail.

## Test Plan
- [x] `PATH="/workspace/bin:$PATH" make -C /workspace/docs lint_prose FILES="src/langsmith/engine.mdx" NO_COLOR=1`
- [x] `git -C /workspace/docs diff --check -- src/langsmith/engine.mdx`

Made by [Open SWE](https://openswe.vercel.app/agents/3d8ac621-f88b-29d3-10fe-f467b4813801)