### PR TITLE
Docs/fix article lambda agent

### DIFF
--- a/src/oss/javascript/integrations/tools/lambda_agent.mdx
+++ b/src/oss/javascript/integrations/tools/lambda_agent.mdx
@@ -7,7 +7,7 @@ Full docs here: https://docs.aws.amazon.com/lambda/index.html
 
 **AWS Lambda** is a serverless computing service provided by Amazon Web Services (AWS), designed to allow developers to build and run applications and services without the need for provisioning or managing servers. This serverless architecture enables you to focus on writing and deploying code, while AWS automatically takes care of scaling, patching, and managing the infrastructure required to run your applications.
 
-By including a AWSLambda in the list of tools provided to an Agent, you can grant your Agent the ability to invoke code running in your AWS Cloud for whatever purposes you need.
+By including an AWSLambda in the list of tools provided to an Agent, you can grant your Agent the ability to invoke code running in your AWS Cloud for whatever purposes you need.
 
 When an Agent uses the AWSLambda tool, it will provide an argument of type `string` which will in turn be passed into the Lambda function via the `event` parameter.
 
@@ -38,7 +38,7 @@ const emailSenderTool = new AWSLambda({
   description:
     "Sends an email with the specified content to testing123@gmail.com",
   region: "us-east-1", // optional: AWS region in which the function is deployed
-  accessKeyId: "abc123", // optional: access key id for a IAM user with invoke permissions
+  accessKeyId: "abc123", // optional: access key id for an IAM user with invoke permissions
   secretAccessKey: "xyz456", // optional: secret access key for that IAM user
   functionName: "SendEmailViaSES", // the function name as seen in AWS Console
 });

--- a/src/oss/python/integrations/providers/isaacus.mdx
+++ b/src/oss/python/integrations/providers/isaacus.mdx
@@ -27,10 +27,10 @@ uv add langchain-isaacus
 
 You should then set your `ISAACUS_API_KEY` environment variable to your Isaacus API key.
 <CodeGroup>
-```bash bash
+```bash macOS/Linux
 export ISAACUS_API_KEY="your_api_key_here"
 ```
-```powershell powershell
+```powershell Windows
 $env:ISAACUS_API_KEY="your_api_key_here"
 ```
 </CodeGroup>


### PR DESCRIPTION
Two article fixes in the same file:
- "a AWSLambda" -> "an AWSLambda"
- "a IAM user" -> "an IAM user"

Both "AWS" and "IAM" are read as letters and start with a vowel sound,
so they take "an".

Docs only, no functional changes.