### PR TITLE
docs: mention trace redaction environment variable

### DIFF
--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -37,12 +37,21 @@ Explicit `-a`/`--agent` always overrides both, and `-r`/`--resume` bypasses both
 
 With LangSmith tracing enabled, Deep Agents Code redacts detected secrets from agent-trace inputs and outputs by default. If redaction cannot be configured, tracing is disabled for that run. To opt out:
 
-```toml title="~/.deepagents/config.toml"
-[tracing]
-langsmith_redact = false
-```
+<Tabs>
+    <Tab title="Config file">
+        ```toml title="~/.deepagents/config.toml"
+        [tracing]
+        langsmith_redact = false
+        ```
+    </Tab>
+    <Tab title="Environment variable">
+        ```bash
+        export DEEPAGENTS_CODE_LANGSMITH_REDACT=0
+        ```
+    </Tab>
+</Tabs>
 
-This setting does not redact general personally identifiable information (PII), trace metadata, or traces emitted by shell processes. For broader options, see [Redact secrets from traces](/langsmith/redact-secrets).
+The environment variable takes precedence over the config file. This setting does not redact general personally identifiable information (PII), trace metadata, or traces emitted by shell processes. For broader options, see [Redact secrets from traces](/langsmith/redact-secrets).
 
 ## Provider configuration
 


### PR DESCRIPTION
## Overview

Deep Agents Code supports opting out of LangSmith trace secret redaction through either `config.toml` or an environment variable, but the config file page only showed the TOML option. This update presents both methods together and clarifies that `DEEPAGENTS_CODE_LANGSMITH_REDACT` takes precedence over the config file.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Feature PR: https://github.com/langchain-ai/deepagents/pull/4356

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed