### PR TITLE
Docs/fix article postgres family vectorstores

### DIFF
--- a/src/oss/python/integrations/document_loaders/google_alloydb.mdx
+++ b/src/oss/python/integrations/document_loaders/google_alloydb.mdx
@@ -17,7 +17,7 @@ To run this notebook, you will need to do the following:
 
 * [Create a Google Cloud Project](https://developers.google.com/workspace/guides/create-project)
 * [Enable the AlloyDB API](https://console.cloud.google.com/flows/enableapi?apiid=alloydb.googleapis.com)
-* [Create a AlloyDB cluster and instance.](https://cloud.google.com/alloydb/docs/cluster-create)
+* [Create an AlloyDB cluster and instance.](https://cloud.google.com/alloydb/docs/cluster-create)
 * [Create a AlloyDB database.](https://cloud.google.com/alloydb/docs/quickstart/create-and-connect)
 * [Add a User to the database.](https://cloud.google.com/alloydb/docs/database-users/about)
 

--- a/src/oss/python/integrations/providers/isaacus.mdx
+++ b/src/oss/python/integrations/providers/isaacus.mdx
@@ -27,10 +27,10 @@ uv add langchain-isaacus
 
 You should then set your `ISAACUS_API_KEY` environment variable to your Isaacus API key.
 <CodeGroup>
-```bash bash
+```bash macOS/Linux
 export ISAACUS_API_KEY="your_api_key_here"
 ```
-```powershell powershell
+```powershell Windows
 $env:ISAACUS_API_KEY="your_api_key_here"
 ```
 </CodeGroup>

--- a/src/oss/python/integrations/vectorstores/google_alloydb.mdx
+++ b/src/oss/python/integrations/vectorstores/google_alloydb.mdx
@@ -17,7 +17,7 @@ To run this notebook, you will need to do the following:
 
 * [Create a Google Cloud Project](https://developers.google.com/workspace/guides/create-project)
 * [Enable the AlloyDB API](https://console.cloud.google.com/flows/enableapi?apiid=alloydb.googleapis.com)
-* [Create a AlloyDB cluster and instance.](https://cloud.google.com/alloydb/docs/cluster-create)
+* [Create an AlloyDB cluster and instance.](https://cloud.google.com/alloydb/docs/cluster-create)
 * [Create a AlloyDB database.](https://cloud.google.com/alloydb/docs/quickstart/create-and-connect)
 * [Add a User to the database.](https://cloud.google.com/alloydb/docs/database-users/about)
 
@@ -194,7 +194,7 @@ docs = await store.asimilarity_search_by_vector(query_vector, k=2)
 print(docs)
 ```
 
-## Add a index
+## Add an index
 
 Speed up vector search queries by applying a vector index. Learn more about [vector indexes](https://cloud.google.com/blog/products/databases/faster-similarity-search-performance-with-pgvector-indexes).
 
@@ -242,7 +242,7 @@ custom_store = await AlloyDBVectorStore.create(
     table_name=TABLE_NAME,
     embedding_service=embedding,
     metadata_columns=["len"],
-    # Connect to a existing VectorStore by customizing the table schema:
+    # Connect to an existing VectorStore by customizing the table schema:
     # id_column="uuid",
     # content_column="documents",
     # embedding_column="vectors",

--- a/src/oss/python/integrations/vectorstores/google_cloud_sql_pg.mdx
+++ b/src/oss/python/integrations/vectorstores/google_cloud_sql_pg.mdx
@@ -195,7 +195,7 @@ docs = await store.asimilarity_search_by_vector(query_vector, k=2)
 print(docs)
 ```
 
-## Add a index
+## Add an index
 
 Speed up vector search queries by applying a vector index. Learn more about [vector indexes](https://cloud.google.com/blog/products/databases/faster-similarity-search-performance-with-pgvector-indexes).
 
@@ -243,7 +243,7 @@ custom_store = await PostgresVectorStore.create(
     table_name=TABLE_NAME,
     embedding_service=embedding,
     metadata_columns=["len"],
-    # Connect to a existing VectorStore by customizing the table schema:
+    # Connect to an existing VectorStore by customizing the table schema:
     # id_column="uuid",
     # content_column="documents",
     # embedding_column="vectors",

--- a/src/oss/python/integrations/vectorstores/pgvectorstore.mdx
+++ b/src/oss/python/integrations/vectorstores/pgvectorstore.mdx
@@ -218,7 +218,7 @@ docs = await store.asimilarity_search_by_vector(query_vector, k=2)
 print(docs)
 ```
 
-## Add a index
+## Add an index
 
 Speed up vector search queries by applying a vector index. Learn more about [vector indexes](https://cloud.google.com/blog/products/databases/faster-similarity-search-performance-with-pgvector-indexes).
 


### PR DESCRIPTION
Fixed three "a" -> "an" article errors in a shared boilerplate template
used across the Postgres-family vectorstore integration pages:

- "## Add a index" -> "## Add an index"
- "Connect to a existing VectorStore" -> "Connect to an existing VectorStore"
- "Create a AlloyDB cluster" -> "Create an AlloyDB cluster"

Files touched: oss/python/integrations/vectorstores/pgvectorstore.mdx,
oss/python/integrations/vectorstores/google_alloydb.mdx,
oss/python/integrations/vectorstores/google_cloud_sql_pg.mdx,
oss/python/integrations/document_loaders/google_alloydb.mdx.

Docs only, no functional changes.