### PR TITLE
fix(docs): normalize cURL capitalization

### DIFF
--- a/src/langsmith/background-run.mdx
+++ b/src/langsmith/background-run.mdx
@@ -34,7 +34,7 @@ First let's set up our client and thread:
     console.log(thread);
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
       --url <DEPLOYMENT_URL>/threads \
@@ -75,7 +75,7 @@ If we list the current runs on this thread, we will see that it's empty:
     console.log(runs);
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request GET \
         --url <DEPLOYMENT_URL>/threads/<THREAD_ID>/runs
@@ -106,7 +106,7 @@ Now let's kick off a run:
     let run = await client.runs.create(thread["thread_id"], assistantID, { input });
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
         --url <DEPLOYMENT_URL>/threads/<THREAD_ID>/runs \
@@ -131,7 +131,7 @@ The first time we poll it, we can see `status=pending`:
     console.log(await client.runs.get(thread["thread_id"], run["run_id"]));
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request GET \
         --url <DEPLOYMENT_URL>/threads/<THREAD_ID>/runs/<RUN_ID>
@@ -200,7 +200,7 @@ Now we can join the run, wait for it to finish and check that status again:
     console.log(await client.runs.get(thread["thread_id"], run["run_id"]));
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request GET \
         --url <DEPLOYMENT_URL>/threads/<THREAD_ID>/runs/<RUN_ID>/join &&
@@ -271,7 +271,7 @@ Perfect! The run succeeded as we would expect. We can double check that the run 
     console.log(finalResult);
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request GET \
         --url <DEPLOYMENT_URL>/threads/<THREAD_ID>/state
@@ -446,7 +446,7 @@ We can also just print the content of the last AIMessage:
     console.log(finalResult['values']['messages'][finalResult['values']['messages'].length-1]['content'][0]['text']);
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request GET \
         --url <DEPLOYMENT_URL>/threads/<THREAD_ID>/state | jq -r '.values.messages[-1].content.[0].text'

--- a/src/langsmith/cancel-run.mdx
+++ b/src/langsmith/cancel-run.mdx
@@ -28,7 +28,7 @@ Create a client and thread:
     const thread = await client.threads.create();
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
       --url <DEPLOYMENT_URL>/threads \
@@ -79,7 +79,7 @@ Use **interrupt** when you want to stop a run but keep it for debugging, auditin
     console.log(runAfter["status"]);   // "interrupted"
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     # Create a run (use the run_id and thread_id from the response)
     curl --request POST \
