### PR TITLE
Docs/fix article open agent spec

### DIFF
--- a/src/oss/python/integrations/providers/isaacus.mdx
+++ b/src/oss/python/integrations/providers/isaacus.mdx
@@ -27,10 +27,10 @@ uv add langchain-isaacus
 
 You should then set your `ISAACUS_API_KEY` environment variable to your Isaacus API key.
 <CodeGroup>
-```bash bash
+```bash macOS/Linux
 export ISAACUS_API_KEY="your_api_key_here"
 ```
-```powershell powershell
+```powershell Windows
 $env:ISAACUS_API_KEY="your_api_key_here"
 ```
 </CodeGroup>

--- a/src/oss/python/integrations/providers/open_agent_spec.mdx
+++ b/src/oss/python/integrations/providers/open_agent_spec.mdx
@@ -24,7 +24,7 @@ The following example shows the creation of a simple Agent Spec Agent and its co
 Starting from the Agent Spec Agent creation:
 
 ```python
-# Create a Agent Spec agent
+# Create an Agent Spec agent
 from pyagentspec.agent import Agent
 from pyagentspec.llms.openaicompatibleconfig import OpenAiCompatibleConfig
 from pyagentspec.property import FloatProperty


### PR DESCRIPTION
"# Create a Agent Spec agent" -> "# Create an Agent Spec agent".
"Agent" starts with a vowel sound, so the article should be "an".

Docs only, no functional changes.