### PR TITLE
fix(deepagents): interrupt_on must be a dict, not a list (fault-tolerance.mdx)

### DIFF
--- a/src/oss/deepagents/fault-tolerance.mdx
+++ b/src/oss/deepagents/fault-tolerance.mdx
@@ -111,7 +111,10 @@ from deepagents import create_deep_agent
 agent = create_deep_agent(
     model="google_genai:gemini-3.5-flash",
     tools=[send_email_tool, delete_record_tool],
-    interrupt_on=["send_email", "delete_record"],
+    interrupt_on={
+        "send_email": True,
+        "delete_record": True,
+    },
 )
 ```
 :::
@@ -123,7 +126,10 @@ import { createDeepAgent } from "deepagents";
 const agent = createDeepAgent({
   model: "google_genai:gemini-3.5-flash",
   tools: [sendEmailTool, deleteRecordTool],
-  interruptOn: ["send_email", "delete_record"],
+  interruptOn: {
+    send_email: true,
+    delete_record: true,
+  },
 });
 ```
 :::


### PR DESCRIPTION
## Overview

`interrupt_on` in the "User-fixable" fault-tolerance example is passed as a list:

    interrupt_on=["send_email", "delete_record"]

but `create_deep_agent`'s real signature takes a dict:

    interrupt_on: dict[str, bool | InterruptOnConfig] | None = None

Reproduced with the exact snippet (real tools standing in for
send_email_tool/delete_record_tool):

    ValueError: dictionary update sequence element #0 has length 10;
    2 is required

The error gives no indication the actual problem is list-vs-dict, so
anyone copying this snippet hits a confusing failure with no fix path.
Same bug appears in the TypeScript block right below it
(`interruptOn: [...]`).

Fixed both to the dict form used everywhere else in the docs, and
verified the corrected version constructs the agent with no error.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs

None.