### PR TITLE
docs(deepagents): update LangSmith redaction default

### DIFF
--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -35,23 +35,29 @@ Explicit `-a`/`--agent` always overrides both, and `-r`/`--resume` bypasses both
 
 ## Redact LangSmith trace secrets
 
-With LangSmith tracing enabled, Deep Agents Code redacts detected secrets from agent-trace inputs and outputs by default. If redaction cannot be configured, tracing is disabled for that run. To opt out:
+With LangSmith tracing enabled, Deep Agents Code sends agent-trace inputs and outputs without client-side secret redaction by default.
+
+<Warning>
+    Without redaction, secrets may be uploaded to LangSmith as part of agent traces.
+</Warning>
+
+To redact detected secrets before upload:
 
 <Tabs>
     <Tab title="Config file">
         ```toml title="~/.deepagents/config.toml"
         [tracing]
-        langsmith_redact = false
+        langsmith_redact = true
         ```
     </Tab>
     <Tab title="Environment variable">
         ```bash
-        export DEEPAGENTS_CODE_LANGSMITH_REDACT=0
+        export DEEPAGENTS_CODE_LANGSMITH_REDACT=true
         ```
     </Tab>
 </Tabs>
 
-The environment variable takes precedence over the config file. This setting does not redact general personally identifiable information (PII), trace metadata, or traces emitted by shell processes. For broader options, see [Redact secrets from traces](/langsmith/redact-secrets).
+The environment variable takes precedence over the config file. When redaction is enabled, Deep Agents Code disables tracing for that run if redaction cannot be configured. Secret redaction does not redact general personally identifiable information (PII), trace metadata, or traces emitted by shell processes. For broader options, see [Redact secrets from traces](/langsmith/redact-secrets).
 
 ## Provider configuration
 

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -346,8 +346,8 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
     Override the LangSmith project name for Deep Agents Code's own agent traces. Shell commands still run with the user's original `LANGSMITH_PROJECT`, so app, test, or script traces can appear in a separate project. See [Trace with LangSmith](/oss/deepagents/code/quickstart#trace-with-langsmith).
 </ResponseField>
 
-<ResponseField name="DEEPAGENTS_CODE_LANGSMITH_REDACT" type="string" default="true" post={["optional"]}>
-    Toggle client-side secret redaction for Deep Agents Code's LangSmith agent-trace inputs and outputs. Accepts `1`, `true`, `yes`, or `on` to enable redaction and `0`, `false`, `no`, or `off` to disable it, case-insensitively. If redaction cannot be configured, tracing is disabled for that run. See [Configure LangSmith trace redaction](/oss/deepagents/code/config-file#redact-langsmith-trace-secrets).
+<ResponseField name="DEEPAGENTS_CODE_LANGSMITH_REDACT" type="string" default="false" post={["optional"]}>
+    Toggle client-side secret redaction for Deep Agents Code's LangSmith agent-trace inputs and outputs. Accepts `1`, `true`, `yes`, or `on` to enable redaction and `0`, `false`, `no`, or `off` to disable it, case-insensitively. When redaction is enabled, tracing is disabled for that run if redaction cannot be configured. See [Configure LangSmith trace redaction](/oss/deepagents/code/config-file#redact-langsmith-trace-secrets).
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS" type="string" post={["optional"]}>


### PR DESCRIPTION
## Overview

Users who enable LangSmith tracing need the documentation to match its security-sensitive runtime default. After [langchain-ai/deepagents#4970](https://github.com/langchain-ai/deepagents/pull/4970), Deep Agents Code sends agent-trace inputs and outputs without client-side secret redaction unless users opt in.

This update shows how to enable redaction with `DEEPAGENTS_CODE_LANGSMITH_REDACT=true` or `[tracing] langsmith_redact = true`, warns that secrets may otherwise be uploaded unredacted, and clarifies that tracing fails closed when requested redaction cannot be configured.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Feature PR: https://github.com/langchain-ai/deepagents/pull/4970

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used root-relative paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

- Review focus: Confirm the warning and fail-closed description accurately communicate the new default.
- Validation: Targeted Vale lint passed locally and in both git hooks; the TOML and shell examples were also validated.
- This PR was prepared with assistance from an AI coding agent.
