### PR TITLE
Docs/fix article ibm watsonx

### DIFF
--- a/src/oss/python/integrations/chat/ibm_watsonx.mdx
+++ b/src/oss/python/integrations/chat/ibm_watsonx.mdx
@@ -187,7 +187,7 @@ human = "{input}"
 prompt = ChatPromptTemplate.from_messages([("system", system), ("human", human)])
 ```
 
-Provide a inputs and run the chain.
+Provide inputs and run the chain.
 
 ```python
 chain = prompt | chat

--- a/src/oss/python/integrations/providers/isaacus.mdx
+++ b/src/oss/python/integrations/providers/isaacus.mdx
@@ -27,10 +27,10 @@ uv add langchain-isaacus
 
 You should then set your `ISAACUS_API_KEY` environment variable to your Isaacus API key.
 <CodeGroup>
-```bash bash
+```bash macOS/Linux
 export ISAACUS_API_KEY="your_api_key_here"
 ```
-```powershell powershell
+```powershell Windows
 $env:ISAACUS_API_KEY="your_api_key_here"
 ```
 </CodeGroup>


### PR DESCRIPTION
"Provide a inputs and run the chain." -> "Provide inputs and run the
chain." "Inputs" is plural, so it doesn't take an indefinite article.

Docs only, no functional changes.