### PR TITLE
docs: add LLM Gateway spend monitoring guide

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -2258,6 +2258,7 @@
               "langsmith/llm-gateway",
               "langsmith/llm-gateway-admin-setup",
               "langsmith/llm-gateway-quickstart",
+              "langsmith/llm-gateway-monitoring",
               "langsmith/llm-gateway-coding-agents",
               "langsmith/llm-gateway-access",
               "langsmith/llm-gateway-langchain-provider",

--- a/src/langsmith/llm-gateway-monitoring.mdx
+++ b/src/langsmith/llm-gateway-monitoring.mdx
@@ -1,0 +1,74 @@
+---
+title: Monitor LLM Gateway spend
+description: View and analyze LLM Gateway costs by workspace, user, API key, and model.
+---
+
+The LLM Gateway spend dashboard shows how much LLM cost your organization has accrued through the gateway. Use it to compare spend over time and identify the workspaces, users, API keys, and models that account for that spend.
+
+The dashboard is available to all LLM Gateway users.
+
+<Warning>
+The dashboard is not currently available in the EU, APAC, or AWS environments.
+</Warning>
+
+## Open the dashboard
+
+To view gateway spend:
+
+1. In LangSmith, open **Settings**.
+1. Select **LLM Gateway**, then **Monitoring**.
+1. Select the workspace you want to analyze.
+
+The dashboard displays data after the selected workspace sends traffic through the LLM Gateway. If the workspace has no gateway traffic, the dashboard displays an empty state.
+
+## Set the time range and granularity
+
+Use the time controls to define the period covered by every summary, chart, and table on the page:
+
+- **Time range**: Select a preset range from one day to one year, or choose custom dates. Dates and time buckets use UTC.
+- **Granularity**: Group spend into hourly, daily, or weekly buckets. The available options depend on the length of the selected time range.
+- **Previous or next period**: Shift backward or forward by one period of the same length to compare adjacent time ranges.
+
+## Break down and filter spend
+
+Select **Breakdown by** to group spend across one of these dimensions:
+
+- **User**: Attributes spend to the user associated with the personal access token that invoked the gateway. Requests made with a workspace- or organization-scoped service key appear as **Unaffiliated with any user**.
+- **API key**: Attributes spend to the LangSmith API key that invoked the gateway.
+- **Model**: Attributes spend to the model used for the request.
+
+After you select a dimension, use the adjacent filter to focus on specific users, API keys, or models. You can select up to six entities at once. Select **All** to remove the filter.
+
+## Interpret the spend summary
+
+The summary cards describe spend for the selected workspace, time range, dimension, and filters:
+
+- **Total Spend**: The sum of gateway spend over the selected time range.
+- **Hourly, Daily, or Weekly Avg**: Total spend divided by the number of time buckets in the selected range.
+- **Hourly, Daily, or Weekly Avg / dimension**: Average spend per selected user, API key, or model for each time bucket. When you have not applied an entity filter, this metric uses the top 10 entities by spend.
+
+## Analyze the chart and table
+
+The stacked bar chart shows how each entity contributed to spend in every time bucket. Hover over a bar to view the bucket total and the contribution from each visible entity. The chart displays the six highest-spend entities as individual series and combines the remaining entities into **Other**.
+
+The table summarizes the same selection with one row per visible entity. Use it to compare:
+
+- **Hourly, Daily, or Weekly Avg**: The entity's total spend divided by the number of time buckets.
+- **Spend Share**: The percentage of spend attributed to the entity.
+- **Total Spend**: The entity's total spend over the selected time range.
+
+Select a column heading to sort the table.
+
+## Drill into a user or API key
+
+Select a user or API key row to open a detailed view:
+
+- From a user, view spend grouped by API key.
+- From an API key, view spend grouped by user.
+
+The detailed view has its own entity filter, time range, and granularity controls. Changes in this view do not change the controls on the main dashboard.
+
+## See also
+
+- [LLM Gateway overview](/langsmith/llm-gateway)
+- [Configure spend policies](/langsmith/llm-gateway-spend-policies)

--- a/src/langsmith/llm-gateway-monitoring.mdx
+++ b/src/langsmith/llm-gateway-monitoring.mdx
@@ -15,7 +15,7 @@ The dashboard is not currently available in the EU, APAC, or AWS environments.
 
 To view gateway spend:
 
