### PR TITLE
Docs/fix article elasticsearch ingest

### DIFF
--- a/src/oss/python/integrations/providers/isaacus.mdx
+++ b/src/oss/python/integrations/providers/isaacus.mdx
@@ -27,10 +27,10 @@ uv add langchain-isaacus
 
 You should then set your `ISAACUS_API_KEY` environment variable to your Isaacus API key.
 <CodeGroup>
-```bash bash
+```bash macOS/Linux
 export ISAACUS_API_KEY="your_api_key_here"
 ```
-```powershell powershell
+```powershell Windows
 $env:ISAACUS_API_KEY="your_api_key_here"
 ```
 </CodeGroup>

--- a/src/oss/python/integrations/vectorstores/elasticsearch.mdx
+++ b/src/oss/python/integrations/vectorstores/elasticsearch.mdx
@@ -422,7 +422,7 @@ db = ElasticsearchStore(
     strategy=DenseVectorStrategy(model_id="sentence-transformers__all-minilm-l6-v2"),
 )
 
-# Setup a Ingest Pipeline to perform the embedding
+# Setup an Ingest Pipeline to perform the embedding
 # of the text field
 db.client.ingest.put_pipeline(
     id="test_pipeline",


### PR DESCRIPTION
"Setup a Ingest Pipeline" -> "Setup an Ingest Pipeline". "Ingest" starts
with a vowel sound, so the article should be "an".

Docs only, no functional changes.