### PR TITLE
docs(langsmith): add public runs v2 migration

### DIFF
--- a/src/langsmith/smithdb-sdk-migration.mdx
+++ b/src/langsmith/smithdb-sdk-migration.mdx
@@ -8,6 +8,7 @@ import SmithdbMigrationRunsQuery from '/snippets/langsmith/smithdb-migration/run
 import SmithdbMigrationRunsRetrieve from '/snippets/langsmith/smithdb-migration/runs-retrieve.mdx';
 import SmithdbMigrationRunsGetUrl from '/snippets/langsmith/smithdb-migration/runs-geturl.mdx';
 import SmithdbMigrationRunsAddToAnnotationQueue from '/snippets/langsmith/smithdb-migration/runs-add-to-annotation-queue.mdx';
+import SmithdbMigrationPublicRuns from '/snippets/langsmith/smithdb-migration/public-runs.mdx';
 import SmithdbMigrationFeedbackCreate from '/snippets/langsmith/smithdb-migration/feedback-create.mdx';
 import SmithdbMigrationThreadsQuery from '/snippets/langsmith/smithdb-migration/threads-query.mdx';
 import SmithdbMigrationThreadsListTraces from '/snippets/langsmith/smithdb-migration/threads-list-traces.mdx';
@@ -149,21 +150,9 @@ than guessing.
 
 <SmithdbMigrationRunsAddToAnnotationQueue />
 
+<SmithdbMigrationPublicRuns />
+
 <SmithdbMigrationFeedbackCreate />
