### PR TITLE
docs: add CockroachDB hybrid search to vector store integration page

### DIFF
--- a/src/oss/python/integrations/providers/cockroachdb.mdx
+++ b/src/oss/python/integrations/providers/cockroachdb.mdx
@@ -53,10 +53,11 @@ CockroachDB can be used as a vector store with native `VECTOR` type and C-SPANN 
 - Native vector support (v24.2+)
 - C-SPANN indexes optimized for distributed systems (v25.2+)
 - Advanced metadata filtering
+- Hybrid search combining full-text and vector similarity (v0.3.0+)
 - Multi-tenancy with prefix columns
 - Horizontal scalability
 
-See [CockroachDB vector store documentation](https://github.com/cockroachdb/langchain-cockroachdb/) for detailed usage.
+See the [CockroachDB entry in the vector stores overview](/oss/integrations/vectorstores#cockroachdb) for links to detailed usage.
 
 **Quick example:**
 
@@ -83,6 +84,29 @@ vectorstore = AsyncCockroachDBVectorStore(
 # Use it
 ids = await vectorstore.aadd_texts(["Hello world"])
 results = await vectorstore.asimilarity_search("Hi", k=1)
+```
+
+**Hybrid search** (v0.3.0+) runs full-text and vector search in parallel and fuses the ranked results, using reciprocal rank fusion by default:
+
+```python
+from langchain_cockroachdb import HybridSearchConfig
+
+# create_tsvector=True adds the TSVECTOR column and GIN index
+await engine.ainit_vectorstore_table(
+    table_name="documents",
+    vector_dimension=1536,
+    create_tsvector=True,
+)
+
+vectorstore = AsyncCockroachDBVectorStore(
+    engine=engine,
+    embeddings=OpenAIEmbeddings(),
+    collection_name="documents",
+    hybrid_search_config=HybridSearchConfig(),
+)
+
+# The regular search methods now do hybrid search transparently
+results = await vectorstore.asimilarity_search("distributed database performance", k=5)
 ```
 
 ### Chat Message History


### PR DESCRIPTION
## Description

langchain-cockroachdb v0.3.0 ([changelog](https://github.com/cockroachdb/langchain-cockroachdb/blob/main/CHANGELOG.md)) adds hybrid search execution: full-text and vector search run in parallel and the results are fused with reciprocal rank fusion or a weighted sum.

Since the dedicated CockroachDB vector store page was removed in the recent curation pass (#4865), this PR documents the feature on the provider page: a short hybrid search example in the vector store section, the feature bullet, and an internal link to the vector stores overview in place of the external repo link.

## Related

- Package: https://pypi.org/project/langchain-cockroachdb/
- Feature PR: https://github.com/cockroachdb/langchain-cockroachdb/pull/12