### PR TITLE
docs: add dotenv gateway setup example

### DIFF
--- a/src/langsmith/llm-gateway-quickstart.mdx
+++ b/src/langsmith/llm-gateway-quickstart.mdx
@@ -16,9 +16,11 @@ Before you start, confirm that:
 
 ## 1. Set environment variables
 
-Set the following in your terminal (or add them to your `~/.zshrc` to persist across sessions):
+Set the environment variables in your terminal, or add them to a `.env` file:
 
-```bash
+<CodeGroup>
+
+```bash Terminal
 export BASE_URL="https://gateway.smith.langchain.com"
 
 export ANTHROPIC_BASE_URL="$BASE_URL/anthropic"
@@ -32,6 +34,21 @@ export OPENAI_API_KEY="$LANGSMITH_API_KEY"
 export GEMINI_API_KEY="$LANGSMITH_API_KEY"
 export GOOGLE_API_KEY="$LANGSMITH_API_KEY"
 ```
+
+```bash .env
+ANTHROPIC_BASE_URL=https://gateway.smith.langchain.com/anthropic
+OPENAI_BASE_URL=https://gateway.smith.langchain.com/openai/v1
+GOOGLE_GEMINI_BASE_URL=https://gateway.smith.langchain.com/gemini
+
+LANGSMITH_API_KEY=lsv2_..._....cbed3e
+
+ANTHROPIC_API_KEY=lsv2_..._....cbed3e
+OPENAI_API_KEY=lsv2_..._....cbed3e
+GEMINI_API_KEY=lsv2_..._....cbed3e
+GOOGLE_API_KEY=lsv2_..._....cbed3e
+```
+
+</CodeGroup>
 
 This points all provider SDKs at the LangSmith Gateway and uses your LangSmith API key for authentication. The gateway resolves actual provider keys from your workspace's Provider Secrets—you never need local copies of provider API keys.
 


### PR DESCRIPTION
## Description
Add a `.env` tab to the LLM Gateway quickstart so users can copy valid dotenv syntax instead of adapting terminal `export` commands. The example avoids shell interpolation for compatibility with dotenv loaders.

## Test Plan
- [x] Validate the `.env` example by sourcing it and checking the resolved values
- [x] Run scoped Vale prose lint

Made by [Open SWE](https://openswe.vercel.app/agents/44ccb2d3-66c9-2d21-8238-80faa8d1bf64)