### PR TITLE
docs: update SmithDB exceptions table for TypeScript and add cURL tab

### DIFF
--- a/src/langsmith/smithdb-sdk-migration.mdx
+++ b/src/langsmith/smithdb-sdk-migration.mdx
@@ -81,30 +81,31 @@ than guessing.
     | *(not available)* | `APIResponseValidationError` | New: raised when a response does not match the expected schema |
   </Tab>
   <Tab title="TypeScript">
-    The SmithDB-backed methods raise new exception classes instead of the legacy `langsmith` utils error classes.
+    The SmithDB-backed methods raise new exception classes instead of plain `Error`.
 
-    | Before (`langsmith` utils error) | After (`langsmith` OpenAPI client error) | Notes |
+    | Before (plain `Error`) | After (`langsmith`) | Notes |
     |---|---|---|
-    | `LangSmithError` | `LangsmithError` | Base exception class for the SDK; casing changed |
-    | `LangSmithAPIError` | `InternalServerError` | 5xx |
-    | `LangSmithRequestTimeout` | `APIConnectionTimeoutError` | Raised when a request times out |
-    | `LangSmithUserError` | *(removed)* | No direct equivalent. The 403 org-scoped-key case now raises `PermissionDeniedError`; client-side argument validation now throws a standard `Error` |
-    | `LangSmithRateLimitError` | `RateLimitError` | 429; unchanged name |
-    | `LangSmithAuthError` | `AuthenticationError` | 401 |
-    | `LangSmithNotFoundError` | `NotFoundError` | 404; unchanged name |
-    | `LangSmithConflictError` | `ConflictError` | 409; unchanged name |
-    | `LangSmithConnectionError` | `APIConnectionError` | Raised when the client cannot connect to the API |
-    | `LangSmithExceptionGroup` | *(removed)* | No equivalent |
-    | *(not available)* | `APIError` | New: base class for all API-related errors, with `status`, `headers`, and `error` properties |
-    | *(not available)* | `BadRequestError` | New: 400 |
-    | *(not available)* | `PermissionDeniedError` | New: 403 |
-    | *(not available)* | `UnprocessableEntityError` | New: 422 |
-    | *(not available)* | `APIUserAbortError` | New: raised when a request is aborted via an `AbortController` |
+    | *(not available)* | `LangsmithError` | base class for all SDK errors |
+    | *(not available)* | `InternalServerError` | 5xx |
+    | *(not available)* | `APIConnectionTimeoutError` | Raised when a request times out |
+    | *(not available)* | `RateLimitError` | 429 |
+    | *(not available)* | `AuthenticationError` | 401 |
+    | *(not available)* | `NotFoundError` | 404 |
+    | *(not available)* | `ConflictError` | 409 |
+    | *(not available)* | `APIConnectionError` | Raised when the client cannot connect to the API |
+    | *(not available)* | `APIError` | base class for all API-related errors, with `status`, `headers`, and `error` properties |
+    | *(not available)* | `BadRequestError` | 400 |
+    | *(not available)* | `PermissionDeniedError` | 403 |
+    | *(not available)* | `UnprocessableEntityError` | 422 |
+    | *(not available)* | `APIUserAbortError` | Raised when a request is aborted via an `AbortController` |
   </Tab>
   <Tab title="Java">
-    No change. Exception classes are unaffected by this migration.
+    No change. Error handling is unaffected by this migration.
   </Tab>
   <Tab title="Go">
+    No change. Error handling is unaffected by this migration.
+  </Tab>
+  <Tab title="cURL">
     No change. Error handling is unaffected by this migration.
   </Tab>
 </Tabs>


### PR DESCRIPTION
## Summary
- Update the TypeScript exceptions table on the SmithDB migration guide
- Add a cURL tab to the exceptions section

## Test plan
- [x] `make lint_prose` passes on the changed file