### PR TITLE
Note self-hosted no longer tracks long-lived trace usage

### DIFF
--- a/src/langsmith/granular-usage.mdx
+++ b/src/langsmith/granular-usage.mdx
@@ -14,6 +14,8 @@ DEFAULT_ORG_FEATURE_ENABLE_GRANULAR_USAGE_REPORTING=true
 GRANULAR_USAGE_TABLE_ENABLED=true
 ```
 
+Starting with self-hosted version 0.16.0, long-lived trace usage is no longer tracked for [Self-hosted](/langsmith/self-hosted) deployments. The **Long-lived only** retention filter always shows zero results for these deployments.
+
 **LangSmith Deployment usage** uses a separate data source. For more details, refer to the [LangSmith Deployment section](/langsmith/granular-usage#langsmith-deployment-usage-kind%3Dlangsmith_deployments).
 </Note>
 


### PR DESCRIPTION
## Summary
- Adds a note to the Granular Usage doc clarifying that self-hosted deployments (as of version 0.16.0) don't track long-lived trace usage, so the "Long-lived only" filter always returns zero results there instead of looking broken.


![Uploading Screenshot 2026-07-24 at 14.53.18.png…]()
