### PR TITLE
docs: fix missing space in deepagents RAG guide

### DIFF
--- a/src/oss/deepagents/rag.mdx
+++ b/src/oss/deepagents/rag.mdx
@@ -317,7 +317,7 @@ This might be private data, recent data, or data that is not part of the trainin
 ### Split documents
 
 The loaded documentation is long with over 100k tokens total, which makes it too large to fit into the context window of many models.
-Even for those models that could fit the full corpus in their context window, models can struggle to find information in very long inputs. Using the context window for large amounts of content is also nottoken efficient.
+Even for those models that could fit the full corpus in their context window, models can struggle to find information in very long inputs. Using the context window for large amounts of content is also not token efficient.
 
 For ease of use, split the @[`Document`] objects into chunks. These chunks will be used for embedding and vector storage in the next steps.
 


### PR DESCRIPTION
## Overview
Fixes a missing space typo in the deepagents RAG guide: "nottoken" to "not token" in the Split documents section.

## Type of change
**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue: N/A — trivial one word fix and opened directly as a PR
- Feature PR: N/A
- Linear issue: N/A
- Slack thread: N/A

## Checklist
- [x] I have read the contributing guidelines, including the language policy
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used root relative paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes
Single-character whitespace fix, no code or nav changes, didn't spin up `docs dev` for this since there's nothing to render/test beyond the text itself.