### PR TITLE
chore: rename LangChain reference MCP server

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "type": "http",
       "url": "https://docs.langchain.com/mcp"
     },
-    "docs-langchain-reference": {
+    "reference-langchain": {
       "type": "http",
       "url": "https://reference.langchain.com/mcp"
     },


### PR DESCRIPTION
The repository's MCP guidance recommends `docs-langchain` for conceptual documentation and `reference-langchain` for API reference, but `.mcp.json` still used `docs-langchain-reference`.

Rename the key to `reference-langchain` so the repository configuration is consistent with the docs guidance itself. `reference-langchain` directly matches `reference.langchain.com` and cleanly distinguishes the reference server from `docs-langchain`. The `http` type and `https://reference.langchain.com/mcp` endpoint are unchanged.