### PR TITLE
docs: add Deep Agents Code MCP setup

### DIFF
--- a/src/use-these-docs.mdx
+++ b/src/use-these-docs.mdx
@@ -34,27 +34,6 @@ Our documentation exposes two complementary **Model Context Protocol (MCP) serve
 
 Adding both gives your coding agent access to the full picture: the **why and how** from the guides, plus the **exact API details** from the reference docs.
 
-### Connect with Deep Agents Code
-
-Add both servers to your user-level `~/.deepagents/.mcp.json` file to make them available in every Deep Agents Code project, or add them to a project-level `.mcp.json` file for only that project:
-
-```json
-{
-  "mcpServers": {
-    "docs-langchain": {
-      "type": "http",
-      "url": "https://docs.langchain.com/mcp"
-    },
-    "reference-langchain": {
-      "type": "http",
-      "url": "https://reference.langchain.com/mcp"
-    }
-  }
-}
-```
-
-Launch or restart `dcode` to load the servers. In an interactive session, run `/mcp` to inspect server status and loaded tools. For discovery locations and precedence rules, see [MCP tools](/oss/python/deepagents/code/mcp-tools).
-
 ### Connect with Claude Code
 
 If you're using Claude Code, run these commands in your terminal to add both servers to your current project:
@@ -108,6 +87,27 @@ Add the following to your MCP settings configuration file:
   }
 }
 ```
+
+### Connect with Deep Agents Code
+
+Add both servers to your user-level `~/.deepagents/.mcp.json` file to make them available in every Deep Agents Code project, or add them to a project-level `.mcp.json` file for only that project:
+
+```json
+{
+  "mcpServers": {
+    "docs-langchain": {
+      "type": "http",
+      "url": "https://docs.langchain.com/mcp"
+    },
+    "reference-langchain": {
+      "type": "http",
+      "url": "https://reference.langchain.com/mcp"
+    }
+  }
+}
+```
+
+Launch or restart `dcode` to load the servers. In an interactive session, run `/mcp` to inspect server status and loaded tools. For discovery locations and precedence rules, see [MCP tools](/oss/python/deepagents/code/mcp-tools).
 
 ### Connect with VS Code
 

--- a/src/use-these-docs.mdx
+++ b/src/use-these-docs.mdx
@@ -34,6 +34,27 @@ Our documentation exposes two complementary **Model Context Protocol (MCP) serve
 
 Adding both gives your coding agent access to the full picture: the **why and how** from the guides, plus the **exact API details** from the reference docs.
 
+### Connect with Deep Agents Code
+
+Add both servers to your user-level `~/.deepagents/.mcp.json` file to make them available in every Deep Agents Code project, or add them to a project-level `.mcp.json` file for only that project:
+
+```json
+{
+  "mcpServers": {
+    "docs-langchain": {
+      "type": "http",
+      "url": "https://docs.langchain.com/mcp"
+    },
+    "reference-langchain": {
+      "type": "http",
+      "url": "https://reference.langchain.com/mcp"
+    }
+  }
+}
+```
+
+Launch or restart `dcode` to load the servers. In an interactive session, run `/mcp` to inspect server status and loaded tools. For discovery locations and precedence rules, see [MCP tools](/oss/python/deepagents/code/mcp-tools).
+
 ### Connect with Claude Code
 
 If you're using Claude Code, run these commands in your terminal to add both servers to your current project:


### PR DESCRIPTION
## Overview

Deep Agents Code users visiting the programmatic docs page did not have setup instructions alongside the other supported coding agents. This update adds a **Connect with Deep Agents Code** section with configuration for both LangChain MCP servers, explains user and project scope, and links to the complete MCP tools guide.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: N/A
- Feature PR: N/A
- Linear issue: N/A
- Slack thread: N/A

## Checklist

- [ ] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed