### PR TITLE
docs: add Context Hub webhook guide

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -1416,8 +1416,8 @@
                   "langsmith/context-hub",
                   "langsmith/context-engineering-concepts",
                   "langsmith/use-the-context-hub",
-                  "langsmith/context-hub-webhooks",
-                  "langsmith/manage-contexts-sdk"
+                  "langsmith/manage-contexts-sdk",
+                  "langsmith/context-hub-webhooks"
                 ]
               },
               {

--- a/src/docs.json
+++ b/src/docs.json
@@ -1416,6 +1416,7 @@
                   "langsmith/context-hub",
                   "langsmith/context-engineering-concepts",
                   "langsmith/use-the-context-hub",
+                  "langsmith/context-hub-webhooks",
                   "langsmith/manage-contexts-sdk"
                 ]
               },

--- a/src/langsmith/context-hub-webhooks.mdx
+++ b/src/langsmith/context-hub-webhooks.mdx
@@ -4,9 +4,11 @@ sidebarTitle: Commit webhooks
 description: Send Context Hub commit events to an external HTTPS endpoint and verify that LangSmith signed each request.
 ---
 
-Context Hub commit webhooks notify external services whenever an agent or skill commit is created in your workspace. Use them to trigger automation from Context Hub changes, including commits created through [LangSmith Fleet](/langsmith/fleet).
+import WebhookSignatureVerification from '/snippets/langsmith/webhook-signature-verification.mdx';
 
-Managing Context Hub webhooks requires the `prompts:update` permission, which Workspace Admins and Workspace Editors have by default.
+[Context Hub](/langsmith/context-hub) commit webhooks notify external services whenever an agent or skill commit is created in your [workspace](/langsmith/administration-overview#workspaces). Use them to trigger automation from Context Hub changes, including commits created through [LangSmith Fleet](/langsmith/fleet).
+
+Managing Context Hub webhooks requires the [`prompts:update`](/langsmith/organization-workspace-operations) permission, which [Workspace Admins](/langsmith/rbac#workspace-admin) and [Workspace Editors](/langsmith/rbac#workspace-editor) have by default.
 
 ## Add a webhook
 
@@ -14,7 +16,7 @@ Each webhook applies to the entire workspace. Every configured endpoint receives
 
 To add a webhook:
 
-1. In the LangSmith UI, go to **Settings** → **Integrations** → **Context Hub webhooks**.
+1. In the [LangSmith UI](https://smith.langchain.com), go to **Settings** → **Integrations** → **Context Hub webhooks**.
 1. Click **Add webhook**.
 1. Enter a publicly reachable HTTPS URL.
 1. (Optional) Add custom request headers, such as an `Authorization` header.
@@ -61,7 +63,7 @@ sha256=<lowercase hex HMAC-SHA256 digest>
 
 Compute the HMAC-SHA256 digest over the exact raw request body bytes with the webhook's signing secret. Verify the signature before parsing the JSON, and compare the complete header value in constant time. Parsing and reserializing the body before verification can change its bytes and invalidate the signature.
 
-<Snippet file="langsmith/webhook-signature-verification.mdx" />
+<WebhookSignatureVerification />
 
 ## Event envelope
 

--- a/src/langsmith/context-hub-webhooks.mdx
+++ b/src/langsmith/context-hub-webhooks.mdx
@@ -1,0 +1,143 @@
+---
+title: Configure Context Hub commit webhooks
+sidebarTitle: Commit webhooks
+description: Send Context Hub commit events to an external HTTPS endpoint and verify that LangSmith signed each request.
+---
+
+Context Hub commit webhooks notify external services whenever an agent or skill commit is created in your workspace. Use them to trigger automation from Context Hub changes, including commits created through [LangSmith Fleet](/langsmith/fleet).
+
+Managing Context Hub webhooks requires the `prompts:update` permission, which Workspace Admins and Workspace Editors have by default.
+
+## Add a webhook
+
+Each webhook applies to the entire workspace. Every configured endpoint receives every agent and skill commit, including commits created by Fleet. The `context_hub.commit.created.v1` event does not support filtering by repository or event type.
+
+To add a webhook:
+
+1. In the LangSmith UI, go to **Settings** → **Integrations** → **Context Hub webhooks**.
+1. Click **Add webhook**.
+1. Enter a publicly reachable HTTPS URL.
+1. (Optional) Add custom request headers, such as an `Authorization` header.
+1. Click **Add webhook**.
+1. Copy the generated signing secret and store it securely.
+
+The number of subscriptions you can add depends on your workspace configuration.
+
+## Manage a webhook
+
+The webhook list displays endpoint URLs and custom header names. Header values and signing secrets remain hidden until you click **Reveal secrets**. You can reveal them later if you still have permission to manage Context Hub webhooks.
+
+Use the controls on a webhook to manage it:
+
+- **Edit webhook**: Change the HTTPS URL or replace its custom headers. Editing does not change the signing secret.
+- **Roll signing secret**: Generate and reveal a new signing secret. LangSmith uses the new secret for future deliveries immediately, and the previous secret stops working. Update every consumer that verifies the webhook.
+- **Delete webhook**: Stop the endpoint from receiving future Context Hub commit events from the workspace.
+
+## Delivery
+
+LangSmith sends a JSON `POST` request for each event. Custom headers cannot override `Content-Type` or `X-LangSmith-Signature`, which LangSmith sets after applying custom headers.
+
+| Property | Value |
+| --- | --- |
+| Method | `POST` |
+| URL | Publicly reachable HTTPS endpoint |
+| Content type | `application/json` |
+| Signature | `X-LangSmith-Signature` header, signed with the webhook's signing secret |
+| Timeout | 20 seconds per attempt |
+| Attempts | Up to 4 attempts: 1 initial attempt and up to 3 retries |
+| Retry conditions | Transport failures, HTTP `408`, `425`, `429`, and `5xx` responses |
+| Permanent responses | Other `4xx` responses are not retried |
+| Response handling | A status below `400` succeeds. Response bodies do not affect success. |
+
+Retries contain the byte-identical request body and retain the event `id`. Deduplicate events by `id` before producing downstream effects.
+
+## Verify the signature
+
+Each request includes an `X-LangSmith-Signature` header in this format:
+
+```text
+sha256=<lowercase hex HMAC-SHA256 digest>
+```
+
+Compute the HMAC-SHA256 digest over the exact raw request body bytes with the webhook's signing secret. Verify the signature before parsing the JSON, and compare the complete header value in constant time. Parsing and reserializing the body before verification can change its bytes and invalidate the signature.
+
+<Snippet file="langsmith/webhook-signature-verification.mdx" />
+
+## Event envelope
+
+The outer `id`, `type`, `created`, and `data` envelope is frozen. The `.v1` suffix on the event type versions the `data.commit` schema.
+
+```json
+{
+  "id": "0198...",
+  "type": "context_hub.commit.created.v1",
+  "created": 1720000000,
+  "data": {
+    "commit": {
+      "repo_id": "...",
+      "repo_handle": "my-agent",
+      "repo_type": "agent",
+      "commit_hash": "newcommithash0002",
+      "parent_commit_hash": "parentcommithash0001",
+      "created_at": "2023-11-14T22:13:20Z",
+      "created_by": "user@example.com",
+      "url": "https://smith.example.com/context/my-agent/newcommithash0002",
+      "files_changed": [
+        { "path": "skills/kept", "action": "modified" },
+        { "path": "skills/added", "action": "added" },
+        { "path": "skills/gone", "action": "removed" }
+      ]
+    }
+  }
+}
+```
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `id` | UUID | Unique event identifier that remains stable across retries. Use it to deduplicate events. |
+| `type` | string | Exact event type. Currently `context_hub.commit.created.v1`. |
+| `created` | integer | Unix seconds in UTC when the event was enqueued. |
+| `data` | object | Versioned event data. Contains `data.commit`. |
+
+### `data.commit`
+
+The `data.commit` object describes the Context Hub commit that triggered the event.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `repo_id` | UUID | Context Hub repository ID. |
+| `repo_handle` | string | Repository handle. |
+| `repo_type` | string | Repository type: `agent` or `skill`. |
+| `commit_hash` | string | Hash of the new commit. |
+| `parent_commit_hash` | string | Hash of the parent commit. Omitted for an initial commit or when unavailable. |
+| `created_at` | string | RFC 3339 timestamp when the commit was created. |
+| `created_by` | string | LangSmith user ID that created the commit. Omitted when unavailable. |
+| `url` | string | Deep link to the commit in the LangSmith UI. |
+| `files_changed` | array | File changes included in the commit. Each entry contains `path` and `action`. |
+
+### `data.commit.files_changed`
+
+Each entry summarizes a changed path. It does not contain the file contents.
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `path` | string | Path changed by the commit. |
+| `action` | string | Change type: `added`, `modified`, or `removed`. |
+
+## Handle event versions
+
+Branch on the complete event type before parsing `data.commit`:
+
+```typescript
+if (event.type === "context_hub.commit.created.v1") {
+  await handleCommitCreatedV1(event.data.commit);
+} else {
+  // Ignore unknown event types and versions safely.
+}
+```
+
+A breaking change to `data.commit` uses a new event type suffix, such as `.v2`. Ignore unknown types instead of trying to parse them as v1, and allow unknown fields so compatible additions do not break your handler.
+
+## Next step
+
+- [Use the Context Hub](/langsmith/use-the-context-hub): Create, inspect, and promote agent and skill commits.

--- a/src/langsmith/context-hub.mdx
+++ b/src/langsmith/context-hub.mdx
@@ -8,7 +8,7 @@ mode: wide
 
 The Context Hub gives your team version-controlled, environment-aware management of the instructions and tools your agents use in production. A _context_ is a versioned bundle of agent instructions and tools, either a skill or a full agent, that you manage in LangSmith and promote to an environment so your agents can pull it.
 
-<CardGroup cols={3}>
+<CardGroup cols={2}>
   <Card title="Concepts" icon="bulb" href="/langsmith/context-engineering-concepts" arrow="true">
     Learn the core concepts of context engineering: skills, agents, versioning, and sharing.
   </Card>
@@ -17,5 +17,8 @@ The Context Hub gives your team version-controlled, environment-aware management
   </Card>
   <Card title="Manage contexts with the SDK" icon="code" href="/langsmith/manage-contexts-sdk" arrow="true">
     Push, pull, list, and delete agent and skill repos in the Context Hub programmatically.
+  </Card>
+  <Card title="Configure commit webhooks" icon="webhook" href="/langsmith/context-hub-webhooks" arrow="true">
+    Send every agent and skill commit in your workspace to an external HTTPS endpoint.
   </Card>
 </CardGroup>

--- a/src/langsmith/engine-webhooks.mdx
+++ b/src/langsmith/engine-webhooks.mdx
@@ -48,63 +48,7 @@ sha256=<hex-encoded HMAC-SHA256 digest>
 
 Verify the signature before parsing or acting on the payload. The HMAC input is the exact raw request body bytes, and the HMAC key is the subscription's signing secret. Do not parse and reserialize the JSON body before verification.
 
-<CodeGroup>
-
-```python Python
-import hashlib
-import hmac
-from typing import Optional
-
-
-def verify_langsmith_signature(
-    *,
-    body: bytes,
-    signing_secret: str,
-    signature_header: Optional[str],
-) -> bool:
-    if not signature_header or not signature_header.startswith("sha256="):
-        return False
-
-    expected = "sha256=" + hmac.new(
-        signing_secret.encode("utf-8"),
-        body,
-        hashlib.sha256,
-    ).hexdigest()
-
-    return hmac.compare_digest(expected, signature_header)
-```
-
-```typescript TypeScript
-import { createHmac, timingSafeEqual } from "node:crypto";
-
-export function verifyLangSmithSignature({
-  body,
-  signingSecret,
-  signatureHeader,
-}: {
-  body: Buffer;
-  signingSecret: string;
-  signatureHeader: string | undefined;
-}) {
-  if (!signatureHeader?.startsWith("sha256=")) {
-    return false;
-  }
-
-  const expected = `sha256=${createHmac("sha256", signingSecret)
-    .update(body)
-    .digest("hex")}`;
-
-  const expectedBytes = Buffer.from(expected);
-  const actualBytes = Buffer.from(signatureHeader);
-
-  return (
-    expectedBytes.length === actualBytes.length &&
-    timingSafeEqual(expectedBytes, actualBytes)
-  );
-}
-```
-
-</CodeGroup>
+<Snippet file="langsmith/webhook-signature-verification.mdx" />
 
 ### Roll a signing secret
 

--- a/src/langsmith/engine-webhooks.mdx
+++ b/src/langsmith/engine-webhooks.mdx
@@ -4,6 +4,8 @@ sidebarTitle: Engine webhook events
 description: Reference for the webhook events LangSmith Engine sends when it creates issues or links new traces to existing issues.
 ---
 
+import WebhookSignatureVerification from '/snippets/langsmith/webhook-signature-verification.mdx';
+
 Forward LangSmith-detected agent issues into your incident-management, paging, or chat tools. [LangSmith Engine](/langsmith/engine) sends a webhook event to your endpoint when it opens a new issue, or when it links a new trace to an issue it has already opened.
 
 To configure webhook subscriptions, open the **Engine Settings** panel on the **Engine** tab of a tracing project. See [Configure LangSmith Engine](/langsmith/engine#configure-langsmith-engine).
@@ -48,7 +50,7 @@ sha256=<hex-encoded HMAC-SHA256 digest>
 
 Verify the signature before parsing or acting on the payload. The HMAC input is the exact raw request body bytes, and the HMAC key is the subscription's signing secret. Do not parse and reserialize the JSON body before verification.
 
-<Snippet file="langsmith/webhook-signature-verification.mdx" />
+<WebhookSignatureVerification />
 
 ### Roll a signing secret
 

--- a/src/langsmith/use-the-context-hub.mdx
+++ b/src/langsmith/use-the-context-hub.mdx
@@ -70,3 +70,4 @@ Agent runtimes that resolve context by environment tag (for example, `:productio
 
 - [Context engineering concepts](/langsmith/context-engineering-concepts): learn about skills, agents, versioning, and sharing.
 - [Manage contexts with the SDK](/langsmith/manage-contexts-sdk): push, pull, list, and delete contexts programmatically.
+- [Configure commit webhooks](/langsmith/context-hub-webhooks): send workspace Context Hub commits to an external HTTPS endpoint.

--- a/src/snippets/langsmith/webhook-signature-verification.mdx
+++ b/src/snippets/langsmith/webhook-signature-verification.mdx
@@ -1,0 +1,57 @@
+<CodeGroup>
+
+```python Python
+import hashlib
+import hmac
+from typing import Optional
+
+
+def verify_langsmith_signature(
+    *,
+    body: bytes,
+    signing_secret: str,
+    signature_header: Optional[str],
+) -> bool:
+    if not signature_header or not signature_header.startswith("sha256="):
+        return False
+
+    expected = "sha256=" + hmac.new(
+        signing_secret.encode("utf-8"),
+        body,
+        hashlib.sha256,
+    ).hexdigest()
+
+    return hmac.compare_digest(expected, signature_header)
+```
+
+```typescript TypeScript
+import { createHmac, timingSafeEqual } from "node:crypto";
+
+export function verifyLangSmithSignature({
+  body,
+  signingSecret,
+  signatureHeader,
+}: {
+  body: Buffer;
+  signingSecret: string;
+  signatureHeader: string | undefined;
+}) {
+  if (!signatureHeader?.startsWith("sha256=")) {
+    return false;
+  }
+
+  const expected = `sha256=${createHmac("sha256", signingSecret)
+    .update(body)
+    .digest("hex")}`;
+
+  const expectedBytes = Buffer.from(expected);
+  const actualBytes = Buffer.from(signatureHeader);
+
+  return (
+    expectedBytes.length === actualBytes.length &&
+    timingSafeEqual(expectedBytes, actualBytes)
+  );
+}
+```
+
+</CodeGroup>


### PR DESCRIPTION
## Why

Context Hub commit webhooks now have a workspace-wide settings experience and a stable delivery contract. This guide makes the shipped configuration, signing, retry, deduplication, and v1 payload behavior available without requiring readers to inspect the implementation.

## What changed

- Add the Context Hub commit webhook guide and navigation entry.
- Link the guide from the Context Hub overview and UI workflow.
- Document workspace scope, Fleet-originated commits, management behavior, delivery semantics, and every v1 payload field.
- Extract the existing Engine webhook signature examples into one reusable snippet shared by both webhook guides.

## Review carefully

- Confirm the Settings navigation and management behavior match the landed UI from #30422.
- Confirm retry classification, payload fields, and optional-field behavior match the backend implementation.
- Confirm extracting the Engine signature examples into a shared snippet preserves their rendered presentation.

## Validation

- Python and TypeScript signature harnesses: valid signature accepted; tampered body, malformed header, and incorrect signature rejected.
- `make lint_prose FILES="src/langsmith/context-hub-webhooks.mdx src/langsmith/context-hub.mdx src/langsmith/use-the-context-hub.mdx src/langsmith/engine-webhooks.mdx src/snippets/langsmith/webhook-signature-verification.mdx"`
- `uv run --group test codespell` on the touched MDX files
- `make build`
- `mise exec -- make broken-links-with-anchors`

## AI involvement

This PR was implemented with assistance from an AI coding agent. The agent reviewed the landed backend and UI source, authored the documentation changes, ran the code-example harnesses and documentation checks, and prepared this PR description.