### PR TITLE
docs: replace retired Anthropic model IDs in provider integration examples

### DIFF
--- a/src/oss/python/integrations/providers/log10.mdx
+++ b/src/oss/python/integrations/providers/log10.mdx
@@ -68,7 +68,7 @@ llm = ChatOpenAI(model="gpt-3.5-turbo", callbacks=[log10_callback], temperature=
 completion = llm.predict_messages(messages, tags=["foobar"])
 print(completion)
 
-llm = ChatAnthropic(model="claude-2", callbacks=[log10_callback], temperature=0.7, tags=["baz"])
+llm = ChatAnthropic(model="claude-sonnet-4-6", callbacks=[log10_callback], temperature=0.7, tags=["baz"])
 llm.predict_messages(messages)
 print(completion)
 

--- a/src/oss/python/integrations/providers/portkey/index.mdx
+++ b/src/oss/python/integrations/providers/portkey/index.mdx
@@ -55,7 +55,7 @@ The request is routed through your Portkey AI Gateway to the specified `provider
 
 The power of the AI gateway comes when you're able to use the above code snippet to connect with 150+ models across 20+ providers supported through the AI gateway.
 
-Let's modify the code above to make a call to Anthropic's `claude-3-opus-20240229` model.
+Let's modify the code above to make a call to Anthropic's `claude-opus-4-8` model.
 
 Portkey supports **[Virtual Keys](https://docs.portkey.ai/docs/product/ai-gateway-streamline-llm-integrations/virtual-keys)** which are an easy way to store and manage API keys in a secure vault. Let's try using a Virtual Key to make LLM calls. You can navigate to the Virtual Keys tab in Portkey and create a new key for Anthropic.
 
@@ -72,7 +72,7 @@ VIRTUAL_KEY = "..." # Anthropic's virtual key we copied above
 
 portkey_headers = createHeaders(api_key=PORTKEY_API_KEY,virtual_key=VIRTUAL_KEY)
 
-llm = ChatOpenAI(api_key="X", base_url=PORTKEY_GATEWAY_URL, default_headers=portkey_headers, model="claude-3-opus-20240229")
+llm = ChatOpenAI(api_key="X", base_url=PORTKEY_GATEWAY_URL, default_headers=portkey_headers, model="claude-opus-4-8")
 
 llm.invoke("What is the meaning of life, universe and everything?")
 ```
@@ -98,7 +98,7 @@ config = {
         "weight": 0.5
     }, {
         "virtual_key": "anthropic-25654", # Anthropic's virtual key
-        "override_params": {"model": "claude-3-opus-20240229"},
+        "override_params": {"model": "claude-opus-4-8"},
         "weight": 0.5
     }]
 }
@@ -117,7 +117,7 @@ llm = ChatOpenAI(api_key="X", base_url=PORTKEY_GATEWAY_URL, default_headers=port
 llm.invoke("What is the meaning of life, universe and everything?")
 ```
 
-When the LLM is invoked, Portkey will distribute the requests to `gpt-4` and `claude-3-opus-20240229` in the ratio of the defined weights.
+When the LLM is invoked, Portkey will distribute the requests to `gpt-4` and `claude-opus-4-8` in the ratio of the defined weights.
 
 You can find more [Portkey config examples](https://docs.portkey.ai/docs/api-reference/config-object#examples).
 


### PR DESCRIPTION
## Overview

The log10 provider page instantiates `ChatAnthropic` with `claude-2` (retired July 2025), and the Portkey gateway page uses `claude-3-opus-20240229` (retired January 2026) in two code examples and twice in prose. Updated to `claude-sonnet-4-6` and `claude-opus-4-8` respectively Opus for Portkey, since that page's load-balancing example deliberately contrasts two large models.

## Type of change
**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue: N/A
- Feature PR: same fix class as #4719 and #4894

## Checklist
- [x] I have read the contributing guidelines, including the language policy
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used root relative paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed (N/A)

## Additional notes
Deliberately excluded: the deprecated experimental `ChatAnthropicTools` page (page is marked deprecated), the legacy `AnthropicLLM` page (`claude-2.1` there targets the legacy Text Completions API, which modern models don't serve), and OpenAI model IDs (out of scope for this PR).

Prepared with assistance from an AI coding agent; reviewed by me.