### PR TITLE
docs(fleet): document registering an OAuth provider for manual MCP OAuth

### DIFF
--- a/src/langsmith/fleet/remote-mcp-servers.mdx
+++ b/src/langsmith/fleet/remote-mcp-servers.mdx
@@ -113,8 +113,41 @@ Select an authentication type based on the server's requirements:
     You can add multiple headers if your MCP server requires additional authentication or configuration parameters. Each header key-value pair is sent with every request to the server.
     </Info>
 
-- **OAuth 2.1 (Auto)**: Select this for servers that support OAuth via dynamic client registration. You'll be prompted to log in with your account for that service.
-- **OAuth 2.1 (Manual)**: Select this for servers that support OAuth, but require specifying the client ID/secret beforehand. OAuth providers used in this flow must have **PKCE** enabled.
+- **OAuth 2.1 (Auto)**: Use this whenever the server supports OAuth via **dynamic client registration (DCR)**. Fleet registers a client for you and prompts you to log in with your account for that service. No prior setup is required, so prefer this option when the server supports it.
+- **OAuth 2.1 (Manual)**: Use this for servers that support OAuth but not dynamic client registration, so you must supply a client ID and secret yourself. Before adding the server, [register the provider](#register-an-oauth-provider) once at the organization level. Only providers with **PKCE** enabled can be selected here.
+
+### Register an OAuth provider
+
+For **OAuth 2.1 (Manual)**, register the OAuth provider once at the organization level, then select it when you add the MCP server.
+
+<Note>
+Managing OAuth providers requires the `workspaces:manage` permission, included in the [Workspace Admin](/langsmith/rbac#workspace-admin) role.
+</Note>
+
+<Steps>
+  <Step title="Create the OAuth application with your identity provider">
+    In your identity provider (for example, GitHub or Google), create an OAuth application and set its redirect (callback) URL to:
+
+    ```
+    https://<your-langsmith-host>/host-oauth-callback/<provider-id>
+    ```
+
+    Replace `<provider-id>` with the Provider ID you choose in the next step. Note the application's **client ID** and **client secret**.
+  </Step>
+  <Step title="Register the provider in LangSmith">
+    Navigate to [**Settings** > **OAuth providers**](https://smith.langchain.com/settings/oauth-providers) and click **OAuth Provider**, then fill in:
+
+    - **Provider ID**: A short identifier using letters, numbers, hyphens, and underscores (for example, `github`). This value appears in the redirect URL above.
+    - **Display Name**: A human-readable name (for example, `GitHub OAuth`).
+    - **Client ID** and **Client Secret**: From the OAuth application you created. Leave the secret empty for public clients that don't use one.
+    - **Authorization URL** and **Token URL**: The provider's OAuth endpoints (for example, `https://example.com/oauth/authorize` and `https://example.com/oauth/token`).
+    - **Enable PKCE**: Required — a provider must have PKCE enabled to be selectable when you add a manual-OAuth MCP server.
+    - **Scope** (under **Advanced**): Optional. Overrides the `scope` parameter sent to the authorization URL.
+  </Step>
+  <Step title="Select the provider when adding the server">
+    When adding the MCP server, choose **OAuth 2.1 (Manual)** and select the provider you registered.
+  </Step>
+</Steps>
 
 ## Update your MCP server URL
 


### PR DESCRIPTION
## What

Adds a **Register an OAuth provider** section to the Fleet *Remote MCP servers* page and clarifies the two OAuth 2.1 auth types.

The page told users that **OAuth 2.1 (Manual)** needs a client ID/secret and a PKCE-enabled provider, but never said *where* to register that provider or what it requires. This fills that gap:

- **Auto vs Manual**: Auto uses dynamic client registration (no setup, prefer it); Manual is for servers without DCR, where you supply the client ID/secret.
- **Register an OAuth provider** (Settings > OAuth providers): the fields (Provider ID, Display Name, Client ID/Secret, Authorization/Token URL, Enable PKCE, Scope), the redirect/callback URL to register with the identity provider (`https://<your-langsmith-host>/host-oauth-callback/<provider-id>`), and the PKCE requirement for the provider to be selectable.

## Accuracy

Every detail is cross-checked against the product code (`CreateOAuthProviderModal`, `CreateMcpServerModal`'s PKCE filter, the `settings/oauth-providers` route, and the host-backend callback resolver) — nothing invented.

## Scope / follow-ups

Intentionally left out (would need confirmation, not documenting speculatively): token refresh/expiry lifecycle for the OAuth paths, and manual-OAuth failure/troubleshooting symptoms.