### PR TITLE
docs: replace retired Anthropic model ID in code examples

### DIFF
--- a/src/langsmith/observability-studio.mdx
+++ b/src/langsmith/observability-studio.mdx
@@ -110,7 +110,7 @@ class Configuration:
     )
 
     model: Annotated[str, {"__template_metadata__": {"kind": "llm"}}] = field(
-        default="anthropic/claude-3-5-sonnet-20240620",
+        default="anthropic/claude-sonnet-4-6",
         metadata={
             "description": "The name of the language model to use for the agent's main interactions. "
             "Should be in the form: provider/model-name.",

--- a/src/oss/langgraph/use-graph-api.mdx
+++ b/src/oss/langgraph/use-graph-api.mdx
@@ -1527,7 +1527,7 @@ By default, the retry policy retries on any exception except for the following:
   // Create an in-memory database
   const db: typeof Database.prototype = new Database(":memory:");
 
-  const model = new ChatAnthropic({ model: "claude-3-5-sonnet-20240620" });
+  const model = new ChatAnthropic({ model: "claude-sonnet-4-6" });
 
   const callModel: GraphNode<typeof State> = async (state) => {
     const response = await model.invoke(state.messages);

--- a/src/oss/python/integrations/tools/stripe.mdx
+++ b/src/oss/python/integrations/tools/stripe.mdx
@@ -73,7 +73,7 @@ from langchain.agents import create_agent
 
 
 model = ChatAnthropic(
-    model="claude-3-5-sonnet-20240620",
+    model="claude-sonnet-4-6",
 )
 
 langgraph_agent_executor = create_agent(model, stripe_agent_toolkit.get_tools())


### PR DESCRIPTION
Follow-up to #4719, covering the first-party (non-Bedrock) occurrences of the same problem: three code examples reference `claude-3-5-sonnet-20240620`, which was retired in October 2025 — users copying them get a model-not-found error.

Affected: the Stripe toolkit agent example (Python), the LangGraph `use-graph-api` example (JS), and the Studio agent-configuration example (a `provider/model-name` default). All updated to `claude-sonnet-4-6`, consistent with the model used in the shared chat-model-tabs snippet.

The remaining occurrence in `overview.mdx` (Bedrock-style ID) is intentionally left to open PR #4448, which already covers that file.

Prepared with assistance from an AI coding agent; reviewed by me.