### PR TITLE
docs(langsmith): document required session_id for feedback creation in SmithDB migration guide

### DIFF
--- a/src/code-samples/langsmith/smithdb-migration/feedback-create-after.go
+++ b/src/code-samples/langsmith/smithdb-migration/feedback-create-after.go
@@ -1,0 +1,54 @@
+// :snippet-start: feedback-create-after-go
+// :codegroup-tab: After
+package main
+
+import (
+	"context"
+
+	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/shared"
+)
+
+// :remove-start:
+func main() {
+// :remove-end:
+ctx := context.Background()
+client := langsmith.NewClient()
+
+runID := "<run-id>"
+sessionID := "<session-id>"
+var err error
+// :remove-start:
+sessions, err := client.Sessions.List(ctx, langsmith.SessionListParams{
+	Name:  langsmith.F("default"),
+	Limit: langsmith.F(int64(1)),
+})
+if err != nil {
+	panic(err.Error())
+}
+sessionID = sessions.Items[0].ID
+found, err := client.Runs.Query(ctx, langsmith.RunQueryParams{
+	Session: langsmith.F([]string{sessionID}),
+	Limit:   langsmith.F(int64(1)),
+})
+if err != nil {
+	panic(err.Error())
+}
+runID = found.Runs[0].ID
+// :remove-end:
+_, err = client.Feedback.New(ctx, langsmith.FeedbackNewParams{
+	FeedbackCreateSchema: langsmith.FeedbackCreateSchemaParam{
+		RunID:     langsmith.F(runID),
+		Key:       langsmith.F("user_feedback"),
+		Score:     langsmith.F[langsmith.FeedbackCreateSchemaScoreUnionParam](shared.UnionFloat(1.0)),
+		SessionID: langsmith.F(sessionID),
+	},
+})
+// :remove-start:
+if err != nil {
+	panic(err.Error())
+}
+}
+
+// :remove-end:
+// :snippet-end:

--- a/src/code-samples/langsmith/smithdb-migration/feedback-create-after.kt
+++ b/src/code-samples/langsmith/smithdb-migration/feedback-create-after.kt
@@ -1,0 +1,48 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 21
+//KOTLIN 2.2.0
+//DEPS com.langchain.smith:langsmith-java:0.1.0-beta.18
+
+// :snippet-start: feedback-create-after-kt
+// :codegroup-tab: After
+import com.langchain.smith.client.LangsmithClient
+import com.langchain.smith.client.okhttp.LangsmithOkHttpClient
+import com.langchain.smith.models.feedback.FeedbackCreateSchema
+// :remove-start:
+import com.langchain.smith.models.runs.RunQueryParams
+import com.langchain.smith.models.sessions.SessionListParams
+// :remove-end:
+
+// :remove-start:
+fun main() {
+    if (System.getenv("LANGSMITH_API_KEY").isNullOrBlank()) {
+        println("[smithdb-feedback-create-after] Skipping (LANGSMITH_API_KEY is not set).")
+        return
+    }
+
+// :remove-end:
+val client: LangsmithClient = LangsmithOkHttpClient.fromEnv()
+
+var runId = "<run-id>"
+var sessionId = "<session-id>"
+// :remove-start:
+val project = client.sessions()
+    .list(SessionListParams.builder().name("default").limit(1L).build())
+    .items().first()
+sessionId = project.id()
+runId = client.runs()
+    .query(RunQueryParams.builder().addSession(project.id()).limit(1L).build())
+    .items().first().id()
+// :remove-end:
+client.feedback().create(
+    FeedbackCreateSchema.builder()
+        .runId(runId)
+        .key("user_feedback")
+        .score(1.0)
+        .sessionId(sessionId)
+        .build()
+)
+// :remove-start:
+}
+// :remove-end:
+// :snippet-end:

