### PR TITLE
fix: correct serverless sizes

### DIFF
--- a/src/langsmith/cloud-platform-features.mdx
+++ b/src/langsmith/cloud-platform-features.mdx
@@ -61,8 +61,8 @@ Both Serverless and Dedicated are available in three sizes: Small, Medium, and L
 
 | Resource | Serverless S | Serverless M | Serverless L | Dedicated S | Dedicated M | Dedicated L |
 |---|---|---|---|---|---|---|
-| Runtime compute (vCPU) | 1 | 5 | 9 | 3 | 5 | 10 |
-| Runtime memory (GiB) | 3 | 6 | 11 | 6 | 12 | 24 |
+| Runtime compute (vCPU) | 1 | 2 | 4 | 3 | 5 | 10 |
+| Runtime memory (GiB) | 2 | 5 | 9 | 6 | 12 | 24 |
 | Database compute (vCPU) | — | — | — | 1 | 2 | 4 |
 | Database memory (GiB) | — | — | — | 4 | 8 | 16 |
 | Storage | Shared | Shared | Shared | Auto-scaling | Auto-scaling | Auto-scaling |


### PR DESCRIPTION
## Overview
Updating Serverless compute sizes to reflect the correct figures. 

## Type of change

**Type:** Fix typo

- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Slack thread: https://langchain.slack.com/archives/C0B6NJL18P3/p1784300228103449

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
