### PR TITLE
docs: restore SearchApi tool integration page

### DIFF
--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -22,6 +22,7 @@ The following table shows tools that execute online searches in some shape or fo
 | [Nimble Search](/oss/integrations/tools/nimble_search) | Free trial available | URL, Content, Title |
 | [Parallel Search](/oss/integrations/tools/parallel_search) | Paid | URL, Title, Excerpts |
 | [Perplexity Search](/oss/integrations/tools/perplexity_search) | Paid (with monthly free tier) | URL, Title, Snippet, Date, Last Updated |
+| [SearchApi](/oss/integrations/tools/searchapi) | Free trial available | URL, Snippet, Title |
 | [Tavily Search](/oss/integrations/tools/tavily_search) | 1000 free searches/month | URL, Content, Title, Images, Answer |
 | [Apify](/oss/integrations/tools/apify_actors) | Free tier, pay-per-use (varies by Actor) | Actor output (varies by Actor) |
 | [You.com Search](/oss/integrations/tools/you) | $100 in credits on sign up | URL, Title, Page Content |
@@ -159,6 +160,7 @@ The following platforms provide access to multiple tools and services through a 
 <Card title="Scrapeless Crawl" icon="link" href="/oss/integrations/tools/scrapeless_crawl" arrow="true" cta="View guide" />
 <Card title="Scrapeless Scraping API" icon="link" href="/oss/integrations/tools/scrapeless_scraping_api" arrow="true" cta="View guide" />
 <Card title="Scrapeless Universal Scraping" icon="link" href="/oss/integrations/tools/scrapeless_universal_scraping" arrow="true" cta="View guide" />
+<Card title="SearchApi" icon="link" href="/oss/integrations/tools/searchapi" arrow="true" cta="View guide" />
 <Card title="SpiceDB" icon="link" href="/oss/integrations/tools/spicedb" arrow="true" cta="View guide" />
 <Card title="Stardog" icon="link" href="/oss/integrations/tools/stardog" arrow="true" cta="View guide" />
 <Card title="Stripe" icon="link" href="/oss/integrations/tools/stripe" arrow="true" cta="View guide" />

--- a/src/oss/python/integrations/tools/searchapi.mdx
+++ b/src/oss/python/integrations/tools/searchapi.mdx
@@ -1,0 +1,80 @@
+---
+title: "SearchApi"
+description: "Integrate with the SearchApi real-time SERP tool using LangChain Python."
+---
+
+This page shows how to use [SearchApi](https://www.searchapi.io/) to search the web. SearchApi is a real-time SERP API that returns structured results from Google Search, Google News, Google Jobs, Google Scholar, YouTube, and many other engines. Go to [searchapi.io](https://www.searchapi.io/) to sign up for a free account and get an API key.
+
+First, install `langchain-community` and set your API key as an environment variable:
+
+```python
+pip install -qU langchain-community
+```
+
+```python
+import os
+
+os.environ["SEARCHAPI_API_KEY"] = ""
+```
+
+## Basic usage
+
+```python
+from langchain_community.utilities import SearchApiAPIWrapper
+
+search = SearchApiAPIWrapper()
+search.run("Obama's first name?")
+```
+
+## Using as a tool in an agent
+
+Wrap the search in a tool and hand it to an agent:
+
+```python
+from langchain_community.utilities import SearchApiAPIWrapper
+from langchain_core.tools import Tool
+from langgraph.prebuilt import create_react_agent
+
+search = SearchApiAPIWrapper()
+tools = [
+    Tool(
+        name="intermediate_answer",
+        func=search.run,
+        description="useful for when you need to ask with search",
+    )
+]
+
+agent = create_react_agent("openai:gpt-4.1-mini", tools)
+
+input_message = {
+    "role": "user",
+    "content": "Who lived longer: Plato, Socrates, or Aristotle?",
+}
+
+for step in agent.stream(
+    {"messages": [input_message]},
+    stream_mode="values",
+):
+    step["messages"][-1].pretty_print()
+```
+
+## Custom parameters and engines
+
+The SearchApi wrapper can be customized to use different engines like [Google News](https://www.searchapi.io/docs/google-news), [Google Jobs](https://www.searchapi.io/docs/google-jobs), [Google Scholar](https://www.searchapi.io/docs/google-scholar), and others described in the [SearchApi documentation](https://www.searchapi.io/docs/google). All parameters supported by SearchApi can be passed when executing a query:
+
+```python
+search = SearchApiAPIWrapper(engine="google_jobs")
+search.run("AI Engineer", location="Portugal", gl="pt")[0:500]
+```
+
+## Getting results with metadata
+
+Use `results()` to get the raw structured response instead of a plain-text answer:
+
+```python
+import pprint
+
+search = SearchApiAPIWrapper(engine="google_scholar")
+results = search.results("Large Language Models")
+pprint.pp(results)
+```


### PR DESCRIPTION
## What

Restores the **SearchApi** tool integration page, which existed in the previous docs (`docs/docs/integrations/tools/searchapi.ipynb` in `langchain-ai/langchain`, last version at [`d07cb63`](https://github.com/langchain-ai/langchain/blob/d07cb63c758153f3f45d345901711d2d9f2491fc/docs/docs/integrations/tools/searchapi.ipynb)) but did not survive the docs migration — `/oss/python/integrations/tools/searchapi` currently returns **404**, while `SearchApiAPIWrapper` still ships in `langchain-community` ([API reference](https://python.langchain.com/api_reference/community/utilities/langchain_community.utilities.searchapi.SearchApiAPIWrapper.html)).

## Changes

- Adds `src/oss/python/integrations/tools/searchapi.mdx`, converted from the last version of the original notebook: basic usage, agent tool usage with `create_react_agent`, custom engines (Google News/Jobs/Scholar), and `results()` with metadata
- Registers the page in the tools index: web-search comparison table + alphabetical card list

## Notes

- Code examples are taken from the previous official notebook (already modernized there to `langgraph.prebuilt.create_react_agent`), not newly invented
- Table pricing column uses "Free trial available" per SearchApi's sign-up flow

Happy to adjust format or placement if the index tables are maintained elsewhere.