--- a/src/code-samples/langsmith/smithdb-migration/feedback-create-after.sh
+++ b/src/code-samples/langsmith/smithdb-migration/feedback-create-after.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# :snippet-start: feedback-create-after-sh
+RUN_ID="<run-id>"
+SESSION_ID="<session-id>"
+# :remove-start:
+SESSION_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=default&limit=1" \
+  -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
+[ -n "$SESSION_ID" ] && [ "$SESSION_ID" != "null" ] || { echo "error: could not resolve session id for \"default\"" >&2; exit 1; }
+FOUND=$(curl -s -X POST "https://api.smith.langchain.com/api/v1/runs/query" \
+  -H "x-api-key: $LANGSMITH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg pid "$SESSION_ID" '{"session": [$pid], "limit": 1}')")
+RUN_ID=$(echo "$FOUND" | jq -r '.runs[0].id')
+[ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ] || { echo "error: could not resolve a run id" >&2; exit 1; }
+# :remove-end:
+
+curl -X POST "https://api.smith.langchain.com/api/v1/feedback" \
+  -H "x-api-key: $LANGSMITH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg run "$RUN_ID" --arg session "$SESSION_ID" '{"run_id": $run, "key": "user_feedback", "score": 1, "session_id": $session}')"
+# :snippet-end:

--- a/src/code-samples/langsmith/smithdb-migration/feedback-create-after.ts
+++ b/src/code-samples/langsmith/smithdb-migration/feedback-create-after.ts
@@ -1,0 +1,28 @@
+// :snippet-start: feedback-create-after-js
+// :codegroup-tab: After
+import { Client } from "langsmith";
+
+const client = new Client();
+let runId = "<run-id>";
+let sessionId = "<session-id>";
+// :remove-start:
+const project = await client.readProject({ projectName: "default" });
+sessionId = project.id;
+const runs = [];
+for await (const run of client.listRuns({ projectName: "default", limit: 1 })) {
+  runs.push(run);
+}
+if (runs.length === 0) {
+  throw new Error("expected at least one run in the 'default' project");
+}
+runId = runs[0].id;
+// :remove-end:
+await client.createFeedback(runId, "user_feedback", {
+  score: 1,
+  sessionId,
+});
+// :snippet-end:
+
+// :remove-start:
+console.log("✓ feedback-create-after validated");
+// :remove-end:

--- a/src/code-samples/langsmith/smithdb-migration/feedback-create-before.go
+++ b/src/code-samples/langsmith/smithdb-migration/feedback-create-before.go
@@ -1,0 +1,52 @@
+// :snippet-start: feedback-create-before-go
+// :codegroup-tab: Before
+package main
+
+import (
+	"context"
+
+	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/shared"
+)
+
+// :remove-start:
+func main() {
+// :remove-end:
+ctx := context.Background()
+client := langsmith.NewClient()
+
+runID := "<run-id>"
+var err error
+// :remove-start:
+sessions, err := client.Sessions.List(ctx, langsmith.SessionListParams{
+	Name:  langsmith.F("default"),
+	Limit: langsmith.F(int64(1)),
+})
+if err != nil {
+	panic(err.Error())
+}
+projectID := sessions.Items[0].ID
+found, err := client.Runs.Query(ctx, langsmith.RunQueryParams{
+	Session: langsmith.F([]string{projectID}),
+	Limit:   langsmith.F(int64(1)),
+})
+if err != nil {
+	panic(err.Error())
+}
+runID = found.Runs[0].ID
+// :remove-end:
+_, err = client.Feedback.New(ctx, langsmith.FeedbackNewParams{
+	FeedbackCreateSchema: langsmith.FeedbackCreateSchemaParam{
+		RunID: langsmith.F(runID),
+		Key:   langsmith.F("user_feedback"),
+		Score: langsmith.F[langsmith.FeedbackCreateSchemaScoreUnionParam](shared.UnionFloat(1.0)),
+	},
+})
+// :remove-start:
+if err != nil {
+	panic(err.Error())
+}
+}
+
+// :remove-end:
+// :snippet-end:

--- a/src/code-samples/langsmith/smithdb-migration/feedback-create-before.kt
+++ b/src/code-samples/langsmith/smithdb-migration/feedback-create-before.kt
@@ -1,0 +1,45 @@
+///usr/bin/env jbang "$0" "$@" ; exit $?
+//JAVA 21
+//KOTLIN 2.2.0
+//DEPS com.langchain.smith:langsmith-java:0.1.0-beta.18
+
+// :snippet-start: feedback-create-before-kt
+// :codegroup-tab: Before
+import com.langchain.smith.client.LangsmithClient
+import com.langchain.smith.client.okhttp.LangsmithOkHttpClient
+import com.langchain.smith.models.feedback.FeedbackCreateSchema
+// :remove-start:
+import com.langchain.smith.models.runs.RunQueryParams
+import com.langchain.smith.models.sessions.SessionListParams
+// :remove-end:
+
+// :remove-start:
+fun main() {
+    if (System.getenv("LANGSMITH_API_KEY").isNullOrBlank()) {
+        println("[smithdb-feedback-create-before] Skipping (LANGSMITH_API_KEY is not set).")
+        return
+    }
+
+// :remove-end:
+val client: LangsmithClient = LangsmithOkHttpClient.fromEnv()
+
+var runId = "<run-id>"
+// :remove-start:
+val project = client.sessions()
+    .list(SessionListParams.builder().name("default").limit(1L).build())
+    .items().first()
+runId = client.runs()
+    .query(RunQueryParams.builder().addSession(project.id()).limit(1L).build())
+    .items().first().id()
+// :remove-end:
+client.feedback().create(
+    FeedbackCreateSchema.builder()
+        .runId(runId)
+        .key("user_feedback")
+        .score(1.0)
+        .build()
+)
+// :remove-start:
+}
+// :remove-end:
+// :snippet-end:

--- a/src/code-samples/langsmith/smithdb-migration/feedback-create-before.sh
+++ b/src/code-samples/langsmith/smithdb-migration/feedback-create-before.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# :snippet-start: feedback-create-before-sh
+RUN_ID="<run-id>"
+# :remove-start:
+SESSION_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=default&limit=1" \
+  -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
+[ -n "$SESSION_ID" ] && [ "$SESSION_ID" != "null" ] || { echo "error: could not resolve session id for \"default\"" >&2; exit 1; }
+FOUND=$(curl -s -X POST "https://api.smith.langchain.com/api/v1/runs/query" \
+  -H "x-api-key: $LANGSMITH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg pid "$SESSION_ID" '{"session": [$pid], "limit": 1}')")
+RUN_ID=$(echo "$FOUND" | jq -r '.runs[0].id')
+[ -n "$RUN_ID" ] && [ "$RUN_ID" != "null" ] || { echo "error: could not resolve a run id" >&2; exit 1; }
+# :remove-end:
+
+curl -X POST "https://api.smith.langchain.com/api/v1/feedback" \
+  -H "x-api-key: $LANGSMITH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg run "$RUN_ID" '{"run_id": $run, "key": "user_feedback", "score": 1}')"
+# :snippet-end:

--- a/src/code-samples/langsmith/smithdb-migration/feedback-create-before.ts
+++ b/src/code-samples/langsmith/smithdb-migration/feedback-create-before.ts
@@ -1,0 +1,24 @@
+// :snippet-start: feedback-create-before-js
+// :codegroup-tab: Before
+import { Client } from "langsmith";
+
+const client = new Client();
+let runId = "<run-id>";
+// :remove-start:
+const runs = [];
+for await (const run of client.listRuns({ projectName: "default", limit: 1 })) {
+  runs.push(run);
+}
+if (runs.length === 0) {
+  throw new Error("expected at least one run in the 'default' project");
+}
+runId = runs[0].id;
+// :remove-end:
+await client.createFeedback(runId, "user_feedback", {
+  score: 1,
+});
+// :snippet-end:
+
+// :remove-start:
+console.log("✓ feedback-create-before validated");
+// :remove-end:

