### PR TITLE
chore: llm-gateway: unhide gateway docs [closes ENT-1014]

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -2225,6 +2225,10 @@
                     "tag": "Private beta",
                     "pages": [
                       "langsmith/llm-gateway",
+                      "langsmith/llm-gateway-admin-setup",
+                      "langsmith/llm-gateway-quickstart",
+                      "langsmith/llm-gateway-coding-agents",
+                      "langsmith/llm-gateway-access",
                       "langsmith/llm-gateway-custom-providers",
                       "langsmith/llm-gateway-spend-policies",
                       "langsmith/llm-gateway-redaction"

--- a/src/langsmith/llm-gateway-access.mdx
+++ b/src/langsmith/llm-gateway-access.mdx
@@ -1,7 +1,6 @@
 ---
 title: Traces, Engine, and access control
 description: Understand where gateway traces land, how policy violations surface in LangSmith Engine, and who can see and configure what.
-hidden: true
 ---
 
 <Note>

--- a/src/langsmith/llm-gateway-admin-setup.mdx
+++ b/src/langsmith/llm-gateway-admin-setup.mdx
@@ -1,7 +1,6 @@
 ---
 title: Admin setup
 description: One-time organization setup to enable the LLM Gateway and grant user access.
-hidden: true
 ---
 
 <Note>

--- a/src/langsmith/llm-gateway-coding-agents.mdx
+++ b/src/langsmith/llm-gateway-coding-agents.mdx
@@ -1,7 +1,6 @@
 ---
 title: Set up coding agents
 description: Configure Claude Code, Codex, Gemini CLI, and Deep Agents to route LLM calls through the LLM Gateway.
-hidden: true
 ---
 
 <Note>

--- a/src/langsmith/llm-gateway-quickstart.mdx
+++ b/src/langsmith/llm-gateway-quickstart.mdx
@@ -1,7 +1,6 @@
 ---
 title: LLM Gateway quickstart
 description: Make your first gateway-proxied LLM call.
-hidden: true
 ---
 
 <Note>

--- a/src/langsmith/llm-gateway-quickstart.mdx
+++ b/src/langsmith/llm-gateway-quickstart.mdx
@@ -1,5 +1,5 @@
 ---
-title: LLM Gateway quickstart
+title: Quickstart
 description: Make your first gateway-proxied LLM call.
 ---
 


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->
Unhiding Gateway pages from nav

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->

- [ENT-1382: LLM Gateway: unhide docs pages](https://linear.app/langchain/issue/ENT-1382/llm-gateway-unhide-docs-pages)

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
