### PR TITLE
docs(langchain): update `ToolRetryMiddleware` configuration

### DIFF
--- a/src/oss/langchain/middleware/built-in.mdx
+++ b/src/oss/langchain/middleware/built-in.mdx
@@ -1356,14 +1356,16 @@ const agent = createAgent({
 </ParamField>
 
 <ParamField body="retry_on" type="tuple[type[Exception], ...] | callable" default="(Exception,)">
-    Either a tuple of exception types to retry on, or a callable that takes an exception and returns `True` if it should be retried.
+    Either a tuple of exception types to retry on, or a callable that takes an exception and returns `True` if it should be retried. By default, all exceptions are retried. Exceptions that do not match propagate immediately and are not handled by `on_failure`.
 </ParamField>
 
-<ParamField body="on_failure" type="string | callable" default="return_message">
+<ParamField body="on_failure" type="string | callable" default="continue">
     Behavior when all retries are exhausted. Options:
-    - `'return_message'` - Return a `ToolMessage` with error details (allows LLM to handle failure)
-    - `'raise'` - Re-raise the exception (stops agent execution)
+    - `'continue'` (default) - Return a `ToolMessage` with error details, allowing the LLM to handle the failure
+    - `'error'` - Re-raise the exception, stopping agent execution
     - Custom callable - Function that takes the exception and returns a string for the `ToolMessage` content
+
+    **Deprecated values:** `'return_message'` (use `'continue'` instead) and `'raise'` (use `'error'` instead).
 </ParamField>
 
 <ParamField body="backoff_factor" type="number" default="2.0">
@@ -1437,8 +1439,8 @@ The middleware automatically retries failed tool calls with exponential backoff.
 - `jitter` - Add random variation (default: True)
 
 **Failure handling:**
-- `on_failure='return_message'` - Return error message
-- `on_failure='raise'` - Re-raise exception
+- `on_failure='continue'` (default) - Return error message
+- `on_failure='error'` - Re-raise exception
 - Custom function - Function returning error message
 :::
 :::js


### PR DESCRIPTION
## Description
Updates the built-in middleware guide to use the current Python `on_failure` values and explain how `retry_on` affects exception propagation.

## Test Plan
- [x] Reviewed all documentation references to `ToolRetryMiddleware`
- [ ] Vale prose lint (blocked because the repository target requires Homebrew)

Made by [Open SWE](https://openswe.vercel.app/agents/98d413e7-9150-507c-543c-a9d17f752651)