### PR TITLE
docs: add Meta model provider to Deep Agents Code providers

### DIFF
--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -70,6 +70,7 @@ Using a provider not listed here? See [Arbitrary providers](/oss/deepagents/code
 | Cohere | [`langchain-cohere`](/oss/integrations/chat/cohere) | `COHERE_API_KEY` | ❌ |
 | Fireworks | [`langchain-fireworks`](/oss/integrations/chat/fireworks) | `FIREWORKS_API_KEY` | ✅ |
 | Together | [`langchain-together`](/oss/integrations/chat/together) | `TOGETHER_API_KEY` | ❌ |
+| Meta | [`langchain-meta`](https://github.com/langchain-ai/langchain-meta) | `MODEL_API_KEY` | ✅ |
 | Mistral AI | [`langchain-mistralai`](/oss/integrations/chat/mistralai) | `MISTRAL_API_KEY` | ✅ |
 | DeepSeek | [`langchain-deepseek`](/oss/integrations/chat/deepseek) | `DEEPSEEK_API_KEY` | ✅ |
 | IBM (watsonx.ai) | [`langchain-ibm`](/oss/integrations/chat/ibm_watsonx) | `WATSONX_APIKEY` | ❌ |


### PR DESCRIPTION
Deep Agents Code added the Meta Model API as a supported model provider (`deepagents-code` PR #4650), but the provider reference on the Deep Agents Code providers page did not list it. This adds a `Meta` row to the provider reference table so users know the extra/package (`langchain-meta`), credential environment variable (`MODEL_API_KEY`), and that model profiles are available.

Made by [Open SWE](https://openswe.vercel.app/agents/d476eaa4-0802-4440-6367-941bd825fc86)