### PR TITLE
docs: add Weaviate to vector store picker and document async usage

### DIFF
--- a/src/oss/python/integrations/vectorstores/index.mdx
+++ b/src/oss/python/integrations/vectorstores/index.mdx
@@ -853,6 +853,34 @@ vector_store = ValkeyVectorStore(
 )
 ```
 </Accordion>
+
+<Accordion title="Weaviate">
+
+<CodeGroup>
+```bash pip
+pip install -qU langchain-weaviate
+```
+
+```bash uv
+uv add langchain-weaviate
+```
+</CodeGroup>
+```python
+import weaviate
+from langchain_weaviate import WeaviateVectorStore
+
+# Assumes a local Weaviate instance on http://localhost:8080 with gRPC on 50051.
+# See the Weaviate guide for other deployment options (Weaviate Cloud, Docker, etc.).
+weaviate_client = weaviate.connect_to_local()
+
+vector_store = WeaviateVectorStore(
+    client=weaviate_client,
+    index_name="langchain_example",
+    text_key="text",
+    embedding=embeddings,
+)
+```
+</Accordion>
 </AccordionGroup>
 
 <IntegrationFeatured />

--- a/src/oss/python/integrations/vectorstores/weaviate.mdx
+++ b/src/oss/python/integrations/vectorstores/weaviate.mdx
@@ -267,6 +267,48 @@ db_with_mt.similarity_search(query, tenant="Foo")
  Document(page_content='Putin’s latest attack on Ukraine was premeditated and unprovoked. \n\nHe rejected repeated efforts at diplomacy. \n\nHe thought the West and NATO wouldn’t respond. And he thought he could divide us at home. Putin was wrong. We were ready.  Here is what we did.   \n\nWe prepared extensively and carefully. \n\nWe spent months building a coalition of other freedom-loving nations from Europe and the Americas to Asia and Africa to confront Putin. \n\nI spent countless hours unifying our European allies. We shared with the world in advance what we knew Putin was planning and precisely how he would try to falsely justify his aggression.  \n\nWe countered Russia’s lies with truth.   \n\nAnd now that he has acted the free world is holding him accountable. \n\nAlong with twenty-seven members of the European Union including France, Germany, Italy, as well as countries like the United Kingdom, Canada, Japan, Korea, Australia, New Zealand, and many others, even Switzerland.', metadata={'source': 'state_of_the_union.txt'})]
 ```
 
+## Asynchronous usage
+
+`langchain-weaviate` supports Weaviate's native asynchronous client. Provide a connected [`WeaviateAsyncClient`](https://weaviate.io/developers/weaviate/client-libraries/python/async) as the `client_async` argument (alongside the synchronous `client`), and the async methods — `afrom_texts`, `aadd_texts`, `asimilarity_search`, `asimilarity_search_with_score`, `amax_marginal_relevance_search`, and their variants — will use it directly instead of running the synchronous client in a thread pool.
+
+<Note>
+Native async support requires `langchain-weaviate` `0.0.8` or higher. If you call an async method without passing `client_async`, the store falls back to running the synchronous client in an executor and logs a warning, so your code still works but does not get true async I/O.
+</Note>
+
+Unlike the synchronous `connect_to_local()` helper, the `use_async_with_*` helpers return a client that is **not** yet connected — you must `await client.connect()` before using it. The synchronous `client` is still required, since it is used for collection/schema management.
+
+```python
+import weaviate
+from langchain_weaviate import WeaviateVectorStore
+
+# Synchronous client (used for schema/collection management)
+weaviate_client = weaviate.connect_to_local()
+
+# Asynchronous client — must be connected explicitly
+weaviate_client_async = weaviate.use_async_with_local()
+await weaviate_client_async.connect()
+
+db = await WeaviateVectorStore.afrom_texts(
+    texts,
+    embeddings,
+    client=weaviate_client,
+    client_async=weaviate_client_async,
+)
+
+results = await db.asimilarity_search(
+    "What did the president say about Ketanji Brown Jackson", k=3
+)
+for doc in results:
+    print(doc.page_content[:100] + "...")
+```
+
+When you are finished, close both clients to release their connections:
+
+```python
+weaviate_client.close()
+await weaviate_client_async.close()
+```
+
 ## Retriever options
 
 Weaviate can also be used as a retriever


### PR DESCRIPTION
## What & why

Two fixes for the Weaviate content in the Python vector store docs:

### 1. Weaviate missing from the vector store picker
Weaviate was absent from the **Select vector store** accordion at [`integrations/vectorstores`](https://docs.langchain.com/oss/python/integrations/vectorstores), even though it already appears in the feature-comparison table and the guide-card list further down the same page. This adds the missing `Weaviate` accordion (installation + `WeaviateVectorStore` instantiation), matching the `client=`-based format used by other client-backed stores (Qdrant, Oracle).

### 2. Document async usage
The dedicated Weaviate page had no coverage of the native async client. Adds an **Asynchronous usage** section documenting the `client_async` / `WeaviateAsyncClient` support (available in `langchain-weaviate` 0.0.8+), including:
- passing both `client` and `client_async`
- the gotcha that `use_async_with_*` returns an **unconnected** client requiring `await client.connect()`
- the fall-back-to-executor behavior (with warning) when `client_async` is omitted

## Notes
- Docs-only change; no code affected.
- The async API referenced here ships in `langchain-weaviate` 0.0.8.