### PR TITLE
docs(deepagents): add v0.7.0 changelog entry

### DIFF
--- a/src/oss/python/releases/changelog.mdx
+++ b/src/oss/python/releases/changelog.mdx
@@ -10,14 +10,27 @@ rss: true
 </Callout>
 
 
-<Update label="Jul 7, 2026" tags={["deepagents"]} rss={{ title: "Jul 7, 2026 - deepagents" }}>
-    ## `deepagents` v0.7.0a6
+<Update label="Jul 24, 2026" tags={["deepagents"]} rss={{ title: "Jul 24, 2026 - deepagents" }}>
+    ## `deepagents` v0.7.0b2
 
-    - **New [`delete`](/oss/deepagents/tools#built-in-harness-tools) filesystem tool**: Delete a file, or recursively delete a directory and its contents. Backends that don't support deletion have the tool automatically hidden from the model.
-    - **`write_file` now overwrites existing files**: `write_file` used to error if the target file already existed. It now overwrites it — use `edit_file` for targeted changes to an existing file.
-    - **[Override a default middleware instance](/oss/deepagents/customization#override-a-default-middleware-instance)**: A `middleware=` (or subagent `middleware`) instance whose `.name` matches a default now replaces that default in place, instead of erroring on duplicate middleware.
-    - **[Restrict filesystem tools](/oss/deepagents/overview#virtual-filesystem-access)**: `FilesystemMiddleware` now accepts a `tools` allowlist to expose only a subset of the built-in filesystem tools to the model, building on the middleware-override behavior above.
-    - **[Structured system prompt configuration](/oss/deepagents/customization#system-prompt)**: The `system_prompt` parameter now accepts a `SystemPromptConfig` dict with `prefix`, `base`, and `suffix` keys, enabling callers to replace or remove the built-in base prompt and add text before or after it.
+    A leaner, more configurable harness by default. On a default-agent turn, input tokens drop **65%** (5,395 → 1,895 vs. v0.6.12), validated against our [revamped evaluation suite](https://www.langchain.com/blog/how-we-benchmark-deep-agents) with no quality regression.
+
+    ### Optimizations
+
+    - **Lean prompts by default**: The authored base prompt starts empty and tool-usage prose that duplicated tool schemas has been trimmed. Isolated to the default agent's tool schemas, total description tokens drop **43%** (4,005 → 2,302); combined with the empty base prompt and opt-in todos, a default-agent turn's input tokens drop **65%** since v0.6.12 (5,395 → 1,895). Tool behavior is unchanged. ([#4859](https://github.com/langchain-ai/deepagents/pull/4859), [#4979](https://github.com/langchain-ai/deepagents/pull/4979), [#5009](https://github.com/langchain-ai/deepagents/pull/5009))
+
+    ### Features
+
+    - **[Override a default middleware instance](/oss/deepagents/customization#middleware)**: A `middleware=` (or subagent `middleware`) instance whose `.name` matches a built-in now replaces that default in place, rather than erroring on a duplicate. For example, pass your own `SummarizationMiddleware(...)` to change the token trigger or summary model without disabling the built-in default. ([#4251](https://github.com/langchain-ai/deepagents/pull/4251))
+    - **Filesystem tools**: New [`delete`](/oss/deepagents/tools#built-in-harness-tools) tool removes a file or recursively removes a directory ([#3659](https://github.com/langchain-ai/deepagents/pull/3659), [#3851](https://github.com/langchain-ai/deepagents/pull/3851)); `write_file` now overwrites an existing file instead of erroring ([#4109](https://github.com/langchain-ai/deepagents/pull/4109)); `FilesystemMiddleware` accepts a [tool allowlist](/oss/deepagents/overview#virtual-filesystem-access) to expose only selected built-in tools ([#4325](https://github.com/langchain-ai/deepagents/pull/4325), [#4698](https://github.com/langchain-ai/deepagents/pull/4698)); and reads and searches are tuned for open models — paginated `read_file` reports total and remaining lines plus the next `offset` ([#4540](https://github.com/langchain-ai/deepagents/pull/4540)), `grep`/`glob` return partial results with a `truncated` flag instead of hanging on large trees ([#4063](https://github.com/langchain-ai/deepagents/pull/4063)), and `grep` gains a 1,000-match cap with streamed output and optional context lines ([#4570](https://github.com/langchain-ai/deepagents/pull/4570), [#4706](https://github.com/langchain-ai/deepagents/pull/4706)).
+    - **More prompt-caching support**: Bedrock prompt caching via the `deepagents[aws]` extra ([#4108](https://github.com/langchain-ai/deepagents/issues/4108)), and automatic Fireworks prompt-cache session affinity ([#4598](https://github.com/langchain-ai/deepagents/pull/4598)).
+    - **NVIDIA support**: A built-in Nemotron 3 Ultra harness profile plus NIM app-origin attribution. ([#4192](https://github.com/langchain-ai/deepagents/pull/4192), [#4455](https://github.com/langchain-ai/deepagents/pull/4455))
+
+    ### Breaking changes
+
+    - **Planning todos are opt-in**: `create_deep_agent` no longer includes `ToDoListMiddleware` by default, so the `write_todos` tool, `todos` state channel, and todo-planning prompt are absent unless restored with `middleware=[ToDoListMiddleware()]`. (The OpenAI Codex harness profile still opts in automatically.) ([#4929](https://github.com/langchain-ai/deepagents/pull/4929))
+    - **Backend compatibility shims removed**: Pass concrete `BackendProtocol` instances instead of factories, configure `StoreBackend` with an explicit `namespace`, and use the current `ls` / `glob` / `grep` / `ReadResult` APIs. Removed symbols include `BackendFactory`, `BACKEND_TYPES`, `FileFormat`, and `Unset`. New files store string `FileData.content`; older `list[str]` content stays readable and converts on next write. ([#4541](https://github.com/langchain-ai/deepagents/pull/4541))
+    - **Output format changes**: Empty `ls` / `glob` output is now `No files found` instead of `[]`, and `read_file` no longer renders a fixed-width `cat -n`-style gutter — update any parsers of raw tool output. ([#4561](https://github.com/langchain-ai/deepagents/pull/4561))
 
 </Update>
 <Update label="May 12, 2026" tags={["deepagents"]} rss={{ title: "May 12, 2026 - langchain" }}>


### PR DESCRIPTION
## Overview

Adds the final `deepagents` v0.7.0 changelog entry, replacing the pre-release `v0.7.0a6` block. The v0.7.0 release focuses on making the harness more configurable and leaner by default. Content is sourced from the [`0.7.0b1`](https://github.com/langchain-ai/deepagents/releases/tag/deepagents%3D%3D0.7.0b1) and [`0.7.0b2`](https://github.com/langchain-ai/deepagents/releases/tag/deepagents%3D%3D0.7.0b2) release notes and grouped into Features, Optimizations, and Breaking changes.

Note: the `SystemPromptConfig` item from the old a6 entry was dropped because that feature was reverted ([deepagents#4969](https://github.com/langchain-ai/deepagents/pull/4969)) before the GA release.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- Feature PRs: langchain-ai/deepagents#4251, #4109, #4325, #4859, #4929, #4541, #5009

## Checklist
- [x] I have read the contributing guidelines, including the language policy
- [x] I have tested my changes locally (Vale: 0 errors, 0 warnings)
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed (not needed)
