### PR TITLE
docs: complete Oracle samples table and cross-link the oracle/langchain-oracle repo

### DIFF
--- a/src/oss/python/integrations/providers/oci.mdx
+++ b/src/oss/python/integrations/providers/oci.mdx
@@ -323,6 +323,7 @@ For comprehensive guides covering all features, see the [langchain-oci samples](
 | [07: Async for Production](https://github.com/oracle/langchain-oracle/tree/main/samples/07-async-for-production) | Advanced | ainvoke, astream, FastAPI |
 | [09: Provider Deep Dive](https://github.com/oracle/langchain-oracle/tree/main/samples/09-provider-deep-dive) | Specialized | Meta, Gemini, Cohere, xAI specifics |
 | [10: Embeddings](https://github.com/oracle/langchain-oracle/tree/main/samples/10-embeddings) | Specialized | Text & image embeddings, RAG |
+| [11: Deepagents](https://github.com/oracle/langchain-oracle/tree/main/samples/11-deepagents) | Specialized | Deep agents with Autonomous Database & OpenSearch datastores |
 
 ---
 

--- a/src/oss/python/integrations/providers/oracleai.mdx
+++ b/src/oss/python/integrations/providers/oracleai.mdx
@@ -67,3 +67,9 @@ from langchain_oracledb.vectorstores.oraclevs import OracleVS
 ## End to end demo
 
 Please check the [Oracle AI Vector Search End-to-End Demo Guide](https://github.com/langchain-ai/langchain/blob/v0.3/cookbook/oracleai_demo.ipynb).
+
+## Additional resources
+
+- [GitHub repository](https://github.com/oracle/langchain-oracle) — the official `oracle/langchain-oracle` monorepo, which also ships [`langgraph-oracledb`](https://github.com/oracle/langchain-oracle/tree/main/libs/langgraph-oracledb) (LangGraph checkpointers and stores backed by Oracle Database) and [`@oracle/langchain-oracledb`](https://github.com/oracle/langchain-oracle/tree/main/libs/js/langchain-oracledb) for LangChain.js
+- [Samples](https://github.com/oracle/langchain-oracle/tree/main/samples) — a numbered learning path covering chat, agents, tool calling, structured output, embeddings, and RAG with Oracle datastores
+- [`langchain-oracledb` package documentation](https://github.com/oracle/langchain-oracle/tree/main/libs/oracledb)


### PR DESCRIPTION
## Summary

Two small updates to the Oracle integration provider pages, from the maintainers of [`oracle/langchain-oracle`](https://github.com/oracle/langchain-oracle):

- **`providers/oci.mdx`** — the Samples table was missing the newest track, [11: Deepagents](https://github.com/oracle/langchain-oracle/tree/main/samples/11-deepagents) (deep agents with Autonomous Database & OpenSearch datastores). Added it.
- **`providers/oracleai.mdx`** — this page previously had no link to the official integration repository or its samples. Added an *Additional resources* section pointing to the `oracle/langchain-oracle` monorepo (which also ships `langgraph-oracledb` and the LangChain.js package `@oracle/langchain-oracledb`), the samples learning path, and the `langchain-oracledb` package docs.

No content was removed; both changes are additive.