### PR TITLE
fix: clarify Datadog log forwarding

### DIFF
--- a/src/langsmith/deploy-to-cloud.mdx
+++ b/src/langsmith/deploy-to-cloud.mdx
@@ -132,7 +132,7 @@ LangSmith Cloud can forward Agent Server logs to Datadog. To turn on log forward
 - **`DD_API_KEY`**: Your [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/). Log forwarding requires it. Setting `DD_API_KEY` also enables Datadog tracing.
 - **`DD_LOGS_ENABLED=true`**: Forwards Agent Server logs to Datadog.
 
-To correlate logs with traces, also set `DD_LOG_INJECTION=true`. For the full list of supported Datadog variables (`DD_SITE`, `DD_ENV`, `DD_SERVICE`, and more), see [`DD_API_KEY`](/langsmith/env-var-cloud#dd_api_key).
+To correlate logs with traces, also set `DD_LOG_INJECTION=true`. For the full list of Datadog variables (`DD_SITE`, `DD_ENV`, `DD_SERVICE`, and more), see [Supported Datadog environment variables](/langsmith/env-var-cloud#dd_api_key).
 
 <Tabs>
   <Tab title="LangSmith UI">

--- a/src/langsmith/deploy-to-cloud.mdx
+++ b/src/langsmith/deploy-to-cloud.mdx
@@ -129,10 +129,10 @@ Build and server logs are available for each revision.
 
 LangSmith Cloud can forward Agent Server logs to Datadog. To turn on log forwarding, set both of these environment variables or secrets on the deployment:
 
-- **`DD_API_KEY`**: Your [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/). Log forwarding requires it. Setting `DD_API_KEY` also enables Datadog tracing.
+- **`DD_API_KEY`**: Your [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/). Log forwarding requires it.
 - **`DD_LOGS_ENABLED=true`**: Forwards Agent Server logs to Datadog.
 
-To correlate logs with traces, also set `DD_LOG_INJECTION=true`. For the full list of Datadog variables (`DD_SITE`, `DD_ENV`, `DD_SERVICE`, and more), see [Supported Datadog environment variables](/langsmith/env-var-cloud#dd_api_key).
+To correlate logs with traces, also set `DD_LOGS_INJECTION=true`. For the full list of Datadog variables (`DD_SITE`, `DD_ENV`, `DD_SERVICE`, and more), see [Supported Datadog environment variables](/langsmith/env-var-cloud#dd_api_key).
 
 <Tabs>
   <Tab title="LangSmith UI">

--- a/src/langsmith/deploy-to-cloud.mdx
+++ b/src/langsmith/deploy-to-cloud.mdx
@@ -127,11 +127,11 @@ Build and server logs are available for each revision.
 
 ### Forward server logs to Datadog
 
-LangSmith Cloud can forward Agent Server logs to Datadog when Datadog tracing is configured for the deployment. To enable log forwarding, add the following environment variables or secrets to the deployment:
+LangSmith Cloud can forward Agent Server logs to Datadog when Datadog tracing is configured for the deployment. To forward logs, set `DD_API_KEY` and `DD_LOGS_ENABLED=true`. You can also set `DD_LOG_INJECTION=true` to correlate logs with traces.
 
-- **`DD_API_KEY`**: Required. Enables Datadog tracing and wraps the application process with `ddtrace-run`.
-- **`DD_LOGS_ENABLED=true`**: Required. Sends Agent Server logs to Datadog.
-- **`DD_LOG_INJECTION=true`**: Recommended. Adds trace and span identifiers to logs for trace correlation.
+- **`DD_API_KEY`**: Enables Datadog tracing and wraps the application process with `ddtrace-run`.
+- **`DD_LOGS_ENABLED=true`**: Enables Agent Server log forwarding to Datadog.
+- **`DD_LOG_INJECTION=true`**: Adds trace and span identifiers to logs for trace correlation.
 
 Common optional Datadog variables include `DD_SITE`, `DD_ENV`, and `DD_SERVICE`. For more information, see [Cloud Agent Server environment variables](/langsmith/env-var-cloud).
 

--- a/src/langsmith/deploy-to-cloud.mdx
+++ b/src/langsmith/deploy-to-cloud.mdx
@@ -123,7 +123,17 @@ When [creating a new deployment](#create-new-deployment), a new revision is crea
 
 ## View build and server logs
 
-Build and server logs are available for each revision. LangSmith Cloud also supports native Datadog forwarding for server logs and traces. To enable Datadog logs, configure the deployment with `DD_API_KEY`, `DD_LOGS_ENABLED=true`, and `DD_LOG_INJECTION=true`. For more information, see [`DD_API_KEY`](/langsmith/env-var#dd_api_key).
+Build and server logs are available for each revision.
+
+### Forward server logs to Datadog
+
+LangSmith Cloud can forward Agent Server logs to Datadog when Datadog tracing is configured for the deployment. To enable log forwarding, add the following environment variables or secrets to the deployment:
+
+- **`DD_API_KEY`**: Required. Enables Datadog tracing and wraps the application process with `ddtrace-run`.
+- **`DD_LOGS_ENABLED=true`**: Required. Sends Agent Server logs to Datadog.
+- **`DD_LOG_INJECTION=true`**: Recommended. Adds trace and span identifiers to logs for trace correlation.
+
+Common optional Datadog variables include `DD_SITE`, `DD_ENV`, and `DD_SERVICE`. For more information, see [Cloud Agent Server environment variables](/langsmith/env-var-cloud).
 
 <Tabs>
   <Tab title="LangSmith UI">

--- a/src/langsmith/deploy-to-cloud.mdx
+++ b/src/langsmith/deploy-to-cloud.mdx
@@ -127,13 +127,12 @@ Build and server logs are available for each revision.
 
 ### Forward server logs to Datadog
 
-LangSmith Cloud can forward Agent Server logs to Datadog when Datadog tracing is configured for the deployment. To forward logs, set `DD_API_KEY` and `DD_LOGS_ENABLED=true`. You can also set `DD_LOG_INJECTION=true` to correlate logs with traces.
+LangSmith Cloud can forward Agent Server logs to Datadog. To turn on log forwarding, set both of these environment variables or secrets on the deployment:
 
-- **`DD_API_KEY`**: Enables Datadog tracing and wraps the application process with `ddtrace-run`.
-- **`DD_LOGS_ENABLED=true`**: Enables Agent Server log forwarding to Datadog.
-- **`DD_LOG_INJECTION=true`**: Adds trace and span identifiers to logs for trace correlation.
+- **`DD_API_KEY`**: Your [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/). Log forwarding requires it. Setting `DD_API_KEY` also enables Datadog tracing.
+- **`DD_LOGS_ENABLED=true`**: Forwards Agent Server logs to Datadog.
 
-Common optional Datadog variables include `DD_SITE`, `DD_ENV`, and `DD_SERVICE`. For more information, see [Cloud Agent Server environment variables](/langsmith/env-var-cloud).
+To correlate logs with traces, also set `DD_LOG_INJECTION=true`. For the full list of supported Datadog variables (`DD_SITE`, `DD_ENV`, `DD_SERVICE`, and more), see [`DD_API_KEY`](/langsmith/env-var-cloud#dd_api_key).
 
 <Tabs>
   <Tab title="LangSmith UI">

--- a/src/langsmith/deploy-to-cloud.mdx
+++ b/src/langsmith/deploy-to-cloud.mdx
@@ -132,7 +132,7 @@ LangSmith Cloud can forward Agent Server logs to Datadog. To turn on log forward
 - **`DD_API_KEY`**: Your [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/). Log forwarding requires it.
 - **`DD_LOGS_ENABLED=true`**: Forwards Agent Server logs to Datadog.
 
-To correlate logs with traces, also set `DD_LOGS_INJECTION=true`. For the full list of Datadog variables (`DD_SITE`, `DD_ENV`, `DD_SERVICE`, and more), see [Supported Datadog environment variables](/langsmith/env-var-cloud#dd_api_key).
+To correlate logs with traces, also set `DD_LOGS_INJECTION=true`. For the full list of Datadog variables (`DD_SITE`, `DD_ENV`, `DD_SERVICE`, and more), see [Supported Datadog environment variables](/langsmith/env-var#dd_api_key).
 
 <Tabs>
   <Tab title="LangSmith UI">

--- a/src/snippets/langsmith/env-vars/shared.mdx
+++ b/src/snippets/langsmith/env-vars/shared.mdx
@@ -50,7 +50,8 @@ Specify `DD_API_KEY` (your [Datadog API Key](https://docs.datadoghq.com/account_
 
 Use the following `DD_*` environment variables with `DD_API_KEY`:
 
-- **Trace configuration**: Set `DD_SITE`, `DD_ENV`, `DD_SERVICE`, and `DD_TRACE_ENABLED` as needed to configure tracing instrumentation. See [`DD_*` environment variables](https://ddtrace.readthedocs.io/en/stable/configuration.html) for more details.
+- **Enable or disable tracing**: Tracing is enabled automatically when `DD_API_KEY` is set. Set `DD_TRACE_ENABLED=false` to disable it.
+- **Trace configuration**: Set `DD_SITE`, `DD_ENV`, and `DD_SERVICE` as needed to configure the tracing instrumentation. See [`DD_*` environment variables](https://ddtrace.readthedocs.io/en/stable/configuration.html) for more details.
 - **Log forwarding**: Set `DD_LOGS_ENABLED=true` to send Agent Server logs to Datadog. Omit this variable or set it to `false` to disable log forwarding. `DD_API_KEY` must also be set for log forwarding to take effect.
 - **Trace correlation in logs**: Set `DD_LOG_INJECTION=true` to include trace and span identifiers in logs.
 - **Troubleshooting**: Enable `DD_TRACE_DEBUG=true` and set `DD_LOG_LEVEL=debug` to troubleshoot Datadog tracing and log forwarding.

--- a/src/snippets/langsmith/env-vars/shared.mdx
+++ b/src/snippets/langsmith/env-vars/shared.mdx
@@ -46,17 +46,17 @@ Defaults to `*` (all origins).
 
 ## Supported Datadog environment variables {#dd_api_key}
 
-Set these environment variables or secrets on the deployment to send Agent Server traces and logs to Datadog. Every variable takes effect only when `DD_API_KEY` is set: it authenticates the deployment with Datadog and wraps the application process in the [`ddtrace-run` command](https://ddtrace.readthedocs.io/en/stable/installation_quickstart.html).
+Set these environment variables or secrets on the deployment to send Agent Server traces and logs to Datadog. Every variable takes effect only when `DD_API_KEY` is set, which wraps the application process in Datadog's [`ddtrace-run`](https://ddtrace.readthedocs.io/en/stable/installation_quickstart.html) tracer and log-collection agent.
 
-- **`DD_API_KEY`**: Your [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/). Required. Authenticates the deployment with Datadog and enables Datadog tracing.
+- **`DD_API_KEY`**: Your [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/). Required. Sending any traces or logs to Datadog requires it.
 - **`DD_LOGS_ENABLED`**: Set to `true` to forward Agent Server logs to Datadog. Omit it or set it to `false` to disable log forwarding.
-- **`DD_LOG_INJECTION`**: Set to `true` to add trace and span identifiers to logs so that logs correlate with traces.
-- **`DD_TRACE_ENABLED`**: Enables tracing. Defaults to `true` when `DD_API_KEY` is set. Set it to `false` to disable tracing.
+- **`DD_LOGS_INJECTION`**: Set to `true` to add trace and span identifiers to logs so that logs correlate with traces.
+- **`DD_TRACE_ENABLED`**: Controls Datadog trace collection. Set to `true` to collect traces or `false` to disable it.
 - **`DD_SITE`**: The Datadog site to send data to, such as `datadoghq.com` or `datadoghq.eu`. Defaults to `datadoghq.com`.
 - **`DD_ENV`**: The environment name applied to traces and logs, such as `production`.
 - **`DD_SERVICE`**: The service name applied to traces and logs.
-- **`DD_TRACE_DEBUG`**: Set to `true` to enable debug logging in the tracer when troubleshooting.
-- **`DD_LOG_LEVEL`**: The tracer log level, such as `debug`, when troubleshooting.
+- **`DD_TRACE_DEBUG`**: Set to `true` to enable debug logging in the `ddtrace` tracer when troubleshooting.
+- **`DD_LOG_LEVEL`**: The Datadog Agent log level, such as `debug`, when troubleshooting.
 
 For the full set of tracing options, see the [`DD_*` environment variables](https://ddtrace.readthedocs.io/en/stable/configuration.html) reference.
 

--- a/src/snippets/langsmith/env-vars/shared.mdx
+++ b/src/snippets/langsmith/env-vars/shared.mdx
@@ -44,7 +44,7 @@ For advanced CORS configuration, see [how to add custom CORS configuration](/lan
 
 Defaults to `*` (all origins).
 
-## `DD_API_KEY`
+## Supported Datadog environment variables {#dd_api_key}
 
 Specify `DD_API_KEY` (your [Datadog API Key](https://docs.datadoghq.com/account_management/api-app-keys/)) to automatically enable Datadog tracing for the deployment. If `DD_API_KEY` is specified, the application process is wrapped in the [`ddtrace-run` command](https://ddtrace.readthedocs.io/en/stable/installation_quickstart.html).
 

--- a/src/snippets/langsmith/env-vars/shared.mdx
+++ b/src/snippets/langsmith/env-vars/shared.mdx
@@ -51,7 +51,7 @@ Specify `DD_API_KEY` (your [Datadog API Key](https://docs.datadoghq.com/account_
 Use the following `DD_*` environment variables with `DD_API_KEY`:
 
 - **Trace configuration**: Set `DD_SITE`, `DD_ENV`, `DD_SERVICE`, and `DD_TRACE_ENABLED` as needed to configure tracing instrumentation. See [`DD_*` environment variables](https://ddtrace.readthedocs.io/en/stable/configuration.html) for more details.
-- **Log forwarding**: Set `DD_LOGS_ENABLED=true` to send Agent Server logs to Datadog. `DD_API_KEY` must also be set for log forwarding to take effect.
+- **Log forwarding**: Set `DD_LOGS_ENABLED=true` to send Agent Server logs to Datadog. Omit this variable or set it to `false` to disable log forwarding. `DD_API_KEY` must also be set for log forwarding to take effect.
 - **Trace correlation in logs**: Set `DD_LOG_INJECTION=true` to include trace and span identifiers in logs.
 - **Troubleshooting**: Enable `DD_TRACE_DEBUG=true` and set `DD_LOG_LEVEL=debug` to troubleshoot Datadog tracing and log forwarding.
 

--- a/src/snippets/langsmith/env-vars/shared.mdx
+++ b/src/snippets/langsmith/env-vars/shared.mdx
@@ -46,15 +46,19 @@ Defaults to `*` (all origins).
 
 ## Supported Datadog environment variables {#dd_api_key}
 
-Specify `DD_API_KEY` (your [Datadog API Key](https://docs.datadoghq.com/account_management/api-app-keys/)) to automatically enable Datadog tracing for the deployment. If `DD_API_KEY` is specified, the application process is wrapped in the [`ddtrace-run` command](https://ddtrace.readthedocs.io/en/stable/installation_quickstart.html).
+Set these environment variables or secrets on the deployment to send Agent Server traces and logs to Datadog. Every variable takes effect only when `DD_API_KEY` is set: it authenticates the deployment with Datadog and wraps the application process in the [`ddtrace-run` command](https://ddtrace.readthedocs.io/en/stable/installation_quickstart.html).
 
-Use the following `DD_*` environment variables with `DD_API_KEY`:
+- **`DD_API_KEY`**: Your [Datadog API key](https://docs.datadoghq.com/account_management/api-app-keys/). Required. Authenticates the deployment with Datadog and enables Datadog tracing.
+- **`DD_LOGS_ENABLED`**: Set to `true` to forward Agent Server logs to Datadog. Omit it or set it to `false` to disable log forwarding.
+- **`DD_LOG_INJECTION`**: Set to `true` to add trace and span identifiers to logs so that logs correlate with traces.
+- **`DD_TRACE_ENABLED`**: Enables tracing. Defaults to `true` when `DD_API_KEY` is set. Set it to `false` to disable tracing.
+- **`DD_SITE`**: The Datadog site to send data to, such as `datadoghq.com` or `datadoghq.eu`. Defaults to `datadoghq.com`.
+- **`DD_ENV`**: The environment name applied to traces and logs, such as `production`.
+- **`DD_SERVICE`**: The service name applied to traces and logs.
+- **`DD_TRACE_DEBUG`**: Set to `true` to enable debug logging in the tracer when troubleshooting.
+- **`DD_LOG_LEVEL`**: The tracer log level, such as `debug`, when troubleshooting.
 
-- **Enable or disable tracing**: Tracing is enabled automatically when `DD_API_KEY` is set. Set `DD_TRACE_ENABLED=false` to disable it.
-- **Trace configuration**: Set `DD_SITE`, `DD_ENV`, and `DD_SERVICE` as needed to configure the tracing instrumentation. See [`DD_*` environment variables](https://ddtrace.readthedocs.io/en/stable/configuration.html) for more details.
-- **Log forwarding**: Set `DD_LOGS_ENABLED=true` to send Agent Server logs to Datadog. Omit this variable or set it to `false` to disable log forwarding. `DD_API_KEY` must also be set for log forwarding to take effect.
-- **Trace correlation in logs**: Set `DD_LOG_INJECTION=true` to include trace and span identifiers in logs.
-- **Troubleshooting**: Enable `DD_TRACE_DEBUG=true` and set `DD_LOG_LEVEL=debug` to troubleshoot Datadog tracing and log forwarding.
+For the full set of tracing options, see the [`DD_*` environment variables](https://ddtrace.readthedocs.io/en/stable/configuration.html) reference.
 
 <Note>
 Enabling `DD_API_KEY` (and thus `ddtrace-run`) can override or interfere with other auto-instrumentation solutions (such as OpenTelemetry) that you may have instrumented into your application code.

--- a/src/snippets/langsmith/env-vars/shared.mdx
+++ b/src/snippets/langsmith/env-vars/shared.mdx
@@ -46,11 +46,14 @@ Defaults to `*` (all origins).
 
 ## `DD_API_KEY`
 
-Specify `DD_API_KEY` (your [Datadog API Key](https://docs.datadoghq.com/account_management/api-app-keys/)) to automatically enable Datadog tracing for the deployment. Specify other [`DD_*` environment variables](https://ddtrace.readthedocs.io/en/stable/configuration.html) to configure the tracing instrumentation.
+Specify `DD_API_KEY` (your [Datadog API Key](https://docs.datadoghq.com/account_management/api-app-keys/)) to automatically enable Datadog tracing for the deployment. If `DD_API_KEY` is specified, the application process is wrapped in the [`ddtrace-run` command](https://ddtrace.readthedocs.io/en/stable/installation_quickstart.html).
 
-If `DD_API_KEY` is specified, the application process is wrapped in the [`ddtrace-run` command](https://ddtrace.readthedocs.io/en/stable/installation_quickstart.html). Other `DD_*` environment variables, such as `DD_SITE`, `DD_ENV`, `DD_SERVICE`, and `DD_TRACE_ENABLED`, are typically needed to properly configure the tracing instrumentation. See [`DD_*` environment variables](https://ddtrace.readthedocs.io/en/stable/configuration.html) for more details.
+Use the following `DD_*` environment variables with `DD_API_KEY`:
 
-To send logs to Datadog, also set `DD_LOGS_ENABLED=true`. Set `DD_LOG_INJECTION=true` to include trace and span identifiers in logs for trace correlation. You can enable `DD_TRACE_DEBUG=true` and set `DD_LOG_LEVEL=debug` to troubleshoot.
+- **Trace configuration**: Set `DD_SITE`, `DD_ENV`, `DD_SERVICE`, and `DD_TRACE_ENABLED` as needed to configure tracing instrumentation. See [`DD_*` environment variables](https://ddtrace.readthedocs.io/en/stable/configuration.html) for more details.
+- **Log forwarding**: Set `DD_LOGS_ENABLED=true` to send Agent Server logs to Datadog. `DD_API_KEY` must also be set for log forwarding to take effect.
+- **Trace correlation in logs**: Set `DD_LOG_INJECTION=true` to include trace and span identifiers in logs.
+- **Troubleshooting**: Enable `DD_TRACE_DEBUG=true` and set `DD_LOG_LEVEL=debug` to troubleshoot Datadog tracing and log forwarding.
 
 <Note>
 Enabling `DD_API_KEY` (and thus `ddtrace-run`) can override or interfere with other auto-instrumentation solutions (such as OpenTelemetry) that you may have instrumented into your application code.


### PR DESCRIPTION
## Description
Makes Datadog Agent Server log forwarding more visible from Cloud deployment logs docs and clarifies the related `DD_*` variables under `DD_API_KEY`.

## Test Plan
- [x] `make -C /workspace/docs lint_prose FILES="src/langsmith/deploy-to-cloud.mdx src/snippets/langsmith/env-vars/shared.mdx"`
- [x] `make -C /workspace/docs build`
- [x] `mint broken-links --check-anchors` from `build/` (only existing false positives in generated API/snippet pages)

Made by [Open SWE](https://openswe.vercel.app/agents/7589687b-e069-8780-3ff2-065089f5248a)