### PR TITLE
docs: fix duplicate word in llm-auth-proxy-self-hosted.mdx

### DIFF
--- a/src/langsmith/llm-auth-proxy-self-hosted.mdx
+++ b/src/langsmith/llm-auth-proxy-self-hosted.mdx
@@ -809,7 +809,7 @@ Yes. When the auth proxy is only reachable through internal Kubernetes networkin
 </Accordion>
 
 <Accordion title="When should I use the LLM auth proxy versus OAuth client credentials on a model configuration?">
-Use the LLM auth proxy when authentication needs custom logic beyond OAuth2 `client_credentials`. For example, exchanging the LangSmith JWT for a provider-specific token, injecting GCP or AWS identity, or rewriting request and response bodies. Use [OAuth client credentials on a model configuration](/langsmith/model-configurations#oauth-client-credentials) when each workspace or team needs needs self-service control over its own OAuth2 `client_credentials` against a custom gateway. Both can coexist within the same organization; routing is per-configuration.
+Use the LLM auth proxy when authentication needs custom logic beyond OAuth2 `client_credentials`. For example, exchanging the LangSmith JWT for a provider-specific token, injecting GCP or AWS identity, or rewriting request and response bodies. Use [OAuth client credentials on a model configuration](/langsmith/model-configurations#oauth-client-credentials) when each workspace or team needs self-service control over its own OAuth2 `client_credentials` against a custom gateway. Both can coexist within the same organization; routing is per-configuration.
 </Accordion>
 
 ## Helm chart reference


### PR DESCRIPTION
## Overview
Small typo fix: duplicated word "needs needs" -> "needs" in the FAQ
accordion about choosing between the LLM auth proxy and OAuth client
credentials.

## Type of change
**Type:** Fix typo/bug/link/formatting

## Checklist
- [x] I have read the contributing guidelines
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used root relative paths for internal links
- [ ] N/A - no navigation changes needed