### PR TITLE
docs: fix stale and inconsistent model IDs in OSS examples

### DIFF
--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -41,7 +41,7 @@ Each provider is a TOML table under `[models.providers]`:
 [models.providers.<name>]
 display_name = "My Provider"
 api_key_url = "https://provider.example/keys"
-models = ["gpt-4o"]
+models = ["gpt-5.5"]
 api_key_env = "OPENAI_API_KEY"
 base_url = "https://api.openai.com/v1"
 class_path = "my_package.models:MyChatModel"
@@ -51,7 +51,7 @@ enabled = true
 temperature = 0
 max_tokens = 4096
 
-[models.providers.<name>.params."gpt-4o"]
+[models.providers.<name>.params."gpt-5.5"]
 temperature = 0.7
 ```
 
@@ -98,7 +98,7 @@ Providers have the following configuration options:
 </ResponseField>
 
 <ResponseField name="params" type="object" post={["optional"]}>
-    Extra keyword arguments forwarded to the model constructor. Flat keys (e.g., `temperature = 0`) apply to every model from this provider. Model-keyed sub-tables (e.g., `[params."gpt-4o"]`) override individual values for that model only; the merge is shallow (model wins on conflict).
+    Extra keyword arguments forwarded to the model constructor. Flat keys (e.g., `temperature = 0`) apply to every model from this provider. Model-keyed sub-tables (e.g., `[params."gpt-5.5"]`) override individual values for that model only; the merge is shallow (model wins on conflict).
 
     Do not put credentials (e.g., `api_key`) in `params`. Use [`api_key_env`](#provider-configuration) to point at an environment variable instead.
 </ResponseField>

--- a/src/oss/deepagents/human-in-the-loop.mdx
+++ b/src/oss/deepagents/human-in-the-loop.mdx
@@ -607,7 +607,7 @@ const requestApproval = tool(
 async function main() {
   const checkpointer = new MemorySaver();
   const model = new ChatOpenAI({
-    model: "gpt-4o-mini",
+    model: "gpt-5.4-mini",
     maxTokens: 4096,
   });
 

--- a/src/oss/langchain/multi-agent/custom-workflow.mdx
+++ b/src/oss/langchain/multi-agent/custom-workflow.mdx
@@ -80,7 +80,7 @@ import { z } from "zod";
 import { createAgent } from "langchain";
 import { StateGraph, START, END, StateSchema, MessagesValue } from "@langchain/langgraph";
 
-const agent = createAgent({ model: "openai:gpt-4o", tools: [...] });
+const agent = createAgent({ model: "openai:gpt-5.5", tools: [...] });
 
 const AgentState = new StateSchema({
   messages: MessagesValue,

--- a/src/oss/langchain/multi-agent/skills-sql-assistant.mdx
+++ b/src/oss/langchain/multi-agent/skills-sql-assistant.mdx
@@ -1296,7 +1296,7 @@ class SkillMiddleware(AgentMiddleware):
 # Example: from langchain_anthropic import ChatAnthropic
 # model = ChatAnthropic(model="claude-3-5-sonnet-20241022")
 from langchain_openai import ChatOpenAI
-model = ChatOpenAI(model="gpt-4")
+model = ChatOpenAI(model="gpt-5.5")
 
 # Create the agent with skill support
 agent = create_agent(

--- a/src/oss/langchain/retrieval.mdx
+++ b/src/oss/langchain/retrieval.mdx
@@ -234,7 +234,7 @@ const fetchUrl = tool(
 );
 
 const agent = createAgent({
-    model: "claude-sonnet-4-0",
+    model: "claude-sonnet-4-6",
     tools: [fetchUrl],
     systemPrompt,
 });
@@ -300,7 +300,7 @@ Your answers should be clear, concise, and technically accurate.
 
 tools = [fetch_documentation]
 
-model = init_chat_model("claude-sonnet-4-0", max_tokens=32_000)
+model = init_chat_model("claude-sonnet-4-6", max_tokens=32_000)
 
 agent = create_agent(
     model=model,
@@ -378,7 +378,7 @@ Your answers should be clear, concise, and technically accurate.
 const tools = [fetchDocumentation];
 
 const agent = createAgent({
-  model: "claude-sonnet-4-0"
+  model: "claude-sonnet-4-6"
   tools,  // [!code highlight]
   systemPrompt,  // [!code highlight]
   name: "Agentic RAG",

--- a/src/oss/langchain/tools.mdx
+++ b/src/oss/langchain/tools.mdx
@@ -948,7 +948,7 @@ There are two approaches depending on whether tools are known ahead of time:
         });
 
         const agent = await createDeepAgent({
-            model: "claude-sonnet-4-20250514",
+            model: "claude-sonnet-4-6",
             tools: tools,
             middleware: [stateBasedTools] as any,
         });
@@ -1046,7 +1046,7 @@ There are two approaches depending on whether tools are known ahead of time:
         });
 
         const agent = await createDeepAgent({
-          model: "claude-sonnet-4-20250514",
+          model: "claude-sonnet-4-6",
           backend: new StoreBackend(),
           store,
           checkpointer,
@@ -1145,7 +1145,7 @@ There are two approaches depending on whether tools are known ahead of time:
         });
 
         const agent = await createDeepAgent({
-          model: "claude-sonnet-4-20250514",
+          model: "claude-sonnet-4-6",
           store,
           checkpointer,
           tools,
@@ -1204,7 +1204,7 @@ There are two approaches depending on whether tools are known ahead of time:
             return handler(request)
 
     agent = create_agent(
-        model="gpt-4o",
+        model="gpt-5.5",
         tools=[get_weather],  # Only static tools registered here
         middleware=[DynamicToolMiddleware()],
     )
@@ -1259,7 +1259,7 @@ There are two approaches depending on whether tools are known ahead of time:
     });
 
     const agent = createAgent({
-      model: "gpt-4o",
+      model: "gpt-5.5",
       tools: [getWeather], // Only static tools registered here
       middleware: [dynamicToolMiddleware],
     });

--- a/src/oss/langgraph/streaming.mdx
+++ b/src/oss/langgraph/streaming.mdx
@@ -1153,7 +1153,7 @@ const checkHotels = tool(
 );
 
 export const agent = createAgent({
-  model: new ChatOpenAI({ model: "gpt-4o-mini" }),
+  model: new ChatOpenAI({ model: "gpt-5.4-mini" }),
   tools: [searchFlights, checkHotels],
   checkpointer: new MemorySaver(),
 });
@@ -1883,7 +1883,7 @@ Set `streaming=False` when initializing the model.
     from langchain_openai import ChatOpenAI
 
     # Set streaming=False to disable streaming for the chat model
-    model = ChatOpenAI(model="o1-preview", streaming=False)
+    model = ChatOpenAI(model="gpt-5.5", streaming=False)
     ```
     </Tab>
 </Tabs>
