### PR TITLE
Fix Command Literal annotation in parent-graph navigation example

### DIFF
--- a/src/oss/langgraph/use-graph-api.mdx
+++ b/src/oss/langgraph/use-graph-api.mdx
@@ -3453,7 +3453,7 @@ If you are using [subgraphs](/oss/langgraph/use-subgraphs), you might want to na
 
 :::python
 ```python
-def my_node(state: State) -> Command[Literal["my_other_node"]]:
+def my_node(state: State) -> Command[Literal["other_subgraph"]]:
     return Command(
         update={"foo": "bar"},
         goto="other_subgraph",  # where `other_subgraph` is a node in the parent graph


### PR DESCRIPTION
## Overview
In the "Navigate to a node in a parent graph" example on the LangGraph `use-graph-api` page (Python tab), the function is annotated `-> Command[Literal["my_other_node"]]` but the body routes to `goto="other_subgraph"` with `graph=Command.PARENT`. Since the `Command[Literal[...]]` parameter declares the possible `goto` destinations, this updates the annotation to match the actual destination.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- See #4676 for context — the same class of inconsistency on the `thinking-in-langgraph` page (left to its reporter, who has offered a PR there). This instance was found by scanning all Python code blocks in `src/` for `Command[Literal[...]]` annotations whose `goto=` targets are missing from the Literal; these were the only two instances in the repo.

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev` (not run — single annotation change inside a fenced code block)
- [x] All code examples have been tested and work correctly (annotation-only change; `codespell src` and `make check-cross-refs` pass)
- [x] I have used **root relative** paths for internal links (no links changed)
- [ ] I have updated navigation in `src/docs.json` if needed (n/a)

## Additional notes
The example is an illustrative fragment (no runnable imports), so "tested" here means: verified the annotation now agrees with the `goto` target, and repo checks (`codespell`, cross-ref check) pass on the branch.