@@ -142,7 +142,7 @@ Use **rollback** when you want to fully discard a run and its effects (for examp
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     # Create a run, then cancel with rollback
     curl --request POST \
@@ -203,7 +203,7 @@ By default, the cancel request returns after the cancellation is requested and t
     console.log(runInterrupted["status"])  // "interrupted"
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     # Create a run
     curl --request POST \
@@ -263,7 +263,7 @@ Cancel specific runs by passing their IDs.
     // Bulk delete by run IDs is not supported in the Javascript SDK
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     # Create two runs (capture run_id from each response)
     curl --request POST \
@@ -325,7 +325,7 @@ Cancel all runs that match a status across all threads in a deployment. Valid st
     // Bulk delete by status is not supported in the Javascript SDK
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     # Create a run
     curl --request POST \
@@ -437,7 +437,7 @@ When starting a run with streaming or when waiting on a run, you can set `on_dis
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     # runs.wait: create run and wait for output; cancel if client disconnects
     curl --request POST \

--- a/src/langsmith/cron-jobs.mdx
+++ b/src/langsmith/cron-jobs.mdx
@@ -52,7 +52,7 @@ First, let's set up our SDK client, assistant, and thread:
     console.log(thread);
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
         --url <DEPLOYMENT_URL>/assistants/search \
@@ -112,7 +112,7 @@ To create a cron job associated with a specific thread, you can write:
     );
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
         --url <DEPLOYMENT_URL>/threads/<THREAD_ID>/runs/crons \
@@ -137,7 +137,7 @@ Note that it is **very** important to delete `Cron` jobs that are no longer usef
     await client.crons.delete(cronJob["cron_id"]);
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request DELETE \
         --url <DEPLOYMENT_URL>/runs/crons/<CRON_ID>
@@ -172,7 +172,7 @@ You can also create stateless cron jobs by using the following code. Stateless c
     );
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
         --url <DEPLOYMENT_URL>/runs/crons \
@@ -197,7 +197,7 @@ Again, remember to delete your job once you are done with it!
     await client.crons.delete(cronJobStateless["cron_id"]);
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request DELETE \
         --url <DEPLOYMENT_URL>/runs/crons/<CRON_ID>
@@ -257,7 +257,7 @@ Every time a stateless cron is triggered, a new thread is created. Control what 
     });
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     # Create a stateless cron that keeps threads after execution.
     # Configure checkpointer.ttl in langgraph.json to auto-delete old threads.

--- a/src/langsmith/custom-auth.mdx
+++ b/src/langsmith/custom-auth.mdx
@@ -111,7 +111,7 @@ To leverage custom authentication and access user-level metadata in your deploym
       const threads = await remoteGraph.invoke(...);
       ```
         </Tab>
-        <Tab title="CURL">
+        <Tab title="cURL">
       ```bash
       curl -H "Authorization: Bearer ${your-token}" http://localhost:2024/threads
       ```

--- a/src/langsmith/enqueue-concurrent.mdx
+++ b/src/langsmith/enqueue-concurrent.mdx
@@ -11,7 +11,7 @@ Enqueue is the default double texting (multi-tasking) strategy when creating run
 
 ## Setup
 
-First, we will define a quick helper function for printing out JS and CURL model outputs (you can skip this if using Python):
+First, we will define a quick helper function for printing out JS and cURL model outputs (you can skip this if using Python):
 
 <Tabs>
     <Tab title="Javascript">
@@ -28,7 +28,7 @@ First, we will define a quick helper function for printing out JS and CURL model
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     # PLACE THIS IN A FILE CALLED pretty_print.sh
     pretty_print() {
@@ -79,7 +79,7 @@ Then, let's import our required packages and instantiate our client, assistant, 
     const thread = await client.threads.create();
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
       --url <DEPLOYMENT_URL>/threads \
@@ -125,7 +125,7 @@ Now let's start two runs, with the second interrupting the first one with a mult
     )
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
     --url <DEPLOY<ENT_URL>>/threads/<THREAD_ID>/runs \
@@ -172,7 +172,7 @@ Verify that the thread has data from both runs:
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     source pretty_print.sh && curl --request GET \
     --url <DEPLOYMENT_URL>/threads/<THREAD_ID>/runs/<RUN_ID>/join && \

--- a/src/langsmith/interrupt-concurrent.mdx
+++ b/src/langsmith/interrupt-concurrent.mdx
@@ -9,7 +9,7 @@ The guide covers the `interrupt` option for double texting, which interrupts the
 
 ## Setup
 
-First, we will define a quick helper function for printing out JS and CURL model outputs (you can skip this if using Python):
+First, we will define a quick helper function for printing out JS and cURL model outputs (you can skip this if using Python):
 
 <Tabs>
     <Tab title="Javascript">
@@ -26,7 +26,7 @@ First, we will define a quick helper function for printing out JS and CURL model
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     # PLACE THIS IN A FILE CALLED pretty_print.sh
     pretty_print() {
@@ -75,7 +75,7 @@ Now, let's import our required packages and instantiate our client, assistant, a
     const thread = await client.threads.create();
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
       --url <DEPLOYMENT_URL>/threads \
@@ -134,7 +134,7 @@ Now we can start our two runs and join the second one until it has completed:
     await client.runs.join(thread["thread_id"], run["run_id"]);
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
     --url <DEPLOY<ENT_URL>>/threads/<THREAD_ID>/runs \
@@ -177,7 +177,7 @@ We can see that the thread has partial data from the first run + data from the s
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     source pretty_print.sh && curl --request GET \
     --url <DEPLOYMENT_URL>/threads/<THREAD_ID>/state | \

--- a/src/langsmith/reject-concurrent.mdx
+++ b/src/langsmith/reject-concurrent.mdx
@@ -9,7 +9,7 @@ The guide covers the `reject` option for double texting, which rejects the new r
 
 ## Setup
 
-First, we will define a quick helper function for printing out JS and CURL model outputs (you can skip this if using Python):
+First, we will define a quick helper function for printing out JS and cURL model outputs (you can skip this if using Python):
 
 <Tabs>
     <Tab title="Javascript">
@@ -26,7 +26,7 @@ First, we will define a quick helper function for printing out JS and CURL model
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     # PLACE THIS IN A FILE CALLED pretty_print.sh
     pretty_print() {
@@ -74,7 +74,7 @@ Now, let's import our required packages and instantiate our client, assistant, a
     const thread = await client.threads.create();
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
       --url <DEPLOYMENT_URL>/threads \
@@ -131,7 +131,7 @@ Now we can run a thread and try to run a second one with the "reject" option, wh
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
     --url <DEPLOY<ENT_URL>>/threads/<THREAD_ID>/runs \
@@ -185,7 +185,7 @@ We can verify that the original thread finished executing:
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     source pretty_print.sh && curl --request GET \
     --url <DEPLOYMENT_URL>/threads/<THREAD_ID>/runs/<RUN_ID>/join && \

--- a/src/langsmith/rollback-concurrent.mdx
+++ b/src/langsmith/rollback-concurrent.mdx
@@ -9,7 +9,7 @@ The guide covers the `rollback` option for double texting, which interrupts the 
 
 ## Setup
 
-First, we will define a quick helper function for printing out JS and CURL model outputs (you can skip this if using Python):
+First, we will define a quick helper function for printing out JS and cURL model outputs (you can skip this if using Python):
 
 <Tabs>
     <Tab title="Javascript">
@@ -26,7 +26,7 @@ First, we will define a quick helper function for printing out JS and CURL model
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     # PLACE THIS IN A FILE CALLED pretty_print.sh
     pretty_print() {
@@ -76,7 +76,7 @@ Now, let's import our required packages and instantiate our client, assistant, a
     const thread = await client.threads.create();
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
       --url <DEPLOYMENT_URL>/threads \
@@ -131,7 +131,7 @@ Now let's run a thread with the multitask parameter set to "rollback":
     await client.runs.join(thread["thread_id"], run["run_id"]);
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
     --url <DEPLOY<ENT_URL>>/threads/<THREAD_ID>/runs \
@@ -174,7 +174,7 @@ We can see that the thread has data only from the second run
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     source pretty_print.sh && curl --request GET \
     --url <DEPLOYMENT_URL>/threads/<THREAD_ID>/state | \

--- a/src/langsmith/same-thread.mdx
+++ b/src/langsmith/same-thread.mdx
@@ -40,7 +40,7 @@ You'll see that the second agent will respond using information from the [checkp
     const defaultAssistant = assistants.find(a => !a.config);
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
         --url <DEPLOYMENT_URL>/assistants \
@@ -73,7 +73,7 @@ We can see that these agents are different:
     console.log(openAIAssistant);
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request GET \
         --url <DEPLOYMENT_URL>/assistants/<OPENAI_ASSISTANT_ID>
@@ -109,7 +109,7 @@ Output:
     console.log(defaultAssistant);
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request GET \
         --url <DEPLOYMENT_URL>/assistants/<DEFAULT_ASSISTANT_ID>
@@ -174,7 +174,7 @@ We can now run the OpenAI assistant on the thread first.
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     thread_id=$(curl --request POST \
         --url <DEPLOYMENT_URL>/threads \
@@ -269,7 +269,7 @@ Now, we can run it on the default assistant and see that this second assistant i
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
         --url <DEPLOYMENT_URL>/threads/<THREAD_ID>/runs/stream \

--- a/src/langsmith/stateless-runs.mdx
+++ b/src/langsmith/stateless-runs.mdx
@@ -27,7 +27,7 @@ First, let's setup our client:
     const assistantId = "agent";
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
         --url <DEPLOYMENT_URL>/assistants/search \
@@ -92,7 +92,7 @@ We can stream the results of a stateless run in an almost identical fashion to h
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
         --url <DEPLOYMENT_URL>/runs/stream \
@@ -139,7 +139,7 @@ In addition to streaming, you can also wait for a stateless result by using the 
     console.log(statelessRunResult);
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
         --url <DEPLOYMENT_URL>/runs/wait \

--- a/src/langsmith/use-webhooks.mdx
+++ b/src/langsmith/use-webhooks.mdx
@@ -52,7 +52,7 @@ Before making API calls, set up your assistant and thread.
     console.log(thread);
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
         --url <DEPLOYMENT_URL>/assistants/search \
@@ -119,7 +119,7 @@ For example, if your server listens for webhook events at `https://my-server.app
     }
     ```
     </Tab>
-    <Tab title="CURL">
+    <Tab title="cURL">
     ```bash
     curl --request POST \
         --url <DEPLOYMENT_URL>/threads/<THREAD_ID>/runs/stream \


### PR DESCRIPTION
Standardizes the cURL brand spelling across LangSmith documentation tabs and prose. This replaces all remaining uppercase `CURL` instances in manually authored docs with `cURL`.

Vale passes on all 11 changed files, and no uppercase `CURL` instances remain under `src/`.

AI-agent assistance was used for this documentation-only change.

Made by [Open SWE](https://openswe.vercel.app/agents/64b68fe7-5695-69a2-6e52-8c0fe12a9016)