### PR TITLE
docs: fix duplicate word in content-builder.mdx

### DIFF
--- a/src/oss/deepagents/content-builder.mdx
+++ b/src/oss/deepagents/content-builder.mdx
@@ -570,7 +570,7 @@ Before finishing:
 
 They instruct the agent to call the `researcher` subagent first, write markdown under `blogs/`, `linkedin/`, or `tweets/`, and call `generate_cover` or `generate_social_image` for images.
 
-When you later create the agent and specify the skills folder(s), then the frontmatter of the `SKILLS.md` files from those skill folders get loaded this into the system prompt so the agent can use the skill when a task task matches a skill description.
+When you later create the agent and specify the skills folder(s), then the frontmatter of the `SKILLS.md` files from those skill folders get loaded this into the system prompt so the agent can use the skill when a task matches a skill description.
 
 </Step>
 </Steps>


### PR DESCRIPTION
## Overview
Small typo fix: duplicated word "task task" -> "task" in the skills
frontmatter explanation.

## Type of change
**Type:** Fix typo/bug/link/formatting

## Checklist
- [x] I have read the contributing guidelines
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used root relative paths for internal links
- [ ] N/A - no navigation changes needed