@@ -1896,7 +1896,7 @@ Set `streaming: false` when initializing the model.
 import { ChatOpenAI } from "@langchain/openai";
 
 const model = new ChatOpenAI({
-  model: "o1-preview",
+  model: "gpt-5.5",
   // Set streaming: false to disable streaming for the chat model
   streaming: false,
 });

--- a/src/snippets/chat-model-tabs-da.mdx
+++ b/src/snippets/chat-model-tabs-da.mdx
@@ -163,7 +163,7 @@
 
             os.environ["GOOGLE_API_KEY"] = "..."
 
-            model = ChatGoogleGenerativeAI(model="gemini-3.1-pro-preview")
+            model = ChatGoogleGenerativeAI(model="gemini-3.5-flash")
             agent = create_deep_agent(model=model)
             ```
         </CodeGroup>


### PR DESCRIPTION
Cleans up outdated and inconsistent model IDs in OSS example docs. Two related changes:

## 1. Consistent Gemini model in the Deep Agents config tabs

`src/snippets/chat-model-tabs-da.mdx` showed three equivalent ways to configure Google, but the "Model Class" example used `gemini-3.1-pro-preview` while the other two used `gemini-3.5-flash`. Unified on `gemini-3.5-flash` (matches the other two and the models-page prose example).

## 2. Replace stale model IDs with current GA equivalents

Several OSS example pages referenced previous-generation or deprecated models, which contradicts the "always use the latest GA model" guideline and dates the examples. Replaced each with the current ID already used as canonical in `oss/langchain/models.mdx`, tier-matched:

| Stale ID | → | Files |
|---|---|---|
| `gpt-4o`, `gpt-4`, `o1-preview` | `gpt-5.5` | tools, custom-workflow, skills-sql-assistant, config-file, streaming |
| `gpt-4o-mini` | `gpt-5.4-mini` | langgraph/streaming, human-in-the-loop |
| `claude-sonnet-4-0`, `claude-sonnet-4-20250514` | `claude-sonnet-4-6` | retrieval, tools |

## Review notes

- `make lint_prose` passes clean on all changed files.
- Replacement IDs were taken from the repo's own maintained `oss/langchain/models.mdx`, not from memory — treating that page as the in-repo source of truth for current GA IDs.
- The `o1-preview` example was a generic "how to disable streaming" demo (its sibling tab uses `claude-sonnet-4-6` the same way), so the swap does not change what it teaches.
- **Deliberately left as-is:** same-generation variants (`gpt-5-mini`, `gpt-5-nano-2025-08-07` inside a printed response dump) — current-gen, not stale. And cosmetic `:::python`/`:::js` mismatches where both sides already use current models, to avoid churn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
