### PR TITLE
chore: run OpenAPI spec sync daily instead of weekly

### DIFF
--- a/.github/workflows/refresh-langsmith-openapi.yml
+++ b/.github/workflows/refresh-langsmith-openapi.yml
@@ -3,8 +3,8 @@ name: Refresh LangSmith OpenAPI spec
 
 on:
   schedule:
-    # Weekly on Monday at 10:00 AM UTC
-    - cron: "0 10 * * 1"
+    # Daily at 10:00 AM UTC
+    - cron: "0 10 * * *"
   workflow_dispatch: {}
 
 jobs:
@@ -59,7 +59,7 @@ jobs:
             --title "chore: refresh LangSmith platform OpenAPI spec" \
             --body "$(cat <<'EOF'
           ## Summary
-          Automated weekly refresh of the LangSmith Platform API spec.
+          Automated daily refresh of the LangSmith Platform API spec.
 
           ## Details
           - Fetched latest spec from api.smith.langchain.com


### PR DESCRIPTION
## Summary

Changes the `refresh-langsmith-openapi` workflow cron schedule from weekly (Mondays at 10:00 AM UTC) to daily (every day at 10:00 AM UTC), so the published API spec stays closer to what's live.

## Changes

- Updated cron from `0 10 * * 1` → `0 10 * * *`
- Updated automated PR body text to say "daily" instead of "weekly"

🤖 Generated with [Claude Code](https://claude.ai/claude-code)