### PR TITLE
docs: fix duplicate word in FakeListChatModel comment

### DIFF
--- a/src/oss/javascript/integrations/chat/fake.mdx
+++ b/src/oss/javascript/integrations/chat/fake.mdx
@@ -45,7 +45,7 @@ for await (const chunk of stream) {
 console.log(chunks.join(""));
 
 /**
- * The FakeListChatModel can also be used to simulate delays in either either synchronous or streamed responses.
+ * The FakeListChatModel can also be used to simulate delays in either synchronous or streamed responses.
  */
 
 const slowChat = new FakeListChatModel({


### PR DESCRIPTION
## Overview
Small typo fix: duplicated word "either either" -> "either" in the
JSDoc comment for FakeListChatModel.

## Type of change
**Type:** Fix typo/bug/link/formatting

## Checklist
- [x] I have read the contributing guidelines
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used root relative paths for internal links
- [ ] N/A - no navigation changes needed