-
-## Soon to be deprecated
-
-The following methods may be deprecated before the end of this month. Preview customers will be notified when changes are made.
-
-### Share run methods
-
-| Python | TypeScript |
-|---|---|
-| [`share_run`](https://reference.langchain.com/python/langsmith/client/Client/share_run) | [`shareRun`](https://reference.langchain.com/javascript/langsmith/client/Client/shareRun) |
-| [`unshare_run`](https://reference.langchain.com/python/langsmith/client/Client/unshare_run) | [`unshareRun`](https://reference.langchain.com/javascript/langsmith/client/Client/unshareRun) |
-| [`list_shared_runs`](https://reference.langchain.com/python/langsmith/client/Client/list_shared_runs) | [`listSharedRuns`](https://reference.langchain.com/javascript/langsmith/client/Client/listSharedRuns) |
-| [`read_run_shared_link`](https://reference.langchain.com/python/langsmith/client/Client/read_run_shared_link) | [`readRunSharedLink`](https://reference.langchain.com/javascript/langsmith/client/Client/readRunSharedLink) |
-| [`read_shared_run`](https://reference.langchain.com/python/langsmith/client/Client/read_shared_run) | No TypeScript equivalent |
 
 ## Discontinued
 

--- a/src/langsmith/smithdb-sdk-migration.mdx
+++ b/src/langsmith/smithdb-sdk-migration.mdx
@@ -49,8 +49,8 @@ The SmithDB-backed methods require a minimum SDK version:
 
 | Language | Package | Minimum version |
 |---|---|---|
-| Python | `langsmith` | `>=0.10.7` |
-| TypeScript | `langsmith` | `>=0.8.4` |
+| Python | `langsmith` | `>=0.10.8` |
+| TypeScript | `langsmith` | `>=0.8.5` |
 | Java | `langsmith-java` | `0.1.0-beta.18` |
 | Go | `langsmith-go` | `v0.22.0` |
 

--- a/src/snippets/code-samples/smithdb-migration/public-runs-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/public-runs-after-js.mdx
@@ -1,0 +1,45 @@
+```typescript
+const PUBLIC_RUN_SELECTS = [
+  "ID",
+  "NAME",
+  "RUN_TYPE",
+  "STATUS",
+  "START_TIME",
+] as const;
+
+// Share a trace.
+const share = await client.runs.share.create(runId, {
+  session_id: projectId,
+  trace_id: traceId,
+});
+if (!share.share_token) {
+  throw new Error("The server did not return a share token");
+}
+const shareToken = share.share_token;
+
+// Query the public trace and use its stored start time for a point read.
+const response = await client.public.runs.query(shareToken, {
+  selects: [...PUBLIC_RUN_SELECTS],
+});
+const runs = response.items ?? [];
+const item = runs.find((candidate) => candidate.id === runId);
+if (!item?.start_time) {
+  throw new Error("The public run or its start_time was not found");
+}
+const run = await client.public.runs.retrieve(runId, {
+  share_token: shareToken,
+  selects: [...PUBLIC_RUN_SELECTS],
+  start_time: item.start_time,
+});
+
+// Retrieve the deployment-aware public URL for an authenticated run.
+const authenticatedRun = await client.runs.retrieve(runId, {
+  project_id: projectId,
+  start_time: item.start_time,
+  selects: ["SHARE_URL"],
+});
+const shareUrl = authenticatedRun.share_url;
+
+// Remove public access by root trace ID.
+await client.runs.share.delete(traceId, { session_id: projectId });
+```

--- a/src/snippets/code-samples/smithdb-migration/public-runs-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/public-runs-after-py.mdx
@@ -1,0 +1,39 @@
+```python
+PUBLIC_RUN_SELECTS = ["ID", "NAME", "RUN_TYPE", "STATUS", "START_TIME"]
+
+# Share a trace.
+share = await client.runs.share.create(
+    run_id,
+    session_id=project_id,
+    trace_id=trace_id,
+)
+if not share.share_token:
+    raise RuntimeError("The server did not return a share token")
+share_token = share.share_token
+
+# Query the public trace and use its stored start time for a point read.
+response = await client.public.runs.query(
+    share_token,
+    selects=PUBLIC_RUN_SELECTS,
+)
+runs = response.items
+item = next(run for run in runs if str(run.id) == run_id)
+run = await client.public.runs.retrieve(
+    run_id,
+    share_token=share_token,
+    selects=PUBLIC_RUN_SELECTS,
+    start_time=item.start_time,
+)
+
+# Retrieve the deployment-aware public URL for an authenticated run.
+authenticated_run = await client.runs.retrieve(
+    run_id,
+    project_id=project_id,
+    start_time=item.start_time,
+    selects=["SHARE_URL"],
+)
+share_url = authenticated_run.share_url
+
+# Remove public access by root trace ID.
+await client.runs.share.delete(trace_id, session_id=project_id)
+```

--- a/src/snippets/code-samples/smithdb-migration/public-runs-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/public-runs-after-sh.mdx
@@ -1,0 +1,37 @@
+```bash
+# Share a trace.
+curl --request POST \
+  "$API_URL/v2/runs/$RUN_ID/share" \
+  --header "X-API-Key: $LANGSMITH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data "{\"session_id\":\"$PROJECT_ID\",\"trace_id\":\"$TRACE_ID\"}"
+
+# Query the public trace.
+curl --request POST \
+  "$API_URL/v2/public/$SHARE_TOKEN/runs/v2/query" \
+  --header "Content-Type: application/json" \
+  --data '{"selects":["ID","NAME","RUN_TYPE","STATUS","START_TIME"]}'
+
+# Retrieve one public run using its exact start time from the query response.
+curl --get "$API_URL/v2/public/$SHARE_TOKEN/run/$RUN_ID" \
+  --data-urlencode "start_time=$START_TIME" \
+  --data-urlencode "selects=ID" \
+  --data-urlencode "selects=NAME" \
+  --data-urlencode "selects=RUN_TYPE" \
+  --data-urlencode "selects=STATUS" \
+  --data-urlencode "selects=START_TIME"
+
+# Retrieve the deployment-aware public URL for an authenticated run.
+curl --get "$API_URL/v2/runs/$RUN_ID" \
+  --header "X-API-Key: $LANGSMITH_API_KEY" \
+  --data-urlencode "project_id=$PROJECT_ID" \
+  --data-urlencode "start_time=$START_TIME" \
+  --data-urlencode "selects=SHARE_URL"
+
+# Remove public access by root trace ID.
+curl --request DELETE \
+  "$API_URL/v2/runs/$TRACE_ID/share" \
+  --header "X-API-Key: $LANGSMITH_API_KEY" \
+  --header "Content-Type: application/json" \
+  --data "{\"session_id\":\"$PROJECT_ID\"}"
+```

--- a/src/snippets/code-samples/smithdb-migration/public-runs-before-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/public-runs-before-js.mdx
@@ -1,0 +1,16 @@
+```typescript
+// Share a trace.
+const shareUrl = await client.shareRun(runId);
+
+// Read the shared runs and one specific run.
+const runs = await client.listSharedRuns(shareToken);
+const [run] = await client.listSharedRuns(shareToken, {
+  runIds: [runId],
+});
+
+// Check whether the run is shared.
+const existingShareUrl = await client.readRunSharedLink(runId);
+
+// Remove public access.
+await client.unshareRun(runId);
+```

--- a/src/snippets/code-samples/smithdb-migration/public-runs-before-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/public-runs-before-py.mdx
@@ -1,0 +1,14 @@
+```python
+# Share a trace.
+share_url = client.share_run(run_id)
+
+# Read the shared runs and one specific run.
+runs = list(client.list_shared_runs(share_token))
+run = client.read_shared_run(share_token, run_id=run_id)
+
+# Check whether the run is shared.
+share_url = client.read_run_shared_link(run_id)
+
+# Remove public access.
+client.unshare_run(run_id)
+```

--- a/src/snippets/code-samples/smithdb-migration/public-runs-before-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/public-runs-before-sh.mdx
@@ -1,0 +1,20 @@
+```bash
+# Share a run.
+curl --request PUT \
+  "$API_URL/api/v1/runs/$RUN_ID/share" \
+  --header "X-API-Key: $LANGSMITH_API_KEY"
+
+# Query the public trace and retrieve one public run.
+curl --request POST \
+  "$API_URL/api/v1/public/$SHARE_TOKEN/runs/query" \
+  --header "Content-Type: application/json" \
+  --data '{}'
+curl "$API_URL/api/v1/public/$SHARE_TOKEN/run/$RUN_ID"
+
+# Read the share state, then remove public access.
+curl "$API_URL/api/v1/runs/$RUN_ID/share" \
+  --header "X-API-Key: $LANGSMITH_API_KEY"
+curl --request DELETE \
+  "$API_URL/api/v1/runs/$RUN_ID/share" \
+  --header "X-API-Key: $LANGSMITH_API_KEY"
+```

--- a/src/snippets/langsmith/smithdb-migration/public-runs.mdx
+++ b/src/snippets/langsmith/smithdb-migration/public-runs.mdx
@@ -99,7 +99,7 @@ Do not construct the public URL from the API origin. Retrieving `share_url` uses
 | Operation | Before | After |
 |---|---|---|
 | Share | Run ID, shared trace ID, and share token | `share_token` |
-| Unshare | Empty response | `204 No Content` |
+| Unshare | `{"message": "Run unshared"}` | `204 No Content` |
 | Query public runs | `runs` and `cursors` | `items` |
 | Retrieve a public run | Full legacy run | Select-driven run object |
 | Read share state | Share-state object or `null` | Run object with `share_url` when shared |

--- a/src/snippets/langsmith/smithdb-migration/public-runs.mdx
+++ b/src/snippets/langsmith/smithdb-migration/public-runs.mdx
@@ -1,0 +1,142 @@
+import SmithdbPublicRunsBeforePy from '/snippets/code-samples/smithdb-migration/public-runs-before-py.mdx';
+import SmithdbPublicRunsAfterPy from '/snippets/code-samples/smithdb-migration/public-runs-after-py.mdx';
+import SmithdbPublicRunsBeforeJs from '/snippets/code-samples/smithdb-migration/public-runs-before-js.mdx';
+import SmithdbPublicRunsAfterJs from '/snippets/code-samples/smithdb-migration/public-runs-after-js.mdx';
+import SmithdbPublicRunsBeforeSh from '/snippets/code-samples/smithdb-migration/public-runs-before-sh.mdx';
+import SmithdbPublicRunsAfterSh from '/snippets/code-samples/smithdb-migration/public-runs-after-sh.mdx';
+
+## Share and read public runs
+
+Share a trace, remove its public access, or read the runs in a publicly shared trace. The v2 methods use explicit SmithDB coordinates and return select-driven run objects.
+
+Public read methods do not require a LangSmith API key. Treat the share token as a secret because anyone with the token can read the shared trace.
+
+<Note>
+The public-share migration requires `langsmith>=0.10.8` for Python or `langsmith>=0.8.5` for TypeScript. Deprecation and removal dates for the legacy public-share methods have not yet been announced.
+</Note>
+
+### Main changes
+
+#### Method names
+
+<Tabs>
+  <Tab title="Python">
+    | Before | After |
+    |---|---|
+    | `client.share_run()` | `client.runs.share.create()` |
+    | `client.unshare_run()` | `client.runs.share.delete()` |
+    | `client.list_shared_runs()` | `client.public.runs.query()` |
+    | `client.read_shared_run()` | `client.public.runs.retrieve()` |
+    | `client.read_run_shared_link()` | `client.runs.retrieve(selects=["SHARE_URL"])` |
+
+    <Note>
+    The v2 resource methods are async. Call them with `await`.
+    </Note>
+  </Tab>
+  <Tab title="TypeScript">
+    | Before | After |
+    |---|---|
+    | `client.shareRun()` | `client.runs.share.create()` |
+    | `client.unshareRun()` | `client.runs.share.delete()` |
+    | `client.listSharedRuns()` | `client.public.runs.query()` |
+    | `client.listSharedRuns({ runIds: [...] })` | `client.public.runs.retrieve()` |
+    | `client.readRunSharedLink()` | `client.runs.retrieve({ selects: ["SHARE_URL"] })` |
+
+    TypeScript did not have a direct equivalent of Python's `read_shared_run`. Filtered `listSharedRuns` calls migrate to the point-read method.
+  </Tab>
+  <Tab title="Java">
+    The Java SDK has no legacy convenience methods to migrate. Use [`ShareService`](https://javadoc.io/doc/com.langchain.smith/langsmith-java/latest/com/langchain/smith/services/blocking/runs/ShareService.html) and the public [`RunService`](https://javadoc.io/doc/com.langchain.smith/langsmith-java/latest/com/langchain/smith/services/blocking/public_/RunService.html) for v2 access. Kotlin uses the Java SDK; there is no separate Kotlin reference site.
+  </Tab>
+  <Tab title="Go">
+    The Go SDK has no legacy convenience methods to migrate. Use [`RunShareService`](https://pkg.go.dev/github.com/langchain-ai/langsmith-go#RunShareService) and [`PublicRunService`](https://pkg.go.dev/github.com/langchain-ai/langsmith-go#PublicRunService) for v2 access.
+  </Tab>
+  <Tab title="cURL">
+    | Operation | Before | After |
+    |---|---|---|
+    | Share | `PUT /api/v1/runs/{run_id}/share` | `POST /v2/runs/{run_id}/share` |
+    | Unshare | `DELETE /api/v1/runs/{run_id}/share` | `DELETE /v2/runs/{trace_id}/share` |
+    | Query public runs | `POST /api/v1/public/{share_token}/runs/query` | `POST /v2/public/{share_token}/runs/v2/query` |
+    | Retrieve a public run | `GET /api/v1/public/{share_token}/run/{run_id}` | `GET /v2/public/{share_token}/run/{run_id}` |
+    | Read share state | `GET /api/v1/runs/{run_id}/share` | `GET /v2/runs/{run_id}?selects=SHARE_URL` |
+
+    The legacy `GET /api/v1/public/{share_token}/run` endpoint without a run ID has no direct v2 equivalent.
+  </Tab>
+</Tabs>
+
+#### Share and unshare parameters
+
+<Tabs>
+  <Tab title="Python">
+    - `runs.share.create` takes the run ID as its positional argument. Pass `session_id` (the tracing project UUID) and `trace_id` (the root trace UUID).
+    - `runs.share.delete` takes the root trace ID, not an arbitrary child run ID. Pass the tracing project UUID as `session_id`.
+    - `share_id` is removed. The server generates the share token.
+  </Tab>
+  <Tab title="TypeScript">
+    - `runs.share.create` takes the run ID as its positional argument. Pass `session_id` and the root `trace_id` in the options object.
+    - `runs.share.delete` takes the root trace ID and an options object containing `session_id`.
+    - `shareId` is removed. The server generates the share token.
+  </Tab>
+  <Tab title="cURL">
+    - The v2 share request body contains `session_id` and `trace_id`.
+    - The v2 unshare path identifies the root trace. Its request body contains `session_id`.
+    - The v2 unshare operation is idempotent and returns `204 No Content`.
+  </Tab>
+</Tabs>
+
+Although generated parameter types may mark these coordinates as optional, provide `session_id` and `trace_id` when sharing, and provide `session_id` when unsharing. SmithDB uses these coordinates for the lookup.
+
+#### Public read parameters
+
+- `public.runs.query` takes the share token and a `selects` list. The token scopes the query to the complete shared trace. The legacy run-ID filter and cursor response are removed.
+- `public.runs.retrieve` requires the run ID, share token, exact run `start_time`, and a `selects` list. Obtain the exact stored start time from `public.runs.query`.
+- The public point read returns only selected fields. Use `ID`, `NAME`, `RUN_TYPE`, `STATUS`, and `START_TIME` for the examples below.
+- To retrieve the public URL for an authenticated run, call `runs.retrieve` with `selects=["SHARE_URL"]`, then read `run.share_url`. Supplying `start_time` gives SmithDB the most efficient lookup.
+
+Do not construct the public URL from the API origin. Retrieving `share_url` uses the deployment's configured application origin and works for both Cloud and self-hosted deployments.
+
+#### Responses
+
+| Operation | Before | After |
+|---|---|---|
+| Share | Run ID, shared trace ID, and share token | `share_token` |
+| Unshare | Empty response | `204 No Content` |
+| Query public runs | `runs` and `cursors` | `items` |
+| Retrieve a public run | Full legacy run | Select-driven run object |
+| Read share state | Share-state object or `null` | Run object with `share_url` when shared |
+
+### Examples
+
+The examples query the public trace before the point read because `public.runs.retrieve` requires the run's exact stored `start_time`.
+
+<Tabs>
+  <Tab title="Python">
+    <Tabs sync={false}>
+      <Tab title="Before">
+        <SmithdbPublicRunsBeforePy />
+      </Tab>
+      <Tab title="After">
+        <SmithdbPublicRunsAfterPy />
+      </Tab>
+    </Tabs>
+  </Tab>
+  <Tab title="TypeScript">
+    <Tabs sync={false}>
+      <Tab title="Before">
+        <SmithdbPublicRunsBeforeJs />
+      </Tab>
+      <Tab title="After">
+        <SmithdbPublicRunsAfterJs />
+      </Tab>
+    </Tabs>
+  </Tab>
+  <Tab title="cURL">
+    <Tabs sync={false}>
+      <Tab title="Before">
+        <SmithdbPublicRunsBeforeSh />
+      </Tab>
+      <Tab title="After">
+        <SmithdbPublicRunsAfterSh />
+      </Tab>
+    </Tabs>
+  </Tab>
+</Tabs>

--- a/src/snippets/langsmith/smithdb-migration/public-runs.mdx
+++ b/src/snippets/langsmith/smithdb-migration/public-runs.mdx
@@ -11,10 +11,6 @@ Share a trace, remove its public access, or read the runs in a publicly shared t
 
 Public read methods do not require a LangSmith API key. Treat the share token as a secret because anyone with the token can read the shared trace.
 
-<Note>
-The public-share migration requires `langsmith>=0.10.8` for Python or `langsmith>=0.8.5` for TypeScript. Deprecation and removal dates for the legacy public-share methods have not yet been announced.
-</Note>
-
 ### Main changes
 
 #### Method names


### PR DESCRIPTION
## Summary

- Replace the placeholder public-share deprecation list with a complete migration guide for the SmithDB-backed public runs APIs.
- Document method, endpoint, parameter, and response changes for sharing, unsharing, querying public runs, point reads, and retrieving `share_url`.
- Add verified Python, TypeScript, and cURL before/after examples, plus supplemental Java, Go, and Kotlin guidance.

## Why

The public runs endpoints and generated SDK resources now use explicit SmithDB coordinates and select-driven responses. Existing users need a concrete migration path before the legacy methods are formally deprecated.

## Review notes

Please review the required `session_id`, `trace_id`, and `start_time` guidance carefully. Generated SDK types mark some share coordinates optional, but the server contract and integration tests provide them. Deprecation and removal dates remain documented as not yet announced.

## Test plan

- [x] End-to-end verification against the configured LangSmith dev environment: legacy share/query/read/share-state/unshare and v2 share/query/read/share-URL/unshare
- [x] Verified v2 selected-field response shapes and idempotent `204 No Content` unshare
- [x] Verified temporary dev project cleanup
- [x] `make lint_prose` on all changed files: 0 findings
- [x] `make broken-links`
- [x] Markdown and whitespace validation
- [x] Python and shell example syntax checks
- [x] TypeScript examples checked against the SDK integration-test form

## AI involvement

Codex drafted and edited this documentation. API contracts and examples were verified against the server handlers, generated SDK resources, SDK integration tests, and live requests to the LangSmith dev environment; a human should review the coordinate requirements and migration wording.