### PR TITLE
fix(vercel): use python3.13 runtime in Vercel Sandbox Python examples

### DIFF
--- a/src/oss/deepagents/sandboxes.mdx
+++ b/src/oss/deepagents/sandboxes.mdx
@@ -452,7 +452,7 @@ You can also call the backend `execute()` method directly in your application co
 
         from langchain_vercel_sandbox import VercelSandbox
 
-        sandbox = Sandbox.create()
+        sandbox = Sandbox.create(runtime="python3.13")
         backend = VercelSandbox(sandbox=sandbox)
 
         try:
@@ -705,7 +705,7 @@ Use `upload_files()` to populate the sandbox before the agent runs. Paths must b
 
         from langchain_vercel_sandbox import VercelSandbox
 
-        sandbox = Sandbox.create()
+        sandbox = Sandbox.create(runtime="python3.13")
         backend = VercelSandbox(sandbox=sandbox)
 
         backend.upload_files(
@@ -877,7 +877,7 @@ Use `download_files()` to retrieve files from the sandbox after the agent finish
 
         from langchain_vercel_sandbox import VercelSandbox
 
-        sandbox = Sandbox.create()
+        sandbox = Sandbox.create(runtime="python3.13")
         backend = VercelSandbox(sandbox=sandbox)
 
         results = backend.download_files(["/src/index.py", "/output.txt"])

--- a/src/oss/python/integrations/sandboxes/vercel.mdx
+++ b/src/oss/python/integrations/sandboxes/vercel.mdx
@@ -36,7 +36,7 @@ from vercel.sandbox import Sandbox
 
 from langchain_vercel_sandbox import VercelSandbox
 
-sandbox = Sandbox.create()
+sandbox = Sandbox.create(runtime="python3.13")
 backend = VercelSandbox(sandbox=sandbox)
 
 try:
@@ -55,7 +55,7 @@ from langchain_anthropic import ChatAnthropic
 from deepagents import create_deep_agent
 from langchain_vercel_sandbox import VercelSandbox
 
-sandbox = Sandbox.create()
+sandbox = Sandbox.create(runtime="python3.13")
 backend = VercelSandbox(sandbox=sandbox)
 
 agent = create_deep_agent(

--- a/src/snippets/deepagents-sandbox-basic-py.mdx
+++ b/src/snippets/deepagents-sandbox-basic-py.mdx
@@ -237,7 +237,7 @@
         from langchain_vercel_sandbox import VercelSandbox
         from vercel.sandbox import Sandbox
 
-        sandbox = Sandbox.create()
+        sandbox = Sandbox.create(runtime="python3.13")
         backend = VercelSandbox(sandbox=sandbox)
 
         agent = create_deep_agent(

--- a/src/snippets/sandboxes-basic-tabs-py.mdx
+++ b/src/snippets/sandboxes-basic-tabs-py.mdx
@@ -183,7 +183,7 @@ import DeepagentsSandboxBasicDaytonaPy from '/snippets/code-samples/deepagents-s
         from langchain_vercel_sandbox import VercelSandbox
         from vercel.sandbox import Sandbox
 
-        sandbox = Sandbox.create()
+        sandbox = Sandbox.create(runtime="python3.13")
         backend = VercelSandbox(sandbox=sandbox)
 
         agent = create_deep_agent(


### PR DESCRIPTION
## What

The Vercel Sandbox **Python** examples create the sandbox with `Sandbox.create()` and no `runtime`, which defaults to `node24` (Vercel's JavaScript runtime). The same examples then run Python (`python --version`, "run pytest", etc.), so following them as written fails.

## Repro (live)

Running the example verbatim with `langchain-vercel-sandbox` 0.0.1 + `vercel` 0.5.9:

```
sandbox = Sandbox.create()                     # defaults to node24
backend.execute("python --version")
# output:    'bash: line 1: python: command not found'
# exit_code: 127
```

With the one-line change:

```
sandbox = Sandbox.create(runtime="python3.13")
backend.execute("python --version")
# output:    'Python 3.13.1'
# exit_code: 0
```

Per Vercel's docs, `python3.13` is the only runtime that ships `python`/`pip`/`uv`; the `node*` runtimes ship `npm`/`pnpm` only ([runtimes docs](https://vercel.com/docs/sandbox/concepts/runtimes)). Vercel's own Python example uses `runtime: "python3.13"`.

## Change

Adds `runtime="python3.13"` to the 7 Vercel Python snippets:
- `src/oss/python/integrations/sandboxes/vercel.mdx` (2)
- `src/oss/deepagents/sandboxes.mdx` (3)
- `src/snippets/sandboxes-basic-tabs-py.mdx` (1)
- `src/snippets/deepagents-sandbox-basic-py.mdx` (1)

The JS example already sets `runtime: "node24"` and runs TypeScript (verified: `node hello.ts` works on node24), so it's unaffected.