-1. In LangSmith, open **Settings**.
+1. In the [LangSmith UI](https://smith.langchain.com), open **Settings**.
 1. Select **LLM Gateway**, then **Monitoring**.
 1. Select the workspace you want to analyze.
 

--- a/src/langsmith/llm-gateway-monitoring.mdx
+++ b/src/langsmith/llm-gateway-monitoring.mdx
@@ -5,7 +5,7 @@ description: View and analyze LLM Gateway costs by workspace, user, API key, and
 
 The LLM Gateway **Spend Monitoring** dashboard shows how much LLM cost your [organization](/langsmith/administration-overview#organizations) has accrued through the gateway. Use it to compare spend over time and identify the [workspaces](/langsmith/administration-overview#workspaces), users, [API keys](/langsmith/create-account-api-key), and models that account for that spend.
 
-The dashboard is available to all [paid LLM Gateway plans](/langsmith/pricing-plans).
+The dashboard is available to all [plans with LLM Gateway](/langsmith/pricing-plans).
 
 <Warning>
 The dashboard is not currently available in the EU, APAC, or AWS environments.

--- a/src/langsmith/llm-gateway-monitoring.mdx
+++ b/src/langsmith/llm-gateway-monitoring.mdx
@@ -3,7 +3,7 @@ title: Monitor LLM Gateway spend
 description: View and analyze LLM Gateway costs by workspace, user, API key, and model.
 ---
 
-The LLM Gateway spend dashboard shows how much LLM cost your organization has accrued through the gateway. Use it to compare spend over time and identify the workspaces, users, API keys, and models that account for that spend.
+The LLM Gateway **Spend Monitoring** dashboard shows how much LLM cost your [organization](/langsmith/administration-overview#organizations) has accrued through the gateway. Use it to compare spend over time and identify the [workspaces](/langsmith/administration-overview#workspaces), users, [API keys](/langsmith/create-account-api-key), and models that account for that spend.
 
 The dashboard is available to all paid LLM Gateway plans.
 

--- a/src/langsmith/llm-gateway-monitoring.mdx
+++ b/src/langsmith/llm-gateway-monitoring.mdx
@@ -1,11 +1,11 @@
 ---
 title: Monitor LLM Gateway spend
-description: View and analyze LLM Gateway costs by workspace, user, API key, and model.
+description: View and analyze LLM Gateway costs by user, API key, and model.
 ---
 
-The LLM Gateway **Spend Monitoring** dashboard shows how much LLM cost your [organization](/langsmith/administration-overview#organizations) has accrued through the gateway. Use it to compare spend over time and identify the [workspaces](/langsmith/administration-overview#workspaces), users, [API keys](/langsmith/create-account-api-key), and models that account for that spend.
+The LLM Gateway **Spend Monitoring** dashboard shows how much LLM cost a [workspace](/langsmith/administration-overview#workspaces) has accrued through the gateway. Use it to compare spend over time and identify the users, [API keys](/langsmith/create-account-api-key), and models that account for that spend. The dashboard covers one workspace at a time; switch workspaces to compare them.
 
-The dashboard is available to all [plans with LLM Gateway](/langsmith/pricing-plans).
+Viewing the dashboard requires the [Organization Admin](/langsmith/rbac#organization-admin) role and a Plus or Enterprise [plan](/langsmith/pricing-plans). Without both, the **Usage** tab does not appear.
 
 <Warning>
 The dashboard is not currently available in the EU, APAC, or AWS environments.
@@ -15,8 +15,8 @@ The dashboard is not currently available in the EU, APAC, or AWS environments.
 
 To view gateway spend:
 
-1. In the [LangSmith UI](https://smith.langchain.com), open **Settings**.
-1. Select **LLM Gateway**, then **Monitoring**.
+1. In the [LangSmith UI](https://smith.langchain.com), select **LLM Gateway** in the left navigation.
+1. Select **Usage**.
 1. Select the workspace you want to analyze.
 
 The dashboard displays data after the selected workspace sends traffic through the LLM Gateway. If the workspace has no gateway traffic, the dashboard displays an empty state.
@@ -37,7 +37,7 @@ Select **Breakdown by** to group spend across one of these dimensions:
 - **API key**: Attributes spend to the LangSmith API key that invoked the gateway.
 - **Model**: Attributes spend to the model used for the request.
 
-After you select a dimension, use the adjacent filter to focus on specific users, API keys, or models. You can select up to six entities at once. Select **All** to remove the filter.
+After you select a dimension, use the adjacent filter to focus on specific users, API keys, or models. You can select up to six entities at once. To remove the filter, select the **All** option at the bottom of the list.
 
 ## Interpret the spend summary
 
@@ -49,7 +49,7 @@ The summary cards describe spend for the selected workspace, time range, dimensi
 
 ## Analyze the chart and table
 
-The stacked bar chart shows how each entity contributed to spend in every time bucket. Hover over a bar to view the bucket total and the contribution from each visible entity. The chart displays the six highest-spend entities as individual series and combines the remaining entities into **Other**.
+The stacked bar chart shows how each entity contributed to spend in every time bucket. Hover over a bar to view the bucket total and the contribution from each visible entity. When no filter is applied, the chart displays the six highest-spend entities as individual series and combines the remaining entities into **Other**.
 
 The table summarizes the same selection with one row per visible entity. Use it to compare:
 
@@ -67,8 +67,6 @@ Select a user or API key row to open a detailed view:
 - From an API key, view spend grouped by user.
 
 The detailed view has its own entity filter, time range, and granularity controls. Changes in this view do not change the controls on the main dashboard.
-
-
 
 ## See also
 

--- a/src/langsmith/llm-gateway-monitoring.mdx
+++ b/src/langsmith/llm-gateway-monitoring.mdx
@@ -5,7 +5,7 @@ description: View and analyze LLM Gateway costs by workspace, user, API key, and
 
 The LLM Gateway spend dashboard shows how much LLM cost your organization has accrued through the gateway. Use it to compare spend over time and identify the workspaces, users, API keys, and models that account for that spend.
 
-The dashboard is available to all LLM Gateway users.
+The dashboard is available to all paid LLM Gateway plans.
 
 <Warning>
 The dashboard is not currently available in the EU, APAC, or AWS environments.
@@ -20,6 +20,10 @@ To view gateway spend:
 1. Select the workspace you want to analyze.
 
 The dashboard displays data after the selected workspace sends traffic through the LLM Gateway. If the workspace has no gateway traffic, the dashboard displays an empty state.
+
+<Warning>
+The dashboard currently only pulls the Top 6 dimensions of any workspace.
+</Warning>
 
 ## Set the time range and granularity
 
@@ -67,6 +71,8 @@ Select a user or API key row to open a detailed view:
 - From an API key, view spend grouped by user.
 
 The detailed view has its own entity filter, time range, and granularity controls. Changes in this view do not change the controls on the main dashboard.
+
+
 
 ## See also
 

--- a/src/langsmith/llm-gateway-monitoring.mdx
+++ b/src/langsmith/llm-gateway-monitoring.mdx
@@ -5,7 +5,7 @@ description: View and analyze LLM Gateway costs by workspace, user, API key, and
 
 The LLM Gateway **Spend Monitoring** dashboard shows how much LLM cost your [organization](/langsmith/administration-overview#organizations) has accrued through the gateway. Use it to compare spend over time and identify the [workspaces](/langsmith/administration-overview#workspaces), users, [API keys](/langsmith/create-account-api-key), and models that account for that spend.
 
-The dashboard is available to all paid LLM Gateway plans.
+The dashboard is available to all [paid LLM Gateway plans](/langsmith/pricing-plans).
 
 <Warning>
 The dashboard is not currently available in the EU, APAC, or AWS environments.
@@ -20,10 +20,6 @@ To view gateway spend:
 1. Select the workspace you want to analyze.
 
 The dashboard displays data after the selected workspace sends traffic through the LLM Gateway. If the workspace has no gateway traffic, the dashboard displays an empty state.
-
-<Warning>
-The dashboard currently only pulls the Top 6 dimensions of any workspace.
-</Warning>
 
 ## Set the time range and granularity
 


### PR DESCRIPTION
## Description
Adds a public-facing guide to the LLM Gateway spend dashboard, covering availability, navigation, dimensions, filters, summary metrics, charts, tables, and drilldowns. Adds the page to the LLM Gateway navigation for editorial review.

## Test Plan
- [x] Validate `src/docs.json` syntax and internal link targets
- [ ] View preview: https://langchain-5e9cc07a-preview-opensw-1785249875-a13f774.mintlify.site/langsmith/llm-gateway-monitoring

Made by [Open SWE](https://openswe.vercel.app/agents/1c715973-648e-f374-e816-b0e8dafd8b70)