--- a/src/code-samples/langsmith/smithdb-migration/feedback-create.py
+++ b/src/code-samples/langsmith/smithdb-migration/feedback-create.py
@@ -1,0 +1,49 @@
+# :snippet-start: feedback-create-before-py
+# :codegroup-tab: Before
+from langsmith import Client
+
+client = Client()
+run_id = "<run-id>"
+# :remove-start:
+project = client.read_project(project_name="default")
+runs = list(client.list_runs(project_name="default", limit=1))
+assert len(runs) > 0, "expected at least one run in the 'default' project"
+run_id = str(runs[0].id)
+# :remove-end:
+client.create_feedback(
+    run_id=run_id,
+    key="user_feedback",
+    score=1,
+)
+# :snippet-end:
+
+# :remove-start:
+print("✓ feedback-create-before validated")
+# :remove-end:
+
+
+# :snippet-start: feedback-create-after-py
+# :codegroup-tab: After
+from langsmith import Client
+
+client = Client()
+run_id = "<run-id>"
+session_id = "<session-id>"
+# :remove-start:
+project = client.read_project(project_name="default")
+session_id = str(project.id)
+runs = list(client.list_runs(project_name="default", limit=1))
+assert len(runs) > 0, "expected at least one run in the 'default' project"
+run_id = str(runs[0].id)
+# :remove-end:
+client.create_feedback(
+    run_id=run_id,
+    key="user_feedback",
+    score=1,
+    session_id=session_id,
+)
+# :snippet-end:
+
+# :remove-start:
+print("✓ feedback-create-after validated")
+# :remove-end:

--- a/src/langsmith/smithdb-sdk-migration.mdx
+++ b/src/langsmith/smithdb-sdk-migration.mdx
@@ -8,6 +8,7 @@ import SmithdbMigrationRunsQuery from '/snippets/langsmith/smithdb-migration/run
 import SmithdbMigrationRunsRetrieve from '/snippets/langsmith/smithdb-migration/runs-retrieve.mdx';
 import SmithdbMigrationRunsGetUrl from '/snippets/langsmith/smithdb-migration/runs-geturl.mdx';
 import SmithdbMigrationRunsAddToAnnotationQueue from '/snippets/langsmith/smithdb-migration/runs-add-to-annotation-queue.mdx';
+import SmithdbMigrationFeedbackCreate from '/snippets/langsmith/smithdb-migration/feedback-create.mdx';
 import SmithdbMigrationThreadsQuery from '/snippets/langsmith/smithdb-migration/threads-query.mdx';
 import SmithdbMigrationThreadsListTraces from '/snippets/langsmith/smithdb-migration/threads-list-traces.mdx';
 import SmithdbMigrationExperimentRunsQuery from '/snippets/langsmith/smithdb-migration/experiment-runs-query.mdx';
@@ -147,6 +148,8 @@ than guessing.
 <SmithdbMigrationExperimentRunsQuery />
 
 <SmithdbMigrationRunsAddToAnnotationQueue />
+
+<SmithdbMigrationFeedbackCreate />
 
 ## Soon to be deprecated
 

--- a/src/snippets/code-samples/smithdb-migration/feedback-create-after-go.mdx
+++ b/src/snippets/code-samples/smithdb-migration/feedback-create-after-go.mdx
@@ -1,0 +1,25 @@
+```go After
+package main
+
+import (
+	"context"
+
+	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/shared"
+)
+
+ctx := context.Background()
+client := langsmith.NewClient()
+
+runID := "<run-id>"
+sessionID := "<session-id>"
+var err error
+_, err = client.Feedback.New(ctx, langsmith.FeedbackNewParams{
+	FeedbackCreateSchema: langsmith.FeedbackCreateSchemaParam{
+		RunID:     langsmith.F(runID),
+		Key:       langsmith.F("user_feedback"),
+		Score:     langsmith.F[langsmith.FeedbackCreateSchemaScoreUnionParam](shared.UnionFloat(1.0)),
+		SessionID: langsmith.F(sessionID),
+	},
+})
+```

