### PR TITLE
fix: clarify Redis cluster IAM version support

### DIFF
--- a/src/langsmith/self-host-external-redis.mdx
+++ b/src/langsmith/self-host-external-redis.mdx
@@ -371,10 +371,10 @@ If you need more granular control, add the `fsGroup` to each pod's security cont
 
 ## IAM authentication
 
-As of LangSmith helm chart version **0.12.34**, we support IAM authentication for Redis. This allows you to use cloud provider workload identity instead of static passwords.
+As of LangSmith helm chart version **0.12.34**, LangSmith supports IAM authentication for standalone Redis. As of LangSmith version **v0.16.0** (v16), Redis Cluster also supports IAM authentication. This allows you to use cloud provider workload identity instead of static passwords.
 
 <Note>
-IAM authentication is supported for both standalone Redis and Redis Cluster configurations. However, not all cloud providers support IAM authentication for all Redis offerings. Check your cloud provider's documentation to verify IAM support for your specific Redis setup (e.g., GCP only supports IAM for Memorystore Cluster, not standalone Memorystore).
+Redis Cluster with IAM authentication requires LangSmith v0.16.0 or later. Earlier LangSmith versions support IAM authentication only for standalone Redis. Also, not all cloud providers support IAM authentication for all Redis offerings. Check your cloud provider's documentation to verify IAM support for your specific Redis setup (e.g., GCP only supports IAM for Memorystore Cluster, not standalone Memorystore).
 </Note>
 
 <Tabs>


### PR DESCRIPTION
## Description
Clarifies that Redis Cluster with IAM authentication requires LangSmith v0.16.0 (v16) or later, while earlier versions only support IAM authentication for standalone Redis.

## Test Plan
- [x] `make lint_prose FILES="src/langsmith/self-host-external-redis.mdx"`

Made by [Open SWE](https://openswe.vercel.app/agents/77596464-803c-8426-7cd8-8089fc7db316)