### PR TITLE
ci: harden docs workflow inputs

### DIFF
--- a/.github/workflows/check-deprecated.yml
+++ b/.github/workflows/check-deprecated.yml
@@ -25,9 +25,11 @@ jobs:
           persist-credentials: false
 
       - name: Check for create_react_agent in diff
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           # Get the diff of added lines only (lines starting with +, excluding the +++ header)
-          ADDED_LINES=$(git diff origin/${{ github.base_ref }}...HEAD --diff-filter=ACMR -- '*.py' '*.md' '*.mdx' '*.ipynb' | grep -E '^\+' | grep -v '^\+\+\+' || true)
+          ADDED_LINES=$(git diff "origin/$BASE_REF"...HEAD --diff-filter=ACMR -- '*.py' '*.md' '*.mdx' '*.ipynb' | grep -E '^\+' | grep -v '^\+\+\+' || true)
 
           # Check if any added lines contain create_react_agent
           if echo "$ADDED_LINES" | grep -q 'create_react_agent'; then

--- a/.github/workflows/check-external-doc-links.yml
+++ b/.github/workflows/check-external-doc-links.yml
@@ -24,9 +24,11 @@ jobs:
           persist-credentials: false
 
       - name: Check for links to js.langchain.com and python.langchain.com
+        env:
+          BASE_REF: ${{ github.base_ref }}
         run: |
           # Get the diff of added lines only (lines starting with +, excluding the +++ header)
-          ADDED_LINES=$(git diff origin/${{ github.base_ref }}...HEAD --diff-filter=ACMR -- '*.md' '*.mdx' | grep -E '^\+' | grep -v '^\+\+\+' || true)
+          ADDED_LINES=$(git diff "origin/$BASE_REF"...HEAD --diff-filter=ACMR -- '*.md' '*.mdx' | grep -E '^\+' | grep -v '^\+\+\+' || true)
 
           # Check if any added lines contain links to the old doc sites
           if echo "$ADDED_LINES" | grep -qE '(js\.langchain\.com|python\.langchain\.com)'; then

--- a/.github/workflows/check-removed-pages-redirects.yml
+++ b/.github/workflows/check-removed-pages-redirects.yml
@@ -21,7 +21,9 @@ jobs:
           fetch-depth: 0
 
       - name: Fetch base branch
-        run: git fetch origin "${{ github.base_ref }}"
+        env:
+          BASE_REF: ${{ github.base_ref }}
+        run: git fetch origin "$BASE_REF"
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -29,10 +31,13 @@ jobs:
           python-version: "3.13"
 
       - name: Get base branch docs.json
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          BASE_REF_NAME: ${{ github.base_ref }}
         run: |
-          BASE_REF="${{ github.event.pull_request.base.sha }}"
+          BASE_REF="$BASE_SHA"
           if [ -z "$BASE_REF" ]; then
-            BASE_REF="origin/${{ github.base_ref }}"
+            BASE_REF="origin/$BASE_REF_NAME"
           fi
           git show "${BASE_REF}:src/docs.json" > base_docs.json
 

--- a/.github/workflows/test-code-samples-linear.yml
+++ b/.github/workflows/test-code-samples-linear.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Create Linear issue
-        uses: ctriolo/action-create-linear-issue@v0.7
+        uses: ctriolo/action-create-linear-issue@699c7c2f0639181e0eaf5622d2987c6584f48a5a # v0.7
         with:
           linear-api-key: ${{ secrets.LINEAR_API_KEY }}
           linear-team-key: ${{ vars.LINEAR_TEAM_KEY }}

--- a/.github/workflows/test-code-samples.yml
+++ b/.github/workflows/test-code-samples.yml
@@ -47,18 +47,22 @@ jobs:
 
       - name: Get modified code sample paths
         id: files
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          PR_BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BEFORE_SHA: ${{ github.event.before }}
         run: |
-          if [[ "${{ github.event_name }}" == "schedule" || "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          if [[ "$EVENT_NAME" == "schedule" || "$EVENT_NAME" == "workflow_dispatch" ]]; then
             echo "run_all=true" >> "$GITHUB_OUTPUT"
             echo "Full run: testing all code samples"
           else
             echo "run_all=false" >> "$GITHUB_OUTPUT"
 
-            if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-              git fetch origin "${{ github.event.pull_request.base.ref }}"
-              BASE=$(git merge-base HEAD origin/${{ github.event.pull_request.base.ref }})
+            if [[ "$EVENT_NAME" == "pull_request" ]]; then
+              git fetch origin "$PR_BASE_REF"
+              BASE=$(git merge-base HEAD "origin/$PR_BASE_REF")
             else
-              BASE="${{ github.event.before }}"
+              BASE="$BEFORE_SHA"
             fi
 
             FILES=$(git diff --name-only "$BASE" HEAD -- src/code-samples/ \
@@ -136,12 +140,14 @@ jobs:
           GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
           DAYTONA_API_KEY: ${{ secrets.DAYTONA_API_KEY }}
           DAYTONA_API_URL: ${{ secrets.DAYTONA_API_URL }}
+          RUN_ALL: ${{ steps.files.outputs.run_all }}
+          MODIFIED_FILES: ${{ steps.files.outputs.files }}
         run: |
-          if [[ "${{ steps.files.outputs.run_all }}" == "true" ]]; then
+          if [[ "$RUN_ALL" == "true" ]]; then
             echo "Running all code samples..."
             make test-code-samples
           else
-            FILES="${{ steps.files.outputs.files }}"
+            FILES="$MODIFIED_FILES"
             FILES=$(echo "$FILES" | tr -d '\n' | xargs)
             if [[ -z "$FILES" ]]; then
               echo "No code samples to test"


### PR DESCRIPTION
## Summary
- Pin `ctriolo/action-create-linear-issue` to the immutable commit SHA for `v0.7` so the `LINEAR_API_KEY` is no longer exposed to a mutable third-party action tag.
- Pass GitHub PR base refs/SHAs and workflow output values through environment variables before shell use.
- Apply the same base-ref hardening to adjacent docs diff-check workflows to avoid the same pattern recurring.

## Corridor findings
- Fixes https://app.corridor.dev/projects/86f45f70-3153-46d0-b0f6-5ec9dba1ace1/findings/eb002ea1-903e-4a2b-94a5-5ebc4b60bab2
- Fixes https://app.corridor.dev/projects/86f45f70-3153-46d0-b0f6-5ec9dba1ace1/findings/1bbe3c85-75f4-4ece-8c96-cd857c5be291

## Validation
- `ruby -e 'require \"yaml\"; Dir[\"/tmp/docs/.github/workflows/*.yml\"].each { |p| YAML.load_file(p) }; puts \"parsed workflows\"'`
- `git diff --check`