--- a/src/snippets/code-samples/smithdb-migration/feedback-create-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/feedback-create-after-js.mdx
@@ -1,0 +1,11 @@
+```ts After
+import { Client } from "langsmith";
+
+const client = new Client();
+let runId = "<run-id>";
+let sessionId = "<session-id>";
+await client.createFeedback(runId, "user_feedback", {
+  score: 1,
+  sessionId,
+});
+```

--- a/src/snippets/code-samples/smithdb-migration/feedback-create-after-kt.mdx
+++ b/src/snippets/code-samples/smithdb-migration/feedback-create-after-kt.mdx
@@ -1,0 +1,18 @@
+```kotlin After
+import com.langchain.smith.client.LangsmithClient
+import com.langchain.smith.client.okhttp.LangsmithOkHttpClient
+import com.langchain.smith.models.feedback.FeedbackCreateSchema
+
+val client: LangsmithClient = LangsmithOkHttpClient.fromEnv()
+
+var runId = "<run-id>"
+var sessionId = "<session-id>"
+client.feedback().create(
+    FeedbackCreateSchema.builder()
+        .runId(runId)
+        .key("user_feedback")
+        .score(1.0)
+        .sessionId(sessionId)
+        .build()
+)
+```

--- a/src/snippets/code-samples/smithdb-migration/feedback-create-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/feedback-create-after-py.mdx
@@ -1,0 +1,13 @@
+```python After
+from langsmith import Client
+
+client = Client()
+run_id = "<run-id>"
+session_id = "<session-id>"
+client.create_feedback(
+    run_id=run_id,
+    key="user_feedback",
+    score=1,
+    session_id=session_id,
+)
+```

--- a/src/snippets/code-samples/smithdb-migration/feedback-create-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/feedback-create-after-sh.mdx
@@ -1,0 +1,9 @@
+```bash
+RUN_ID="<run-id>"
+SESSION_ID="<session-id>"
+
+curl -X POST "https://api.smith.langchain.com/api/v1/feedback" \
+  -H "x-api-key: $LANGSMITH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg run "$RUN_ID" --arg session "$SESSION_ID" '{"run_id": $run, "key": "user_feedback", "score": 1, "session_id": $session}')"
+```

--- a/src/snippets/code-samples/smithdb-migration/feedback-create-before-go.mdx
+++ b/src/snippets/code-samples/smithdb-migration/feedback-create-before-go.mdx
@@ -1,0 +1,23 @@
+```go Before
+package main
+
+import (
+	"context"
+
+	"github.com/langchain-ai/langsmith-go"
+	"github.com/langchain-ai/langsmith-go/shared"
+)
+
+ctx := context.Background()
+client := langsmith.NewClient()
+
+runID := "<run-id>"
+var err error
+_, err = client.Feedback.New(ctx, langsmith.FeedbackNewParams{
+	FeedbackCreateSchema: langsmith.FeedbackCreateSchemaParam{
+		RunID: langsmith.F(runID),
+		Key:   langsmith.F("user_feedback"),
+		Score: langsmith.F[langsmith.FeedbackCreateSchemaScoreUnionParam](shared.UnionFloat(1.0)),
+	},
+})
+```

--- a/src/snippets/code-samples/smithdb-migration/feedback-create-before-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/feedback-create-before-js.mdx
@@ -1,0 +1,9 @@
+```ts Before
+import { Client } from "langsmith";
+
+const client = new Client();
+let runId = "<run-id>";
+await client.createFeedback(runId, "user_feedback", {
+  score: 1,
+});
+```

--- a/src/snippets/code-samples/smithdb-migration/feedback-create-before-kt.mdx
+++ b/src/snippets/code-samples/smithdb-migration/feedback-create-before-kt.mdx
@@ -1,0 +1,16 @@
+```kotlin Before
+import com.langchain.smith.client.LangsmithClient
+import com.langchain.smith.client.okhttp.LangsmithOkHttpClient
+import com.langchain.smith.models.feedback.FeedbackCreateSchema
+
+val client: LangsmithClient = LangsmithOkHttpClient.fromEnv()
+
+var runId = "<run-id>"
+client.feedback().create(
+    FeedbackCreateSchema.builder()
+        .runId(runId)
+        .key("user_feedback")
+        .score(1.0)
+        .build()
+)
+```

