### PR TITLE
Docs/fix tab titles multi agent

### DIFF
--- a/src/oss/langchain/multi-agent/handoffs-customer-support.mdx
+++ b/src/oss/langchain/multi-agent/handoffs-customer-support.mdx
@@ -96,11 +96,11 @@ Set up [LangSmith](https://smith.langchain.com) to inspect what is happening ins
 
 :::python
 <CodeGroup>
-```bash bash
+```bash Shell
 export LANGSMITH_TRACING="true"
 export LANGSMITH_API_KEY="..."
 ```
-```python python
+```python Python
 import getpass
 import os
 
@@ -112,11 +112,11 @@ os.environ["LANGSMITH_API_KEY"] = getpass.getpass()
 
 :::js
 <CodeGroup>
-```bash bash
+```bash Shell
 export LANGSMITH_TRACING="true"
 export LANGSMITH_API_KEY="..."
 ```
-```typescript typescript
+```typescript TypeScript
 process.env.LANGSMITH_TRACING = "true";
 process.env.LANGSMITH_API_KEY = "...";
 ```

--- a/src/oss/langchain/multi-agent/router-knowledge-base.mdx
+++ b/src/oss/langchain/multi-agent/router-knowledge-base.mdx
@@ -100,11 +100,11 @@ Set up [LangSmith](https://smith.langchain.com) to inspect what is happening ins
 
 :::python
 <CodeGroup>
-```bash bash
+```bash Shell
 export LANGSMITH_TRACING="true"
 export LANGSMITH_API_KEY="..."
 ```
-```python python
+```python Python
 import getpass
 import os
 
@@ -116,11 +116,11 @@ os.environ["LANGSMITH_API_KEY"] = getpass.getpass()
 
 :::js
 <CodeGroup>
-```bash bash
+```bash Shell
 export LANGSMITH_TRACING="true"
 export LANGSMITH_API_KEY="..."
 ```
-```typescript typescript
+```typescript TypeScript
 process.env.LANGSMITH_TRACING = "true";
 process.env.LANGSMITH_API_KEY = "...";
 ```

--- a/src/oss/langchain/multi-agent/skills-sql-assistant.mdx
+++ b/src/oss/langchain/multi-agent/skills-sql-assistant.mdx
@@ -122,11 +122,11 @@ Set up [LangSmith](https://smith.langchain.com) to inspect what is happening ins
 
 :::python
 <CodeGroup>
-```bash bash
+```bash Shell
 export LANGSMITH_TRACING="true"
 export LANGSMITH_API_KEY="..."
 ```
-```python python
+```python Python
 import getpass
 import os
 
@@ -138,11 +138,11 @@ os.environ["LANGSMITH_API_KEY"] = getpass.getpass()
 
 :::js
 <CodeGroup>
-```bash bash
+```bash Shell
 export LANGSMITH_TRACING="true"
 export LANGSMITH_API_KEY="..."
 ```
-```typescript typescript
+```typescript TypeScript
 process.env.LANGSMITH_TRACING = "true";
 process.env.LANGSMITH_API_KEY = "...";
 ```

--- a/src/oss/langchain/multi-agent/subagents-personal-assistant.mdx
+++ b/src/oss/langchain/multi-agent/subagents-personal-assistant.mdx
@@ -73,11 +73,11 @@ Set up [LangSmith](https://smith.langchain.com) to inspect what is happening ins
 
 :::python
 <CodeGroup>
-```bash bash
+```bash Shell
 export LANGSMITH_TRACING="true"
 export LANGSMITH_API_KEY="..."
 ```
-```python python
+```python Python
 import getpass
 import os
 
@@ -89,11 +89,11 @@ os.environ["LANGSMITH_API_KEY"] = getpass.getpass()
 
 :::js
 <CodeGroup>
-```bash bash
+```bash Shell
 export LANGSMITH_TRACING="true"
 export LANGSMITH_API_KEY="..."
 ```
-```typescript typescript
+```typescript TypeScript
 process.env.LANGSMITH_TRACING = "true";
 process.env.LANGSMITH_API_KEY = "...";
 ```

--- a/src/oss/python/integrations/providers/isaacus.mdx
+++ b/src/oss/python/integrations/providers/isaacus.mdx
@@ -27,10 +27,10 @@ uv add langchain-isaacus
 
 You should then set your `ISAACUS_API_KEY` environment variable to your Isaacus API key.
 <CodeGroup>
-```bash bash
+```bash macOS/Linux
 export ISAACUS_API_KEY="your_api_key_here"
 ```
-```powershell powershell
+```powershell Windows
 $env:ISAACUS_API_KEY="your_api_key_here"
 ```
 </CodeGroup>


### PR DESCRIPTION
Four multi-agent tutorial pages have CodeGroup tabs whose titles just
repeat the fence language instead of describing the tab: "bash bash",
"python python", "typescript typescript".

Fixed to "Shell", "Python", "TypeScript" respectively, matching the
existing convention elsewhere in the docs (e.g.
langsmith/trace-with-vercel-ai-sdk.mdx uses "```bash Shell";
langsmith/evaluate-llm-application.mdx uses "```python Python" and
"```typescript TypeScript").

Files touched: oss/langchain/multi-agent/skills-sql-assistant.mdx,
subagents-personal-assistant.mdx, handoffs-customer-support.mdx,
router-knowledge-base.mdx.

Docs only, no functional changes.