### PR TITLE
docs: replace retired Anthropic model IDs in JS integration examples

### DIFF
--- a/src/oss/javascript/integrations/chat/index.mdx
+++ b/src/oss/javascript/integrations/chat/index.mdx
@@ -72,7 +72,7 @@ description: "Integrate with chat models using LangChain JavaScript."
         import { ChatAnthropic } from "@langchain/anthropic";
 
         const model = new ChatAnthropic({
-        model: "claude-3-sonnet-20240620",
+        model: "claude-sonnet-4-6",
         temperature: 0
         });
         ```

--- a/src/oss/javascript/integrations/retrievers/perplexity_search.mdx
+++ b/src/oss/javascript/integrations/retrievers/perplexity_search.mdx
@@ -91,7 +91,7 @@ Context: {context}
 
 Question: {question}`);
 
-const llm = new ChatAnthropic({ model: "claude-3-5-haiku-latest" });
+const llm = new ChatAnthropic({ model: "claude-haiku-4-5" });
 
 const formatDocs = (docs: Document[]) =>
   docs.map((doc) => doc.pageContent).join("\n\n");

--- a/src/oss/javascript/integrations/tools/perplexity_search.mdx
+++ b/src/oss/javascript/integrations/tools/perplexity_search.mdx
@@ -75,7 +75,7 @@ The tool returns a JSON-encoded array of search results, each with `title`, `url
 import { ChatAnthropic } from "@langchain/anthropic";
 import { createReactAgent } from "@langchain/langgraph/prebuilt";
 
-const llm = new ChatAnthropic({ model: "claude-3-5-haiku-latest" });
+const llm = new ChatAnthropic({ model: "claude-haiku-4-5" });
 
 const agent = createReactAgent({
   llm,


### PR DESCRIPTION
## Overview

Three JS integration examples instantiate `ChatAnthropic` with retired model IDs: the chat models index uses `claude-3-sonnet-20240620` (a nonexistent ID Claude 3 Sonnet was `20240229`; both retired July 2025), and the Perplexity retriever and
tool pages use `claude-3-5-haiku-latest` (Claude 3.5 Haiku retired February 2026). Users copying these get model-not-found errors. Updated to `claude-sonnet-4-6` and `claude-haiku-4-5`, matching current usage elsewhere in the docs.

## Type of change
**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue: N/A
- Feature PR: same fix class as #4719 and #4894

## Checklist
- [x] I have read the contributing guidelines, including the language policy
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used root relative paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed (N/A)

## Additional notes
Model-ID-only changes inside existing code blocks. Replacement IDs match those already used in the shared chat-model-tabs snippet.

Prepared with assistance from an AI coding agent; reviewed by the author.