### PR TITLE
docs(deepagents-code): add uninstall instructions

### DIFF
--- a/src/oss/deepagents/code/overview.mdx
+++ b/src/oss/deepagents/code/overview.mdx
@@ -70,6 +70,42 @@ Persistent memory carries context across conversations, customizable skills shap
     Deep Agents Code is not officially supported on Windows. Windows users can try running it under [Windows Subsystem for Linux (WSL)](https://learn.microsoft.com/en-us/windows/wsl/install).
 </Note>
 
+## Uninstall
+
+Deep Agents Code installs as a [uv](https://docs.astral.sh/uv/) tool. To remove it:
+
+```bash
+uv tool uninstall deepagents-code
+```
+
+This removes the `dcode` and `deepagents-code` executables along with their isolated virtual environment.
+
+Your configuration and data live separately under `~/.deepagents` — `config.toml`, `hooks.json`, a global `.env`, and a `.state/` directory holding sessions and saved credentials (see [App data](/oss/deepagents/code/data-locations)). These are **not** removed by the uninstall above. To also delete them:
+
+```bash
+rm -rf ~/.deepagents
+```
+
+<Warning>
+    `rm -rf ~/.deepagents` permanently deletes your saved sessions, credentials, and customizations. Skip this step if you plan to reinstall and want to keep them.
+</Warning>
+
+Optionally, clear uv's shared tool cache — but only if no other uv tools rely on it:
+
+<CodeGroup>
+    ```bash macOS
+    rm -rf ~/Library/Caches/uv
+    ```
+
+    ```bash Linux
+    rm -rf ~/.cache/uv
+    ```
+</CodeGroup>
+
+<Note>
+    If a `dcode` from another package manager (or a duplicate or aliased `PATH` entry) still resolves after uninstalling, that's shell-profile or `PATH` cleanup on your side — the uninstall doesn't manage it.
+</Note>
+
 ## Capabilities
 
 Deep Agents Code has the following built-in capabilities:


### PR DESCRIPTION
## Description

The Deep Agents Code overview page documented installing and updating but had no uninstall instructions at all — nothing on `uv tool uninstall`, the persistent `~/.deepagents` config/data directory, uv's tool cache, or leftover `PATH` entries. This adds an Uninstall section that mirrors the authoritative steps in the installer's header comment.

The section covers removing the uv tool (which drops the `dcode` / `deepagents-code` executables and their isolated venv), notes that user config and data under `~/.deepagents` persist separately and shows how to wipe them (with a warning that doing so is destructive), how to optionally clear uv's shared tool cache per OS, and clarifies that a lingering `dcode` from another package manager or an aliased `PATH` entry is the user's own shell cleanup. It reuses the page's existing component style (`CodeGroup`, `Warning`, `Note`) and links to the App data page for the `~/.deepagents` layout.

## Test Plan

- [ ] Preview the overview page and confirm the Uninstall section renders with the code blocks, macOS/Linux tabs, and callouts intact.

Made by [Open SWE](https://openswe.vercel.app/agents/870c16ab-41c7-3eee-e0d1-55385367ec4f)