### PR TITLE
docs: document Deep Agents Code trace redaction

### DIFF
--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -33,6 +33,17 @@ recent = "frontend-dev"  # last /agents switch (written automatically)
 
 Explicit `-a`/`--agent` always overrides both, and `-r`/`--resume` bypasses both so the thread's original agent is restored. See [Command reference](/oss/deepagents/code/cli-reference#command-line-options) for related flags.
 
+## Redact LangSmith trace secrets
+
+Deep Agents Code redacts detected secrets from LangSmith agent-trace inputs and outputs by default. If redaction cannot be configured, tracing is disabled for that run. To opt out for controlled local debugging:
+
+```toml title="~/.deepagents/config.toml"
+[tracing]
+langsmith_redact = false
+```
+
+This setting does not redact general personally identifiable information (PII), trace metadata, or traces emitted by shell processes. For broader options, see [Redact secrets from traces](/langsmith/redact-secrets).
+
 ## Provider configuration
 
 Each provider is a TOML table under `[models.providers]`:

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -35,7 +35,7 @@ Explicit `-a`/`--agent` always overrides both, and `-r`/`--resume` bypasses both
 
 ## Redact LangSmith trace secrets
 
-Deep Agents Code redacts detected secrets from LangSmith agent-trace inputs and outputs by default. If redaction cannot be configured, tracing is disabled for that run. To opt out for controlled local debugging:
+With LangSmith tracing enabled, Deep Agents Code redacts detected secrets from agent-trace inputs and outputs by default. If redaction cannot be configured, tracing is disabled for that run. To opt out:
 
 ```toml title="~/.deepagents/config.toml"
 [tracing]

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -330,6 +330,10 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
     Override the LangSmith project name for Deep Agents Code's own agent traces. Shell commands still run with the user's original `LANGSMITH_PROJECT`, so app, test, or script traces can appear in a separate project. See [Trace with LangSmith](/oss/deepagents/code/quickstart#trace-with-langsmith).
 </ResponseField>
 
+<ResponseField name="DEEPAGENTS_CODE_LANGSMITH_REDACT" type="string" default="true" post={["optional"]}>
+    Toggle client-side secret redaction for Deep Agents Code's LangSmith agent-trace inputs and outputs. Accepts `1`, `true`, `yes`, or `on` to enable redaction and `0`, `false`, `no`, or `off` to disable it, case-insensitively. If redaction cannot be configured, tracing is disabled for that run. See [Configure LangSmith trace redaction](/oss/deepagents/code/config-file#redact-langsmith-trace-secrets).
+</ResponseField>
+
 <ResponseField name="DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS" type="string" post={["optional"]}>
     A second LangSmith project to *also* write agent traces to. When set and tracing is active, each agent run is dual-written to the primary project (from `DEEPAGENTS_CODE_LANGSMITH_PROJECT`, or `deepagents-code` by default) and this project. Off by default. See [Trace with LangSmith](/oss/deepagents/code/quickstart#trace-with-langsmith).
 </ResponseField>


### PR DESCRIPTION
## Overview

Deep Agents Code users who enable LangSmith tracing receive client-side secret redaction by default. This update documents the redaction scope, the fail-closed behavior when redaction cannot be configured, the controlled-debugging opt-out, and the corresponding environment variable.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Feature PR: https://github.com/langchain-ai/deepagents/pull/4356

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed
