### PR TITLE
docs: add Microsoft Foundry hosted agents

### DIFF
--- a/src/oss/python/integrations/providers/microsoft.mdx
+++ b/src/oss/python/integrations/providers/microsoft.mdx
@@ -14,7 +14,7 @@ This page covers all LangChain integrations with [Microsoft Azure](https://porta
     For agent hosting, use [Microsoft Foundry hosted agents](#microsoft-foundry-hosted-agents) to deploy custom LangGraph code on a managed agent platform with built-in runtime, sessions, scaling, identity, and protocol endpoints.
 
     **Samples and tutorials:**
-    - [langchain-ai/langchain-azure hosted agent samples](https://github.com/langchain-ai/langchain-azure/tree/main/samples/hosting/langgraph-hosted-agents): Run LangGraph agents locally or deploy them to Microsoft Foundry with samples for the Responses and Invocations protocols.
+    - [microsoft-foundry/foundry-samples LangGraph hosted agent samples](https://github.com/microsoft-foundry/foundry-samples/tree/main/samples/python/hosted-agents/langgraph): Run LangGraph agents locally or deploy them to Microsoft Foundry with Responses, Invocations, and A2A samples.
     - [Azure-Samples/langchain-azure-openai-starter](https://github.com/Azure-Samples/langchain-azure-openai-starter): Start with a production-ready LangChain and Azure OpenAI app template that lets you deploy directly to Azure with a single `azd` command.
     - [microsoft/langchain-for-beginners](https://github.com/microsoft/langchain-for-beginners): A hands-on course introducing LangChain with Azure OpenAI.
     - [Azure-Samples/langchain-agent-python](https://github.com/Azure-Samples/langchain-agent-python): Build and deploy LangChain agents on Azure.
@@ -740,7 +740,7 @@ The `AzureAIServicesToolkit` toolkit includes the following tools:
 [Microsoft Foundry hosted agents](https://learn.microsoft.com/en-us/azure/foundry/how-to/develop/langchain-hosted-agents) run custom LangGraph code in a managed runtime. Use the `langchain_azure_ai.agents.hosting` package to expose a compiled LangGraph graph while Foundry manages the runtime, sessions, scaling, identity, and protocol endpoints.
 
 <Note>
-    LangGraph hosting support requires `langchain-azure-ai[hosting]>=1.2.4`.
+    LangGraph hosting support requires `langchain-azure-ai[hosting]>=1.2.8`.
 </Note>
 
 Before you begin, you need an Azure subscription, a Foundry project, a deployed chat model, Python 3.10 or later, and Azure CLI authentication. Deploying the agent also requires the Foundry Project Manager role on the project.

--- a/src/oss/python/integrations/providers/microsoft.mdx
+++ b/src/oss/python/integrations/providers/microsoft.mdx
@@ -7,11 +7,14 @@ sidebarTitle: "Microsoft"
 This page covers all LangChain integrations with [Microsoft Azure](https://portal.azure.com) and other [Microsoft](https://www.microsoft.com) products.
 
 <Tip>
-    **Recommended: Azure OpenAI**
+    **Recommended: Azure OpenAI and Microsoft Foundry**
 
     We recommend using @[Azure OpenAI][AzureOpenAI] across [chat models](#chat-models), [LLMs](#llms), and [embedding models](#embedding-models). With the [v1 API](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/api-version-lifecycle?tabs=python) (Generally Available as of August 2025), you can use your Azure endpoint and API keys directly with the @[`langchain-openai`] package to call any model deployed in [Microsoft Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/) (including OpenAI, Llama, DeepSeek, Mistral, and Phi) through a single interface. You also get native support for Microsoft Entra ID authentication and access to the latest features including the [Responses API](#responses-api) and [reasoning models](/oss/integrations/chat/azure_chat_openai). [Get started here](#azure-openai).
 
+    For agent hosting, use [Microsoft Foundry hosted agents](#microsoft-foundry-hosted-agents) to deploy custom LangGraph code on a managed agent platform with built-in runtime, sessions, scaling, identity, and protocol endpoints.
+
     **Samples and tutorials:**
+    - [langchain-ai/langchain-azure hosted agent samples](https://github.com/langchain-ai/langchain-azure/tree/main/samples/hosting/langgraph-hosted-agents): Run LangGraph agents locally or deploy them to Microsoft Foundry with samples for the Responses and Invocations protocols.
     - [Azure-Samples/langchain-azure-openai-starter](https://github.com/Azure-Samples/langchain-azure-openai-starter): Start with a production-ready LangChain and Azure OpenAI app template that lets you deploy directly to Azure with a single `azd` command.
     - [microsoft/langchain-for-beginners](https://github.com/microsoft/langchain-for-beginners): A hands-on course introducing LangChain with Azure OpenAI.
     - [Azure-Samples/langchain-agent-python](https://github.com/Azure-Samples/langchain-agent-python): Build and deploy LangChain agents on Azure.

--- a/src/oss/python/integrations/providers/microsoft.mdx
+++ b/src/oss/python/integrations/providers/microsoft.mdx
@@ -730,3 +730,29 @@ The `AzureAIServicesToolkit` toolkit includes the following tools:
 - Text to Speech: [AzureAITextToSpeechTool](/oss/integrations/tools/azure_ai_services#azureaitexttospeechtool)
 - Text Analytics for Health: [AzureAITextAnalyticsHealthTool](/oss/integrations/tools/azure_ai_services#azureaitextanalyticshealthtool)
 
+## Runtime
+
+### Microsoft Foundry hosted agents
+
+[Microsoft Foundry hosted agents](https://learn.microsoft.com/en-us/azure/foundry/how-to/develop/langchain-hosted-agents) run custom LangGraph code in a managed runtime. Use the `langchain_azure_ai.agents.hosting` package to expose a compiled LangGraph graph while Foundry manages the runtime, sessions, scaling, identity, and protocol endpoints.
+
+<Note>
+    LangGraph hosting support requires `langchain-azure-ai[hosting]>=1.2.4`.
+</Note>
+
+Before you begin, you need an Azure subscription, a Foundry project, a deployed chat model, Python 3.10 or later, and Azure CLI authentication. Deploying the agent also requires the Foundry Project Manager role on the project.
+
+Choose a hosting protocol based on how clients interact with the agent:
+
+| Protocol | Host class | Endpoint | Use when |
+| --- | --- | --- | --- |
+| Responses | `ResponsesHostServer` | `/responses` | You need OpenAI-compatible chat, streaming, response history, or conversation threading. Start here for most conversational agents. |
+| Invocations | `InvocationsHostServer` | `/invocations` | You need a custom JSON shape, a webhook-style endpoint, or non-conversational processing. |
+
+To host and deploy a graph:
+
+1. Pass the compiled graph to the host server for your chosen protocol.
+2. Set `FOUNDRY_PROJECT_ENDPOINT` and `FOUNDRY_MODEL_NAME`, then run and test the host locally.
+3. Use `azd ai agent init` to initialize a hosted-agent project, `azd ai agent run` to test its container, and `azd provision` and `azd deploy` to deploy it. You can also deploy with the Foundry Toolkit Visual Studio Code extension.
+
+The Microsoft Learn guide includes complete examples for both protocols, conversation state, human-in-the-loop flows, testing, deployment, and troubleshooting.


### PR DESCRIPTION
## Overview

Add a Runtime section to the Microsoft integrations provider page that explains how to host compiled LangGraph agents as Microsoft Foundry hosted agents.

The section covers the minimum package version and prerequisites, the Responses and Invocations protocols, and the high-level local development and deployment flow. It links to the Microsoft Learn guide for the complete walkthrough instead of duplicating it.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: N/A
- Feature PR: N/A

<!-- For LangChain employees, if applicable: -->
- Linear issue: N/A
- Slack thread: N/A

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly (no code examples added)
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed (no navigation change needed)

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes

- Source: [Host LangGraph agents as Foundry hosted agents](https://learn.microsoft.com/en-us/azure/foundry/how-to/develop/langchain-hosted-agents).
- The change passes targeted Vale lint and the documentation build.
- AI agent involvement: GitHub Copilot CLI helped draft and validate this documentation update; the author reviewed and approved the change.
