### PR TITLE
docs: add deployment/deprecation details to SmithDB migration guide

### DIFF
--- a/src/langsmith/smithdb-sdk-migration.mdx
+++ b/src/langsmith/smithdb-sdk-migration.mdx
@@ -16,6 +16,8 @@ import SmithdbMigrationTracesListRuns from '/snippets/langsmith/smithdb-migratio
 
 ## Context
 
+<Warning>This migration guide, including the deprecation and removal dates below, is in **preview** and subject to change before general availability later this month.</Warning>
+
 In May 2026, we released [SmithDB](https://www.langchain.com/blog/introducing-smithdb?utm_source=docs), a new observability database built for modern AI agents. SmithDB delivers industry-leading performance across every key observability workload, making core LangSmith experiences dramatically faster.
 
 SmithDB-powered methods are now available to SDK users in eligible regions.
@@ -24,9 +26,21 @@ SmithDB-powered methods are now available to SDK users in eligible regions.
 
 | Deployment | Status |
 |---|---|
-| US SaaS | Available. Methods are fully SmithDB-backed. |
-| EU and other SaaS regions | Methods are available but not yet backed by SmithDB. |
-| Self-hosted | Supported starting with self-hosted version 0.16.0. No feature flag is required. |
+| GCP `us-central` Cloud | Available. New methods are fully SmithDB-backed. |
+| Other Cloud regions | Available. SmithDB-backed later this year. |
+| Self-Hosted | New methods require version `>=v0.16` and SmithDB enabled. |
+
+## Deprecation and removal
+
+Each SDK method and its underlying endpoint share the same deprecation date.
+
+| Deployment | Deprecation | Removal |
+|---|---|---|
+| GCP `us-central` Cloud | End of July 2026 | 31 Jan 2027 |
+| Other Cloud regions | TBD | TBD |
+| Self-Hosted | `>=v0.16` | `>=v0.18` |
+
+A detailed deprecation process will be linked here before the general availability of this guide.
 
 ## Minimum SDK version
 
@@ -134,3 +148,23 @@ than guessing.
 <SmithdbMigrationExperimentRunsQuery />
 
 <SmithdbMigrationRunsAddToAnnotationQueue />
+
+## Soon to be deprecated
+
+The following methods may be deprecated before the end of this month. Preview customers will be notified when changes are made.
+
+### Share run methods
+
+| Python | TypeScript |
+|---|---|
+| [`share_run`](https://reference.langchain.com/python/langsmith/client/Client/share_run) | [`shareRun`](https://reference.langchain.com/javascript/langsmith/client/Client/shareRun) |
+| [`unshare_run`](https://reference.langchain.com/python/langsmith/client/Client/unshare_run) | [`unshareRun`](https://reference.langchain.com/javascript/langsmith/client/Client/unshareRun) |
+| [`list_shared_runs`](https://reference.langchain.com/python/langsmith/client/Client/list_shared_runs) | [`listSharedRuns`](https://reference.langchain.com/javascript/langsmith/client/Client/listSharedRuns) |
+| [`read_run_shared_link`](https://reference.langchain.com/python/langsmith/client/Client/read_run_shared_link) | [`readRunSharedLink`](https://reference.langchain.com/javascript/langsmith/client/Client/readRunSharedLink) |
+| [`read_shared_run`](https://reference.langchain.com/python/langsmith/client/Client/read_shared_run) | No TypeScript equivalent |
+
+### Get run URL
+
+| Python | TypeScript |
+|---|---|
+| [`get_run_url`](https://reference.langchain.com/python/langsmith/client/Client/get_run_url) | [`getRunUrl`](https://reference.langchain.com/javascript/langsmith/client/Client/getRunUrl) |


### PR DESCRIPTION
## Summary
- Adds a preview warning: this guide is being shared with partner customers ahead of general availability, so content is subject to change.
- Updates the deployment support table and adds a deprecation/removal table per deployment.
- Adds a "Soon to be deprecated" section listing the share-run methods and `get_run_url`, likely to be deprecated before end of month, with links to Python and TypeScript reference docs.