### PR TITLE
Docs/fix article chroma ai native

### DIFF
--- a/src/oss/python/integrations/providers/isaacus.mdx
+++ b/src/oss/python/integrations/providers/isaacus.mdx
@@ -27,10 +27,10 @@ uv add langchain-isaacus
 
 You should then set your `ISAACUS_API_KEY` environment variable to your Isaacus API key.
 <CodeGroup>
-```bash bash
+```bash macOS/Linux
 export ISAACUS_API_KEY="your_api_key_here"
 ```
-```powershell powershell
+```powershell Windows
 $env:ISAACUS_API_KEY="your_api_key_here"
 ```
 </CodeGroup>

--- a/src/oss/python/integrations/vectorstores/chroma.mdx
+++ b/src/oss/python/integrations/vectorstores/chroma.mdx
@@ -5,7 +5,7 @@ description: "Integrate with the Chroma vector store using LangChain Python."
 
 This notebook covers how to get started with the `Chroma` vector store.
 
->[Chroma](https://docs.trychroma.com/getting-started) is a AI-native open-source vector database focused on developer productivity and happiness. Chroma is licensed under Apache 2.0. View the full docs of `Chroma` at [this page](https://docs.trychroma.com/reference/py-collection), and find the API reference for the LangChain integration at [this page](https://reference.langchain.com/python/langchain-chroma/vectorstores/Chroma).
+>[Chroma](https://docs.trychroma.com/getting-started) is an AI-native open-source vector database focused on developer productivity and happiness. Chroma is licensed under Apache 2.0. View the full docs of `Chroma` at [this page](https://docs.trychroma.com/reference/py-collection), and find the API reference for the LangChain integration at [this page](https://reference.langchain.com/python/langchain-chroma/vectorstores/Chroma).
 
 <Info>
 **Chroma Cloud**


### PR DESCRIPTION
"is a AI-native open-source vector database" -> "is an AI-native
open-source vector database". "AI" starts with a vowel sound, so the
article should be "an".

Docs only, no functional changes.