### PR TITLE
docs(langsmith): group v2 endpoints by resource with standardized titles

### DIFF
--- a/scripts/process_langsmith_openapi.py
+++ b/scripts/process_langsmith_openapi.py
@@ -89,24 +89,20 @@ HIDDEN_PATH_PREFIXES: list[str] = [
     "/v2/sandboxes/internal/",
 ]
 
-# Newer v2 API endpoints (paths under ``/v2/``) are pulled into a dedicated
-# sidebar group so readers notice them, rather than being scattered through the
-# feature groups alongside their v1 counterparts.
+# v2 API endpoints (paths under ``/v2/``) carry their backend resource tag
+# (runs, datasets, threads), so they group with their v1 siblings automatically.
+# Append a "(v2)" marker to their titles so the two versions are distinguishable
+# in the sidebar. Sandboxes are a v2-only feature with no v1 counterpart, so they
+# are excluded from the marker.
 V2_PATH_PREFIX = "/v2/"
-V2_TAG = "v2"
-V2_GROUP = "v2 endpoints"
-
-# v2 paths that are standalone features (not a newer version of a v1 endpoint)
-# stay in their own feature group instead of the v2 group.
-V2_GROUP_EXCLUDE_PREFIXES: list[str] = [
+V2_LABEL_SUFFIX = " (v2)"
+V2_LABEL_EXCLUDE_PREFIXES: list[str] = [
     "/v2/sandboxes/",
 ]
 
 # Map raw tag names to human-readable group headings (``x-group``).
 # Tags not listed here keep their original name as the group heading.
 TAG_GROUPS: dict[str, str] = {
-    # Newer v2 endpoints (see V2_GROUP).
-    V2_TAG: V2_GROUP,
     # Tracing
     "run": "Tracing",
     "runs": "Tracing",
@@ -185,14 +181,15 @@ TAG_GROUPS: dict[str, str] = {
     "public": "System",
     "ace": "System",
     "backfills": "System",
-    "threads": "System",
+    # Threads
+    "threads": "Threads",
 }
 
 # Display order for groups in the generated docs sidebar.
 # Groups not listed here are appended alphabetically after the listed ones.
 GROUP_ORDER: list[str] = [
-    V2_GROUP,
     "Tracing",
+    "Threads",
     "Datasets",
     "Evaluation",
     "Feedback & Annotation",
@@ -246,13 +243,16 @@ def process_spec(spec: dict) -> dict:
                 operation["x-hidden"] = True
                 hidden_count += 1
 
-    # 1b. Reassign visible v2 operations to a dedicated group so the newer
-    # endpoints stand out. Runs after hiding so hidden v2 ops stay hidden.
+    # 1b. Append a "(v2)" marker to visible v2 operation titles so they are
+    # distinguishable from their v1 siblings within the same resource group.
+    # Runs after hiding so hidden v2 ops are skipped; sandboxes are excluded
+    # (v2-only feature, no v1 counterpart). Idempotent on re-runs.
     v2_count = 0
+    marker = V2_LABEL_SUFFIX.strip()
     for path, methods in spec.get("paths", {}).items():
         if not path.startswith(V2_PATH_PREFIX):
             continue
-        if any(path.startswith(p) for p in V2_GROUP_EXCLUDE_PREFIXES):
+        if any(path.startswith(p) for p in V2_LABEL_EXCLUDE_PREFIXES):
             continue
         for method, operation in methods.items():
             if not isinstance(operation, dict):
@@ -261,24 +261,12 @@ def process_spec(spec: dict) -> dict:
                 continue
             if operation.get("x-hidden"):
                 continue
-            operation["tags"] = [V2_TAG]
+            summary = (operation.get("summary") or "").rstrip()
+            if not summary:
+                summary = f"{method.upper()} {path}"
+            if not summary.endswith(marker):
+                operation["summary"] = f"{summary}{V2_LABEL_SUFFIX}"
             v2_count += 1
-
-    # 1c. Move v2-tagged paths to the front of ``paths``. Mintlify orders
-    # auto-generated sidebar groups by the order operations appear in the spec
-    # (not by the ``tags`` array), so the v2 group must lead the paths to render
-    # first, directly under the reference overview page.
-    def _is_v2_path(methods: dict) -> bool:
-        return any(
-            isinstance(op, dict) and op.get("tags") == [V2_TAG]
-            for op in methods.values()
-        )
-
-    paths = spec.get("paths", {})
-    v2_paths = {p: m for p, m in paths.items() if _is_v2_path(m)}
-    if v2_paths:
-        rest = {p: m for p, m in paths.items() if p not in v2_paths}
-        spec["paths"] = {**v2_paths, **rest}
 
     # 2. Ensure top-level tags array exists and add x-group.
     if "tags" not in spec:
@@ -323,7 +311,7 @@ def process_spec(spec: dict) -> dict:
     print(
         f"Processed {total_count} operations: "
         f"{hidden_count} hidden, {total_count - hidden_count} public "
-        f"({v2_count} grouped under {V2_GROUP!r})",
+        f"({v2_count} labeled '(v2)')",
         file=sys.stderr,
     )
 

--- a/scripts/process_langsmith_openapi.py
+++ b/scripts/process_langsmith_openapi.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import re
 import ssl
 import sys
 import urllib.error
@@ -224,6 +225,25 @@ def _should_hide_by_tags(tags: list[str]) -> bool:
     return any(tag in HIDDEN_TAGS for tag in tags)
 
 
+_BETA_PREFIX_RE = re.compile(r"^\[Beta\]\s*(.+)$")
+_TRAILING_V2_RE = re.compile(r"^(.*\S)\s+V2$")
+
+
+def _normalize_summary(summary: str) -> str:
+    """Rewrite inline markers to a trailing suffix.
+
+    ``"[Beta] X"`` becomes ``"X (Beta)"`` and ``"X V2"`` becomes ``"X (v2)"`` so
+    version and release-stage markers read consistently across the reference.
+    """
+    beta = _BETA_PREFIX_RE.match(summary)
+    if beta:
+        summary = f"{beta.group(1).rstrip()} (Beta)"
+    trailing = _TRAILING_V2_RE.match(summary)
+    if trailing:
+        summary = f"{trailing.group(1)} (v2)"
+    return summary
+
+
 def process_spec(spec: dict) -> dict:
     """Add ``x-hidden`` and ``x-group`` annotations to *spec* in place."""
     hidden_count = 0
@@ -243,30 +263,70 @@ def process_spec(spec: dict) -> dict:
                 operation["x-hidden"] = True
                 hidden_count += 1
 
-    # 1b. Append a "(v2)" marker to visible v2 operation titles so they are
-    # distinguishable from their v1 siblings within the same resource group.
-    # Runs after hiding so hidden v2 ops are skipped; sandboxes are excluded
-    # (v2-only feature, no v1 counterpart). Idempotent on re-runs.
+    # 1b. Standardize endpoint titles: normalize inline markers to a trailing
+    # suffix (see _normalize_summary), and append a "(v2)" marker to visible
+    # non-sandbox /v2/ operations so they are distinguishable from their v1
+    # siblings. Idempotent on re-runs.
     v2_count = 0
     marker = V2_LABEL_SUFFIX.strip()
     for path, methods in spec.get("paths", {}).items():
-        if not path.startswith(V2_PATH_PREFIX):
-            continue
-        if any(path.startswith(p) for p in V2_LABEL_EXCLUDE_PREFIXES):
-            continue
+        is_v2 = path.startswith(V2_PATH_PREFIX) and not any(
+            path.startswith(p) for p in V2_LABEL_EXCLUDE_PREFIXES
+        )
         for method, operation in methods.items():
             if not isinstance(operation, dict):
                 continue
             if method in ("parameters", "summary", "description", "servers"):
                 continue
-            if operation.get("x-hidden"):
+            summary = _normalize_summary((operation.get("summary") or "").strip())
+            if is_v2 and not operation.get("x-hidden"):
+                if not summary:
+                    summary = f"{method.upper()} {path}"
+                if not summary.endswith(marker):
+                    summary = f"{summary}{V2_LABEL_SUFFIX}"
+                v2_count += 1
+            if summary:
+                operation["summary"] = summary
+
+    # 1c. Place each v2 endpoint that has a direct v1 counterpart immediately
+    # after it, sharing the v1 tag, so the two versions sit together in the
+    # sidebar. Only /v2/ paths with a matching "/api/v1/..." path are paired;
+    # the rest stay grouped by their own resource tag.
+    paths = spec.get("paths", {})
+    v2_after_v1: dict[str, str] = {}
+    for path in paths:
+        if not path.startswith(V2_PATH_PREFIX):
+            continue
+        if any(path.startswith(p) for p in V2_LABEL_EXCLUDE_PREFIXES):
+            continue
+        v1_path = "/api/v1" + path[len("/v2"):]
+        if v1_path not in paths:
+            continue
+        v2_after_v1[v1_path] = path
+        v1_tags = next(
+            (
+                op["tags"]
+                for op in paths[v1_path].values()
+                if isinstance(op, dict) and op.get("tags")
+            ),
+            None,
+        )
+        if v1_tags:
+            for op in paths[path].values():
+                if isinstance(op, dict) and "tags" in op:
+                    op["tags"] = list(v1_tags)
+
+    if v2_after_v1:
+        v2_targets = set(v2_after_v1.values())
+        reordered: dict = {}
+        for p, methods in paths.items():
+            if p in v2_targets:
                 continue
-            summary = (operation.get("summary") or "").rstrip()
-            if not summary:
-                summary = f"{method.upper()} {path}"
-            if not summary.endswith(marker):
-                operation["summary"] = f"{summary}{V2_LABEL_SUFFIX}"
-            v2_count += 1
+            reordered[p] = methods
+            if p in v2_after_v1:
+                vp = v2_after_v1[p]
+                reordered[vp] = paths[vp]
+        spec["paths"] = reordered
 
     # 2. Ensure top-level tags array exists and add x-group.
     if "tags" not in spec:

--- a/scripts/process_langsmith_openapi.py
+++ b/scripts/process_langsmith_openapi.py
@@ -101,6 +101,23 @@ V2_LABEL_EXCLUDE_PREFIXES: list[str] = [
     "/v2/sandboxes/",
 ]
 
+# Canonical base titles for v2 operations whose backend wording diverges from
+# their v1 sibling, so the two versions read identically (the "(v2)" suffix is
+# added automatically). Keyed by (HTTP method, path).
+V2_TITLE_OVERRIDES: dict[tuple[str, str], str] = {
+    ("POST", "/v2/runs/query"): "Query runs",
+    ("GET", "/v2/runs/{run_id}"): "Read run",
+    ("POST", "/v2/runs/{run_id}/share"): "Share run",
+}
+
+# Acronyms and proper nouns to preserve verbatim when sentence-casing titles.
+TITLE_PRESERVE: set[str] = {
+    "API", "AWS", "GitHub", "HTTP", "HTTPS", "ID", "JSON", "LangGraph",
+    "LangSmith", "LCU", "LLM", "MCP", "NPS", "OAuth2", "SCIM", "SDK", "SSO",
+    "TCP", "TTL", "UI", "URI", "URL", "WebSocket",
+}
+_TITLE_PRESERVE_BY_UPPER: dict[str, str] = {t.upper(): t for t in TITLE_PRESERVE}
+
 # Map raw tag names to human-readable group headings (``x-group``).
 # Tags not listed here keep their original name as the group heading.
 TAG_GROUPS: dict[str, str] = {
@@ -227,21 +244,64 @@ def _should_hide_by_tags(tags: list[str]) -> bool:
 
 _BETA_PREFIX_RE = re.compile(r"^\[Beta\]\s*(.+)$")
 _TRAILING_V2_RE = re.compile(r"^(.*\S)\s+V2$")
+_TRAILING_MARKER_RE = re.compile(r"\s*\((Beta|v2)\)\s*$", re.IGNORECASE)
 
 
-def _normalize_summary(summary: str) -> str:
-    """Rewrite inline markers to a trailing suffix.
+def _sentence_case(text: str) -> str:
+    """Sentence-case *text*, preserving allow-listed acronyms and proper nouns."""
+    words = text.split()
+    out = []
+    for i, word in enumerate(words):
+        canonical = _TITLE_PRESERVE_BY_UPPER.get(word.upper())
+        if canonical:
+            out.append(canonical)
+        elif i == 0:
+            out.append(word[:1].upper() + word[1:].lower())
+        else:
+            out.append(word.lower())
+    return " ".join(out)
 
-    ``"[Beta] X"`` becomes ``"X (Beta)"`` and ``"X V2"`` becomes ``"X (v2)"`` so
-    version and release-stage markers read consistently across the reference.
+
+def _standardize_title(
+    summary: str, *, override: str | None = None, v2_path: bool = False
+) -> str:
+    """Return a sentence-cased title with a trailing ``(Beta)``/``(v2)`` marker.
+
+    Strips a ``"[Beta] "`` prefix and a trailing ``" V2"`` and re-adds them as
+    consistent suffixes. ``override`` replaces the base title (used to make a v2
+    endpoint read identically to its v1 sibling); ``v2_path`` forces the
+    ``(v2)`` suffix for operations under ``/v2/``.
     """
-    beta = _BETA_PREFIX_RE.match(summary)
+    text = summary.strip()
+    beta = False
+    v2 = v2_path
+    # Strip any markers applied by a previous run so re-processing is idempotent.
+    while True:
+        match = _TRAILING_MARKER_RE.search(text)
+        if not match:
+            break
+        if match.group(1).lower() == "beta":
+            beta = True
+        else:
+            v2 = True
+        text = text[: match.start()].strip()
+    # Strip the raw backend markers ("[Beta] " prefix, trailing " V2").
+    prefix = _BETA_PREFIX_RE.match(text)
+    if prefix:
+        beta = True
+        text = prefix.group(1).strip()
+    trailing_v2 = _TRAILING_V2_RE.match(text)
+    if trailing_v2:
+        v2 = True
+        text = trailing_v2.group(1).strip()
+    if override:
+        text = override
+    text = _sentence_case(text)
     if beta:
-        summary = f"{beta.group(1).rstrip()} (Beta)"
-    trailing = _TRAILING_V2_RE.match(summary)
-    if trailing:
-        summary = f"{trailing.group(1)} (v2)"
-    return summary
+        text += " (Beta)"
+    if v2:
+        text += V2_LABEL_SUFFIX
+    return text
 
 
 def process_spec(spec: dict) -> dict:
@@ -263,12 +323,11 @@ def process_spec(spec: dict) -> dict:
                 operation["x-hidden"] = True
                 hidden_count += 1
 
-    # 1b. Standardize endpoint titles: normalize inline markers to a trailing
-    # suffix (see _normalize_summary), and append a "(v2)" marker to visible
-    # non-sandbox /v2/ operations so they are distinguishable from their v1
-    # siblings. Idempotent on re-runs.
+    # 1b. Standardize endpoint titles: sentence-case them, normalize inline
+    # markers to a trailing "(Beta)"/"(v2)" suffix, and force the "(v2)" suffix
+    # on visible non-sandbox /v2/ operations so they are distinguishable from
+    # their v1 siblings. Idempotent on re-runs.
     v2_count = 0
-    marker = V2_LABEL_SUFFIX.strip()
     for path, methods in spec.get("paths", {}).items():
         is_v2 = path.startswith(V2_PATH_PREFIX) and not any(
             path.startswith(p) for p in V2_LABEL_EXCLUDE_PREFIXES
@@ -278,15 +337,14 @@ def process_spec(spec: dict) -> dict:
                 continue
             if method in ("parameters", "summary", "description", "servers"):
                 continue
-            summary = _normalize_summary((operation.get("summary") or "").strip())
-            if is_v2 and not operation.get("x-hidden"):
-                if not summary:
-                    summary = f"{method.upper()} {path}"
-                if not summary.endswith(marker):
-                    summary = f"{summary}{V2_LABEL_SUFFIX}"
+            v2_path = is_v2 and not operation.get("x-hidden")
+            raw = operation.get("summary") or f"{method.upper()} {path}"
+            override = V2_TITLE_OVERRIDES.get((method.upper(), path))
+            operation["summary"] = _standardize_title(
+                raw, override=override, v2_path=v2_path
+            )
+            if v2_path:
                 v2_count += 1
-            if summary:
-                operation["summary"] = summary
 
     # 1c. Place each v2 endpoint that has a direct v1 counterpart immediately
     # after it, sharing the v1 tag, so the two versions sit together in the

--- a/scripts/process_langsmith_openapi.py
+++ b/scripts/process_langsmith_openapi.py
@@ -346,46 +346,6 @@ def process_spec(spec: dict) -> dict:
             if v2_path:
                 v2_count += 1
 
-    # 1c. Place each v2 endpoint that has a direct v1 counterpart immediately
-    # after it, sharing the v1 tag, so the two versions sit together in the
-    # sidebar. Only /v2/ paths with a matching "/api/v1/..." path are paired;
-    # the rest stay grouped by their own resource tag.
-    paths = spec.get("paths", {})
-    v2_after_v1: dict[str, str] = {}
-    for path in paths:
-        if not path.startswith(V2_PATH_PREFIX):
-            continue
-        if any(path.startswith(p) for p in V2_LABEL_EXCLUDE_PREFIXES):
-            continue
-        v1_path = "/api/v1" + path[len("/v2"):]
-        if v1_path not in paths:
-            continue
-        v2_after_v1[v1_path] = path
-        v1_tags = next(
-            (
-                op["tags"]
-                for op in paths[v1_path].values()
-                if isinstance(op, dict) and op.get("tags")
-            ),
-            None,
-        )
-        if v1_tags:
-            for op in paths[path].values():
-                if isinstance(op, dict) and "tags" in op:
-                    op["tags"] = list(v1_tags)
-
-    if v2_after_v1:
-        v2_targets = set(v2_after_v1.values())
-        reordered: dict = {}
-        for p, methods in paths.items():
-            if p in v2_targets:
-                continue
-            reordered[p] = methods
-            if p in v2_after_v1:
-                vp = v2_after_v1[p]
-                reordered[vp] = paths[vp]
-        spec["paths"] = reordered
-
     # 2. Ensure top-level tags array exists and add x-group.
     if "tags" not in spec:
         spec["tags"] = []

--- a/src/langsmith/langsmith-platform-openapi.json
+++ b/src/langsmith/langsmith-platform-openapi.json
@@ -1382,7 +1382,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "[Beta] Get Insights Jobs",
+        "summary": "Get Insights Jobs (Beta)",
         "description": "Get all clusters for a session.",
         "operationId": "_Beta__Get_Insights_Jobs_api_v1_sessions__session_id__insights_get",
         "security": [
@@ -1492,7 +1492,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "[Beta] Create Insights Job",
+        "summary": "Create Insights Job (Beta)",
         "description": "Create an insights job.",
         "operationId": "_Beta__Create_Insights_Job_api_v1_sessions__session_id__insights_post",
         "security": [
@@ -1558,7 +1558,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "[Beta] Get Insights Job Configs",
+        "summary": "Get Insights Job Configs (Beta)",
         "description": "Get all insights job configs for a session.",
         "operationId": "_Beta__Get_Insights_Job_Configs_api_v1_sessions__session_id__insights_configs_get",
         "security": [
@@ -1622,7 +1622,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "[Beta] Create Insights Job Config",
+        "summary": "Create Insights Job Config (Beta)",
         "description": "Save an insights job config.",
         "operationId": "_Beta__Create_Insights_Job_Config_api_v1_sessions__session_id__insights_configs_post",
         "security": [
@@ -1688,7 +1688,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "[Beta] Auto-Generate Insights Job Config",
+        "summary": "Auto-Generate Insights Job Config (Beta)",
         "description": "Auto-generate an insights job config.",
         "operationId": "_Beta__Auto_Generate_Insights_Job_Config_api_v1_sessions__session_id__insights_configs_generate_post",
         "security": [
@@ -1754,7 +1754,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "[Beta] Update Insights Job Config",
+        "summary": "Update Insights Job Config (Beta)",
         "description": "Update an insights job config.",
         "operationId": "_Beta__Update_Insights_Job_Config_api_v1_sessions__session_id__insights_configs__config_id__patch",
         "security": [
@@ -1828,7 +1828,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "[Beta] Delete Insights Job Config",
+        "summary": "Delete Insights Job Config (Beta)",
         "description": "Delete an insights job config.",
         "operationId": "_Beta__Delete_Insights_Job_Config_api_v1_sessions__session_id__insights_configs__config_id__delete",
         "security": [
@@ -1894,7 +1894,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "[Beta] Get Insights Job",
+        "summary": "Get Insights Job (Beta)",
         "description": "Get a specific cluster job for a session.",
         "operationId": "_Beta__Get_Insights_Job_api_v1_sessions__session_id__insights__job_id__get",
         "security": [
@@ -1958,7 +1958,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "[Beta] Update Insights Job",
+        "summary": "Update Insights Job (Beta)",
         "description": "Update a session cluster job.",
         "operationId": "_Beta__Update_Insights_Job_api_v1_sessions__session_id__insights__job_id__patch",
         "security": [
@@ -2032,7 +2032,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "[Beta] Delete Insights Job",
+        "summary": "Delete Insights Job (Beta)",
         "description": "Delete a session cluster job.",
         "operationId": "_Beta__Delete_Insights_Job_api_v1_sessions__session_id__insights__job_id__delete",
         "security": [
@@ -2098,7 +2098,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "[Beta] Get Run Cluster From Insights Job",
+        "summary": "Get Run Cluster From Insights Job (Beta)",
         "description": "Get a specific cluster for a session.",
         "operationId": "_Beta__Get_Run_Cluster_from_Insights_Job_api_v1_sessions__session_id__insights__job_id__clusters__cluster_id__get",
         "security": [
@@ -2174,7 +2174,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "[Beta] Get Runs From Insights Job",
+        "summary": "Get Runs From Insights Job (Beta)",
         "description": "Get all runs for a cluster job, optionally filtered by cluster.",
         "operationId": "_Beta__Get_Runs_from_Insights_Job_api_v1_sessions__session_id__insights__job_id__runs_get",
         "security": [
@@ -8455,7 +8455,7 @@
         "tags": [
           "run"
         ],
-        "summary": "List Rule Logs V2",
+        "summary": "List Rule Logs (v2)",
         "description": "List logs for a particular rule with cursor-based pagination.\n\nThis endpoint handles S3-stored outcomes correctly by using run_outcomes_count\nto predict batch sizes and avoid over-fetching.",
         "operationId": "list_rule_logs_v2_api_v1_runs_rules__rule_id__logs_v2_get",
         "security": [
@@ -8941,6 +8941,220 @@
         "x-public": true
       }
     },
+    "/v2/runs/{run_id}": {
+      "get": {
+        "security": [
+          {
+            "API Key": [],
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": [],
+            "Tenant ID": []
+          }
+        ],
+        "description": "**Alpha:** The request and response contract may change;\nReturns one run by ID for the given session and start_time. Use the `selects` query parameter (repeatable) to select fields to return.",
+        "tags": [
+          "run"
+        ],
+        "summary": "Get a single run (v2)",
+        "parameters": [
+          {
+            "description": "application/json",
+            "name": "Accept",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Run UUID",
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "`project_id` is the UUID of the tracing project that owns the run.",
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "description": "`selects` lists which properties to include on the returned run (repeatable query parameter). Accepts any value of the `RunSelectField` enum. If omitted, only `id` is returned.",
+            "name": "selects",
+            "in": "query",
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "items": {
+                "enum": [
+                  "ID",
+                  "NAME",
+                  "RUN_TYPE",
+                  "STATUS",
+                  "START_TIME",
+                  "END_TIME",
+                  "LATENCY_SECONDS",
+                  "FIRST_TOKEN_TIME",
+                  "ERROR",
+                  "ERROR_PREVIEW",
+                  "EXTRA",
+                  "METADATA",
+                  "EVENTS",
+                  "INPUTS",
+                  "INPUTS_PREVIEW",
+                  "OUTPUTS",
+                  "OUTPUTS_PREVIEW",
+                  "MANIFEST",
+                  "PARENT_RUN_IDS",
+                  "PROJECT_ID",
+                  "TRACE_ID",
+                  "THREAD_ID",
+                  "DOTTED_ORDER",
+                  "IS_ROOT",
+                  "REFERENCE_EXAMPLE_ID",
+                  "REFERENCE_DATASET_ID",
+                  "TOTAL_TOKENS",
+                  "PROMPT_TOKENS",
+                  "COMPLETION_TOKENS",
+                  "TOTAL_COST",
+                  "PROMPT_COST",
+                  "COMPLETION_COST",
+                  "PROMPT_TOKEN_DETAILS",
+                  "COMPLETION_TOKEN_DETAILS",
+                  "PROMPT_COST_DETAILS",
+                  "COMPLETION_COST_DETAILS",
+                  "PRICE_MODEL_ID",
+                  "TAGS",
+                  "APP_PATH",
+                  "ATTACHMENTS",
+                  "THREAD_EVALUATION_TIME",
+                  "IS_IN_DATASET",
+                  "SHARE_URL",
+                  "FEEDBACK_STATS"
+                ],
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Selects"
+            }
+          },
+          {
+            "description": "`start_time` is the run's `start_time` (RFC3339 date-time), used together with `project_id` to locate the run.",
+            "name": "start_time",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "format": "date-time",
+              "type": "string",
+              "title": "Start Time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/query.RunResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request (missing or invalid query parameters)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden (insufficient permission)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "run or session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "unprocessable entity (e.g. invalid UUID)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "gateway timeout or deadline exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true
+      }
+    },
     "/api/v1/runs/{run_id}/share": {
       "get": {
         "tags": [
@@ -9111,6 +9325,121 @@
         "x-public": true
       }
     },
+    "/v2/runs/{run_id}/share": {
+      "post": {
+        "security": [
+          {
+            "API Key": []
+          },
+          {
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": []
+          }
+        ],
+        "description": "Creates or returns a share token for a run. Child runs share their trace root.",
+        "tags": [
+          "run"
+        ],
+        "summary": "Share a run (v2)",
+        "parameters": [
+          {
+            "description": "Run UUID",
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/share.CreateShareTokenResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Request Entity Too Large",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/share.CreateShareTokenRequestBody"
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v1/runs/query/validate": {
       "post": {
         "tags": [
@@ -9205,6 +9534,146 @@
           }
         ],
         "x-public": true
+      }
+    },
+    "/v2/runs/query": {
+      "post": {
+        "security": [
+          {
+            "API Key": [],
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": [],
+            "Tenant ID": []
+          }
+        ],
+        "description": "**Alpha:** The request and response contract may change;\nReturns a paginated list of runs for the given projects within min/max start_time. Supports filters, cursor pagination, and `selects` to select fields to return.",
+        "tags": [
+          "run"
+        ],
+        "summary": "Query runs (v2)",
+        "parameters": [
+          {
+            "description": "application/json",
+            "name": "Accept",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "application/json (required for JSON body)",
+            "name": "Content-Type",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/query.QueryRunsResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request (malformed JSON or invalid parameters)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden (insufficient permission)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "unprocessable entity (e.g. invalid UUID)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "gateway timeout or deadline exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/query.QueryRunsRequestBody"
+              }
+            }
+          }
+        }
       }
     },
     "/api/v1/runs/generate-query": {
@@ -32462,7 +32931,7 @@
         "tags": [
           "issues"
         ],
-        "summary": "[Beta] List issues",
+        "summary": "List issues (Beta)",
         "parameters": [
           {
             "description": "Filter by session ID (UUID)",
@@ -32637,7 +33106,7 @@
         "tags": [
           "issues-agent"
         ],
-        "summary": "[Beta] List issues agent configs",
+        "summary": "List issues agent configs (Beta)",
         "responses": {
           "200": {
             "description": "OK",
@@ -32714,7 +33183,7 @@
         "tags": [
           "issues"
         ],
-        "summary": "[Beta] Get issue",
+        "summary": "Get issue (Beta)",
         "parameters": [
           {
             "description": "Issue ID (UUID)",
@@ -32946,7 +33415,7 @@
         "tags": [
           "issues"
         ],
-        "summary": "[Beta] Mark issue viewed",
+        "summary": "Mark issue viewed (Beta)",
         "parameters": [
           {
             "description": "Issue ID (UUID)",
@@ -35109,7 +35578,7 @@
         "tags": [
           "issues-agent"
         ],
-        "summary": "[Beta] Get the issues agent config for a session",
+        "summary": "Get the issues agent config for a session (Beta)",
         "parameters": [
           {
             "description": "Tracer session ID (UUID)",
@@ -35201,7 +35670,7 @@
         "tags": [
           "issues-agent"
         ],
-        "summary": "[Beta] Create the issues agent for a session",
+        "summary": "Create the issues agent for a session (Beta)",
         "parameters": [
           {
             "description": "Tracer session ID (UUID)",
@@ -35303,7 +35772,7 @@
         "tags": [
           "issues-agent"
         ],
-        "summary": "[Beta] Delete the issues agent for a session",
+        "summary": "Delete the issues agent for a session (Beta)",
         "parameters": [
           {
             "description": "Tracer session ID (UUID)",
@@ -35388,7 +35857,7 @@
         "tags": [
           "issues-agent"
         ],
-        "summary": "[Beta] Update the issues agent config for a session",
+        "summary": "Update the issues agent config for a session (Beta)",
         "parameters": [
           {
             "description": "Tracer session ID (UUID)",
@@ -35492,7 +35961,7 @@
         "tags": [
           "issues-agent"
         ],
-        "summary": "[Beta] Save the agent overview for a session",
+        "summary": "Save the agent overview for a session (Beta)",
         "parameters": [
           {
             "description": "Tracer session ID (UUID)",
@@ -35714,7 +36183,7 @@
         "tags": [
           "issues"
         ],
-        "summary": "[Beta] List viewed issues for a session",
+        "summary": "List viewed issues for a session (Beta)",
         "parameters": [
           {
             "description": "Session ID (UUID)",
@@ -36995,475 +37464,6 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/query.PublicSharedTraceRunsRequestBody"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v2/runs/query": {
-      "post": {
-        "security": [
-          {
-            "API Key": [],
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": [],
-            "Tenant ID": []
-          }
-        ],
-        "description": "**Alpha:** The request and response contract may change;\nReturns a paginated list of runs for the given projects within min/max start_time. Supports filters, cursor pagination, and `selects` to select fields to return.",
-        "tags": [
-          "runs"
-        ],
-        "summary": "Query runs (v2)",
-        "parameters": [
-          {
-            "description": "application/json",
-            "name": "Accept",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "application/json (required for JSON body)",
-            "name": "Content-Type",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/query.QueryRunsResponseBody"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request (malformed JSON or invalid parameters)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid authentication",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden (insufficient permission)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "unprocessable entity (e.g. invalid UUID)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "gateway timeout or deadline exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true,
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/query.QueryRunsRequestBody"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v2/runs/{run_id}": {
-      "get": {
-        "security": [
-          {
-            "API Key": [],
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": [],
-            "Tenant ID": []
-          }
-        ],
-        "description": "**Alpha:** The request and response contract may change;\nReturns one run by ID for the given session and start_time. Use the `selects` query parameter (repeatable) to select fields to return.",
-        "tags": [
-          "runs"
-        ],
-        "summary": "Get a single run (v2)",
-        "parameters": [
-          {
-            "description": "application/json",
-            "name": "Accept",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Run UUID",
-            "name": "run_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "description": "`project_id` is the UUID of the tracing project that owns the run.",
-            "name": "project_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string",
-              "title": "Project Id"
-            }
-          },
-          {
-            "description": "`selects` lists which properties to include on the returned run (repeatable query parameter). Accepts any value of the `RunSelectField` enum. If omitted, only `id` is returned.",
-            "name": "selects",
-            "in": "query",
-            "style": "form",
-            "explode": true,
-            "schema": {
-              "items": {
-                "enum": [
-                  "ID",
-                  "NAME",
-                  "RUN_TYPE",
-                  "STATUS",
-                  "START_TIME",
-                  "END_TIME",
-                  "LATENCY_SECONDS",
-                  "FIRST_TOKEN_TIME",
-                  "ERROR",
-                  "ERROR_PREVIEW",
-                  "EXTRA",
-                  "METADATA",
-                  "EVENTS",
-                  "INPUTS",
-                  "INPUTS_PREVIEW",
-                  "OUTPUTS",
-                  "OUTPUTS_PREVIEW",
-                  "MANIFEST",
-                  "PARENT_RUN_IDS",
-                  "PROJECT_ID",
-                  "TRACE_ID",
-                  "THREAD_ID",
-                  "DOTTED_ORDER",
-                  "IS_ROOT",
-                  "REFERENCE_EXAMPLE_ID",
-                  "REFERENCE_DATASET_ID",
-                  "TOTAL_TOKENS",
-                  "PROMPT_TOKENS",
-                  "COMPLETION_TOKENS",
-                  "TOTAL_COST",
-                  "PROMPT_COST",
-                  "COMPLETION_COST",
-                  "PROMPT_TOKEN_DETAILS",
-                  "COMPLETION_TOKEN_DETAILS",
-                  "PROMPT_COST_DETAILS",
-                  "COMPLETION_COST_DETAILS",
-                  "PRICE_MODEL_ID",
-                  "TAGS",
-                  "APP_PATH",
-                  "ATTACHMENTS",
-                  "THREAD_EVALUATION_TIME",
-                  "IS_IN_DATASET",
-                  "SHARE_URL",
-                  "FEEDBACK_STATS"
-                ],
-                "type": "string"
-              },
-              "type": "array",
-              "title": "Selects"
-            }
-          },
-          {
-            "description": "`start_time` is the run's `start_time` (RFC3339 date-time), used together with `project_id` to locate the run.",
-            "name": "start_time",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "format": "date-time",
-              "type": "string",
-              "title": "Start Time"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/query.RunResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request (missing or invalid query parameters)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid authentication",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden (insufficient permission)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "run or session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "unprocessable entity (e.g. invalid UUID)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "gateway timeout or deadline exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true
-      }
-    },
-    "/v2/runs/{run_id}/share": {
-      "post": {
-        "security": [
-          {
-            "API Key": []
-          },
-          {
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": []
-          }
-        ],
-        "description": "Creates or returns a share token for a run. Child runs share their trace root.",
-        "tags": [
-          "runs"
-        ],
-        "summary": "Share a run (v2)",
-        "parameters": [
-          {
-            "description": "Run UUID",
-            "name": "run_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/share.CreateShareTokenResponseBody"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "Request Entity Too Large",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true,
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/share.CreateShareTokenRequestBody"
               }
             }
           }

--- a/src/langsmith/langsmith-platform-openapi.json
+++ b/src/langsmith/langsmith-platform-openapi.json
@@ -11,7 +11,7 @@
         "tags": [
           "info"
         ],
-        "summary": "Get Server Info",
+        "summary": "Get server info",
         "description": "Get information about the current deployment of LangSmith.",
         "operationId": "get_server_info_api_v1_info_get",
         "responses": {
@@ -34,7 +34,7 @@
         "tags": [
           "info"
         ],
-        "summary": "Get Health Info",
+        "summary": "Get health info",
         "description": "Get health information about the current deployment of LangSmith.",
         "operationId": "get_health_info_api_v1_info_health_get",
         "responses": {
@@ -57,7 +57,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Get Tracing Project Prebuilt Dashboard",
+        "summary": "Get tracing project prebuilt dashboard",
         "description": "Get a prebuilt dashboard for a tracing project.",
         "operationId": "get_tracing_project_prebuilt_dashboard_api_v1_sessions__session_id__dashboard_post",
         "security": [
@@ -139,7 +139,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Read Tracer Session",
+        "summary": "Read tracer session",
         "description": "Get a specific project.",
         "operationId": "read_tracer_session_api_v1_sessions__session_id__get",
         "security": [
@@ -236,7 +236,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Update Tracer Session",
+        "summary": "Update tracer session",
         "description": "Update a project.",
         "operationId": "update_tracer_session_api_v1_sessions__session_id__patch",
         "security": [
@@ -300,7 +300,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Delete Tracer Session",
+        "summary": "Delete tracer session",
         "description": "Delete a specific project.",
         "operationId": "delete_tracer_session_api_v1_sessions__session_id__delete",
         "security": [
@@ -354,7 +354,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Read Tracer Sessions",
+        "summary": "Read tracer sessions",
         "description": "List all projects.",
         "operationId": "read_tracer_sessions_api_v1_sessions_get",
         "security": [
@@ -730,7 +730,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Create Tracer Session",
+        "summary": "Create tracer session",
         "description": "Create a new project.",
         "operationId": "create_tracer_session_api_v1_sessions_post",
         "security": [
@@ -794,7 +794,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Delete Tracer Sessions",
+        "summary": "Delete tracer sessions",
         "description": "Delete projects.",
         "operationId": "delete_tracer_sessions_api_v1_sessions_delete",
         "security": [
@@ -851,7 +851,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Read Tracer Sessions Runs Metadata",
+        "summary": "Read tracer sessions runs metadata",
         "description": "Given a session, a number K, and (optionally) a list of metadata keys, return the top K values for each key.",
         "operationId": "read_tracer_sessions_runs_metadata_api_v1_sessions__session_id__metadata_get",
         "security": [
@@ -964,7 +964,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Read Filter Views",
+        "summary": "Read filter views",
         "description": "Get all filter views for a session.",
         "operationId": "read_filter_views_api_v1_sessions__session_id__views_get",
         "security": [
@@ -1038,7 +1038,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Create Filter View",
+        "summary": "Create filter view",
         "description": "Create a new filter view.",
         "operationId": "create_filter_view_api_v1_sessions__session_id__views_post",
         "security": [
@@ -1104,7 +1104,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Read Filter View",
+        "summary": "Read filter view",
         "description": "Get a specific filter view.",
         "operationId": "read_filter_view_api_v1_sessions__session_id__views__view_id__get",
         "security": [
@@ -1168,7 +1168,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Update Filter View",
+        "summary": "Update filter view",
         "description": "Update a filter view.",
         "operationId": "update_filter_view_api_v1_sessions__session_id__views__view_id__patch",
         "security": [
@@ -1242,7 +1242,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Delete Filter View",
+        "summary": "Delete filter view",
         "description": "Delete a specific filter view.",
         "operationId": "delete_filter_view_api_v1_sessions__session_id__views__view_id__delete",
         "security": [
@@ -1306,7 +1306,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Rename Filter View",
+        "summary": "Rename filter view",
         "description": "Rename a filter view (display_name and description only).",
         "operationId": "rename_filter_view_api_v1_sessions__session_id__views__view_id__rename_patch",
         "security": [
@@ -1382,7 +1382,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Get Insights Jobs (Beta)",
+        "summary": "Get insights jobs (Beta)",
         "description": "Get all clusters for a session.",
         "operationId": "_Beta__Get_Insights_Jobs_api_v1_sessions__session_id__insights_get",
         "security": [
@@ -1492,7 +1492,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Create Insights Job (Beta)",
+        "summary": "Create insights job (Beta)",
         "description": "Create an insights job.",
         "operationId": "_Beta__Create_Insights_Job_api_v1_sessions__session_id__insights_post",
         "security": [
@@ -1558,7 +1558,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Get Insights Job Configs (Beta)",
+        "summary": "Get insights job configs (Beta)",
         "description": "Get all insights job configs for a session.",
         "operationId": "_Beta__Get_Insights_Job_Configs_api_v1_sessions__session_id__insights_configs_get",
         "security": [
@@ -1622,7 +1622,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Create Insights Job Config (Beta)",
+        "summary": "Create insights job config (Beta)",
         "description": "Save an insights job config.",
         "operationId": "_Beta__Create_Insights_Job_Config_api_v1_sessions__session_id__insights_configs_post",
         "security": [
@@ -1688,7 +1688,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Auto-Generate Insights Job Config (Beta)",
+        "summary": "Auto-generate insights job config (Beta)",
         "description": "Auto-generate an insights job config.",
         "operationId": "_Beta__Auto_Generate_Insights_Job_Config_api_v1_sessions__session_id__insights_configs_generate_post",
         "security": [
@@ -1754,7 +1754,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Update Insights Job Config (Beta)",
+        "summary": "Update insights job config (Beta)",
         "description": "Update an insights job config.",
         "operationId": "_Beta__Update_Insights_Job_Config_api_v1_sessions__session_id__insights_configs__config_id__patch",
         "security": [
@@ -1828,7 +1828,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Delete Insights Job Config (Beta)",
+        "summary": "Delete insights job config (Beta)",
         "description": "Delete an insights job config.",
         "operationId": "_Beta__Delete_Insights_Job_Config_api_v1_sessions__session_id__insights_configs__config_id__delete",
         "security": [
@@ -1894,7 +1894,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Get Insights Job (Beta)",
+        "summary": "Get insights job (Beta)",
         "description": "Get a specific cluster job for a session.",
         "operationId": "_Beta__Get_Insights_Job_api_v1_sessions__session_id__insights__job_id__get",
         "security": [
@@ -1958,7 +1958,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Update Insights Job (Beta)",
+        "summary": "Update insights job (Beta)",
         "description": "Update a session cluster job.",
         "operationId": "_Beta__Update_Insights_Job_api_v1_sessions__session_id__insights__job_id__patch",
         "security": [
@@ -2032,7 +2032,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Delete Insights Job (Beta)",
+        "summary": "Delete insights job (Beta)",
         "description": "Delete a session cluster job.",
         "operationId": "_Beta__Delete_Insights_Job_api_v1_sessions__session_id__insights__job_id__delete",
         "security": [
@@ -2098,7 +2098,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Get Run Cluster From Insights Job (Beta)",
+        "summary": "Get run cluster from insights job (Beta)",
         "description": "Get a specific cluster for a session.",
         "operationId": "_Beta__Get_Run_Cluster_from_Insights_Job_api_v1_sessions__session_id__insights__job_id__clusters__cluster_id__get",
         "security": [
@@ -2174,7 +2174,7 @@
         "tags": [
           "tracer-sessions"
         ],
-        "summary": "Get Runs From Insights Job (Beta)",
+        "summary": "Get runs from insights job (Beta)",
         "description": "Get all runs for a cluster job, optionally filtered by cluster.",
         "operationId": "_Beta__Get_Runs_from_Insights_Job_api_v1_sessions__session_id__insights__job_id__runs_get",
         "security": [
@@ -2316,7 +2316,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Create Workspace",
+        "summary": "Create workspace",
         "description": "Create a new workspace.",
         "operationId": "create_workspace_api_v1_workspaces_post",
         "security": [
@@ -2368,7 +2368,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "List Workspaces",
+        "summary": "List workspaces",
         "description": "Get all workspaces visible to this auth in the current org. Does not create a new workspace/org.",
         "operationId": "list_workspaces_api_v1_workspaces_get",
         "security": [
@@ -2445,7 +2445,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Patch Workspace",
+        "summary": "Patch workspace",
         "description": "Update a workspace.",
         "operationId": "patch_workspace_api_v1_workspaces__workspace_id__patch",
         "security": [
@@ -2509,7 +2509,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Delete Workspace",
+        "summary": "Delete workspace",
         "operationId": "delete_workspace_api_v1_workspaces__workspace_id__delete",
         "security": [
           {
@@ -2560,7 +2560,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Get Workspace",
+        "summary": "Get workspace",
         "description": "Get a single workspace by ID, scoped to the current org and identity.",
         "operationId": "get_workspace_api_v1_workspaces__workspace_id__get",
         "security": [
@@ -2643,7 +2643,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Get Current Workspace Stats",
+        "summary": "Get current workspace stats",
         "operationId": "get_current_workspace_stats_api_v1_workspaces_current_stats_get",
         "security": [
           {
@@ -2708,7 +2708,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Get Current Workspace Usage Limits Info",
+        "summary": "Get current workspace usage limits info",
         "operationId": "get_current_workspace_usage_limits_info_api_v1_workspaces_current_usage_limits_get",
         "responses": {
           "200": {
@@ -2741,7 +2741,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Get Shared Tokens",
+        "summary": "Get shared tokens",
         "description": "List all shared entities and their tokens by the workspace.",
         "operationId": "get_shared_tokens_api_v1_workspaces_current_shared_get",
         "security": [
@@ -2808,7 +2808,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Bulk Unshare Entities",
+        "summary": "Bulk unshare entities",
         "description": "Bulk unshare entities by share tokens for the workspace.",
         "operationId": "bulk_unshare_entities_api_v1_workspaces_current_shared_delete",
         "security": [
@@ -2860,7 +2860,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "List Current Workspace Secrets",
+        "summary": "List current workspace secrets",
         "operationId": "list_current_workspace_secrets_api_v1_workspaces_current_secrets_get",
         "responses": {
           "200": {
@@ -2895,7 +2895,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Upsert Current Workspace Secrets",
+        "summary": "Upsert current workspace secrets",
         "operationId": "upsert_current_workspace_secrets_api_v1_workspaces_current_secrets_post",
         "requestBody": {
           "content": {
@@ -2950,7 +2950,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Get Current Workspace Encrypted Secrets",
+        "summary": "Get current workspace encrypted secrets",
         "description": "Get encrypted workspace secrets for use with Fleet and external services.",
         "operationId": "get_current_workspace_encrypted_secrets_api_v1_workspaces_current_secrets_encrypted_get",
         "security": [
@@ -3044,7 +3044,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "List Tag Keys",
+        "summary": "List tag keys",
         "operationId": "list_tag_keys_api_v1_workspaces_current_tag_keys_get",
         "responses": {
           "200": {
@@ -3079,7 +3079,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Create Tag Key",
+        "summary": "Create tag key",
         "operationId": "create_tag_key_api_v1_workspaces_current_tag_keys_post",
         "requestBody": {
           "content": {
@@ -3132,7 +3132,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Update Tag Key",
+        "summary": "Update tag key",
         "operationId": "update_tag_key_api_v1_workspaces_current_tag_keys__tag_key_id__patch",
         "security": [
           {
@@ -3195,7 +3195,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Get Tag Key",
+        "summary": "Get tag key",
         "operationId": "get_tag_key_api_v1_workspaces_current_tag_keys__tag_key_id__get",
         "security": [
           {
@@ -3248,7 +3248,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Delete Tag Key",
+        "summary": "Delete tag key",
         "operationId": "delete_tag_key_api_v1_workspaces_current_tag_keys__tag_key_id__delete",
         "security": [
           {
@@ -3301,7 +3301,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Create Tag Value",
+        "summary": "Create tag value",
         "operationId": "create_tag_value_api_v1_workspaces_current_tag_keys__tag_key_id__tag_values_post",
         "security": [
           {
@@ -3364,7 +3364,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "List Tag Values",
+        "summary": "List tag values",
         "operationId": "list_tag_values_api_v1_workspaces_current_tag_keys__tag_key_id__tag_values_get",
         "security": [
           {
@@ -3423,7 +3423,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Get Tag Value",
+        "summary": "Get tag value",
         "operationId": "get_tag_value_api_v1_workspaces_current_tag_keys__tag_key_id__tag_values__tag_value_id__get",
         "security": [
           {
@@ -3486,7 +3486,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Update Tag Value",
+        "summary": "Update tag value",
         "operationId": "update_tag_value_api_v1_workspaces_current_tag_keys__tag_key_id__tag_values__tag_value_id__patch",
         "security": [
           {
@@ -3559,7 +3559,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Delete Tag Value",
+        "summary": "Delete tag value",
         "operationId": "delete_tag_value_api_v1_workspaces_current_tag_keys__tag_key_id__tag_values__tag_value_id__delete",
         "security": [
           {
@@ -3622,7 +3622,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Create Tagging",
+        "summary": "Create tagging",
         "operationId": "create_tagging_api_v1_workspaces_current_taggings_post",
         "security": [
           {
@@ -3673,7 +3673,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "List Taggings",
+        "summary": "List taggings",
         "operationId": "list_taggings_api_v1_workspaces_current_taggings_get",
         "security": [
           {
@@ -3739,7 +3739,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Delete Tagging",
+        "summary": "Delete tagging",
         "operationId": "delete_tagging_api_v1_workspaces_current_taggings__tagging_id__delete",
         "security": [
           {
@@ -3792,7 +3792,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "List Tags",
+        "summary": "List tags",
         "operationId": "list_tags_api_v1_workspaces_current_tags_get",
         "security": [
           {
@@ -3857,7 +3857,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "List Tags For Resource",
+        "summary": "List tags for resource",
         "operationId": "list_tags_for_resource_api_v1_workspaces_current_tags_resource_get",
         "security": [
           {
@@ -3924,7 +3924,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "List Tags For Resources",
+        "summary": "List tags for resources",
         "operationId": "list_tags_for_resources_api_v1_workspaces_current_tags_resources_post",
         "requestBody": {
           "content": {
@@ -3991,7 +3991,7 @@
         "tags": [
           "audit-logs"
         ],
-        "summary": "Get Audit Logs",
+        "summary": "Get audit logs",
         "description": "Retrieve audit log records for the authenticated user's organization in OCSF format.\n\nRequires both start_time and end_time parameters to filter logs within a date range.\nSupports cursor-based pagination.\n\nReturns results in OCSF API Activity (Class UID: 6003) format,\nwhich is compatible with security monitoring and SIEM tools.\nReference: https://schema.ocsf.io/1.7.0/classes/api_activity",
         "operationId": "get_audit_logs_api_v1_audit_logs_get",
         "security": [
@@ -4133,7 +4133,7 @@
         "tags": [
           "ttl-settings"
         ],
-        "summary": "List Ttl Settings",
+        "summary": "List TTL settings",
         "description": "List out the configured TTL settings for a given tenant.",
         "operationId": "list_ttl_settings_api_v1_ttl_settings_get",
         "responses": {
@@ -4169,7 +4169,7 @@
         "tags": [
           "ttl-settings"
         ],
-        "summary": "Upsert Ttl Settings",
+        "summary": "Upsert TTL settings",
         "operationId": "upsert_ttl_settings_api_v1_ttl_settings_put",
         "requestBody": {
           "content": {
@@ -4222,7 +4222,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "List Ttl Settings",
+        "summary": "List TTL settings",
         "description": "List out the configured TTL settings for a given org (org-level and tenant-level).",
         "operationId": "list_ttl_settings_api_v1_orgs_ttl_settings_get",
         "responses": {
@@ -4258,7 +4258,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Upsert Ttl Settings",
+        "summary": "Upsert TTL settings",
         "operationId": "upsert_ttl_settings_api_v1_orgs_ttl_settings_put",
         "requestBody": {
           "content": {
@@ -4311,7 +4311,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Count Examples",
+        "summary": "Count examples",
         "description": "Count all examples by query params",
         "operationId": "count_examples_api_v1_examples_count_get",
         "security": [
@@ -4485,7 +4485,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Read Example",
+        "summary": "Read example",
         "description": "Get a specific example.",
         "operationId": "read_example_api_v1_examples__example_id__get",
         "security": [
@@ -4576,7 +4576,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Update Example",
+        "summary": "Update example",
         "description": "Update a specific example.",
         "operationId": "update_example_api_v1_examples__example_id__patch",
         "security": [
@@ -4638,7 +4638,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Delete Example",
+        "summary": "Delete example",
         "description": "Soft delete an example. Only deletes the example in the 'latest' version of the dataset.",
         "operationId": "delete_example_api_v1_examples__example_id__delete",
         "security": [
@@ -4692,7 +4692,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Read Examples",
+        "summary": "Read examples",
         "description": "Get all examples by query params",
         "operationId": "read_examples_api_v1_examples_get",
         "security": [
@@ -4957,7 +4957,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Create Example",
+        "summary": "Create example",
         "description": "Create a new example.",
         "operationId": "create_example_api_v1_examples_post",
         "security": [
@@ -5148,7 +5148,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Delete Examples",
+        "summary": "Delete examples",
         "description": "Soft delete examples. Only deletes the examples in the 'latest' version of the dataset.",
         "operationId": "delete_examples_api_v1_examples_delete",
         "security": [
@@ -5205,7 +5205,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Create Examples",
+        "summary": "Create examples",
         "description": "Create bulk examples.",
         "operationId": "create_examples_api_v1_examples_bulk_post",
         "requestBody": {
@@ -5410,7 +5410,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Legacy Update Examples",
+        "summary": "Legacy update examples",
         "description": "Legacy update examples in bulk. For update involving attachments, use PATCH /v1/platform/datasets/{dataset_id}/examples instead.",
         "operationId": "legacy_update_examples_api_v1_examples_bulk_patch",
         "requestBody": {
@@ -5466,7 +5466,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Upload Examples From Csv",
+        "summary": "Upload examples from csv",
         "description": "Upload examples from a CSV file.\n\nNote: For non-csv upload, please use\nthe POST /v1/platform/datasets/{dataset_id}/examples endpoint which provides more efficient upload.",
         "operationId": "upload_examples_from_csv_api_v1_examples_upload__dataset_id__post",
         "security": [
@@ -5536,7 +5536,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Validate Example",
+        "summary": "Validate example",
         "description": "Validate an example.",
         "operationId": "validate_example_api_v1_examples_validate_post",
         "responses": {
@@ -5570,7 +5570,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Validate Examples",
+        "summary": "Validate examples",
         "description": "Validate examples in bulk.",
         "operationId": "validate_examples_api_v1_examples_validate_bulk_post",
         "responses": {
@@ -5608,7 +5608,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Read Datasets",
+        "summary": "Read datasets",
         "description": "Get all datasets by query params and owner.",
         "operationId": "read_datasets_api_v1_datasets_get",
         "security": [
@@ -5837,7 +5837,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Create Dataset",
+        "summary": "Create dataset",
         "description": "Create a new dataset.",
         "operationId": "create_dataset_api_v1_datasets_post",
         "security": [
@@ -5889,7 +5889,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Delete Datasets",
+        "summary": "Delete datasets",
         "description": "Delete multiple datasets.",
         "operationId": "delete_datasets_api_v1_datasets_delete",
         "security": [
@@ -5947,7 +5947,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Read Datasets Stream",
+        "summary": "Read datasets stream",
         "description": "Stream all datasets by query params and owner as JSON patches.",
         "operationId": "read_datasets_stream_api_v1_datasets_stream_get",
         "security": [
@@ -6153,7 +6153,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Read Dataset",
+        "summary": "Read dataset",
         "description": "Get a specific dataset.",
         "operationId": "read_dataset_api_v1_datasets__dataset_id__get",
         "security": [
@@ -6207,7 +6207,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Delete Dataset",
+        "summary": "Delete dataset",
         "description": "Delete a specific dataset.",
         "operationId": "delete_dataset_api_v1_datasets__dataset_id__delete",
         "security": [
@@ -6259,7 +6259,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Update Dataset",
+        "summary": "Update dataset",
         "description": "Update a specific dataset.",
         "operationId": "update_dataset_api_v1_datasets__dataset_id__patch",
         "security": [
@@ -6333,7 +6333,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Upload Csv Dataset",
+        "summary": "Upload csv dataset",
         "description": "Create a new dataset from a CSV or JSONL file.",
         "operationId": "upload_csv_dataset_api_v1_datasets_upload_post",
         "requestBody": {
@@ -6387,7 +6387,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Upload Experiment",
+        "summary": "Upload experiment",
         "description": "Upload an experiment that has already been run.",
         "operationId": "upload_experiment_api_v1_datasets_upload_experiment_post",
         "requestBody": {
@@ -6441,7 +6441,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Get Dataset Versions",
+        "summary": "Get dataset versions",
         "description": "Get dataset versions.",
         "operationId": "get_dataset_versions_api_v1_datasets__dataset_id__versions_get",
         "security": [
@@ -6557,7 +6557,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Diff Dataset Versions",
+        "summary": "Diff dataset versions",
         "description": "Get diff between two dataset versions.",
         "operationId": "diff_dataset_versions_api_v1_datasets__dataset_id__versions_diff_get",
         "security": [
@@ -6647,7 +6647,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Get Dataset Version",
+        "summary": "Get dataset version",
         "description": "Get dataset version by as_of or exact tag.",
         "operationId": "get_dataset_version_api_v1_datasets__dataset_id__version_get",
         "security": [
@@ -6736,7 +6736,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Update Dataset Version",
+        "summary": "Update dataset version",
         "description": "Set a tag on a dataset version.",
         "operationId": "update_dataset_version_api_v1_datasets__dataset_id__tags_put",
         "security": [
@@ -6802,7 +6802,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Download Dataset Openai",
+        "summary": "Download dataset openai",
         "description": "Download a dataset as OpenAI Evals Jsonl format.",
         "operationId": "download_dataset_openai_api_v1_datasets__dataset_id__openai_get",
         "security": [
@@ -6875,7 +6875,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Download Dataset Openai Ft",
+        "summary": "Download dataset openai ft",
         "description": "Download a dataset as OpenAI Jsonl format.",
         "operationId": "download_dataset_openai_ft_api_v1_datasets__dataset_id__openai_ft_get",
         "security": [
@@ -6948,7 +6948,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Download Dataset Csv",
+        "summary": "Download dataset csv",
         "description": "Download a dataset as CSV format.",
         "operationId": "download_dataset_csv_api_v1_datasets__dataset_id__csv_get",
         "security": [
@@ -7021,7 +7021,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Download Dataset Jsonl",
+        "summary": "Download dataset jsonl",
         "description": "Download a dataset as CSV format.",
         "operationId": "download_dataset_jsonl_api_v1_datasets__dataset_id__jsonl_get",
         "security": [
@@ -7094,7 +7094,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Read Examples With Runs",
+        "summary": "Read examples with runs",
         "description": "Fetch examples for a dataset, and fetch the runs for each example if they are associated with the given session_ids.",
         "operationId": "read_examples_with_runs_api_v1_datasets__dataset_id__runs_post",
         "security": [
@@ -7191,7 +7191,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Read Dataset Share State",
+        "summary": "Read dataset share state",
         "description": "Get the state of sharing a dataset",
         "operationId": "read_dataset_share_state_api_v1_datasets__dataset_id__share_get",
         "security": [
@@ -7253,7 +7253,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Share Dataset",
+        "summary": "Share dataset",
         "description": "Share a dataset.",
         "operationId": "share_dataset_api_v1_datasets__dataset_id__share_put",
         "security": [
@@ -7317,7 +7317,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Unshare Dataset",
+        "summary": "Unshare dataset",
         "description": "Unshare a dataset.",
         "operationId": "unshare_dataset_api_v1_datasets__dataset_id__share_delete",
         "security": [
@@ -7371,7 +7371,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Create Comparative Experiment",
+        "summary": "Create comparative experiment",
         "description": "Create a comparative experiment.",
         "operationId": "create_comparative_experiment_api_v1_datasets_comparative_post",
         "requestBody": {
@@ -7425,7 +7425,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Delete Comparative Experiment",
+        "summary": "Delete comparative experiment",
         "description": "Delete a specific comparative experiment.",
         "operationId": "delete_comparative_experiment_api_v1_datasets_comparative__comparative_experiment_id__delete",
         "security": [
@@ -7479,7 +7479,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Clone Dataset",
+        "summary": "Clone dataset",
         "description": "Clone a dataset.",
         "operationId": "clone_dataset_api_v1_datasets_clone_post",
         "requestBody": {
@@ -7538,7 +7538,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Get Dataset Splits",
+        "summary": "Get dataset splits",
         "operationId": "get_dataset_splits_api_v1_datasets__dataset_id__splits_get",
         "security": [
           {
@@ -7615,7 +7615,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Update Dataset Splits",
+        "summary": "Update dataset splits",
         "operationId": "update_dataset_splits_api_v1_datasets__dataset_id__splits_put",
         "security": [
           {
@@ -7749,7 +7749,7 @@
         "tags": [
           "datasets"
         ],
-        "summary": "Studio Experiment",
+        "summary": "Studio experiment",
         "operationId": "studio_experiment_api_v1_datasets_studio_experiment_post",
         "requestBody": {
           "content": {
@@ -7802,7 +7802,7 @@
         "tags": [
           "run"
         ],
-        "summary": "List Rules",
+        "summary": "List rules",
         "description": "List all run rules.",
         "operationId": "list_rules_api_v1_runs_rules_get",
         "security": [
@@ -7987,7 +7987,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Create Rule",
+        "summary": "Create rule",
         "description": "Create a new run rule.",
         "operationId": "create_rule_api_v1_runs_rules_post",
         "security": [
@@ -8041,7 +8041,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Validate Rule",
+        "summary": "Validate rule",
         "description": "Validate a rule by executing it with test data without creating a saved rule.\n\nThis endpoint allows testing LLM-as-judge evaluators before saving them. It accepts\na rule configuration (same as rule creation) and test data, executes the evaluator,\nand returns the evaluation results in the same format as batch_invoke_evaluator.\n\nOnly LLM-as-judge rules (evaluators) are supported. Code evaluators are not allowed.\n\nThe evaluator execution traces are written to the database (in the \"evaluators\"\nproject), which allows users to see the evaluator execution history.",
         "operationId": "validate_rule_api_v1_runs_rules_validate_post",
         "requestBody": {
@@ -8100,7 +8100,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Update Rule",
+        "summary": "Update rule",
         "description": "Update a run rule.",
         "operationId": "update_rule_api_v1_runs_rules__rule_id__patch",
         "security": [
@@ -8164,7 +8164,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Delete Rule",
+        "summary": "Delete rule",
         "description": "Delete a run rule.",
         "operationId": "delete_rule_api_v1_runs_rules__rule_id__delete",
         "security": [
@@ -8218,7 +8218,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Thread Preview",
+        "summary": "Thread preview",
         "description": "Get preview of a thread.",
         "operationId": "thread_preview_api_v1_runs_threads__thread_id__get",
         "security": [
@@ -8321,7 +8321,7 @@
         "tags": [
           "run"
         ],
-        "summary": "List Rule Logs",
+        "summary": "List rule logs",
         "description": "List logs for a particular rule",
         "operationId": "list_rule_logs_api_v1_runs_rules__rule_id__logs_get",
         "security": [
@@ -8455,7 +8455,7 @@
         "tags": [
           "run"
         ],
-        "summary": "List Rule Logs (v2)",
+        "summary": "List rule logs (v2)",
         "description": "List logs for a particular rule with cursor-based pagination.\n\nThis endpoint handles S3-stored outcomes correctly by using run_outcomes_count\nto predict batch sizes and avoid over-fetching.",
         "operationId": "list_rule_logs_v2_api_v1_runs_rules__rule_id__logs_v2_get",
         "security": [
@@ -8600,7 +8600,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Get Last Applied Rule",
+        "summary": "Get last applied rule",
         "description": "Get the last applied rule.",
         "operationId": "get_last_applied_rule_api_v1_runs_rules__rule_id__last_applied_get",
         "security": [
@@ -8666,7 +8666,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Trigger Rule",
+        "summary": "Trigger rule",
         "description": "Trigger a run rule manually.",
         "operationId": "trigger_rule_api_v1_runs_rules__rule_id__trigger_post",
         "security": [
@@ -8722,7 +8722,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Trigger Rules",
+        "summary": "Trigger rules",
         "description": "Trigger an array of run rules manually.",
         "operationId": "trigger_rules_api_v1_runs_rules_trigger_post",
         "requestBody": {
@@ -8774,7 +8774,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Read Run",
+        "summary": "Read run",
         "description": "Get a specific run.",
         "operationId": "read_run_api_v1_runs__run_id__get",
         "security": [
@@ -8892,7 +8892,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Update Run",
+        "summary": "Update run",
         "description": "Update a run.",
         "operationId": "update_run_api_v1_runs__run_id__patch",
         "security": [
@@ -8957,7 +8957,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Get a single run (v2)",
+        "summary": "Read run (v2)",
         "parameters": [
           {
             "description": "application/json",
@@ -9160,7 +9160,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Read Run Share State",
+        "summary": "Read run share state",
         "description": "Get the state of sharing of a run.",
         "operationId": "read_run_share_state_api_v1_runs__run_id__share_get",
         "security": [
@@ -9222,7 +9222,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Share Run",
+        "summary": "Share run",
         "description": "Share a run.",
         "operationId": "share_run_api_v1_runs__run_id__share_put",
         "security": [
@@ -9276,7 +9276,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Unshare Run",
+        "summary": "Unshare run",
         "description": "Unshare a run.",
         "operationId": "unshare_run_api_v1_runs__run_id__share_delete",
         "security": [
@@ -9342,7 +9342,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Share a run (v2)",
+        "summary": "Share run (v2)",
         "parameters": [
           {
             "description": "Run UUID",
@@ -9445,7 +9445,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Validate Runs Query",
+        "summary": "Validate runs query",
         "description": "Validate runs query syntax, returns errors for broken queries.",
         "operationId": "validate_runs_query_api_v1_runs_query_validate_post",
         "requestBody": {
@@ -9488,7 +9488,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Query Runs",
+        "summary": "Query runs",
         "operationId": "query_runs_api_v1_runs_query_post",
         "requestBody": {
           "content": {
@@ -9681,7 +9681,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Generate Query For Runs",
+        "summary": "Generate query for runs",
         "description": "Get runs filter expression query for a given natural language query.",
         "operationId": "generate_query_for_runs_api_v1_runs_generate_query_post",
         "requestBody": {
@@ -9735,7 +9735,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Stats Runs",
+        "summary": "Stats runs",
         "description": "Get all runs by query in body payload.",
         "operationId": "stats_runs_api_v1_runs_stats_post",
         "requestBody": {
@@ -9800,7 +9800,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Create Run Proxy",
+        "summary": "Create run proxy",
         "description": "Create a new run.",
         "operationId": "create_run_proxy_api_v1_runs_post",
         "responses": {
@@ -9832,7 +9832,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Create Runs Batch Proxy",
+        "summary": "Create runs batch proxy",
         "description": "Proxy POST /runs/batch to Go backend for tests.",
         "operationId": "create_runs_batch_proxy_api_v1_runs_batch_post",
         "responses": {
@@ -9864,7 +9864,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Create Runs Multipart Proxy",
+        "summary": "Create runs multipart proxy",
         "description": "Proxy POST /runs/multipart to Go backend for tests.",
         "operationId": "create_runs_multipart_proxy_api_v1_runs_multipart_post",
         "responses": {
@@ -9896,7 +9896,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Group Runs",
+        "summary": "Group runs",
         "description": "Get runs grouped by an expression",
         "operationId": "group_runs_api_v1_runs_group_post",
         "security": [
@@ -9966,7 +9966,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Stats Group Runs",
+        "summary": "Stats group runs",
         "description": "Get stats for the grouped runs.",
         "operationId": "stats_group_runs_api_v1_runs_group_stats_post",
         "requestBody": {
@@ -10020,7 +10020,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Delete Runs Abac",
+        "summary": "Delete runs abac",
         "description": "Delete specific runs by trace IDs.",
         "operationId": "delete_runs_abac_api_v1_runs_delete_traces_post",
         "requestBody": {
@@ -10072,7 +10072,7 @@
         "tags": [
           "run"
         ],
-        "summary": "Delete Runs",
+        "summary": "Delete runs",
         "description": "Delete specific runs by trace IDs or metadata key-value pairs.",
         "operationId": "delete_runs_api_v1_runs_delete_post",
         "requestBody": {
@@ -10123,7 +10123,7 @@
         "tags": [
           "experiments"
         ],
-        "summary": "Evaluate Experiment Adhoc",
+        "summary": "Evaluate experiment adhoc",
         "description": "Evaluate an existing experiment with a specific evaluator.\n\nThis triggers immediate evaluation using the run_over_dataset approach,\nprocessing runs in batches to handle large experiments efficiently.",
         "operationId": "evaluate_experiment_adhoc_api_v1_runs_experiments__experiment_id__evaluate_post",
         "security": [
@@ -10191,7 +10191,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "Create Feedback Formula Ep",
+        "summary": "Create feedback formula ep",
         "description": "Create a new feedback formula",
         "operationId": "create_feedback_formula_ep_api_v1_feedback_formulas_post",
         "security": [
@@ -10243,7 +10243,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "List Feedback Formula Ep",
+        "summary": "List feedback formula ep",
         "description": "List feedback formulas for a given dataset or tracing project",
         "operationId": "list_feedback_formula_ep_api_v1_feedback_formulas_get",
         "security": [
@@ -10347,7 +10347,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "Get Feedback Formula Ep",
+        "summary": "Get feedback formula ep",
         "description": "Get a feedback formula by id",
         "operationId": "get_feedback_formula_ep_api_v1_feedback_formulas__feedback_formula_id__get",
         "security": [
@@ -10401,7 +10401,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "Update Feedback Formula Ep",
+        "summary": "Update feedback formula ep",
         "description": "Update a feedback formula",
         "operationId": "update_feedback_formula_ep_api_v1_feedback_formulas__feedback_formula_id__put",
         "security": [
@@ -10465,7 +10465,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "Delete Feedback Formula Endpoint",
+        "summary": "Delete feedback formula endpoint",
         "description": "Delete a feedback formula by id",
         "operationId": "delete_feedback_formula_endpoint_api_v1_feedback_formulas__feedback_formula_id__delete",
         "security": [
@@ -10519,7 +10519,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "Read Feedback",
+        "summary": "Read feedback",
         "description": "Get a specific feedback.",
         "operationId": "read_feedback_api_v1_feedback__feedback_id__get",
         "security": [
@@ -10589,7 +10589,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "Update Feedback",
+        "summary": "Update feedback",
         "description": "Replace an existing feedback entry with a new, modified entry.",
         "operationId": "update_feedback_api_v1_feedback__feedback_id__patch",
         "security": [
@@ -10653,7 +10653,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "Delete Feedback",
+        "summary": "Delete feedback",
         "description": "Delete a feedback.",
         "operationId": "delete_feedback_api_v1_feedback__feedback_id__delete",
         "security": [
@@ -10707,7 +10707,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "Read Feedbacks",
+        "summary": "Read feedbacks",
         "description": "List all Feedback by query params.",
         "operationId": "read_feedbacks_api_v1_feedback_get",
         "security": [
@@ -11015,7 +11015,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "Create Feedback",
+        "summary": "Create feedback",
         "description": "Create a new feedback.",
         "operationId": "create_feedback_api_v1_feedback_post",
         "security": [
@@ -11069,7 +11069,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "Eagerly Create Feedback",
+        "summary": "Eagerly create feedback",
         "description": "Deprecated: use POST /feedback instead.\n\nThis method is invoked under the assumption that the run\nis already visible in the app, thus already present in DB",
         "operationId": "eagerly_create_feedback_api_v1_feedback_eager_post",
         "requestBody": {
@@ -11124,7 +11124,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "Create Feedback Ingest Token",
+        "summary": "Create feedback ingest token",
         "description": "Create a new feedback ingest token.",
         "operationId": "create_feedback_ingest_token_api_v1_feedback_tokens_post",
         "security": [
@@ -11198,7 +11198,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "List Feedback Ingest Tokens",
+        "summary": "List feedback ingest tokens",
         "description": "List all feedback ingest tokens for a run.",
         "operationId": "list_feedback_ingest_tokens_api_v1_feedback_tokens_get",
         "security": [
@@ -11258,7 +11258,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "Create Feedback With Token Get",
+        "summary": "Create feedback with token get",
         "description": "Create a new feedback with a token.",
         "operationId": "create_feedback_with_token_get_api_v1_feedback_tokens__token__get",
         "parameters": [
@@ -11388,7 +11388,7 @@
         "tags": [
           "feedback"
         ],
-        "summary": "Create Feedback With Token Post",
+        "summary": "Create feedback with token post",
         "description": "Create a new feedback with a token.",
         "operationId": "create_feedback_with_token_post_api_v1_feedback_tokens__token__post",
         "parameters": [
@@ -11441,7 +11441,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Get Shared Run",
+        "summary": "Get shared run",
         "description": "Get the shared run.",
         "operationId": "get_shared_run_api_v1_public__share_token__run_get",
         "parameters": [
@@ -11496,7 +11496,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Get Shared Run By Id",
+        "summary": "Get shared run by ID",
         "description": "Get the shared run.",
         "operationId": "get_shared_run_by_id_api_v1_public__share_token__run__id__get",
         "parameters": [
@@ -11561,7 +11561,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Query Shared Runs",
+        "summary": "Query shared runs",
         "description": "Get run by ids or the shared run if not specifed.",
         "operationId": "query_shared_runs_api_v1_public__share_token__runs_query_post",
         "parameters": [
@@ -11616,7 +11616,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Read Shared Feedbacks",
+        "summary": "Read shared feedbacks",
         "operationId": "read_shared_feedbacks_api_v1_public__share_token__feedbacks_get",
         "parameters": [
           {
@@ -11833,7 +11833,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Read Shared Dataset",
+        "summary": "Read shared dataset",
         "description": "Get dataset by ids or the shared dataset if not specifed.",
         "operationId": "read_shared_dataset_api_v1_public__share_token__datasets_get",
         "parameters": [
@@ -11920,7 +11920,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Count Shared Examples",
+        "summary": "Count shared examples",
         "description": "Count all examples by query params",
         "operationId": "count_shared_examples_api_v1_public__share_token__examples_count_get",
         "parameters": [
@@ -12038,7 +12038,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Read Shared Examples",
+        "summary": "Read shared examples",
         "description": "Get example by ids or the shared example if not specifed.",
         "operationId": "read_shared_examples_api_v1_public__share_token__examples_get",
         "parameters": [
@@ -12205,7 +12205,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Read Shared Dataset Tracer Sessions",
+        "summary": "Read shared dataset tracer sessions",
         "description": "Get projects run on a dataset that has been shared.",
         "operationId": "read_shared_dataset_tracer_sessions_api_v1_public__share_token__datasets_sessions_get",
         "parameters": [
@@ -12406,7 +12406,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Read Shared Dataset Tracer Sessions Bulk",
+        "summary": "Read shared dataset tracer sessions bulk",
         "description": "Get sessions from multiple datasets using share tokens.",
         "operationId": "read_shared_dataset_tracer_sessions_bulk_api_v1_public_datasets_sessions_bulk_get",
         "parameters": [
@@ -12457,7 +12457,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Query Shared Dataset Runs",
+        "summary": "Query shared dataset runs",
         "description": "Get runs in projects run over a dataset that has been shared.",
         "operationId": "query_shared_dataset_runs_api_v1_public__share_token__datasets_runs_query_post",
         "parameters": [
@@ -12512,7 +12512,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Generate Query For Shared Dataset Runs",
+        "summary": "Generate query for shared dataset runs",
         "description": "Get runs in projects run over a dataset that has been shared.",
         "operationId": "generate_query_for_shared_dataset_runs_api_v1_public__share_token__datasets_runs_generate_query_post",
         "parameters": [
@@ -12567,7 +12567,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Stats Shared Dataset Runs",
+        "summary": "Stats shared dataset runs",
         "description": "Get run stats in projects run over a dataset that has been shared.",
         "operationId": "stats_shared_dataset_runs_api_v1_public__share_token__datasets_runs_stats_post",
         "parameters": [
@@ -12622,7 +12622,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Read Shared Dataset Run",
+        "summary": "Read shared dataset run",
         "description": "Get runs in projects run over a dataset that has been shared.",
         "operationId": "read_shared_dataset_run_api_v1_public__share_token__datasets_runs__run_id__get",
         "parameters": [
@@ -12687,7 +12687,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Read Shared Dataset Feedback",
+        "summary": "Read shared dataset feedback",
         "description": "Get feedback for runs in projects run over a dataset that has been shared.",
         "operationId": "read_shared_dataset_feedback_api_v1_public__share_token__datasets_feedback_get",
         "parameters": [
@@ -12905,7 +12905,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Read Shared Comparative Experiments",
+        "summary": "Read shared comparative experiments",
         "description": "Get all comparative experiments for a given dataset.",
         "operationId": "read_shared_comparative_experiments_api_v1_public__share_token__datasets_comparative_get",
         "parameters": [
@@ -13028,7 +13028,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Get Message Json Schema",
+        "summary": "Get message JSON schema",
         "operationId": "get_message_json_schema_api_v1_public_schemas__version__message_json_get",
         "parameters": [
           {
@@ -13069,7 +13069,7 @@
         "tags": [
           "public"
         ],
-        "summary": "Get Tool Def Json Schema",
+        "summary": "Get tool def JSON schema",
         "operationId": "get_tool_def_json_schema_api_v1_public_schemas__version__tooldef_json_get",
         "parameters": [
           {
@@ -13110,7 +13110,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Get Annotation Queues",
+        "summary": "Get annotation queues",
         "operationId": "get_annotation_queues_api_v1_annotation_queues_get",
         "security": [
           {
@@ -13325,7 +13325,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Create Annotation Queue",
+        "summary": "Create annotation queue",
         "operationId": "create_annotation_queue_api_v1_annotation_queues_post",
         "security": [
           {
@@ -13376,7 +13376,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Delete Annotation Queues",
+        "summary": "Delete annotation queues",
         "description": "Delete multiple annotation queues with partial success support.\n\nReturns:\n    - 200: All queues deleted successfully\n    - 207: Some queues deleted successfully, some failed",
         "operationId": "delete_annotation_queues_api_v1_annotation_queues_delete",
         "security": [
@@ -13434,7 +13434,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Populate Annotation Queue",
+        "summary": "Populate annotation queue",
         "description": "Populate annotation queue with runs from an experiment.",
         "operationId": "populate_annotation_queue_api_v1_annotation_queues_populate_post",
         "requestBody": {
@@ -13486,7 +13486,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Delete Annotation Queue",
+        "summary": "Delete annotation queue",
         "operationId": "delete_annotation_queue_api_v1_annotation_queues__queue_id__delete",
         "security": [
           {
@@ -13537,7 +13537,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Update Annotation Queue",
+        "summary": "Update annotation queue",
         "operationId": "update_annotation_queue_api_v1_annotation_queues__queue_id__patch",
         "security": [
           {
@@ -13598,7 +13598,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Get Annotation Queue",
+        "summary": "Get annotation queue",
         "operationId": "get_annotation_queue_api_v1_annotation_queues__queue_id__get",
         "security": [
           {
@@ -13653,7 +13653,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Add Runs To Annotation Queue",
+        "summary": "Add runs to annotation queue",
         "operationId": "add_runs_to_annotation_queue_api_v1_annotation_queues__queue_id__runs_post",
         "security": [
           {
@@ -13751,7 +13751,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Get Runs From Annotation Queue",
+        "summary": "Get runs from annotation queue",
         "operationId": "get_runs_from_annotation_queue_api_v1_annotation_queues__queue_id__runs_get",
         "security": [
           {
@@ -13886,7 +13886,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Add Runs To Annotation Queue By Key",
+        "summary": "Add runs to annotation queue by key",
         "operationId": "add_runs_to_annotation_queue_by_key_api_v1_annotation_queues__queue_id__runs_by_key_post",
         "security": [
           {
@@ -13969,7 +13969,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Export Annotation Queue Archived Runs",
+        "summary": "Export annotation queue archived runs",
         "operationId": "export_annotation_queue_archived_runs_api_v1_annotation_queues__queue_id__export_post",
         "security": [
           {
@@ -14032,7 +14032,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Get Run From Annotation Queue",
+        "summary": "Get run from annotation queue",
         "description": "Get a run from an annotation queue",
         "operationId": "get_run_from_annotation_queue_api_v1_annotation_queues__queue_id__run__index__get",
         "security": [
@@ -14107,7 +14107,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Get Annotation Queues For Run",
+        "summary": "Get annotation queues for run",
         "operationId": "get_annotation_queues_for_run_api_v1_annotation_queues__run_id__queues_get",
         "security": [
           {
@@ -14166,7 +14166,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Update Run In Annotation Queue",
+        "summary": "Update run in annotation queue",
         "operationId": "update_run_in_annotation_queue_api_v1_annotation_queues__queue_id__runs__queue_run_id__patch",
         "security": [
           {
@@ -14237,7 +14237,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Delete Run From Annotation Queue",
+        "summary": "Delete run from annotation queue",
         "operationId": "delete_run_from_annotation_queue_api_v1_annotation_queues__queue_id__runs__queue_run_id__delete",
         "security": [
           {
@@ -14300,7 +14300,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Delete Runs From Annotation Queue",
+        "summary": "Delete runs from annotation queue",
         "operationId": "delete_runs_from_annotation_queue_api_v1_annotation_queues__queue_id__runs_delete_post",
         "security": [
           {
@@ -14363,7 +14363,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Get Total Size From Annotation Queue",
+        "summary": "Get total size from annotation queue",
         "operationId": "get_total_size_from_annotation_queue_api_v1_annotation_queues__queue_id__total_size_get",
         "security": [
           {
@@ -14418,7 +14418,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Get Total Archived From Annotation Queue",
+        "summary": "Get total archived from annotation queue",
         "operationId": "get_total_archived_from_annotation_queue_api_v1_annotation_queues__queue_id__total_archived_get",
         "security": [
           {
@@ -14507,7 +14507,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Get Size From Annotation Queue",
+        "summary": "Get size from annotation queue",
         "operationId": "get_size_from_annotation_queue_api_v1_annotation_queues__queue_id__size_get",
         "security": [
           {
@@ -14583,7 +14583,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Create Identity Annotation Queue Run Status",
+        "summary": "Create identity annotation queue run status",
         "operationId": "create_identity_annotation_queue_run_status_api_v1_annotation_queues_status__annotation_queue_run_id__post",
         "security": [
           {
@@ -14646,7 +14646,7 @@
         "tags": [
           "annotation-queues"
         ],
-        "summary": "Resolve Annotation Queue Run",
+        "summary": "Resolve annotation queue run",
         "description": "Resolve a queue run ID to its section and run data for deep linking.",
         "operationId": "resolve_annotation_queue_run_api_v1_annotation_queues__queue_id__runs_resolve__queue_run_id__get",
         "security": [
@@ -14768,7 +14768,7 @@
         "tags": [
           "bulk-exports"
         ],
-        "summary": "Get Bulk Exports",
+        "summary": "Get bulk exports",
         "description": "Get the current workspace's bulk exports",
         "operationId": "get_bulk_exports_api_v1_bulk_exports_get",
         "security": [
@@ -14845,7 +14845,7 @@
         "tags": [
           "bulk-exports"
         ],
-        "summary": "Create Bulk Export",
+        "summary": "Create bulk export",
         "description": "Create a new bulk export",
         "operationId": "create_bulk_export_api_v1_bulk_exports_post",
         "security": [
@@ -14899,7 +14899,7 @@
         "tags": [
           "bulk-exports"
         ],
-        "summary": "Get Bulk Export Destinations",
+        "summary": "Get bulk export destinations",
         "description": "Get the current workspace's bulk export destinations",
         "operationId": "get_bulk_export_destinations_api_v1_bulk_exports_destinations_get",
         "responses": {
@@ -14935,7 +14935,7 @@
         "tags": [
           "bulk-exports"
         ],
-        "summary": "Create Bulk Export Destination",
+        "summary": "Create bulk export destination",
         "description": "Create a new bulk export destination",
         "operationId": "create_bulk_export_destination_api_v1_bulk_exports_destinations_post",
         "requestBody": {
@@ -14989,7 +14989,7 @@
         "tags": [
           "bulk-exports"
         ],
-        "summary": "Get Bulk Export Runs Filtered",
+        "summary": "Get bulk export runs filtered",
         "description": "Get bulk export runs for exports that were created from a scheduled bulk export",
         "operationId": "get_bulk_export_runs_filtered_api_v1_bulk_exports_runs_get",
         "security": [
@@ -15078,7 +15078,7 @@
         "tags": [
           "bulk-exports"
         ],
-        "summary": "Get Bulk Export",
+        "summary": "Get bulk export",
         "description": "Get a single bulk export by ID",
         "operationId": "get_bulk_export_api_v1_bulk_exports__bulk_export_id__get",
         "security": [
@@ -15132,7 +15132,7 @@
         "tags": [
           "bulk-exports"
         ],
-        "summary": "Cancel Bulk Export",
+        "summary": "Cancel bulk export",
         "description": "Cancel a bulk export by ID",
         "operationId": "cancel_bulk_export_api_v1_bulk_exports__bulk_export_id__patch",
         "security": [
@@ -15198,7 +15198,7 @@
         "tags": [
           "bulk-exports"
         ],
-        "summary": "Get Bulk Export Destination",
+        "summary": "Get bulk export destination",
         "description": "Get a single bulk export destination by ID",
         "operationId": "get_bulk_export_destination_api_v1_bulk_exports_destinations__destination_id__get",
         "security": [
@@ -15252,7 +15252,7 @@
         "tags": [
           "bulk-exports"
         ],
-        "summary": "Update Bulk Export Destination",
+        "summary": "Update bulk export destination",
         "description": "Update a bulk export destination",
         "operationId": "update_bulk_export_destination_api_v1_bulk_exports_destinations__destination_id__patch",
         "security": [
@@ -15318,7 +15318,7 @@
         "tags": [
           "bulk-exports"
         ],
-        "summary": "Get Bulk Export Runs",
+        "summary": "Get bulk export runs",
         "description": "Get a bulk export's runs",
         "operationId": "get_bulk_export_runs_api_v1_bulk_exports__bulk_export_id__runs_get",
         "security": [
@@ -15407,7 +15407,7 @@
         "tags": [
           "bulk-exports"
         ],
-        "summary": "Get Bulk Export Run",
+        "summary": "Get bulk export run",
         "description": "Get a single bulk export's run by ID",
         "operationId": "get_bulk_export_run_api_v1_bulk_exports__bulk_export_id__runs__run_id__get",
         "security": [
@@ -15473,7 +15473,7 @@
         "tags": [
           "feedback-configs"
         ],
-        "summary": "List Feedback Configs Endpoint",
+        "summary": "List feedback configs endpoint",
         "operationId": "list_feedback_configs_endpoint_api_v1_feedback_configs_get",
         "security": [
           {
@@ -15605,7 +15605,7 @@
         "tags": [
           "feedback-configs"
         ],
-        "summary": "Create Feedback Config Endpoint",
+        "summary": "Create feedback config endpoint",
         "operationId": "create_feedback_config_endpoint_api_v1_feedback_configs_post",
         "security": [
           {
@@ -15656,7 +15656,7 @@
         "tags": [
           "feedback-configs"
         ],
-        "summary": "Update Feedback Config Endpoint",
+        "summary": "Update feedback config endpoint",
         "operationId": "update_feedback_config_endpoint_api_v1_feedback_configs_patch",
         "security": [
           {
@@ -15707,7 +15707,7 @@
         "tags": [
           "feedback-configs"
         ],
-        "summary": "Delete Feedback Config Endpoint",
+        "summary": "Delete feedback config endpoint",
         "description": "Soft delete a feedback config by marking it as deleted.\n\nThe config can be recreated later with the same key (simple reuse pattern).\nExisting feedback records with this key will remain unchanged.",
         "operationId": "delete_feedback_config_endpoint_api_v1_feedback_configs_delete",
         "security": [
@@ -15755,7 +15755,7 @@
         "tags": [
           "model-price-map"
         ],
-        "summary": "Read Model Price Map",
+        "summary": "Read model price map",
         "operationId": "read_model_price_map_api_v1_model_price_map_get",
         "security": [
           {
@@ -15842,7 +15842,7 @@
         "tags": [
           "model-price-map"
         ],
-        "summary": "Create New Model Price",
+        "summary": "Create new model price",
         "operationId": "create_new_model_price_api_v1_model_price_map_post",
         "security": [
           {
@@ -15893,7 +15893,7 @@
         "tags": [
           "model-price-map"
         ],
-        "summary": "Update Model Price",
+        "summary": "Update model price",
         "operationId": "update_model_price_api_v1_model_price_map__id__put",
         "security": [
           {
@@ -15954,7 +15954,7 @@
         "tags": [
           "model-price-map"
         ],
-        "summary": "Delete Model Price",
+        "summary": "Delete model price",
         "operationId": "delete_model_price_api_v1_model_price_map__id__delete",
         "security": [
           {
@@ -16007,7 +16007,7 @@
         "tags": [
           "prompts"
         ],
-        "summary": "Invoke Prompt",
+        "summary": "Invoke prompt",
         "operationId": "invoke_prompt_api_v1_prompts_invoke_prompt_post",
         "requestBody": {
           "content": {
@@ -16047,7 +16047,7 @@
         "tags": [
           "prompts"
         ],
-        "summary": "Prompt Canvas",
+        "summary": "Prompt canvas",
         "operationId": "prompt_canvas_api_v1_prompts_canvas_post",
         "requestBody": {
           "content": {
@@ -16098,7 +16098,7 @@
         "tags": [
           "prompt-webhooks"
         ],
-        "summary": "List Prompt Webhooks",
+        "summary": "List prompt webhooks",
         "description": "List all prompt webhooks for the current tenant.",
         "operationId": "list_prompt_webhooks_api_v1_prompt_webhooks_get",
         "responses": {
@@ -16134,7 +16134,7 @@
         "tags": [
           "prompt-webhooks"
         ],
-        "summary": "Create Prompt Webhook",
+        "summary": "Create prompt webhook",
         "description": "Create a new prompt webhook.",
         "operationId": "create_prompt_webhook_api_v1_prompt_webhooks_post",
         "requestBody": {
@@ -16188,7 +16188,7 @@
         "tags": [
           "prompt-webhooks"
         ],
-        "summary": "Get Prompt Webhook",
+        "summary": "Get prompt webhook",
         "description": "Get a specific prompt webhook.",
         "operationId": "get_prompt_webhook_api_v1_prompt_webhooks__webhook_id__get",
         "security": [
@@ -16242,7 +16242,7 @@
         "tags": [
           "prompt-webhooks"
         ],
-        "summary": "Update Prompt Webhook",
+        "summary": "Update prompt webhook",
         "description": "Update a specific prompt webhook.",
         "operationId": "update_prompt_webhook_api_v1_prompt_webhooks__webhook_id__patch",
         "security": [
@@ -16306,7 +16306,7 @@
         "tags": [
           "prompt-webhooks"
         ],
-        "summary": "Delete Prompt Webhook",
+        "summary": "Delete prompt webhook",
         "description": "Delete a specific prompt webhook.",
         "operationId": "delete_prompt_webhook_api_v1_prompt_webhooks__webhook_id__delete",
         "security": [
@@ -16360,7 +16360,7 @@
         "tags": [
           "prompt-webhooks"
         ],
-        "summary": "Test Prompt Webhook",
+        "summary": "Test prompt webhook",
         "description": "Test a specific prompt webhook.",
         "operationId": "test_prompt_webhook_api_v1_prompt_webhooks_test_post",
         "requestBody": {
@@ -16418,7 +16418,7 @@
         "tags": [
           "playground-settings"
         ],
-        "summary": "List Playground Settings",
+        "summary": "List playground settings",
         "description": "Get all playground settings for this tenant id.",
         "operationId": "list_playground_settings_api_v1_playground_settings_get",
         "responses": {
@@ -16454,7 +16454,7 @@
         "tags": [
           "playground-settings"
         ],
-        "summary": "Create Playground Settings",
+        "summary": "Create playground settings",
         "description": "Create playground settings.",
         "operationId": "create_playground_settings_api_v1_playground_settings_post",
         "requestBody": {
@@ -16508,7 +16508,7 @@
         "tags": [
           "playground-settings"
         ],
-        "summary": "Get Playground Settings",
+        "summary": "Get playground settings",
         "description": "Get a single playground settings by ID.",
         "operationId": "get_playground_settings_api_v1_playground_settings__playground_settings_id__get",
         "security": [
@@ -16561,7 +16561,7 @@
         "tags": [
           "playground-settings"
         ],
-        "summary": "Update Playground Settings",
+        "summary": "Update playground settings",
         "description": "Update playground settings.",
         "operationId": "update_playground_settings_api_v1_playground_settings__playground_settings_id__patch",
         "security": [
@@ -16624,7 +16624,7 @@
         "tags": [
           "playground-settings"
         ],
-        "summary": "Delete Playground Settings",
+        "summary": "Delete playground settings",
         "description": "Delete playground settings.",
         "operationId": "delete_playground_settings_api_v1_playground_settings__playground_settings_id__delete",
         "security": [
@@ -16677,7 +16677,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Clone Section",
+        "summary": "Clone section",
         "description": "Clone a dashboard.",
         "operationId": "clone_section_api_v1_charts_section_clone_post",
         "requestBody": {
@@ -16731,7 +16731,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Read Sections",
+        "summary": "Read sections",
         "description": "Get all sections for the tenant.",
         "operationId": "read_sections_api_v1_charts_section_get",
         "security": [
@@ -16892,7 +16892,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Create Section",
+        "summary": "Create section",
         "description": "Create a new section.",
         "operationId": "create_section_api_v1_charts_section_post",
         "security": [
@@ -16946,7 +16946,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Read Charts",
+        "summary": "Read charts",
         "description": "Get all charts for the tenant.",
         "operationId": "read_charts_api_v1_charts_post",
         "requestBody": {
@@ -17000,7 +17000,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Read Chart Preview",
+        "summary": "Read chart preview",
         "description": "Get a preview for a chart without actually creating it.",
         "operationId": "read_chart_preview_api_v1_charts_preview_post",
         "requestBody": {
@@ -17054,7 +17054,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Create Chart",
+        "summary": "Create chart",
         "description": "Create a new chart.",
         "operationId": "create_chart_api_v1_charts_create_post",
         "requestBody": {
@@ -17108,7 +17108,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Read Single Chart",
+        "summary": "Read single chart",
         "description": "Get a single chart by ID.",
         "operationId": "read_single_chart_api_v1_charts__chart_id__post",
         "security": [
@@ -17172,7 +17172,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Update Chart",
+        "summary": "Update chart",
         "description": "Update a chart.",
         "operationId": "update_chart_api_v1_charts__chart_id__patch",
         "security": [
@@ -17236,7 +17236,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Delete Chart",
+        "summary": "Delete chart",
         "description": "Delete a chart.",
         "operationId": "delete_chart_api_v1_charts__chart_id__delete",
         "security": [
@@ -17290,7 +17290,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Read Single Section",
+        "summary": "Read single section",
         "description": "Get a single section by ID.",
         "operationId": "read_single_section_api_v1_charts_section__section_id__post",
         "security": [
@@ -17354,7 +17354,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Update Section",
+        "summary": "Update section",
         "description": "Update a section.",
         "operationId": "update_section_api_v1_charts_section__section_id__patch",
         "security": [
@@ -17418,7 +17418,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Delete Section",
+        "summary": "Delete section",
         "description": "Delete a section.",
         "operationId": "delete_section_api_v1_charts_section__section_id__delete",
         "security": [
@@ -17472,7 +17472,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Org Read Sections",
+        "summary": "Org read sections",
         "description": "Deprecated: organization usage charts have been retired (HTTP 410).",
         "operationId": "org_read_sections_api_v1_org_charts_section_get",
         "responses": {
@@ -17503,7 +17503,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Org Create Section",
+        "summary": "Org create section",
         "description": "Deprecated: organization usage charts have been retired (HTTP 410).",
         "operationId": "org_create_section_api_v1_org_charts_section_post",
         "responses": {
@@ -17536,7 +17536,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Org Read Charts",
+        "summary": "Org read charts",
         "description": "Deprecated: organization usage charts have been retired (HTTP 410).",
         "operationId": "org_read_charts_api_v1_org_charts_post",
         "responses": {
@@ -17569,7 +17569,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Org Read Chart Preview",
+        "summary": "Org read chart preview",
         "description": "Deprecated: organization usage charts have been retired (HTTP 410).",
         "operationId": "org_read_chart_preview_api_v1_org_charts_preview_post",
         "responses": {
@@ -17602,7 +17602,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Org Create Chart",
+        "summary": "Org create chart",
         "description": "Deprecated: organization usage charts have been retired (HTTP 410).",
         "operationId": "org_create_chart_api_v1_org_charts_create_post",
         "responses": {
@@ -17635,7 +17635,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Org Read Single Chart",
+        "summary": "Org read single chart",
         "description": "Deprecated: organization usage charts have been retired (HTTP 410).",
         "operationId": "org_read_single_chart_api_v1_org_charts__chart_id__post",
         "responses": {
@@ -17666,7 +17666,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Org Delete Chart",
+        "summary": "Org delete chart",
         "description": "Deprecated: organization usage charts have been retired (HTTP 410).",
         "operationId": "org_delete_chart_api_v1_org_charts__chart_id__delete",
         "responses": {
@@ -17697,7 +17697,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Org Update Chart",
+        "summary": "Org update chart",
         "description": "Deprecated: organization usage charts have been retired (HTTP 410).",
         "operationId": "org_update_chart_api_v1_org_charts__chart_id__patch",
         "responses": {
@@ -17730,7 +17730,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Org Read Single Section",
+        "summary": "Org read single section",
         "description": "Deprecated: organization usage charts have been retired (HTTP 410).",
         "operationId": "org_read_single_section_api_v1_org_charts_section__section_id__post",
         "responses": {
@@ -17761,7 +17761,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Org Delete Section",
+        "summary": "Org delete section",
         "description": "Deprecated: organization usage charts have been retired (HTTP 410).",
         "operationId": "org_delete_section_api_v1_org_charts_section__section_id__delete",
         "responses": {
@@ -17792,7 +17792,7 @@
         "tags": [
           "charts"
         ],
-        "summary": "Org Update Section",
+        "summary": "Org update section",
         "description": "Deprecated: organization usage charts have been retired (HTTP 410).",
         "operationId": "org_update_section_api_v1_org_charts_section__section_id__patch",
         "responses": {
@@ -17825,7 +17825,7 @@
         "tags": [
           "mcp"
         ],
-        "summary": "Get Tools",
+        "summary": "Get tools",
         "description": "Return MCP tools — from cache if fresh, otherwise by fetching from remote.\n\nOn cache miss, tries manifest fetch first (fast), then falls back to full\nMCP handshake. Caches the result before returning.\n\nPass force_refresh=true to bypass the cache and always fetch from the\nremote server (the result is still cached via upsert for future requests).\n\nThe ls_user_id query parameter allows service-key callers (which don't carry\nls_user_id in auth) to specify the user for per-user OAuth cache lookups.",
         "operationId": "get_tools_api_v1_mcp_tools_get",
         "security": [
@@ -17918,7 +17918,7 @@
         "tags": [
           "mcp"
         ],
-        "summary": "Invalidate Tools Cache",
+        "summary": "Invalidate tools cache",
         "description": "Invalidate cached MCP tools for a given server URL.\n\nCalled when a tool call fails with a stale-tools error, so subsequent\nrequests to GET /mcp/tools will re-fetch from the remote server.",
         "operationId": "invalidate_tools_cache_api_v1_mcp_tools_delete",
         "security": [
@@ -18003,7 +18003,7 @@
         "tags": [
           "mcp"
         ],
-        "summary": "Proxy Get",
+        "summary": "Proxy get",
         "operationId": "proxy_get_api_v1_mcp_proxy_get",
         "security": [
           {
@@ -18124,7 +18124,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "List Organizations",
+        "summary": "List organizations",
         "description": "Get all orgs visible to this auth",
         "operationId": "list_organizations_api_v1_orgs_get",
         "security": [
@@ -18186,7 +18186,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Create Organization",
+        "summary": "Create organization",
         "operationId": "create_organization_api_v1_orgs_post",
         "security": [
           {
@@ -18233,7 +18233,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Create Customers And Get Stripe Setup Intent",
+        "summary": "Create customers and get stripe setup intent",
         "operationId": "create_customers_and_get_stripe_setup_intent_api_v1_orgs_current_setup_post",
         "responses": {
           "200": {
@@ -18266,7 +18266,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Get Organization Info",
+        "summary": "Get organization info",
         "operationId": "get_organization_info_api_v1_orgs_current_get",
         "responses": {
           "200": {
@@ -18299,7 +18299,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Get Current Organization Info",
+        "summary": "Get current organization info",
         "operationId": "get_current_organization_info_api_v1_orgs_current_info_get",
         "responses": {
           "200": {
@@ -18330,7 +18330,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Update Current Organization Info",
+        "summary": "Update current organization info",
         "operationId": "update_current_organization_info_api_v1_orgs_current_info_patch",
         "requestBody": {
           "content": {
@@ -18383,7 +18383,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Get Organization Billing Info",
+        "summary": "Get organization billing info",
         "operationId": "get_organization_billing_info_api_v1_orgs_current_billing_get",
         "responses": {
           "200": {
@@ -18416,7 +18416,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Get Dashboard",
+        "summary": "Get dashboard",
         "operationId": "get_dashboard_api_v1_orgs_current_dashboard_get",
         "security": [
           {
@@ -18485,7 +18485,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "On Payment Method Created",
+        "summary": "On payment method created",
         "operationId": "on_payment_method_created_api_v1_orgs_current_payment_method_post",
         "requestBody": {
           "content": {
@@ -18536,7 +18536,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Get Company Info",
+        "summary": "Get company info",
         "operationId": "get_company_info_api_v1_orgs_current_business_info_get",
         "responses": {
           "200": {
@@ -18567,7 +18567,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Set Company Info",
+        "summary": "Set company info",
         "operationId": "set_company_info_api_v1_orgs_current_business_info_post",
         "requestBody": {
           "content": {
@@ -18618,7 +18618,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Change Payment Plan",
+        "summary": "Change payment plan",
         "operationId": "change_payment_plan_api_v1_orgs_current_plan_post",
         "requestBody": {
           "content": {
@@ -18669,7 +18669,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "List Organization Roles",
+        "summary": "List organization roles",
         "operationId": "list_organization_roles_api_v1_orgs_current_roles_get",
         "responses": {
           "200": {
@@ -18704,7 +18704,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Create Organization Roles",
+        "summary": "Create organization roles",
         "operationId": "create_organization_roles_api_v1_orgs_current_roles_post",
         "requestBody": {
           "content": {
@@ -18757,7 +18757,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Delete Organization Roles",
+        "summary": "Delete organization roles",
         "operationId": "delete_organization_roles_api_v1_orgs_current_roles__role_id__delete",
         "security": [
           {
@@ -18810,7 +18810,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Update Organization Roles",
+        "summary": "Update organization roles",
         "operationId": "update_organization_roles_api_v1_orgs_current_roles__role_id__patch",
         "security": [
           {
@@ -18875,7 +18875,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Set Role Restriction",
+        "summary": "Set role restriction",
         "operationId": "set_role_restriction_api_v1_orgs_current_roles__role_id__restriction_put",
         "security": [
           {
@@ -18940,7 +18940,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "List Permissions",
+        "summary": "List permissions",
         "operationId": "list_permissions_api_v1_orgs_permissions_get",
         "responses": {
           "200": {
@@ -18971,7 +18971,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "List Pending Organization Invites",
+        "summary": "List pending organization invites",
         "description": "Get all pending orgs visible to this auth",
         "operationId": "list_pending_organization_invites_api_v1_orgs_pending_get",
         "responses": {
@@ -19003,7 +19003,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Get Current Org Members",
+        "summary": "Get current org members",
         "operationId": "get_current_org_members_api_v1_orgs_current_members_get",
         "responses": {
           "200": {
@@ -19034,7 +19034,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Add Member To Current Org",
+        "summary": "Add member to current org",
         "operationId": "add_member_to_current_org_api_v1_orgs_current_members_post",
         "requestBody": {
           "content": {
@@ -19087,7 +19087,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Get Current Active Org Members",
+        "summary": "Get current active org members",
         "operationId": "get_current_active_org_members_api_v1_orgs_current_members_active_get",
         "security": [
           {
@@ -19258,7 +19258,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Get Current Pending Org Members",
+        "summary": "Get current pending org members",
         "operationId": "get_current_pending_org_members_api_v1_orgs_current_members_pending_get",
         "security": [
           {
@@ -19384,7 +19384,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Add Members To Current Org Batch",
+        "summary": "Add members to current org batch",
         "description": "Batch invite up to 500 users to the current org.",
         "operationId": "add_members_to_current_org_batch_api_v1_orgs_current_members_batch_post",
         "requestBody": {
@@ -19446,7 +19446,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Add Basic Auth Members To Current Org",
+        "summary": "Add basic auth members to current org",
         "description": "Batch add up to 500 users to the org and specified workspaces in basic auth mode.",
         "operationId": "add_basic_auth_members_to_current_org_api_v1_orgs_current_members_basic_batch_post",
         "requestBody": {
@@ -19508,7 +19508,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Delete Current Org Pending Member",
+        "summary": "Delete current org pending member",
         "description": "When an admin deletes a pending member invite.",
         "operationId": "delete_current_org_pending_member_api_v1_orgs_current_members__identity_id__pending_delete",
         "security": [
@@ -19560,7 +19560,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Patch Current Org Pending Member",
+        "summary": "Patch current org pending member",
         "description": "Update the role on a pending org member invite.",
         "operationId": "patch_current_org_pending_member_api_v1_orgs_current_members__identity_id__pending_patch",
         "security": [
@@ -19626,7 +19626,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Delete Pending Organization Invite",
+        "summary": "Delete pending organization invite",
         "operationId": "delete_pending_organization_invite_api_v1_orgs_pending__organization_id__delete",
         "security": [
           {
@@ -19673,7 +19673,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Claim Pending Organization Invite",
+        "summary": "Claim pending organization invite",
         "operationId": "claim_pending_organization_invite_api_v1_orgs_pending__organization_id__claim_post",
         "security": [
           {
@@ -19722,7 +19722,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Remove Member From Current Org",
+        "summary": "Remove member from current org",
         "description": "Remove a user from the current organization.",
         "operationId": "remove_member_from_current_org_api_v1_orgs_current_members__identity_id__delete",
         "security": [
@@ -19774,7 +19774,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Update Current Org Member",
+        "summary": "Update current org member",
         "description": "This is used for updating a user's role (all auth modes) or full_name/password (basic auth)",
         "operationId": "update_current_org_member_api_v1_orgs_current_members__identity_id__patch",
         "security": [
@@ -19838,7 +19838,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Update Current User",
+        "summary": "Update current user",
         "description": "Update a user's full_name/password (basic auth only)",
         "operationId": "update_current_user_api_v1_orgs_members_basic_patch",
         "requestBody": {
@@ -19890,7 +19890,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Get Current Sso Settings",
+        "summary": "Get current SSO settings",
         "description": "Get SSO provider settings for the current organization.",
         "operationId": "get_current_sso_settings_api_v1_orgs_current_sso_settings_get",
         "responses": {
@@ -19926,7 +19926,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Create Sso Settings",
+        "summary": "Create SSO settings",
         "description": "Create SSO provider settings for the current organization.",
         "operationId": "create_sso_settings_api_v1_orgs_current_sso_settings_post",
         "requestBody": {
@@ -19980,7 +19980,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Update Sso Settings",
+        "summary": "Update SSO settings",
         "description": "Update SSO provider settings defaults for the current organization.",
         "operationId": "update_sso_settings_api_v1_orgs_current_sso_settings__id__patch",
         "security": [
@@ -20044,7 +20044,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Delete Sso Settings",
+        "summary": "Delete SSO settings",
         "description": "Delete SSO provider settings for the current organization.",
         "operationId": "delete_sso_settings_api_v1_orgs_current_sso_settings__id__delete",
         "security": [
@@ -20100,7 +20100,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Update Allowed Login Methods",
+        "summary": "Update allowed login methods",
         "description": "Update allowed login methods for the current organization.",
         "operationId": "update_allowed_login_methods_api_v1_orgs_current_login_methods_patch",
         "requestBody": {
@@ -20156,7 +20156,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Get Org Usage",
+        "summary": "Get org usage",
         "operationId": "get_org_usage_api_v1_orgs_current_billing_usage_get",
         "security": [
           {
@@ -20235,7 +20235,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Get Granular Usage",
+        "summary": "Get granular usage",
         "description": "Get granular usage data with flexible grouping.\n\n`kind` selects the billable usage domain:\n- `traces` (default): trace counts.\n- `langsmith_deployments`: LangSmith Deployment metrics (nodes\n  executed, agent runs, agent uptime). The three Deployment fields\n  are populated and `traces` is `0`.\n\n`trace_tier` (only meaningful for `kind=traces`) optionally restricts\nresults to a single retention tier (longlived = extended retention,\nshortlived = standard retention). When `group_by=trace_tier`, results\nare split into one record per retention tier per time bucket.\n\n`workspace_ids` filters results to the specified workspaces. Only\nworkspaces the user has read access to are included.",
         "operationId": "get_granular_usage_api_v1_orgs_current_billing_granular_usage_get",
         "security": [
@@ -20348,7 +20348,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Export Granular Usage Csv",
+        "summary": "Export granular usage csv",
         "description": "Export granular usage data as CSV.\n\nSame `kind` semantics as `/granular-usage`. The CSV's value columns\nvary by kind:\n- `traces`: single `Traces` column.\n- `langsmith_deployments`: `Nodes Executed`, `Agent Runs`,\n  `Agent Uptime (seconds)` columns.\nDimension columns are identical across kinds.",
         "operationId": "export_granular_usage_csv_api_v1_orgs_current_billing_granular_usage_export_get",
         "security": [
@@ -20459,7 +20459,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Get Current User Login Methods",
+        "summary": "Get current user login methods",
         "description": "Get login methods for the current user.",
         "operationId": "get_current_user_login_methods_api_v1_orgs_current_user_login_methods_get",
         "responses": {
@@ -20497,7 +20497,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Create Stripe Checkout Sessions Endpoint",
+        "summary": "Create stripe checkout sessions endpoint",
         "description": "Kick off a Stripe checkout session flow.",
         "operationId": "create_stripe_checkout_sessions_endpoint_api_v1_orgs_current_stripe_checkout_session_post",
         "requestBody": {
@@ -20549,7 +20549,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Create Stripe Account Links Endpoint",
+        "summary": "Create stripe account links endpoint",
         "description": "Kick off a Stripe account link flow.",
         "operationId": "create_stripe_account_links_endpoint_api_v1_orgs_current_stripe_account_links_post",
         "requestBody": {
@@ -20601,7 +20601,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "List Org Service Keys",
+        "summary": "List org service keys",
         "operationId": "list_org_service_keys_api_v1_orgs_current_service_keys_get",
         "security": [
           {
@@ -20662,7 +20662,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Create Org Service Key",
+        "summary": "Create org service key",
         "description": "Create org-scoped service key. If workspaces is None, key is org-wide.",
         "operationId": "create_org_service_key_api_v1_orgs_current_service_keys_post",
         "security": [
@@ -20716,7 +20716,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Delete Org Service Key",
+        "summary": "Delete org service key",
         "operationId": "delete_org_service_key_api_v1_orgs_current_service_keys__api_key_id__delete",
         "security": [
           {
@@ -20769,7 +20769,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Update Org Service Key",
+        "summary": "Update org service key",
         "description": "Update an API key's role(s) in place without rotating the key.\n\nRestricted to org admins (ORGANIZATION_MANAGE). Applies to both\norg-scoped and workspace-scoped keys listed in /orgs/current/service-keys.",
         "operationId": "update_org_service_key_api_v1_orgs_current_service_keys__api_key_id__patch",
         "security": [
@@ -20835,7 +20835,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "List Org Personal Access Tokens",
+        "summary": "List org personal access tokens",
         "operationId": "list_org_personal_access_tokens_api_v1_orgs_current_personal_access_tokens_get",
         "security": [
           {
@@ -20896,7 +20896,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Create Org Personal Access Token",
+        "summary": "Create org personal access token",
         "operationId": "create_org_personal_access_token_api_v1_orgs_current_personal_access_tokens_post",
         "security": [
           {
@@ -20949,7 +20949,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Delete Org Personal Access Token",
+        "summary": "Delete org personal access token",
         "operationId": "delete_org_personal_access_token_api_v1_orgs_current_personal_access_tokens__pat_id__delete",
         "security": [
           {
@@ -21004,7 +21004,7 @@
         "tags": [
           "orgs"
         ],
-        "summary": "Set Default Sso Provision",
+        "summary": "Set default SSO provision",
         "description": "Set the current organization as the default for SSO provisioning in self-hosted environments.",
         "operationId": "set_default_sso_provision_api_v1_orgs_current_set_default_sso_provision_post",
         "responses": {
@@ -21062,7 +21062,7 @@
         "tags": [
           "auth"
         ],
-        "summary": "Send Sso Email Confirmation",
+        "summary": "Send SSO email confirmation",
         "description": "Send an email to confirm the email address for an SSO user.",
         "operationId": "send_sso_email_confirmation_api_v1_sso_email_verification_send_post",
         "requestBody": {
@@ -21112,7 +21112,7 @@
         "tags": [
           "auth"
         ],
-        "summary": "Check Sso Email Verification Status",
+        "summary": "Check SSO email verification status",
         "description": "Retrieve the email verification status of an SSO user.",
         "operationId": "check_sso_email_verification_status_api_v1_sso_email_verification_status_post",
         "requestBody": {
@@ -21155,7 +21155,7 @@
         "tags": [
           "auth"
         ],
-        "summary": "Confirm Sso User Email",
+        "summary": "Confirm SSO user email",
         "description": "Confirm the email of an SSO user.",
         "operationId": "confirm_sso_user_email_api_v1_sso_email_verification_confirm_post",
         "requestBody": {
@@ -21200,7 +21200,7 @@
         "tags": [
           "auth"
         ],
-        "summary": "Get Sso Settings",
+        "summary": "Get SSO settings",
         "description": "Get SSO provider settings from login slug.",
         "operationId": "get_sso_settings_api_v1_sso_settings__sso_login_slug__get",
         "parameters": [
@@ -21248,7 +21248,7 @@
         "tags": [
           "auth"
         ],
-        "summary": "Lookup Sso By Email",
+        "summary": "Lookup SSO by email",
         "description": "Look up SSO providers available for a SCIM-provisioned email address.",
         "operationId": "lookup_sso_by_email_api_v1_sso_email_lookup_post",
         "requestBody": {
@@ -21295,7 +21295,7 @@
         "tags": [
           "api-key"
         ],
-        "summary": "Get Api Keys",
+        "summary": "Get API keys",
         "description": "Get the current tenant's API keys",
         "operationId": "get_api_keys_api_v1_api_key_get",
         "responses": {
@@ -21331,7 +21331,7 @@
         "tags": [
           "api-key"
         ],
-        "summary": "Generate Api Key",
+        "summary": "Generate API key",
         "description": "Generate an api key for the user",
         "operationId": "generate_api_key_api_v1_api_key_post",
         "requestBody": {
@@ -21388,7 +21388,7 @@
         "tags": [
           "api-key"
         ],
-        "summary": "Delete Api Key",
+        "summary": "Delete API key",
         "description": "Delete an api key for the user",
         "operationId": "delete_api_key_api_v1_api_key__api_key_id__delete",
         "security": [
@@ -21444,7 +21444,7 @@
         "tags": [
           "api-key"
         ],
-        "summary": "Get Personal Access Tokens",
+        "summary": "Get personal access tokens",
         "description": "DEPRECATED: Use /orgs/current/personal-access-tokens instead",
         "operationId": "get_personal_access_tokens_api_v1_api_key_current_get",
         "responses": {
@@ -21481,7 +21481,7 @@
         "tags": [
           "api-key"
         ],
-        "summary": "Generate Personal Access Token",
+        "summary": "Generate personal access token",
         "description": "DEPRECATED: Use /orgs/current/personal-access-tokens instead",
         "operationId": "generate_personal_access_token_api_v1_api_key_current_post",
         "requestBody": {
@@ -21538,7 +21538,7 @@
         "tags": [
           "api-key"
         ],
-        "summary": "Delete Personal Access Token",
+        "summary": "Delete personal access token",
         "description": "DEPRECATED: Use /orgs/current/personal-access-tokens/{pat_id} instead",
         "operationId": "delete_personal_access_token_api_v1_api_key_current__pat_id__delete",
         "deprecated": true,
@@ -21595,7 +21595,7 @@
         "tags": [
           "tenant"
         ],
-        "summary": "List Tenants",
+        "summary": "List tenants",
         "description": "Get all tenants visible to this auth",
         "operationId": "list_tenants_api_v1_tenants_get",
         "security": [
@@ -21657,7 +21657,7 @@
         "tags": [
           "tenant"
         ],
-        "summary": "Create Tenant",
+        "summary": "Create tenant",
         "description": "Create a new organization and corresponding workspace.",
         "operationId": "create_tenant_api_v1_tenants_post",
         "security": [
@@ -21705,7 +21705,7 @@
         "tags": [
           "me"
         ],
-        "summary": "Get Onboarding State",
+        "summary": "Get onboarding state",
         "description": "Get onboarding state for the current user.",
         "operationId": "get_onboarding_state_api_v1_me_onboarding_state_get",
         "responses": {
@@ -21731,7 +21731,7 @@
         "tags": [
           "me"
         ],
-        "summary": "Create Onboarding State",
+        "summary": "Create onboarding state",
         "description": "Initialize onboarding state for the current user.",
         "operationId": "create_onboarding_state_api_v1_me_onboarding_state_post",
         "responses": {
@@ -21759,7 +21759,7 @@
         "tags": [
           "me"
         ],
-        "summary": "Update Onboarding State Field",
+        "summary": "Update onboarding state field",
         "description": "Update a specific onboarding completion field for the current user.\n\nValid fields:\n- tracing_completed_at\n- lgstudio_completed_at\n- playground_completed_at\n- evaluation_completed_at\n- success_viewed_at",
         "operationId": "update_onboarding_state_field_api_v1_me_onboarding_state__field__put",
         "security": [
@@ -21808,7 +21808,7 @@
         "tags": [
           "me"
         ],
-        "summary": "Get Ls User Id",
+        "summary": "Get ls user ID",
         "description": "Get the LangSmith user ID for the current user.",
         "operationId": "get_ls_user_id_api_v1_me_ls_user_id_get",
         "responses": {
@@ -21837,7 +21837,7 @@
         "tags": [
           "service-accounts"
         ],
-        "summary": "Get Service Accounts",
+        "summary": "Get service accounts",
         "description": "Get the current organization's service accounts.",
         "operationId": "get_service_accounts_api_v1_service_accounts_get",
         "responses": {
@@ -21873,7 +21873,7 @@
         "tags": [
           "service-accounts"
         ],
-        "summary": "Create Service Account",
+        "summary": "Create service account",
         "description": "Create a service account",
         "operationId": "create_service_account_api_v1_service_accounts_post",
         "requestBody": {
@@ -21927,7 +21927,7 @@
         "tags": [
           "service-accounts"
         ],
-        "summary": "Delete Service Account",
+        "summary": "Delete service account",
         "description": "Delete a service account",
         "operationId": "delete_service_account_api_v1_service_accounts__service_account_id__delete",
         "security": [
@@ -21983,7 +21983,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "List Pending Workspace Invites",
+        "summary": "List pending workspace invites",
         "description": "Get all workspaces visible to this auth",
         "operationId": "list_pending_workspace_invites_api_v1_workspaces_pending_get",
         "responses": {
@@ -22015,7 +22015,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Delete Pending Workspace Invite",
+        "summary": "Delete pending workspace invite",
         "operationId": "delete_pending_workspace_invite_api_v1_workspaces_pending__id__delete",
         "security": [
           {
@@ -22062,7 +22062,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Claim Pending Workspace Invite",
+        "summary": "Claim pending workspace invite",
         "operationId": "claim_pending_workspace_invite_api_v1_workspaces_pending__workspace_id__claim_post",
         "deprecated": true,
         "security": [
@@ -22110,7 +22110,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Get Current Workspace Members",
+        "summary": "Get current workspace members",
         "operationId": "get_current_workspace_members_api_v1_workspaces_current_members_get",
         "responses": {
           "200": {
@@ -22141,7 +22141,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Add Member To Current Workspace",
+        "summary": "Add member to current workspace",
         "description": "Add an existing organization member to the current workspace.",
         "operationId": "add_member_to_current_workspace_api_v1_workspaces_current_members_post",
         "requestBody": {
@@ -22195,7 +22195,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Get Current Active Workspace Members",
+        "summary": "Get current active workspace members",
         "operationId": "get_current_active_workspace_members_api_v1_workspaces_current_members_active_get",
         "security": [
           {
@@ -22366,7 +22366,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Get Current Pending Workspace Members",
+        "summary": "Get current pending workspace members",
         "operationId": "get_current_pending_workspace_members_api_v1_workspaces_current_members_pending_get",
         "security": [
           {
@@ -22492,7 +22492,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Add Members To Current Workspace Batch",
+        "summary": "Add members to current workspace batch",
         "description": "Batch invite up to 500 users to the current workspace and organization.",
         "operationId": "add_members_to_current_workspace_batch_api_v1_workspaces_current_members_batch_post",
         "requestBody": {
@@ -22557,7 +22557,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Delete Current Workspace Member",
+        "summary": "Delete current workspace member",
         "operationId": "delete_current_workspace_member_api_v1_workspaces_current_members__identity_id__delete",
         "security": [
           {
@@ -22608,7 +22608,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Patch Current Workspace Member",
+        "summary": "Patch current workspace member",
         "operationId": "patch_current_workspace_member_api_v1_workspaces_current_members__identity_id__patch",
         "security": [
           {
@@ -22671,7 +22671,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Patch Current Workspace Pending Member",
+        "summary": "Patch current workspace pending member",
         "description": "Update the role on a pending workspace member invite.",
         "operationId": "patch_current_workspace_pending_member_api_v1_workspaces_current_members__identity_id__pending_patch",
         "security": [
@@ -22735,7 +22735,7 @@
         "tags": [
           "workspaces"
         ],
-        "summary": "Delete Current Workspace Pending Member",
+        "summary": "Delete current workspace pending member",
         "operationId": "delete_current_workspace_pending_member_api_v1_workspaces_current_members__identity_id__pending_delete",
         "security": [
           {
@@ -22788,7 +22788,7 @@
         "tags": [
           "usage-limits"
         ],
-        "summary": "List Usage Limits",
+        "summary": "List usage limits",
         "description": "List out the configured usage limits for a given tenant.",
         "operationId": "list_usage_limits_api_v1_usage_limits_get",
         "responses": {
@@ -22824,7 +22824,7 @@
         "tags": [
           "usage-limits"
         ],
-        "summary": "Upsert Usage Limit",
+        "summary": "Upsert usage limit",
         "description": "Create a new usage limit.",
         "operationId": "upsert_usage_limit_api_v1_usage_limits_put",
         "requestBody": {
@@ -22878,7 +22878,7 @@
         "tags": [
           "usage-limits"
         ],
-        "summary": "List Org Usage Limits",
+        "summary": "List org usage limits",
         "description": "List out the configured usage limits for a given organization.",
         "operationId": "list_org_usage_limits_api_v1_usage_limits_org_get",
         "responses": {
@@ -22916,7 +22916,7 @@
         "tags": [
           "usage-limits"
         ],
-        "summary": "Delete Usage Limit",
+        "summary": "Delete usage limit",
         "description": "Delete a specific usage limit.",
         "operationId": "delete_usage_limit_api_v1_usage_limits__usage_limit_id__delete",
         "security": [
@@ -22970,7 +22970,7 @@
         "tags": [
           "settings"
         ],
-        "summary": "Get Settings",
+        "summary": "Get settings",
         "description": "Get settings.",
         "operationId": "get_settings_api_v1_settings_get",
         "responses": {
@@ -23004,7 +23004,7 @@
         "tags": [
           "settings"
         ],
-        "summary": "Set Tenant Handle",
+        "summary": "Set tenant handle",
         "description": "Set tenant handle.",
         "operationId": "set_tenant_handle_api_v1_settings_handle_post",
         "requestBody": {
@@ -23058,7 +23058,7 @@
         "tags": [
           "repos"
         ],
-        "summary": "List Repos",
+        "summary": "List repos",
         "description": "Get all repos.",
         "operationId": "list_repos_api_v1_repos_get",
         "security": [
@@ -23429,7 +23429,7 @@
         "tags": [
           "repos"
         ],
-        "summary": "Create Repo",
+        "summary": "Create repo",
         "description": "Create a repo.",
         "operationId": "create_repo_api_v1_repos_post",
         "security": [
@@ -23481,7 +23481,7 @@
         "tags": [
           "repos"
         ],
-        "summary": "Delete Repos",
+        "summary": "Delete repos",
         "description": "Delete multiple repos with partial success support.\n\nReturns:\n    - 200: All repos deleted successfully\n    - 207: Some repos deleted successfully, some failed",
         "operationId": "delete_repos_api_v1_repos_delete",
         "security": [
@@ -23539,7 +23539,7 @@
         "tags": [
           "repos"
         ],
-        "summary": "Get Repo",
+        "summary": "Get repo",
         "description": "Get a repo.",
         "operationId": "get_repo_api_v1_repos__owner___repo__get",
         "security": [
@@ -23601,7 +23601,7 @@
         "tags": [
           "repos"
         ],
-        "summary": "Update Repo",
+        "summary": "Update repo",
         "description": "Update a repo.",
         "operationId": "update_repo_api_v1_repos__owner___repo__patch",
         "security": [
@@ -23673,7 +23673,7 @@
         "tags": [
           "repos"
         ],
-        "summary": "Delete Repo",
+        "summary": "Delete repo",
         "description": "Delete a repo.",
         "operationId": "delete_repo_api_v1_repos__owner___repo__delete",
         "security": [
@@ -23735,7 +23735,7 @@
         "tags": [
           "repos"
         ],
-        "summary": "Fork Repo",
+        "summary": "Fork repo",
         "description": "Fork a repo.",
         "operationId": "fork_repo_api_v1_repos__owner___repo__fork_post",
         "security": [
@@ -23809,7 +23809,7 @@
         "tags": [
           "repos"
         ],
-        "summary": "List Repo Tags",
+        "summary": "List repo tags",
         "description": "Get all repo tags.",
         "operationId": "list_repo_tags_api_v1_repos_tags_get",
         "security": [
@@ -24118,7 +24118,7 @@
         "tags": [
           "repos"
         ],
-        "summary": "Optimize Prompt Job",
+        "summary": "Optimize prompt job",
         "description": "Optimize prompt",
         "operationId": "optimize_prompt_job_api_v1_repos_optimize_job_post",
         "requestBody": {
@@ -24172,7 +24172,7 @@
         "tags": [
           "likes"
         ],
-        "summary": "Like Repo",
+        "summary": "Like repo",
         "description": "Like a repo.",
         "operationId": "like_repo_api_v1_likes__owner___repo__post",
         "security": [
@@ -24246,7 +24246,7 @@
         "tags": [
           "comments"
         ],
-        "summary": "Create Comment",
+        "summary": "Create comment",
         "operationId": "create_comment_api_v1_comments__owner___repo__post",
         "security": [
           {
@@ -24315,7 +24315,7 @@
         "tags": [
           "comments"
         ],
-        "summary": "Get Comments",
+        "summary": "Get comments",
         "operationId": "get_comments_api_v1_comments__owner___repo__get",
         "security": [
           {
@@ -24401,7 +24401,7 @@
         "tags": [
           "comments"
         ],
-        "summary": "Get Sub Comments",
+        "summary": "Get sub comments",
         "operationId": "get_sub_comments_api_v1_comments__owner___repo___parent_comment_id__get",
         "security": [
           {
@@ -24495,7 +24495,7 @@
         "tags": [
           "comments"
         ],
-        "summary": "Create Sub Comment",
+        "summary": "Create sub comment",
         "operationId": "create_sub_comment_api_v1_comments__owner___repo___parent_comment_id__post",
         "security": [
           {
@@ -24578,7 +24578,7 @@
         "tags": [
           "comments"
         ],
-        "summary": "Like Comment",
+        "summary": "Like comment",
         "operationId": "like_comment_api_v1_comments__owner___repo___parent_comment_id__like_post",
         "security": [
           {
@@ -24651,7 +24651,7 @@
         "tags": [
           "comments"
         ],
-        "summary": "Unlike Comment",
+        "summary": "Unlike comment",
         "operationId": "unlike_comment_api_v1_comments__owner___repo___parent_comment_id__like_delete",
         "security": [
           {
@@ -24726,7 +24726,7 @@
         "tags": [
           "tags"
         ],
-        "summary": "Get Tags",
+        "summary": "Get tags",
         "operationId": "get_tags_api_v1_repos__owner___repo__tags_get",
         "security": [
           {
@@ -24782,7 +24782,7 @@
         "tags": [
           "tags"
         ],
-        "summary": "Create Tag",
+        "summary": "Create tag",
         "description": "Create a tag. Requires repo ownership, prompts:tag permission, or ABAC grant.",
         "operationId": "create_tag_api_v1_repos__owner___repo__tags_post",
         "security": [
@@ -24856,7 +24856,7 @@
         "tags": [
           "tags"
         ],
-        "summary": "Get Tag",
+        "summary": "Get tag",
         "operationId": "get_tag_api_v1_repos__owner___repo__tags__tag_name__get",
         "security": [
           {
@@ -24917,7 +24917,7 @@
         "tags": [
           "tags"
         ],
-        "summary": "Update Tag",
+        "summary": "Update tag",
         "description": "Update a tag. Requires repo ownership, prompts:tag permission, or ABAC grant.",
         "operationId": "update_tag_api_v1_repos__owner___repo__tags__tag_name__patch",
         "security": [
@@ -24998,7 +24998,7 @@
         "tags": [
           "tags"
         ],
-        "summary": "Delete Tag",
+        "summary": "Delete tag",
         "description": "Delete a tag. Requires repo ownership, prompts:tag permission, or ABAC grant.",
         "operationId": "delete_tag_api_v1_repos__owner___repo__tags__tag_name__delete",
         "security": [
@@ -25069,7 +25069,7 @@
         "tags": [
           "ownerships"
         ],
-        "summary": "List Repo Owners",
+        "summary": "List repo owners",
         "description": "List all owners of a repo.\n\nRequires read permission on the repo.",
         "operationId": "list_repo_owners_api_v1_repos__owner___repo__owners_get",
         "security": [
@@ -25131,7 +25131,7 @@
         "tags": [
           "ownerships"
         ],
-        "summary": "Add Repo Owner",
+        "summary": "Add repo owner",
         "description": "Add an owner to a repo.\n\nRequires being an existing owner of the repo.",
         "operationId": "add_repo_owner_api_v1_repos__owner___repo__owners_post",
         "security": [
@@ -25203,7 +25203,7 @@
         "tags": [
           "ownerships"
         ],
-        "summary": "Remove Repo Owner",
+        "summary": "Remove repo owner",
         "description": "Remove an owner from a repo.\n\nRequires being an existing owner of the repo.",
         "operationId": "remove_repo_owner_api_v1_repos__owner___repo__owners_delete",
         "security": [
@@ -25275,7 +25275,7 @@
         "tags": [
           "optimization-jobs"
         ],
-        "summary": "List Jobs",
+        "summary": "List jobs",
         "description": "List all prompt optimization jobs.",
         "operationId": "list_jobs_api_v1_repos__owner___repo__optimization_jobs_get",
         "security": [
@@ -25332,7 +25332,7 @@
         "tags": [
           "optimization-jobs"
         ],
-        "summary": "Create Job",
+        "summary": "Create job",
         "description": "Create a new prompt optimization job.",
         "operationId": "create_job_api_v1_repos__owner___repo__optimization_jobs_post",
         "security": [
@@ -25397,7 +25397,7 @@
         "tags": [
           "optimization-jobs"
         ],
-        "summary": "Get Job",
+        "summary": "Get job",
         "description": "Get a specific optimization job.",
         "operationId": "get_job_api_v1_repos__owner___repo__optimization_jobs__job_id__get",
         "security": [
@@ -25451,7 +25451,7 @@
         "tags": [
           "optimization-jobs"
         ],
-        "summary": "Update Job",
+        "summary": "Update job",
         "description": "Replace an existing prompt optimization job with a new, modified job.",
         "operationId": "update_job_api_v1_repos__owner___repo__optimization_jobs__job_id__patch",
         "security": [
@@ -25515,7 +25515,7 @@
         "tags": [
           "optimization-jobs"
         ],
-        "summary": "Delete Job",
+        "summary": "Delete job",
         "description": "Delete a prompt optimization job.",
         "operationId": "delete_job_api_v1_repos__owner___repo__optimization_jobs__job_id__delete",
         "security": [
@@ -25569,7 +25569,7 @@
         "tags": [
           "optimization-jobs"
         ],
-        "summary": "List Job Logs",
+        "summary": "List job logs",
         "description": "List all logs for a specific prompt optimization job.",
         "operationId": "list_job_logs_api_v1_repos__owner___repo__optimization_jobs__job_id__logs_get",
         "security": [
@@ -25627,7 +25627,7 @@
         "tags": [
           "optimization-jobs"
         ],
-        "summary": "Create Log",
+        "summary": "Create log",
         "description": "Create a new log entry for a prompt optimization job.",
         "operationId": "create_log_api_v1_repos__owner___repo__optimization_jobs__job_id__logs_post",
         "security": [
@@ -25693,7 +25693,7 @@
         "tags": [
           "optimization-jobs"
         ],
-        "summary": "Get Log",
+        "summary": "Get log",
         "description": "Get a specific prompt optimization job log.",
         "operationId": "get_log_api_v1_repos__owner___repo__optimization_jobs__job_id__logs__log_id__get",
         "security": [
@@ -25747,7 +25747,7 @@
         "tags": [
           "optimization-jobs"
         ],
-        "summary": "Delete Log",
+        "summary": "Delete log",
         "description": "Delete a prompt optimization job log.",
         "operationId": "delete_log_api_v1_repos__owner___repo__optimization_jobs__job_id__logs__log_id__delete",
         "security": [
@@ -26280,7 +26280,7 @@
         "tags": [
           "aws_marketplace"
         ],
-        "summary": "AWS Marketplace fulfillment URL registration",
+        "summary": "AWS marketplace fulfillment URL registration",
         "parameters": [],
         "responses": {
           "303": {
@@ -27273,7 +27273,7 @@
         "tags": [
           "issues-agent"
         ],
-        "summary": "Get issues-agent (Engine) LCU spend per project for the calling org",
+        "summary": "Get issues-agent (engine) LCU spend per project for the calling org",
         "parameters": [
           {
             "description": "Inclusive window start, RFC 3339. Defaults to first instant of current calendar month (UTC).",
@@ -28381,7 +28381,7 @@
         "tags": [
           "runs"
         ],
-        "summary": "Create a Run",
+        "summary": "Create a run",
         "parameters": [],
         "responses": {
           "202": {
@@ -28490,7 +28490,7 @@
         "tags": [
           "runs"
         ],
-        "summary": "Ingest Runs (Batch JSON)",
+        "summary": "Ingest runs (batch json)",
         "parameters": [],
         "responses": {
           "202": {
@@ -28623,7 +28623,7 @@
         "tags": [
           "runs"
         ],
-        "summary": "Ingest Runs (Multipart)",
+        "summary": "Ingest runs (multipart)",
         "parameters": [],
         "responses": {
           "202": {
@@ -28762,7 +28762,7 @@
         "tags": [
           "runs"
         ],
-        "summary": "Update a Run",
+        "summary": "Update a run",
         "parameters": [
           {
             "description": "Run ID",
@@ -28892,7 +28892,7 @@
         "tags": [
           "integrations"
         ],
-        "summary": "Get Agent Builder integrations settings",
+        "summary": "Get agent builder integrations settings",
         "responses": {
           "200": {
             "description": "OK",
@@ -28976,7 +28976,7 @@
         "tags": [
           "integrations"
         ],
-        "summary": "Update Agent Builder integrations settings",
+        "summary": "Update agent builder integrations settings",
         "parameters": [],
         "responses": {
           "200": {
@@ -29534,7 +29534,7 @@
         "tags": [
           "fleet users"
         ],
-        "summary": "Get Fleet user in tenant",
+        "summary": "Get fleet user in tenant",
         "parameters": [
           {
             "description": "Tenant ID",
@@ -29635,7 +29635,7 @@
         "tags": [
           "fleet users"
         ],
-        "summary": "Get current Fleet user",
+        "summary": "Get current fleet user",
         "responses": {
           "200": {
             "description": "OK",
@@ -30435,7 +30435,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Hard Delete Examples",
+        "summary": "Hard delete examples",
         "parameters": [],
         "responses": {
           "200": {
@@ -30519,7 +30519,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Upload Examples",
+        "summary": "Upload examples",
         "parameters": [
           {
             "description": "Dataset ID",
@@ -30638,7 +30638,7 @@
         "tags": [
           "examples"
         ],
-        "summary": "Update Examples",
+        "summary": "Update examples",
         "parameters": [
           {
             "description": "Dataset ID",
@@ -39738,7 +39738,7 @@
         "tags": [
           "threads"
         ],
-        "summary": "Query Threads (v2)",
+        "summary": "Query threads (v2)",
         "parameters": [],
         "responses": {
           "200": {
@@ -39861,7 +39861,7 @@
         "tags": [
           "threads"
         ],
-        "summary": "Query Single Thread Stats (v2)",
+        "summary": "Query single thread stats (v2)",
         "parameters": [
           {
             "description": "Thread ID",
@@ -40042,7 +40042,7 @@
         "tags": [
           "threads"
         ],
-        "summary": "Query Thread Traces (v2)",
+        "summary": "Query thread traces (v2)",
         "parameters": [
           {
             "description": "Thread ID",

--- a/src/langsmith/langsmith-platform-openapi.json
+++ b/src/langsmith/langsmith-platform-openapi.json
@@ -8941,220 +8941,6 @@
         "x-public": true
       }
     },
-    "/v2/runs/{run_id}": {
-      "get": {
-        "security": [
-          {
-            "API Key": [],
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": [],
-            "Tenant ID": []
-          }
-        ],
-        "description": "**Alpha:** The request and response contract may change;\nReturns one run by ID for the given session and start_time. Use the `selects` query parameter (repeatable) to select fields to return.",
-        "tags": [
-          "run"
-        ],
-        "summary": "Read run (v2)",
-        "parameters": [
-          {
-            "description": "application/json",
-            "name": "Accept",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Run UUID",
-            "name": "run_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          },
-          {
-            "description": "`project_id` is the UUID of the tracing project that owns the run.",
-            "name": "project_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string",
-              "title": "Project Id"
-            }
-          },
-          {
-            "description": "`selects` lists which properties to include on the returned run (repeatable query parameter). Accepts any value of the `RunSelectField` enum. If omitted, only `id` is returned.",
-            "name": "selects",
-            "in": "query",
-            "style": "form",
-            "explode": true,
-            "schema": {
-              "items": {
-                "enum": [
-                  "ID",
-                  "NAME",
-                  "RUN_TYPE",
-                  "STATUS",
-                  "START_TIME",
-                  "END_TIME",
-                  "LATENCY_SECONDS",
-                  "FIRST_TOKEN_TIME",
-                  "ERROR",
-                  "ERROR_PREVIEW",
-                  "EXTRA",
-                  "METADATA",
-                  "EVENTS",
-                  "INPUTS",
-                  "INPUTS_PREVIEW",
-                  "OUTPUTS",
-                  "OUTPUTS_PREVIEW",
-                  "MANIFEST",
-                  "PARENT_RUN_IDS",
-                  "PROJECT_ID",
-                  "TRACE_ID",
-                  "THREAD_ID",
-                  "DOTTED_ORDER",
-                  "IS_ROOT",
-                  "REFERENCE_EXAMPLE_ID",
-                  "REFERENCE_DATASET_ID",
-                  "TOTAL_TOKENS",
-                  "PROMPT_TOKENS",
-                  "COMPLETION_TOKENS",
-                  "TOTAL_COST",
-                  "PROMPT_COST",
-                  "COMPLETION_COST",
-                  "PROMPT_TOKEN_DETAILS",
-                  "COMPLETION_TOKEN_DETAILS",
-                  "PROMPT_COST_DETAILS",
-                  "COMPLETION_COST_DETAILS",
-                  "PRICE_MODEL_ID",
-                  "TAGS",
-                  "APP_PATH",
-                  "ATTACHMENTS",
-                  "THREAD_EVALUATION_TIME",
-                  "IS_IN_DATASET",
-                  "SHARE_URL",
-                  "FEEDBACK_STATS"
-                ],
-                "type": "string"
-              },
-              "type": "array",
-              "title": "Selects"
-            }
-          },
-          {
-            "description": "`start_time` is the run's `start_time` (RFC3339 date-time), used together with `project_id` to locate the run.",
-            "name": "start_time",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "format": "date-time",
-              "type": "string",
-              "title": "Start Time"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/query.RunResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request (missing or invalid query parameters)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid authentication",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden (insufficient permission)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "run or session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "unprocessable entity (e.g. invalid UUID)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "gateway timeout or deadline exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true
-      }
-    },
     "/api/v1/runs/{run_id}/share": {
       "get": {
         "tags": [
@@ -9325,121 +9111,6 @@
         "x-public": true
       }
     },
-    "/v2/runs/{run_id}/share": {
-      "post": {
-        "security": [
-          {
-            "API Key": []
-          },
-          {
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": []
-          }
-        ],
-        "description": "Creates or returns a share token for a run. Child runs share their trace root.",
-        "tags": [
-          "run"
-        ],
-        "summary": "Share run (v2)",
-        "parameters": [
-          {
-            "description": "Run UUID",
-            "name": "run_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "format": "uuid",
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/share.CreateShareTokenResponseBody"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "Request Entity Too Large",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true,
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/share.CreateShareTokenRequestBody"
-              }
-            }
-          }
-        }
-      }
-    },
     "/api/v1/runs/query/validate": {
       "post": {
         "tags": [
@@ -9534,146 +9205,6 @@
           }
         ],
         "x-public": true
-      }
-    },
-    "/v2/runs/query": {
-      "post": {
-        "security": [
-          {
-            "API Key": [],
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": [],
-            "Tenant ID": []
-          }
-        ],
-        "description": "**Alpha:** The request and response contract may change;\nReturns a paginated list of runs for the given projects within min/max start_time. Supports filters, cursor pagination, and `selects` to select fields to return.",
-        "tags": [
-          "run"
-        ],
-        "summary": "Query runs (v2)",
-        "parameters": [
-          {
-            "description": "application/json",
-            "name": "Accept",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "application/json (required for JSON body)",
-            "name": "Content-Type",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/query.QueryRunsResponseBody"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request (malformed JSON or invalid parameters)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid authentication",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden (insufficient permission)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "unprocessable entity (e.g. invalid UUID)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "gateway timeout or deadline exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true,
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/query.QueryRunsRequestBody"
-              }
-            }
-          }
-        }
       }
     },
     "/api/v1/runs/generate-query": {
@@ -37464,6 +36995,475 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/query.PublicSharedTraceRunsRequestBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/runs/query": {
+      "post": {
+        "security": [
+          {
+            "API Key": [],
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": [],
+            "Tenant ID": []
+          }
+        ],
+        "description": "**Alpha:** The request and response contract may change;\nReturns a paginated list of runs for the given projects within min/max start_time. Supports filters, cursor pagination, and `selects` to select fields to return.",
+        "tags": [
+          "runs"
+        ],
+        "summary": "Query runs (v2)",
+        "parameters": [
+          {
+            "description": "application/json",
+            "name": "Accept",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "application/json (required for JSON body)",
+            "name": "Content-Type",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/query.QueryRunsResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request (malformed JSON or invalid parameters)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden (insufficient permission)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "unprocessable entity (e.g. invalid UUID)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "gateway timeout or deadline exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/query.QueryRunsRequestBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/runs/{run_id}": {
+      "get": {
+        "security": [
+          {
+            "API Key": [],
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": [],
+            "Tenant ID": []
+          }
+        ],
+        "description": "**Alpha:** The request and response contract may change;\nReturns one run by ID for the given session and start_time. Use the `selects` query parameter (repeatable) to select fields to return.",
+        "tags": [
+          "runs"
+        ],
+        "summary": "Read run (v2)",
+        "parameters": [
+          {
+            "description": "application/json",
+            "name": "Accept",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Run UUID",
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "`project_id` is the UUID of the tracing project that owns the run.",
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "description": "`selects` lists which properties to include on the returned run (repeatable query parameter). Accepts any value of the `RunSelectField` enum. If omitted, only `id` is returned.",
+            "name": "selects",
+            "in": "query",
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "items": {
+                "enum": [
+                  "ID",
+                  "NAME",
+                  "RUN_TYPE",
+                  "STATUS",
+                  "START_TIME",
+                  "END_TIME",
+                  "LATENCY_SECONDS",
+                  "FIRST_TOKEN_TIME",
+                  "ERROR",
+                  "ERROR_PREVIEW",
+                  "EXTRA",
+                  "METADATA",
+                  "EVENTS",
+                  "INPUTS",
+                  "INPUTS_PREVIEW",
+                  "OUTPUTS",
+                  "OUTPUTS_PREVIEW",
+                  "MANIFEST",
+                  "PARENT_RUN_IDS",
+                  "PROJECT_ID",
+                  "TRACE_ID",
+                  "THREAD_ID",
+                  "DOTTED_ORDER",
+                  "IS_ROOT",
+                  "REFERENCE_EXAMPLE_ID",
+                  "REFERENCE_DATASET_ID",
+                  "TOTAL_TOKENS",
+                  "PROMPT_TOKENS",
+                  "COMPLETION_TOKENS",
+                  "TOTAL_COST",
+                  "PROMPT_COST",
+                  "COMPLETION_COST",
+                  "PROMPT_TOKEN_DETAILS",
+                  "COMPLETION_TOKEN_DETAILS",
+                  "PROMPT_COST_DETAILS",
+                  "COMPLETION_COST_DETAILS",
+                  "PRICE_MODEL_ID",
+                  "TAGS",
+                  "APP_PATH",
+                  "ATTACHMENTS",
+                  "THREAD_EVALUATION_TIME",
+                  "IS_IN_DATASET",
+                  "SHARE_URL",
+                  "FEEDBACK_STATS"
+                ],
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Selects"
+            }
+          },
+          {
+            "description": "`start_time` is the run's `start_time` (RFC3339 date-time), used together with `project_id` to locate the run.",
+            "name": "start_time",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "format": "date-time",
+              "type": "string",
+              "title": "Start Time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/query.RunResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request (missing or invalid query parameters)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden (insufficient permission)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "run or session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "unprocessable entity (e.g. invalid UUID)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "gateway timeout or deadline exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true
+      }
+    },
+    "/v2/runs/{run_id}/share": {
+      "post": {
+        "security": [
+          {
+            "API Key": []
+          },
+          {
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": []
+          }
+        ],
+        "description": "Creates or returns a share token for a run. Child runs share their trace root.",
+        "tags": [
+          "runs"
+        ],
+        "summary": "Share run (v2)",
+        "parameters": [
+          {
+            "description": "Run UUID",
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/share.CreateShareTokenResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Request Entity Too Large",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/share.CreateShareTokenRequestBody"
               }
             }
           }

--- a/src/langsmith/langsmith-platform-openapi.json
+++ b/src/langsmith/langsmith-platform-openapi.json
@@ -6,1816 +6,6 @@
     "version": "0.1.0"
   },
   "paths": {
-    "/v2/datasets/public/{share_token}/experiment-runs": {
-      "post": {
-        "description": "Public share-token variant of POST /v2/datasets/{dataset_id}/experiment-runs.\nReturns a paginated page of dataset examples with runs from the requested experiments.",
-        "tags": [
-          "v2"
-        ],
-        "summary": "Fetch shared experiment runs for dataset examples",
-        "parameters": [
-          {
-            "description": "Dataset share token",
-            "name": "share_token",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/datasets.V2DatasetsExperimentRunsResponseBody"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Bad Gateway",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true,
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/datasets.V2DatasetsExperimentRunsRequestBody"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v2/datasets/{dataset_id}/experiment-runs": {
-      "post": {
-        "security": [
-          {
-            "API Key": [],
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": [],
-            "Tenant ID": []
-          }
-        ],
-        "description": "Returns a paginated page of dataset examples with runs from the requested experiments.\nResponse uses the canonical `{items, next_cursor}` envelope.",
-        "tags": [
-          "v2"
-        ],
-        "summary": "Fetch experiment runs for dataset examples",
-        "parameters": [
-          {
-            "description": "Dataset ID",
-            "name": "dataset_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/datasets.V2DatasetsExperimentRunsResponseBody"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Unprocessable Entity",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "502": {
-            "description": "Bad Gateway",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true,
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/datasets.V2DatasetsExperimentRunsRequestBody"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v2/public/{share_token}/run/{run_id}": {
-      "get": {
-        "description": "**Alpha:** The request and response contract may change;\nReturns one run within the trace identified by the share token. The request supplies only the run ID and that run's exact start_time coordinate.",
-        "tags": [
-          "v2"
-        ],
-        "summary": "Get a public shared trace run",
-        "parameters": [
-          {
-            "description": "application/json",
-            "name": "Accept",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Share token UUID",
-            "name": "share_token",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "description": "Run UUID",
-            "name": "run_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "description": "Run start_time coordinate (RFC3339)",
-            "name": "start_time",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "date-time",
-              "title": "Start Time"
-            }
-          },
-          {
-            "description": "repeatable public run fields to include",
-            "name": "selects",
-            "in": "query",
-            "required": true,
-            "style": "form",
-            "explode": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "string"
-              },
-              "title": "Selects"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/query.RunResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request (missing or malformed start_time)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "share token or run not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "501": {
-            "description": "no V2 backend configured and no V1 proxy fallback",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "gateway timeout or deadline exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true
-      }
-    },
-    "/v2/public/{share_token}/runs/v2/query": {
-      "post": {
-        "description": "**Alpha:** The request and response contract may change;\nReturns all runs within the trace identified by the share token. The share token supplies the tenant, project, and trace scope.",
-        "tags": [
-          "v2"
-        ],
-        "summary": "Query public shared trace runs",
-        "parameters": [
-          {
-            "description": "application/json",
-            "name": "Accept",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "application/json",
-            "name": "Content-Type",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Share token UUID",
-            "name": "share_token",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/query.QueryTraceResponseBody"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request (malformed JSON or invalid parameters)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "share token or shared trace not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "501": {
-            "description": "no V2 backend configured and no V1 proxy fallback",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "gateway timeout or deadline exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true,
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/query.PublicSharedTraceRunsRequestBody"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v2/runs/query": {
-      "post": {
-        "security": [
-          {
-            "API Key": [],
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": [],
-            "Tenant ID": []
-          }
-        ],
-        "description": "**Alpha:** The request and response contract may change;\nReturns a paginated list of runs for the given projects within min/max start_time. Supports filters, cursor pagination, and `selects` to select fields to return.",
-        "tags": [
-          "v2"
-        ],
-        "summary": "Query runs",
-        "parameters": [
-          {
-            "description": "application/json",
-            "name": "Accept",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "application/json (required for JSON body)",
-            "name": "Content-Type",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/query.QueryRunsResponseBody"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request (malformed JSON or invalid parameters)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid authentication",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden (insufficient permission)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "unprocessable entity (e.g. invalid UUID)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "gateway timeout or deadline exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true,
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/query.QueryRunsRequestBody"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v2/runs/{run_id}": {
-      "get": {
-        "security": [
-          {
-            "API Key": [],
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": [],
-            "Tenant ID": []
-          }
-        ],
-        "description": "**Alpha:** The request and response contract may change;\nReturns one run by ID for the given session and start_time. Use the `selects` query parameter (repeatable) to select fields to return.",
-        "tags": [
-          "v2"
-        ],
-        "summary": "Get a single run",
-        "parameters": [
-          {
-            "description": "application/json",
-            "name": "Accept",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Run UUID",
-            "name": "run_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "description": "`project_id` is the UUID of the tracing project that owns the run.",
-            "name": "project_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Project Id"
-            }
-          },
-          {
-            "description": "`selects` lists which properties to include on the returned run (repeatable query parameter). Accepts any value of the `RunSelectField` enum. If omitted, only `id` is returned.",
-            "name": "selects",
-            "in": "query",
-            "style": "form",
-            "explode": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "enum": [
-                  "ID",
-                  "NAME",
-                  "RUN_TYPE",
-                  "STATUS",
-                  "START_TIME",
-                  "END_TIME",
-                  "LATENCY_SECONDS",
-                  "FIRST_TOKEN_TIME",
-                  "ERROR",
-                  "ERROR_PREVIEW",
-                  "EXTRA",
-                  "METADATA",
-                  "EVENTS",
-                  "INPUTS",
-                  "INPUTS_PREVIEW",
-                  "OUTPUTS",
-                  "OUTPUTS_PREVIEW",
-                  "MANIFEST",
-                  "PARENT_RUN_IDS",
-                  "PROJECT_ID",
-                  "TRACE_ID",
-                  "THREAD_ID",
-                  "DOTTED_ORDER",
-                  "IS_ROOT",
-                  "REFERENCE_EXAMPLE_ID",
-                  "REFERENCE_DATASET_ID",
-                  "TOTAL_TOKENS",
-                  "PROMPT_TOKENS",
-                  "COMPLETION_TOKENS",
-                  "TOTAL_COST",
-                  "PROMPT_COST",
-                  "COMPLETION_COST",
-                  "PROMPT_TOKEN_DETAILS",
-                  "COMPLETION_TOKEN_DETAILS",
-                  "PROMPT_COST_DETAILS",
-                  "COMPLETION_COST_DETAILS",
-                  "PRICE_MODEL_ID",
-                  "TAGS",
-                  "APP_PATH",
-                  "ATTACHMENTS",
-                  "THREAD_EVALUATION_TIME",
-                  "IS_IN_DATASET",
-                  "SHARE_URL",
-                  "FEEDBACK_STATS"
-                ],
-                "type": "string"
-              },
-              "title": "Selects"
-            }
-          },
-          {
-            "description": "`start_time` is the run's `start_time` (RFC3339 date-time), used together with `project_id` to locate the run.",
-            "name": "start_time",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "date-time",
-              "title": "Start Time"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/query.RunResponse"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request (missing or invalid query parameters)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid authentication",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden (insufficient permission)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "run or session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "unprocessable entity (e.g. invalid UUID)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "gateway timeout or deadline exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true
-      }
-    },
-    "/v2/runs/{run_id}/share": {
-      "post": {
-        "security": [
-          {
-            "API Key": []
-          },
-          {
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": []
-          }
-        ],
-        "description": "Creates or returns a share token for a run. Child runs share their trace root.",
-        "tags": [
-          "v2"
-        ],
-        "summary": "Share a run",
-        "parameters": [
-          {
-            "description": "Run UUID",
-            "name": "run_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/share.CreateShareTokenResponseBody"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "Bad Request",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "Unauthorized",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "Forbidden",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "Not Found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "413": {
-            "description": "Request Entity Too Large",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "Internal Server Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true,
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/share.CreateShareTokenRequestBody"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v2/threads/query": {
-      "post": {
-        "security": [
-          {
-            "API Key": [],
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": [],
-            "Tenant ID": []
-          }
-        ],
-        "description": "**Alpha:** The request and response contract may change;\nQuery threads within a project (session), with cursor-based pagination.\nReturns threads matching the given time range and optional filter.",
-        "tags": [
-          "v2"
-        ],
-        "summary": "Query Threads",
-        "parameters": [],
-        "responses": {
-          "200": {
-            "description": "items and pagination",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/threads.QueryThreadsResponseBody"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request (malformed JSON or invalid parameters)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid authentication",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden (insufficient permission)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "unprocessable entity (e.g. invalid project UUID)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "gateway timeout or deadline exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true,
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/threads.QueryThreadsRequestBody"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v2/threads/{thread_id}/stats": {
-      "get": {
-        "security": [
-          {
-            "API Key": [],
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": [],
-            "Tenant ID": []
-          }
-        ],
-        "description": "**Alpha:** The request and response contract may change;\nCompute aggregate stats for a single thread (turn count, latency percentiles, token/cost sums, and detail breakdowns) within a project.",
-        "tags": [
-          "v2"
-        ],
-        "summary": "Query Single Thread Stats",
-        "parameters": [
-          {
-            "description": "Thread ID",
-            "name": "thread_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "`filter` narrows which of the thread's traces are aggregated, using a LangSmith filter expression. For example: lt(start_time, \"2025-01-01T00:00:00Z\") or eq(trace_id, \"0190a1b2-c3d4-7ef0-a5b6-6ea3a82e9328\").\nSee https://docs.langchain.com/langsmith/trace-query-syntax#filter-query-language for syntax.",
-            "name": "filter",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "title": "Filter"
-            }
-          },
-          {
-            "example": [
-              "TURNS",
-              "LATENCY_P50"
-            ],
-            "description": "`selects` lists which aggregate stats to compute and return (repeatable query parameter). At least one value is required. Accepts any value of `SingleThreadStatsSelectField`.",
-            "name": "selects",
-            "in": "query",
-            "required": true,
-            "style": "form",
-            "explode": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "enum": [
-                  "TURNS",
-                  "FIRST_START_TIME",
-                  "LAST_START_TIME",
-                  "LAST_END_TIME",
-                  "LATENCY_P50",
-                  "LATENCY_P99",
-                  "PROMPT_TOKENS",
-                  "PROMPT_COST",
-                  "COMPLETION_TOKENS",
-                  "COMPLETION_COST",
-                  "TOTAL_TOKENS",
-                  "TOTAL_COST",
-                  "PROMPT_TOKEN_DETAILS",
-                  "COMPLETION_TOKEN_DETAILS",
-                  "PROMPT_COST_DETAILS",
-                  "COMPLETION_COST_DETAILS",
-                  "FEEDBACK_STATS"
-                ],
-                "type": "string"
-              },
-              "title": "Selects"
-            }
-          },
-          {
-            "description": "`session_id` is the tracing project (session) UUID (required).",
-            "name": "session_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Session Id"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "aggregate stats for the thread",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/threads.QuerySingleThreadStatsResponseBody"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request (missing or invalid query parameters)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid authentication",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden (insufficient permission)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "unprocessable entity (e.g. invalid project UUID)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "gateway timeout or deadline exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true
-      }
-    },
-    "/v2/threads/{thread_id}/traces": {
-      "get": {
-        "security": [
-          {
-            "API Key": [],
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": [],
-            "Tenant ID": []
-          }
-        ],
-        "description": "**Alpha:** The request and response contract may change;\nRetrieve all traces belonging to a specific thread within a project.",
-        "tags": [
-          "v2"
-        ],
-        "summary": "Query Thread Traces",
-        "parameters": [
-          {
-            "description": "Thread ID",
-            "name": "thread_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "`cursor` is the opaque string from a previous response's `next_cursor`. Omit on the first request; pass the returned cursor to fetch the next page.",
-            "name": "cursor",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "title": "Cursor"
-            }
-          },
-          {
-            "description": "`filter` narrows which traces are returned for this thread, using a LangSmith filter expression evaluated against each root trace run.\nFor example: eq(status, \"success\") or has(tags, \"production\").\nSee https://docs.langchain.com/langsmith/trace-query-syntax#filter-query-language for syntax.",
-            "name": "filter",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "title": "Filter"
-            }
-          },
-          {
-            "example": 20,
-            "description": "`page_size` is the maximum number of traces to return in this response. Defaults to 20 when omitted; must be between 1 and 100 inclusive when set.",
-            "name": "page_size",
-            "in": "query",
-            "schema": {
-              "maximum": 100,
-              "default": 20,
-              "type": "integer",
-              "minimum": 1,
-              "title": "Page Size"
-            }
-          },
-          {
-            "description": "`project_id` is the tracing project UUID (required).",
-            "name": "project_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Project Id"
-            }
-          },
-          {
-            "example": [
-              "NAME",
-              "START_TIME"
-            ],
-            "description": "`selects` lists which properties to include on each returned trace (repeatable query parameter). Accepts any value of the `ThreadTraceSelectField` enum. Properties not listed are omitted from each trace object; `trace_id` is always returned.",
-            "name": "selects",
-            "in": "query",
-            "style": "form",
-            "explode": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "enum": [
-                  "THREAD_ID",
-                  "TRACE_ID",
-                  "OP",
-                  "PROMPT_TOKENS",
-                  "COMPLETION_TOKENS",
-                  "TOTAL_TOKENS",
-                  "START_TIME",
-                  "END_TIME",
-                  "LATENCY",
-                  "FIRST_TOKEN_TIME",
-                  "INPUTS_PREVIEW",
-                  "OUTPUTS_PREVIEW",
-                  "INPUTS",
-                  "OUTPUTS",
-                  "ERROR",
-                  "PROMPT_COST",
-                  "COMPLETION_COST",
-                  "TOTAL_COST",
-                  "PROMPT_TOKEN_DETAILS",
-                  "COMPLETION_TOKEN_DETAILS",
-                  "PROMPT_COST_DETAILS",
-                  "COMPLETION_COST_DETAILS",
-                  "NAME",
-                  "ERROR_PREVIEW"
-                ],
-                "type": "string"
-              },
-              "title": "Selects"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "items and pagination",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/threads.QueryThreadTracesResponseBody"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request (missing or invalid query parameters)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid authentication",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden (insufficient permission)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "unprocessable entity (e.g. invalid project UUID)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "gateway timeout or deadline exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true
-      }
-    },
-    "/v2/traces/query": {
-      "post": {
-        "security": [
-          {
-            "API Key": [],
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": [],
-            "Tenant ID": []
-          }
-        ],
-        "description": "Returns a paginated list of traces (root runs) for a single tracing project. Each item carries the trace's root run plus optional trace-wide aggregates (`total_tokens`, `total_cost`, `first_token_time`) under `trace_aggregates`, so clients never have to merge by `trace_id`.\n\nTraces are scanned within a `start_time` window: `min_start_time` defaults to 24 hours before the request, `max_start_time` defaults to the request time. Set either explicitly to widen or narrow the window.\n\nSupports filters (`trace_filter`, `tree_filter`), cursor pagination (`cursor`), and field projection (`selects`).",
-        "tags": [
-          "v2"
-        ],
-        "summary": "Query traces",
-        "parameters": [
-          {
-            "description": "application/json (required for JSON body)",
-            "name": "Content-Type",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/query.QueryTracesResponseBody"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request (malformed JSON or invalid parameters)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid authentication",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden (insufficient permission)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "unprocessable entity (e.g. invalid UUID)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "gateway timeout or deadline exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true,
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/query.QueryTracesRequestBody"
-              }
-            }
-          }
-        }
-      }
-    },
-    "/v2/traces/{trace_id}/runs": {
-      "get": {
-        "security": [
-          {
-            "API Key": [],
-            "Tenant ID": []
-          },
-          {
-            "Bearer Auth": [],
-            "Tenant ID": []
-          }
-        ],
-        "description": "**Alpha:** The request and response contract may change;\nReturns runs for a trace ID within min/max start time. Optional `filter`; repeatable `selects` to select fields to return.",
-        "tags": [
-          "v2"
-        ],
-        "summary": "List runs in a trace",
-        "parameters": [
-          {
-            "description": "application/json",
-            "name": "Accept",
-            "in": "header",
-            "schema": {
-              "type": "string"
-            }
-          },
-          {
-            "description": "Trace UUID",
-            "name": "trace_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid"
-            }
-          },
-          {
-            "description": "`filter` narrows which runs within this trace are returned, using a LangSmith filter expression evaluated against each run. For example: `eq(run_type, \"llm\")` for LLM runs only, or `eq(status, \"error\")` for failed runs.\nSee https://docs.langchain.com/langsmith/trace-query-syntax#filter-query-language for syntax.",
-            "name": "filter",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "title": "Filter"
-            }
-          },
-          {
-            "description": "`max_start_time` is the optional inclusive upper bound for run `start_time` (RFC3339 date-time). Required together with `min_start_time`.",
-            "name": "max_start_time",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date-time",
-              "title": "Max Start Time"
-            }
-          },
-          {
-            "description": "`min_start_time` is the optional inclusive lower bound for run `start_time` (RFC3339 date-time). Required together with `max_start_time`.",
-            "name": "min_start_time",
-            "in": "query",
-            "schema": {
-              "type": "string",
-              "format": "date-time",
-              "title": "Min Start Time"
-            }
-          },
-          {
-            "description": "`project_id` is the UUID of the tracing project that owns the trace.",
-            "name": "project_id",
-            "in": "query",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Project Id"
-            }
-          },
-          {
-            "description": "`selects` lists which properties to include on each returned run (repeatable query parameter). Accepts any value of the `RunSelectField` enum. If omitted, only `id` is returned.",
-            "name": "selects",
-            "in": "query",
-            "style": "form",
-            "explode": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "enum": [
-                  "ID",
-                  "NAME",
-                  "RUN_TYPE",
-                  "STATUS",
-                  "START_TIME",
-                  "END_TIME",
-                  "LATENCY_SECONDS",
-                  "FIRST_TOKEN_TIME",
-                  "ERROR",
-                  "ERROR_PREVIEW",
-                  "EXTRA",
-                  "METADATA",
-                  "EVENTS",
-                  "INPUTS",
-                  "INPUTS_PREVIEW",
-                  "OUTPUTS",
-                  "OUTPUTS_PREVIEW",
-                  "MANIFEST",
-                  "PARENT_RUN_IDS",
-                  "PROJECT_ID",
-                  "TRACE_ID",
-                  "THREAD_ID",
-                  "DOTTED_ORDER",
-                  "IS_ROOT",
-                  "REFERENCE_EXAMPLE_ID",
-                  "REFERENCE_DATASET_ID",
-                  "TOTAL_TOKENS",
-                  "PROMPT_TOKENS",
-                  "COMPLETION_TOKENS",
-                  "TOTAL_COST",
-                  "PROMPT_COST",
-                  "COMPLETION_COST",
-                  "PROMPT_TOKEN_DETAILS",
-                  "COMPLETION_TOKEN_DETAILS",
-                  "PROMPT_COST_DETAILS",
-                  "COMPLETION_COST_DETAILS",
-                  "PRICE_MODEL_ID",
-                  "TAGS",
-                  "APP_PATH",
-                  "ATTACHMENTS",
-                  "THREAD_EVALUATION_TIME",
-                  "IS_IN_DATASET",
-                  "SHARE_URL",
-                  "FEEDBACK_STATS"
-                ],
-                "type": "string"
-              },
-              "title": "Selects"
-            }
-          }
-        ],
-        "responses": {
-          "200": {
-            "description": "OK",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/query.QueryTraceResponseBody"
-                }
-              }
-            }
-          },
-          "400": {
-            "description": "bad request (missing or invalid query parameters)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "401": {
-            "description": "missing or invalid authentication",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "403": {
-            "description": "forbidden (insufficient permission)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "404": {
-            "description": "session not found",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "unprocessable entity (e.g. invalid UUID)",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "500": {
-            "description": "internal server error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "503": {
-            "description": "service unavailable",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          },
-          "504": {
-            "description": "gateway timeout or deadline exceeded",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/shared.ProblemDetails"
-                }
-              }
-            }
-          }
-        },
-        "x-public": true
-      }
-    },
     "/api/v1/info": {
       "get": {
         "tags": [
@@ -27722,10 +25912,10 @@
             "name": "limit",
             "in": "query",
             "schema": {
-              "maximum": 100,
-              "default": 20,
-              "type": "integer",
               "minimum": 1,
+              "default": 20,
+              "maximum": 100,
+              "type": "integer",
               "title": "Limit"
             }
           },
@@ -27734,9 +25924,9 @@
             "name": "offset",
             "in": "query",
             "schema": {
+              "minimum": 0,
               "default": 0,
               "type": "integer",
-              "minimum": 0,
               "title": "Offset"
             }
           },
@@ -28051,8 +26241,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             }
           }
         ],
@@ -28150,8 +26340,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             }
           }
         ],
@@ -28284,8 +26474,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             }
           },
           {
@@ -28295,8 +26485,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             }
           }
         ],
@@ -28391,8 +26581,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             }
           },
           {
@@ -28402,8 +26592,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             }
           }
         ],
@@ -28491,8 +26681,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             }
           },
           {
@@ -28502,8 +26692,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             }
           }
         ],
@@ -29642,10 +27832,10 @@
             "name": "limit",
             "in": "query",
             "schema": {
-              "maximum": 100,
-              "default": 50,
-              "type": "integer",
               "minimum": 1,
+              "default": 50,
+              "maximum": 100,
+              "type": "integer",
               "title": "Limit"
             }
           },
@@ -29653,9 +27843,9 @@
             "name": "offset",
             "in": "query",
             "schema": {
+              "minimum": 0,
               "default": 0,
               "type": "integer",
-              "minimum": 0,
               "title": "Offset"
             }
           }
@@ -30111,8 +28301,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             }
           }
         ],
@@ -31868,8 +30058,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             }
           }
         ],
@@ -31987,8 +30177,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             }
           }
         ],
@@ -32141,10 +30331,10 @@
             "style": "form",
             "explode": false,
             "schema": {
-              "type": "array",
               "items": {
                 "type": "string"
               },
+              "type": "array",
               "title": "Tag Value Id"
             }
           },
@@ -32164,10 +30354,10 @@
             "style": "form",
             "explode": false,
             "schema": {
-              "type": "array",
               "items": {
                 "type": "string"
               },
+              "type": "array",
               "title": "Resource Id"
             }
           },
@@ -32372,10 +30562,10 @@
             "style": "form",
             "explode": false,
             "schema": {
-              "type": "array",
               "items": {
                 "type": "string"
               },
+              "type": "array",
               "title": "Evaluator Ids"
             }
           },
@@ -32506,10 +30696,10 @@
             "style": "form",
             "explode": false,
             "schema": {
-              "type": "array",
               "items": {
                 "type": "string"
               },
+              "type": "array",
               "title": "Resource Id"
             }
           },
@@ -33603,8 +31793,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             }
           }
         ],
@@ -33693,8 +31883,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             }
           }
         ],
@@ -33776,8 +31966,8 @@
             "in": "path",
             "required": true,
             "schema": {
-              "type": "string",
-              "format": "uuid"
+              "format": "uuid",
+              "type": "string"
             }
           }
         ],
@@ -34297,12 +32487,12 @@
             "name": "status",
             "in": "query",
             "schema": {
-              "type": "string",
               "enum": [
                 "open",
                 "completed",
                 "ignored"
               ],
+              "type": "string",
               "title": "Status"
             }
           },
@@ -34311,13 +32501,13 @@
             "name": "severity",
             "in": "query",
             "schema": {
-              "type": "integer",
               "enum": [
                 0,
                 1,
                 2,
                 3
               ],
+              "type": "integer",
               "title": "Severity"
             }
           },
@@ -34344,12 +32534,12 @@
             "name": "sort_by",
             "in": "query",
             "schema": {
-              "type": "string",
               "enum": [
                 "created_at",
                 "updated_at",
                 "severity"
               ],
+              "type": "string",
               "title": "Sort By"
             }
           },
@@ -36248,10 +34438,10 @@
             "style": "form",
             "explode": true,
             "schema": {
-              "type": "array",
               "items": {
                 "type": "string"
               },
+              "type": "array",
               "title": "Name Like"
             }
           },
@@ -36262,10 +34452,10 @@
             "style": "form",
             "explode": true,
             "schema": {
-              "type": "array",
               "items": {
                 "type": "string"
               },
+              "type": "array",
               "title": "Email Like"
             }
           },
@@ -36276,10 +34466,10 @@
             "style": "form",
             "explode": true,
             "schema": {
-              "type": "array",
               "items": {
                 "type": "string"
               },
+              "type": "array",
               "title": "Workspace Name Like"
             }
           },
@@ -36290,10 +34480,10 @@
             "style": "form",
             "explode": true,
             "schema": {
-              "type": "array",
               "items": {
                 "type": "string"
               },
+              "type": "array",
               "title": "Organization Role Like"
             }
           },
@@ -36304,10 +34494,10 @@
             "style": "form",
             "explode": true,
             "schema": {
-              "type": "array",
               "items": {
                 "type": "string"
               },
+              "type": "array",
               "title": "Workspace Role Like"
             }
           }
@@ -38341,6 +36531,939 @@
             "application/json": {
               "schema": {
                 "$ref": "#/components/schemas/tools.UpdateToolPayload"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/datasets/public/{share_token}/experiment-runs": {
+      "post": {
+        "description": "Public share-token variant of POST /v2/datasets/{dataset_id}/experiment-runs.\nReturns a paginated page of dataset examples with runs from the requested experiments.",
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Fetch shared experiment runs for dataset examples (v2)",
+        "parameters": [
+          {
+            "description": "Dataset share token",
+            "name": "share_token",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datasets.V2DatasetsExperimentRunsResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Bad Gateway",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/datasets.V2DatasetsExperimentRunsRequestBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/datasets/{dataset_id}/experiment-runs": {
+      "post": {
+        "security": [
+          {
+            "API Key": [],
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": [],
+            "Tenant ID": []
+          }
+        ],
+        "description": "Returns a paginated page of dataset examples with runs from the requested experiments.\nResponse uses the canonical `{items, next_cursor}` envelope.",
+        "tags": [
+          "datasets"
+        ],
+        "summary": "Fetch experiment runs for dataset examples (v2)",
+        "parameters": [
+          {
+            "description": "Dataset ID",
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/datasets.V2DatasetsExperimentRunsResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "Unprocessable Entity",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "502": {
+            "description": "Bad Gateway",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/datasets.V2DatasetsExperimentRunsRequestBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/public/{share_token}/run/{run_id}": {
+      "get": {
+        "description": "**Alpha:** The request and response contract may change;\nReturns one run within the trace identified by the share token. The request supplies only the run ID and that run's exact start_time coordinate.",
+        "tags": [
+          "runs"
+        ],
+        "summary": "Get a public shared trace run (v2)",
+        "parameters": [
+          {
+            "description": "application/json",
+            "name": "Accept",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Share token UUID",
+            "name": "share_token",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Run UUID",
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "Run start_time coordinate (RFC3339)",
+            "name": "start_time",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "format": "date-time",
+              "type": "string",
+              "title": "Start Time"
+            }
+          },
+          {
+            "description": "repeatable public run fields to include",
+            "name": "selects",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "items": {
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Selects"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/query.RunResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request (missing or malformed start_time)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "share token or run not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "no V2 backend configured and no V1 proxy fallback",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "gateway timeout or deadline exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true
+      }
+    },
+    "/v2/public/{share_token}/runs/v2/query": {
+      "post": {
+        "description": "**Alpha:** The request and response contract may change;\nReturns all runs within the trace identified by the share token. The share token supplies the tenant, project, and trace scope.",
+        "tags": [
+          "runs"
+        ],
+        "summary": "Query public shared trace runs (v2)",
+        "parameters": [
+          {
+            "description": "application/json",
+            "name": "Accept",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "application/json",
+            "name": "Content-Type",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Share token UUID",
+            "name": "share_token",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/query.QueryTraceResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request (malformed JSON or invalid parameters)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "share token or shared trace not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "501": {
+            "description": "no V2 backend configured and no V1 proxy fallback",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "gateway timeout or deadline exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/query.PublicSharedTraceRunsRequestBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/runs/query": {
+      "post": {
+        "security": [
+          {
+            "API Key": [],
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": [],
+            "Tenant ID": []
+          }
+        ],
+        "description": "**Alpha:** The request and response contract may change;\nReturns a paginated list of runs for the given projects within min/max start_time. Supports filters, cursor pagination, and `selects` to select fields to return.",
+        "tags": [
+          "runs"
+        ],
+        "summary": "Query runs (v2)",
+        "parameters": [
+          {
+            "description": "application/json",
+            "name": "Accept",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "application/json (required for JSON body)",
+            "name": "Content-Type",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/query.QueryRunsResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request (malformed JSON or invalid parameters)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden (insufficient permission)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "unprocessable entity (e.g. invalid UUID)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "gateway timeout or deadline exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/query.QueryRunsRequestBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/runs/{run_id}": {
+      "get": {
+        "security": [
+          {
+            "API Key": [],
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": [],
+            "Tenant ID": []
+          }
+        ],
+        "description": "**Alpha:** The request and response contract may change;\nReturns one run by ID for the given session and start_time. Use the `selects` query parameter (repeatable) to select fields to return.",
+        "tags": [
+          "runs"
+        ],
+        "summary": "Get a single run (v2)",
+        "parameters": [
+          {
+            "description": "application/json",
+            "name": "Accept",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Run UUID",
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "`project_id` is the UUID of the tracing project that owns the run.",
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "description": "`selects` lists which properties to include on the returned run (repeatable query parameter). Accepts any value of the `RunSelectField` enum. If omitted, only `id` is returned.",
+            "name": "selects",
+            "in": "query",
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "items": {
+                "enum": [
+                  "ID",
+                  "NAME",
+                  "RUN_TYPE",
+                  "STATUS",
+                  "START_TIME",
+                  "END_TIME",
+                  "LATENCY_SECONDS",
+                  "FIRST_TOKEN_TIME",
+                  "ERROR",
+                  "ERROR_PREVIEW",
+                  "EXTRA",
+                  "METADATA",
+                  "EVENTS",
+                  "INPUTS",
+                  "INPUTS_PREVIEW",
+                  "OUTPUTS",
+                  "OUTPUTS_PREVIEW",
+                  "MANIFEST",
+                  "PARENT_RUN_IDS",
+                  "PROJECT_ID",
+                  "TRACE_ID",
+                  "THREAD_ID",
+                  "DOTTED_ORDER",
+                  "IS_ROOT",
+                  "REFERENCE_EXAMPLE_ID",
+                  "REFERENCE_DATASET_ID",
+                  "TOTAL_TOKENS",
+                  "PROMPT_TOKENS",
+                  "COMPLETION_TOKENS",
+                  "TOTAL_COST",
+                  "PROMPT_COST",
+                  "COMPLETION_COST",
+                  "PROMPT_TOKEN_DETAILS",
+                  "COMPLETION_TOKEN_DETAILS",
+                  "PROMPT_COST_DETAILS",
+                  "COMPLETION_COST_DETAILS",
+                  "PRICE_MODEL_ID",
+                  "TAGS",
+                  "APP_PATH",
+                  "ATTACHMENTS",
+                  "THREAD_EVALUATION_TIME",
+                  "IS_IN_DATASET",
+                  "SHARE_URL",
+                  "FEEDBACK_STATS"
+                ],
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Selects"
+            }
+          },
+          {
+            "description": "`start_time` is the run's `start_time` (RFC3339 date-time), used together with `project_id` to locate the run.",
+            "name": "start_time",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "format": "date-time",
+              "type": "string",
+              "title": "Start Time"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/query.RunResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request (missing or invalid query parameters)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden (insufficient permission)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "run or session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "unprocessable entity (e.g. invalid UUID)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "gateway timeout or deadline exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true
+      }
+    },
+    "/v2/runs/{run_id}/share": {
+      "post": {
+        "security": [
+          {
+            "API Key": []
+          },
+          {
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": []
+          }
+        ],
+        "description": "Creates or returns a share token for a run. Child runs share their trace root.",
+        "tags": [
+          "runs"
+        ],
+        "summary": "Share a run (v2)",
+        "parameters": [
+          {
+            "description": "Run UUID",
+            "name": "run_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/share.CreateShareTokenResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "413": {
+            "description": "Request Entity Too Large",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/share.CreateShareTokenRequestBody"
               }
             }
           }
@@ -40597,6 +39720,883 @@
             }
           }
         }
+      }
+    },
+    "/v2/threads/query": {
+      "post": {
+        "security": [
+          {
+            "API Key": [],
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": [],
+            "Tenant ID": []
+          }
+        ],
+        "description": "**Alpha:** The request and response contract may change;\nQuery threads within a project (session), with cursor-based pagination.\nReturns threads matching the given time range and optional filter.",
+        "tags": [
+          "threads"
+        ],
+        "summary": "Query Threads (v2)",
+        "parameters": [],
+        "responses": {
+          "200": {
+            "description": "items and pagination",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/threads.QueryThreadsResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request (malformed JSON or invalid parameters)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden (insufficient permission)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "unprocessable entity (e.g. invalid project UUID)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "gateway timeout or deadline exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/threads.QueryThreadsRequestBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/threads/{thread_id}/stats": {
+      "get": {
+        "security": [
+          {
+            "API Key": [],
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": [],
+            "Tenant ID": []
+          }
+        ],
+        "description": "**Alpha:** The request and response contract may change;\nCompute aggregate stats for a single thread (turn count, latency percentiles, token/cost sums, and detail breakdowns) within a project.",
+        "tags": [
+          "threads"
+        ],
+        "summary": "Query Single Thread Stats (v2)",
+        "parameters": [
+          {
+            "description": "Thread ID",
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "`filter` narrows which of the thread's traces are aggregated, using a LangSmith filter expression. For example: lt(start_time, \"2025-01-01T00:00:00Z\") or eq(trace_id, \"0190a1b2-c3d4-7ef0-a5b6-6ea3a82e9328\").\nSee https://docs.langchain.com/langsmith/trace-query-syntax#filter-query-language for syntax.",
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "title": "Filter"
+            }
+          },
+          {
+            "example": [
+              "TURNS",
+              "LATENCY_P50"
+            ],
+            "description": "`selects` lists which aggregate stats to compute and return (repeatable query parameter). At least one value is required. Accepts any value of `SingleThreadStatsSelectField`.",
+            "name": "selects",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "items": {
+                "enum": [
+                  "TURNS",
+                  "FIRST_START_TIME",
+                  "LAST_START_TIME",
+                  "LAST_END_TIME",
+                  "LATENCY_P50",
+                  "LATENCY_P99",
+                  "PROMPT_TOKENS",
+                  "PROMPT_COST",
+                  "COMPLETION_TOKENS",
+                  "COMPLETION_COST",
+                  "TOTAL_TOKENS",
+                  "TOTAL_COST",
+                  "PROMPT_TOKEN_DETAILS",
+                  "COMPLETION_TOKEN_DETAILS",
+                  "PROMPT_COST_DETAILS",
+                  "COMPLETION_COST_DETAILS",
+                  "FEEDBACK_STATS"
+                ],
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Selects"
+            }
+          },
+          {
+            "description": "`session_id` is the tracing project (session) UUID (required).",
+            "name": "session_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+              "title": "Session Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "aggregate stats for the thread",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/threads.QuerySingleThreadStatsResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request (missing or invalid query parameters)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden (insufficient permission)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "unprocessable entity (e.g. invalid project UUID)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "gateway timeout or deadline exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true
+      }
+    },
+    "/v2/threads/{thread_id}/traces": {
+      "get": {
+        "security": [
+          {
+            "API Key": [],
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": [],
+            "Tenant ID": []
+          }
+        ],
+        "description": "**Alpha:** The request and response contract may change;\nRetrieve all traces belonging to a specific thread within a project.",
+        "tags": [
+          "threads"
+        ],
+        "summary": "Query Thread Traces (v2)",
+        "parameters": [
+          {
+            "description": "Thread ID",
+            "name": "thread_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "`cursor` is the opaque string from a previous response's `next_cursor`. Omit on the first request; pass the returned cursor to fetch the next page.",
+            "name": "cursor",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "title": "Cursor"
+            }
+          },
+          {
+            "description": "`filter` narrows which traces are returned for this thread, using a LangSmith filter expression evaluated against each root trace run.\nFor example: eq(status, \"success\") or has(tags, \"production\").\nSee https://docs.langchain.com/langsmith/trace-query-syntax#filter-query-language for syntax.",
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "title": "Filter"
+            }
+          },
+          {
+            "example": 20,
+            "description": "`page_size` is the maximum number of traces to return in this response. Defaults to 20 when omitted; must be between 1 and 100 inclusive when set.",
+            "name": "page_size",
+            "in": "query",
+            "schema": {
+              "minimum": 1,
+              "default": 20,
+              "maximum": 100,
+              "type": "integer",
+              "title": "Page Size"
+            }
+          },
+          {
+            "description": "`project_id` is the tracing project UUID (required).",
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "example": [
+              "NAME",
+              "START_TIME"
+            ],
+            "description": "`selects` lists which properties to include on each returned trace (repeatable query parameter). Accepts any value of the `ThreadTraceSelectField` enum. Properties not listed are omitted from each trace object; `trace_id` is always returned.",
+            "name": "selects",
+            "in": "query",
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "items": {
+                "enum": [
+                  "THREAD_ID",
+                  "TRACE_ID",
+                  "OP",
+                  "PROMPT_TOKENS",
+                  "COMPLETION_TOKENS",
+                  "TOTAL_TOKENS",
+                  "START_TIME",
+                  "END_TIME",
+                  "LATENCY",
+                  "FIRST_TOKEN_TIME",
+                  "INPUTS_PREVIEW",
+                  "OUTPUTS_PREVIEW",
+                  "INPUTS",
+                  "OUTPUTS",
+                  "ERROR",
+                  "PROMPT_COST",
+                  "COMPLETION_COST",
+                  "TOTAL_COST",
+                  "PROMPT_TOKEN_DETAILS",
+                  "COMPLETION_TOKEN_DETAILS",
+                  "PROMPT_COST_DETAILS",
+                  "COMPLETION_COST_DETAILS",
+                  "NAME",
+                  "ERROR_PREVIEW"
+                ],
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Selects"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "items and pagination",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/threads.QueryThreadTracesResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request (missing or invalid query parameters)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden (insufficient permission)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "unprocessable entity (e.g. invalid project UUID)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "gateway timeout or deadline exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true
+      }
+    },
+    "/v2/traces/query": {
+      "post": {
+        "security": [
+          {
+            "API Key": [],
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": [],
+            "Tenant ID": []
+          }
+        ],
+        "description": "Returns a paginated list of traces (root runs) for a single tracing project. Each item carries the trace's root run plus optional trace-wide aggregates (`total_tokens`, `total_cost`, `first_token_time`) under `trace_aggregates`, so clients never have to merge by `trace_id`.\n\nTraces are scanned within a `start_time` window: `min_start_time` defaults to 24 hours before the request, `max_start_time` defaults to the request time. Set either explicitly to widen or narrow the window.\n\nSupports filters (`trace_filter`, `tree_filter`), cursor pagination (`cursor`), and field projection (`selects`).",
+        "tags": [
+          "runs"
+        ],
+        "summary": "Query traces (v2)",
+        "parameters": [
+          {
+            "description": "application/json (required for JSON body)",
+            "name": "Content-Type",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/query.QueryTracesResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request (malformed JSON or invalid parameters)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden (insufficient permission)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "unprocessable entity (e.g. invalid UUID)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "gateway timeout or deadline exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/query.QueryTracesRequestBody"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/v2/traces/{trace_id}/runs": {
+      "get": {
+        "security": [
+          {
+            "API Key": [],
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": [],
+            "Tenant ID": []
+          }
+        ],
+        "description": "**Alpha:** The request and response contract may change;\nReturns runs for a trace ID within min/max start time. Optional `filter`; repeatable `selects` to select fields to return.",
+        "tags": [
+          "runs"
+        ],
+        "summary": "List runs in a trace (v2)",
+        "parameters": [
+          {
+            "description": "application/json",
+            "name": "Accept",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "description": "Trace UUID",
+            "name": "trace_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string"
+            }
+          },
+          {
+            "description": "`filter` narrows which runs within this trace are returned, using a LangSmith filter expression evaluated against each run. For example: `eq(run_type, \"llm\")` for LLM runs only, or `eq(status, \"error\")` for failed runs.\nSee https://docs.langchain.com/langsmith/trace-query-syntax#filter-query-language for syntax.",
+            "name": "filter",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "title": "Filter"
+            }
+          },
+          {
+            "description": "`max_start_time` is the optional inclusive upper bound for run `start_time` (RFC3339 date-time). Required together with `min_start_time`.",
+            "name": "max_start_time",
+            "in": "query",
+            "schema": {
+              "format": "date-time",
+              "type": "string",
+              "title": "Max Start Time"
+            }
+          },
+          {
+            "description": "`min_start_time` is the optional inclusive lower bound for run `start_time` (RFC3339 date-time). Required together with `max_start_time`.",
+            "name": "min_start_time",
+            "in": "query",
+            "schema": {
+              "format": "date-time",
+              "type": "string",
+              "title": "Min Start Time"
+            }
+          },
+          {
+            "description": "`project_id` is the UUID of the tracing project that owns the trace.",
+            "name": "project_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "format": "uuid",
+              "type": "string",
+              "title": "Project Id"
+            }
+          },
+          {
+            "description": "`selects` lists which properties to include on each returned run (repeatable query parameter). Accepts any value of the `RunSelectField` enum. If omitted, only `id` is returned.",
+            "name": "selects",
+            "in": "query",
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "items": {
+                "enum": [
+                  "ID",
+                  "NAME",
+                  "RUN_TYPE",
+                  "STATUS",
+                  "START_TIME",
+                  "END_TIME",
+                  "LATENCY_SECONDS",
+                  "FIRST_TOKEN_TIME",
+                  "ERROR",
+                  "ERROR_PREVIEW",
+                  "EXTRA",
+                  "METADATA",
+                  "EVENTS",
+                  "INPUTS",
+                  "INPUTS_PREVIEW",
+                  "OUTPUTS",
+                  "OUTPUTS_PREVIEW",
+                  "MANIFEST",
+                  "PARENT_RUN_IDS",
+                  "PROJECT_ID",
+                  "TRACE_ID",
+                  "THREAD_ID",
+                  "DOTTED_ORDER",
+                  "IS_ROOT",
+                  "REFERENCE_EXAMPLE_ID",
+                  "REFERENCE_DATASET_ID",
+                  "TOTAL_TOKENS",
+                  "PROMPT_TOKENS",
+                  "COMPLETION_TOKENS",
+                  "TOTAL_COST",
+                  "PROMPT_COST",
+                  "COMPLETION_COST",
+                  "PROMPT_TOKEN_DETAILS",
+                  "COMPLETION_TOKEN_DETAILS",
+                  "PROMPT_COST_DETAILS",
+                  "COMPLETION_COST_DETAILS",
+                  "PRICE_MODEL_ID",
+                  "TAGS",
+                  "APP_PATH",
+                  "ATTACHMENTS",
+                  "THREAD_EVALUATION_TIME",
+                  "IS_IN_DATASET",
+                  "SHARE_URL",
+                  "FEEDBACK_STATS"
+                ],
+                "type": "string"
+              },
+              "type": "array",
+              "title": "Selects"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/query.QueryTraceResponseBody"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "bad request (missing or invalid query parameters)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "missing or invalid authentication",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "forbidden (insufficient permission)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "session not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "422": {
+            "description": "unprocessable entity (e.g. invalid UUID)",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "internal server error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "service unavailable",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          },
+          "504": {
+            "description": "gateway timeout or deadline exceeded",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/shared.ProblemDetails"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true
       }
     },
     "/workspaces/current/ttl-settings": {
@@ -79051,10 +79051,6 @@
   ],
   "tags": [
     {
-      "name": "v2",
-      "x-group": "v2 endpoints"
-    },
-    {
       "name": "run",
       "x-group": "Tracing"
     },
@@ -79069,6 +79065,10 @@
     {
       "name": "tracer-sessions",
       "x-group": "Tracing"
+    },
+    {
+      "name": "threads",
+      "x-group": "Threads"
     },
     {
       "name": "datasets",
@@ -79296,10 +79296,6 @@
     },
     {
       "name": "public",
-      "x-group": "System"
-    },
-    {
-      "name": "threads",
       "x-group": "System"
     },
     {


### PR DESCRIPTION
## Why

The LangSmith Platform OpenAPI spec mixes v1 and v2 endpoints in one file, and the backend already tags v2 operations by resource (`runs`, `datasets`, `threads`). This reworks how the reference presents them so a v2 endpoint sits with its v1 sibling and is easy to spot, and cleans up inconsistent endpoint titles across the whole reference.

All changes are driven by `scripts/process_langsmith_openapi.py` (which runs on every spec sync), so they re-derive automatically and need no manual upkeep.

## What changed

- **Group v2 by resource.** Stop collecting v2 endpoints in a separate bucket; let their backend resource tags place them alongside v1 (e.g. runs → Tracing), each marked `(v2)`.
- **Match v1/v2 wording.** Paired endpoints now read identically via canonical-title overrides: "Query runs" / "Query runs (v2)", "Read run" / "Read run (v2)", "Share run" / "Share run (v2)".
- **Sentence-case every title,** preserving an acronym/proper-noun allowlist (`API`, `AWS`, `SCIM`, `TTL`, `OAuth2`, `URL`, `WebSocket`, …).
- **Normalize markers:** `[Beta] X` becomes `X (Beta)`, and trailing `X V2` becomes `X (v2)`.
- **Threads** moved into its own group.

## Relationship to `main`

This **supersedes the earlier "v2 endpoints" bucket approach** already on main — an intentional flip to resource-based grouping after reviewing how v2 actually spreads across resources.

## Please review carefully

- **`V2_TITLE_OVERRIDES`** in the script — the three canonical titles are explicit, because the v1/v2 equivalence is semantic and even crosses HTTP methods (POST "Share a run" ≈ PUT "Share Run"), so it cannot be auto-inferred. New matching pairs get added here.
- **`TITLE_PRESERVE`** acronym allowlist — anything missing gets lowercased; anything wrong gets over-preserved.
- The large `langsmith-platform-openapi.json` diff is fully generated output; the script is the source of truth.

## Known limitation

Within a resource group the v2 endpoints cluster together rather than each sitting directly beside its v1 twin. Mintlify sorts endpoints within a group by path, which cannot be overridden through the spec. Literal adjacency would require script-generated navigation, deferred by decision.

## AI involvement

Authored with Claude Code (investigation, script changes, and spec regeneration); reviewed by @lnhsingh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
