### PR TITLE
docs(langsmith): replace retired Anthropic model IDs in metadata examples

### DIFF
--- a/src/langsmith/cost-tracking.mdx
+++ b/src/langsmith/cost-tracking.mdx
@@ -345,7 +345,7 @@ Skip this section if you are calling LLMs with [LangChain](/oss/langchain/overvi
 2. Specify model name. When using a custom model, the following fields need to be specified in a [run's metadata](/langsmith/add-metadata-tags) in order to associate token counts with costs. It's also helpful to provide these metadata fields to identify the model when viewing traces and when filtering.
 
     - `ls_provider`: The provider of the model, e.g., “openai”, “anthropic”
-    - `ls_model_name`: The name of the model, e.g., “gpt-5.4-mini”, “claude-3-opus-20240229”
+    - `ls_model_name`: The name of the model, e.g., “gpt-5.4-mini”, “claude-opus-4-8”
 
 3. Set model prices. LangSmith maps model names to per-token prices using its [model pricing table](https://smith.langchain.com/settings/workspaces/models) to compute costs from token counts.
 

--- a/src/langsmith/filter-experiments-ui.mdx
+++ b/src/langsmith/filter-experiments-ui.mdx
@@ -16,7 +16,7 @@ In our example, we are going to attach metadata to our experiment around the mod
 models = {
     "openai-gpt-5.5": ChatOpenAI(model="gpt-5.5", temperature=0),
     "openai-gpt-5.4-mini": ChatOpenAI(model="gpt-5.4-mini", temperature=0),
-    "anthropic-claude-3-sonnet-20240229": ChatAnthropic(temperature=0, model_name="claude-3-sonnet-20240229")
+    "anthropic-claude-sonnet-4-6": ChatAnthropic(temperature=0, model_name="claude-sonnet-4-6")
 }
 
 prompts = {

--- a/src/langsmith/log-llm-trace.mdx
+++ b/src/langsmith/log-llm-trace.mdx
@@ -392,7 +392,7 @@ def chat_model(inputs: dict) -> dict:
 When using a custom model, it is recommended to also provide the following `metadata` fields to identify the model when viewing traces and when [filtering](/langsmith/filter-traces-in-application).
 
 - `ls_provider`: The provider of the model, e.g., `"openai"`, `"anthropic"`.
-- `ls_model_name`: The name of the model, e.g., `"gpt-5.4-mini"`, `"claude-3-opus-20240229"`.
+- `ls_model_name`: The name of the model, e.g., `"gpt-5.4-mini"`, `"claude-opus-4-8"`.
 
 <CodeGroup>
 

--- a/src/langsmith/ls-metadata-parameters.mdx
+++ b/src/langsmith/ls-metadata-parameters.mdx
@@ -199,7 +199,7 @@ Identifies the specific model. Combined with `ls_provider`, matches against pric
 
 **Common values:**
 - OpenAI: `"gpt-5.5"`, `"gpt-5.4-mini"`, `"gpt-3.5-turbo"`
-- Anthropic: `"claude-3-5-sonnet-20241022"`, `"claude-3-opus-20240229"`
+- Anthropic: `"claude-sonnet-4-6"`, `"claude-opus-4-8"`
 - Custom: Any model identifier
 
 **When to use:**


### PR DESCRIPTION
## Overview

Four LangSmith pages use retired Anthropic model IDs as example values: the `ls_model_name` examples in cost-tracking and log-llm-trace, the common-values list in the metadata parameters reference (`claude-3-5-sonnet-20241022`, `claude-3-opus-20240229`), and the experiment-filtering guide, which constructs `ChatAnthropic` with `claude-3-sonnet-20240229` (retired July 2025). Updated to `claude-sonnet-4-6` / `claude-opus-4-8` so cost-tracking examples reference models that exist in the pricing database.

## Type of change
**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue: N/A
- Feature PR: same fix class as #4719 and #4894

## Checklist
- [x] I have read the contributing guidelines, including the language policy
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used root relative paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed (N/A)

## Additional notes
Example-value and model-ID changes only; no prose restructuring.

Prepared with assistance from an AI coding agent; reviewed by the author.