### PR TITLE
docs: add E2B to Deep Agents Code remote sandbox provider tabs

### DIFF
--- a/src/oss/deepagents/code/remote-sandboxes.mdx
+++ b/src/oss/deepagents/code/remote-sandboxes.mdx
@@ -1,7 +1,7 @@
 ---
 title: Use remote sandboxes
 sidebarTitle: Remote sandboxes
-description: Run Deep Agents Code tool execution in LangSmith, AgentCore, Daytona, Modal, Runloop, or Vercel sandboxes. Install provider extras, set credentials, and use flags and setup scripts.
+description: Run Deep Agents Code tool execution in LangSmith, AgentCore, Daytona, Modal, Runloop, Vercel, or E2B sandboxes. Install provider dependencies, set credentials, and use flags and setup scripts.
 ---
 
 Deep Agents Code uses the [sandbox as tool](/oss/deepagents/sandboxes#sandbox-as-tool-pattern) pattern: the `dcode` process (LLM loop, memory, tool dispatch) runs on your machine, but agent tool calls (`read_file`, `write_file`, `execute`, etc.) target the remote sandbox, not your local filesystem. To get files into the sandbox, use a [setup script](#setup-scripts) or the provider's file transfer APIs (see [Working with files](/oss/deepagents/sandboxes#working-with-files)).
@@ -10,7 +10,7 @@ For a deeper look at sandbox architecture, integration patterns, and security be
 
 <Steps>
     <Step title="Install provider dependency" icon="download">
-        Each provider ships as an optional extra. Install one from within a session with `/install`, or from the shell with `dcode --install`:
+        Each built-in provider ships as an optional extra. Install one from within a session with `/install`, or from the shell with `dcode --install`. Third-party providers such as E2B install as packages with the `--package` flag:
 
         <Tabs>
             <Tab title="LangSmith">
@@ -71,9 +71,22 @@ For a deeper look at sandbox architecture, integration patterns, and security be
                     ```
                 </CodeGroup>
             </Tab>
+            <Tab title="E2B">
+                E2B is a [third-party provider](#third-party-providers) published by the `langchain-e2b` package. Install it as a package, not a `deepagents-code` extra:
+
+                <CodeGroup>
+                    ```txt In session
+                    /install langchain-e2b --package
+                    ```
+
+                    ```bash Shell
+                    dcode --install langchain-e2b --package
+                    ```
+                </CodeGroup>
+            </Tab>
         </Tabs>
 
-        To install support for every sandbox provider at once, use the `all-sandboxes` extra: `/install all-sandboxes` in a session, or `dcode --install all-sandboxes` from the shell.
+        To install support for every built-in provider at once, use the `all-sandboxes` extra: `/install all-sandboxes` in a session, or `dcode --install all-sandboxes` from the shell. The `all-sandboxes` extra does not include third-party providers such as E2B.
     </Step>
 
     <Step title="Set provider credentials" icon="key">
@@ -117,6 +130,11 @@ For a deeper look at sandbox architecture, integration patterns, and security be
 
                 When running on Vercel, [OIDC](https://vercel.com/docs/oidc) credentials are used automatically instead.
             </Tab>
+            <Tab title="E2B">
+                ```bash
+                export E2B_API_KEY="your-key"
+                ```
+            </Tab>
         </Tabs>
     </Step>
 
@@ -152,6 +170,11 @@ For a deeper look at sandbox architecture, integration patterns, and security be
                 dcode --sandbox vercel
                 ```
             </Tab>
+            <Tab title="E2B">
+                ```bash
+                dcode --sandbox e2b
+                ```
+            </Tab>
         </Tabs>
     </Step>
 </Steps>
@@ -175,6 +198,7 @@ Each provider exposes a default working directory inside the sandbox. Setup scri
 | Modal | `/workspace` |
 | Runloop | `/home/user` |
 | Vercel | `/vercel/sandbox` |
+| E2B | `/home/user` |
 
 Examples:
 
@@ -198,9 +222,9 @@ dcode --sandbox
 
 ## Pluggable providers
 
-The six built-in providers above aren't the only options. Deep Agents Code discovers sandbox providers from three sources, so you can use providers shipped by other packages or declare your own without changing Deep Agents Code:
+The built-in providers are not the only options. Deep Agents Code discovers sandbox providers from three sources, so you can use providers shipped by other packages or declare your own without changing Deep Agents Code:
 
-1. **Built-in providers** — the curated set above, installed as `deepagents-code` extras.
+1. **Built-in providers** — LangSmith, AgentCore, Daytona, Modal, Runloop, and Vercel, shipped with `deepagents-code` (LangSmith by default, the others as extras).
 2. **[Third-party providers](#third-party-providers)** — published by other installed packages via a Python entry point.
 3. **[Config-declared providers](#config-declared-providers)** — defined in your `~/.deepagents/config.toml`.
 


### PR DESCRIPTION
The remote-sandboxes page documents six providers with tabbed install / credentials / run steps and a working-directory table, but E2B only appears as a footnote example in the Third-party providers section, despite being a fully supported provider via the `langchain-e2b` entry-point package.

This adds an E2B tab to all three steps and an E2B row to the working-directory table, without presenting it as a built-in:

- **Install tab**: `/install langchain-e2b --package` (in session) and `dcode --install langchain-e2b --package` (shell), with a note linking to the Third-party providers section. Both commands verified against the `deepagents-code` source (`--install ... --package` argparse flag and the `/install` session command both accept package installs).
- **Credentials tab**: `export E2B_API_KEY="your-key"` (matches `langchain_e2b/provider.py` `_resolve_api_key`).
- **Run tab**: `dcode --sandbox e2b`.
- **Working-directory row**: `E2B | /home/user` (matches `SandboxProviderMetadata.working_dir` in `langchain_e2b`).

Truthfulness adjustments so the new tab does not contradict surrounding prose: the `all-sandboxes` sentence is scoped to built-in providers (the extra does not pull in third-party packages), and the "six built-in providers above" count in Pluggable providers is replaced with an explicit enumeration. The `--sandbox` flag table's built-ins list is intentionally unchanged (e2b is not a built-in), and no snapshot support is claimed (`supports_snapshot_name=False`).

Docs-only change. `make lint_prose` passes on the file.

Drafted with an AI agent (Claude Code); commands and provider facts verified against `langchain-ai/deepagents` and `e2b-dev/langchain-e2b` source.