--- a/src/snippets/code-samples/smithdb-migration/feedback-create-before-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/feedback-create-before-py.mdx
@@ -1,0 +1,11 @@
+```python Before
+from langsmith import Client
+
+client = Client()
+run_id = "<run-id>"
+client.create_feedback(
+    run_id=run_id,
+    key="user_feedback",
+    score=1,
+)
+```

--- a/src/snippets/code-samples/smithdb-migration/feedback-create-before-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/feedback-create-before-sh.mdx
@@ -1,0 +1,8 @@
+```bash
+RUN_ID="<run-id>"
+
+curl -X POST "https://api.smith.langchain.com/api/v1/feedback" \
+  -H "x-api-key: $LANGSMITH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d "$(jq -n --arg run "$RUN_ID" '{"run_id": $run, "key": "user_feedback", "score": 1}')"
+```

--- a/src/snippets/langsmith/smithdb-migration/feedback-create.mdx
+++ b/src/snippets/langsmith/smithdb-migration/feedback-create.mdx
@@ -1,0 +1,135 @@
+import SmithdbFeedbackCreateBeforePy from '/snippets/code-samples/smithdb-migration/feedback-create-before-py.mdx';
+import SmithdbFeedbackCreateAfterPy from '/snippets/code-samples/smithdb-migration/feedback-create-after-py.mdx';
+import SmithdbFeedbackCreateBeforeJs from '/snippets/code-samples/smithdb-migration/feedback-create-before-js.mdx';
+import SmithdbFeedbackCreateAfterJs from '/snippets/code-samples/smithdb-migration/feedback-create-after-js.mdx';
+import SmithdbFeedbackCreateBeforeKt from '/snippets/code-samples/smithdb-migration/feedback-create-before-kt.mdx';
+import SmithdbFeedbackCreateAfterKt from '/snippets/code-samples/smithdb-migration/feedback-create-after-kt.mdx';
+import SmithdbFeedbackCreateBeforeGo from '/snippets/code-samples/smithdb-migration/feedback-create-before-go.mdx';
+import SmithdbFeedbackCreateAfterGo from '/snippets/code-samples/smithdb-migration/feedback-create-after-go.mdx';
+import SmithdbFeedbackCreateBeforeSh from '/snippets/code-samples/smithdb-migration/feedback-create-before-sh.mdx';
+import SmithdbFeedbackCreateAfterSh from '/snippets/code-samples/smithdb-migration/feedback-create-after-sh.mdx';
+
+## Feedback: create
+
+Create feedback (a score, correction, or comment) for a run.
+
+### Main changes
+
+#### Required parameter
+
+The method name and endpoint are unchanged. Only the session (project) ID requirement changes.
+
+<Tabs>
+  <Tab title="Python">
+    <Warning>
+    `create_feedback` now requires `session_id`, the UUID of the project (session) that owns the run. It was previously optional.
+    </Warning>
+
+    | Before | After | Notes |
+    |---|---|---|
+    | `session_id` (optional) | `session_id` (**required**) | UUID of the project that owns the run; resolve it with `client.read_project()` if you do not already have it |
+  </Tab>
+  <Tab title="TypeScript">
+    <Warning>
+    `client.createFeedback` now requires `sessionId`, the UUID of the project (session) that owns the run. It was previously optional.
+    </Warning>
+
+    | Before | After | Notes |
+    |---|---|---|
+    | `sessionId` (optional) | `sessionId` (**required**) | UUID of the project that owns the run; resolve it with `client.readProject()` if you do not already have it |
+  </Tab>
+  <Tab title="Java">
+    <Warning>
+    `FeedbackCreateSchema.sessionId()` is now required. It was previously optional.
+    </Warning>
+
+    | Before | After | Notes |
+    |---|---|---|
+    | `sessionId()` (optional) | `sessionId()` (**required**) | UUID of the project that owns the run; resolve it with `client.sessions().list()` if you do not already have it |
+  </Tab>
+  <Tab title="Go">
+    <Warning>
+    `FeedbackCreateSchemaParam.SessionID` is now required. It was previously optional.
+    </Warning>
+
+    | Before | After | Notes |
+    |---|---|---|
+    | `SessionID` (optional) | `SessionID` (**required**) | UUID of the project that owns the run; resolve it with `client.Sessions.List()` if you do not already have it |
+  </Tab>
+  <Tab title="cURL">
+    <Warning>
+    `POST /api/v1/feedback` now requires a `session_id` field in the request body. It was previously optional.
+    </Warning>
+
+    | Before | After | Notes |
+    |---|---|---|
+    | `session_id` (optional) | `session_id` (**required**) | UUID of the project that owns the run; resolve it with `GET /api/v1/sessions` if you do not already have it |
+  </Tab>
+</Tabs>
+
+### Examples
+
+#### Provide `session_id` when creating feedback
+
+<Tabs>
+  <Tab title="Python">
+    `create_feedback` now requires `session_id` in addition to `run_id`.
+
+    <Tabs sync={false}>
+      <Tab title="Before">
+        <SmithdbFeedbackCreateBeforePy />
+      </Tab>
+      <Tab title="After">
+        <SmithdbFeedbackCreateAfterPy />
+      </Tab>
+    </Tabs>
+  </Tab>
+  <Tab title="TypeScript">
+    `client.createFeedback` now requires `sessionId` in addition to `runId`.
+
+    <Tabs sync={false}>
+      <Tab title="Before">
+        <SmithdbFeedbackCreateBeforeJs />
+      </Tab>
+      <Tab title="After">
+        <SmithdbFeedbackCreateAfterJs />
+      </Tab>
+    </Tabs>
+  </Tab>
+  <Tab title="Java">
+    `.create()` now requires `.sessionId()` in addition to `.runId()`.
+
+    <Tabs sync={false}>
+      <Tab title="Before">
+        <SmithdbFeedbackCreateBeforeKt />
+      </Tab>
+      <Tab title="After">
+        <SmithdbFeedbackCreateAfterKt />
+      </Tab>
+    </Tabs>
+  </Tab>
+  <Tab title="Go">
+    `Feedback.New` now requires `SessionID` in addition to `RunID`.
+
+    <Tabs sync={false}>
+      <Tab title="Before">
+        <SmithdbFeedbackCreateBeforeGo />
+      </Tab>
+      <Tab title="After">
+        <SmithdbFeedbackCreateAfterGo />
+      </Tab>
+    </Tabs>
+  </Tab>
+  <Tab title="cURL">
+    `POST /api/v1/feedback` now requires a `session_id` field in addition to `run_id`.
+
+    <Tabs sync={false}>
+      <Tab title="Before">
+        <SmithdbFeedbackCreateBeforeSh />
+      </Tab>
+      <Tab title="After">
+        <SmithdbFeedbackCreateAfterSh />
+      </Tab>
+    </Tabs>
+  </Tab>
+</Tabs>


### PR DESCRIPTION
## Description
`POST /api/v1/feedback` (and the corresponding SDK `create_feedback` / `createFeedback` / `feedback().create()` / `Feedback.New` methods) is making `session_id` a required field instead of optional.

- Added a "Feedback: create" section to the SmithDB SDK migration guide (`src/langsmith/smithdb-sdk-migration.mdx`) documenting the change.
- Covers all five languages: Python, TypeScript, Java, Go, and cURL, with a before/after parameter table plus runnable before/after code examples per language.
- New code samples live under `src/code-samples/langsmith/smithdb-migration/feedback-create*` and were regenerated into `src/snippets/code-samples/smithdb-migration/` via `make code-snippets`.