### PR TITLE
docs(langsmith): remove Engine gateway routing changelog entries

### DIFF
--- a/src/langsmith/changelog.mdx
+++ b/src/langsmith/changelog.mdx
@@ -106,7 +106,6 @@ If you use self-hosted LangSmith, see the [self-hosted changelog](/langsmith/sel
 - Engine now lets the parent agent recover from model-actionable subtask failures and retries transient provider or network errors before failing a run. This helps issue scans continue through recoverable model errors while preserving hard failures for auth, configuration, and code exceptions.
 - LangSmith exposes [Engine](/langsmith/engine) issue listing and retrieval through hosted MCP tools and generated SDK methods. Agents and API clients can fetch issue details directly by issue ID or filter issues by project, status, severity, tag, and update time.
 - A new [Engine](/langsmith/engine) board callout points you to the trace-scope setting, where you can restrict Engine's reviews to runs matching a run name or metadata value.
-- Self-hosted Engine deployments can route Anthropic-compatible model calls through Gateway or an LSI-compatible endpoint by setting `ENGINE_ANTHROPIC_BASE_URL`.
 - Engine-generated examples with assertions now add the Assertions evaluator when saved to a dataset from an annotation queue, matching the direct Add offline examples flow.
 - The Engine setup screen now shows an estimated monthly cost based on the project's recent trace volume and size, so you know roughly what to expect before starting analysis.
 - The Engine issue list now uses a single filter and sort menu with a compact, nested layout for Priority, Status, Tags, and Sort by, replacing the previous two separate popovers.
@@ -318,7 +317,6 @@ If you use self-hosted LangSmith, see the [self-hosted changelog](/langsmith/sel
 - Engine now lets the parent agent recover from model-actionable subtask failures and retries transient provider or network errors before failing a run. This helps issue scans continue through recoverable model errors while preserving hard failures for auth, configuration, and code exceptions.
 - LangSmith exposes Engine issue listing and retrieval through hosted MCP tools and generated SDK methods. Agents and API clients can fetch issue details directly by issue ID or filter issues by project, status, severity, tag, and update time.
 - A new Engine board callout points you to the trace-scope setting, where you can restrict Engine's reviews to runs matching a run name or metadata value.
-- Self-hosted Engine deployments can route Anthropic-compatible model calls through Gateway or an LSI-compatible endpoint by setting `ENGINE_ANTHROPIC_BASE_URL`.
 - Engine-generated examples with assertions now add the Assertions evaluator when saved to a dataset from an annotation queue, matching the direct Add offline examples flow.
 - The Engine issue list now uses a single filter and sort menu with a compact, collapsible layout for Priority, Status, Tags, and Sort by, replacing the previous two separate popovers.
 - The Engine issue list now shows the active sort order as a removable chip next to your filter chips whenever it differs from the default.
@@ -475,7 +473,6 @@ If you use self-hosted LangSmith, see the [self-hosted changelog](/langsmith/sel
 - When an Engine project reaches its monthly spend limit, the Next Run status chip and project spend card now show a clear "Monthly spend limit reached" state with a button that takes you straight to raising the limit.
 - LangSmith exposes Engine issue listing and retrieval through hosted [MCP tools](/langsmith/langsmith-mcp-server) and generated SDK methods. Agents and API clients can fetch issue details directly by `issue ID` or filter issues by project, status, severity, tag, and update time.
 - A new Engine board callout points you to the trace-scope setting, where you can restrict Engine's reviews to runs matching a run name or metadata value.
-- Self-hosted Engine deployments can route Anthropic-compatible model calls through Gateway or an LSI-compatible endpoint by setting `ENGINE_ANTHROPIC_BASE_URL`.
 
 ### Prompts and playground
 


### PR DESCRIPTION
## What

Removes the Engine gateway routing note from three weekly LangSmith changelog entries.

## Why

The same environment-specific self-hosted note was published repeatedly and should no longer appear on the public changelog.

## How

Deletes only the three matching bullets. The paired source-fragment cleanup is https://github.com/langchain-ai/langchainplus/pull/31025.

## Testing

- [x] `/opt/homebrew/bin/vale --glob='!**/node_modules/**' src/langsmith/changelog.mdx`
- [x] `git diff --check`
- [x] Confirmed the removed sentence no longer appears in the changelog source