### PR TITLE
docs(code): clarify MCP config merge semantics

### DIFF
--- a/src/oss/deepagents/code/mcp-tools.mdx
+++ b/src/oss/deepagents/code/mcp-tools.mdx
@@ -107,7 +107,7 @@ Configs are checked in this order (lowest to highest precedence):
 
 The project root is the nearest parent directory containing a `.git` folder, falling back to the current working directory.
 
-When multiple config files exist, their `mcpServers` entries are merged. If the same server name appears in more than one file, the higher-precedence config wins. This lets a project-level config override a user-level entry (for example, pinning a different version of the same server) without disturbing your other projects.
+When multiple config files exist, their `mcpServers` entries are merged by server name. Differently named servers are preserved. If the same server name appears in more than one file, the higher-precedence definition replaces the entire earlier server object; nested fields are not deep-merged. This lets a project-level config override a user-level entry (for example, pinning a different version of the same server) without disturbing your other projects.
 
 ### Flags
 


### PR DESCRIPTION
## Overview

Deep Agents Code reads MCP configuration from multiple locations, but the precedence documentation did not explain whether overlapping server objects are merged field by field or replaced. This update clarifies that configurations merge by server name: differently named servers remain, while a higher-precedence definition with the same name replaces the entire earlier server object. Nested fields are not deep-merged.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: None
- Feature PR: None
- Linear issue: None
- Slack thread: None

## Checklist

- [ ] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed