### PR TITLE
docs: fix duplicate word in code sample

### DIFF
--- a/src/langsmith/trace-with-microsoft-agent-framework.mdx
+++ b/src/langsmith/trace-with-microsoft-agent-framework.mdx
@@ -66,6 +66,6 @@ agent = ChatAgent(
     chat_client=OpenAIChatClient(model_id="gpt-4o"),
 )
 
-result = await agent.run("What's the the capital of Bavaria?")
+result = await agent.run("What's the capital of Bavaria?")
 print(result.text)
 ```


### PR DESCRIPTION
## Overview
Small typo fix in the example prompt string: "the the capital of
Bavaria" -> "the capital of Bavaria".

## Type of change
**Type:** Fix typo/bug/link/formatting

## Checklist
- [x] I have read the contributing guidelines
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used root relative paths for internal links
- [ ] N/A - no navigation changes needed