### PR TITLE
docs: add current date to calendar agent prompts

### DIFF
--- a/src/oss/langchain/multi-agent/subagents-personal-assistant.mdx
+++ b/src/oss/langchain/multi-agent/subagents-personal-assistant.mdx
@@ -225,10 +225,13 @@ The calendar agent understands natural language scheduling requests and translat
 
 :::python
 ```python
+from datetime import date
+
 from langchain.agents import create_agent
 
 
 CALENDAR_AGENT_PROMPT = (
+    f"Today's date is {date.today().isoformat()}. "
     "You are a calendar scheduling assistant. "
     "Parse natural language scheduling requests (e.g., 'next Tuesday at 2pm') "
     "into proper ISO datetime formats. "
@@ -250,7 +253,15 @@ calendar_agent = create_agent(
 ```typescript
 import { createAgent } from "langchain";
 
+const now = new Date();
+const today = [
+  now.getFullYear(),
+  String(now.getMonth() + 1).padStart(2, "0"),
+  String(now.getDate()).padStart(2, "0"),
+].join("-");
+
 const CALENDAR_AGENT_PROMPT = `
+Today's date is ${today}.
 You are a calendar scheduling assistant.
 Parse natural language scheduling requests (e.g., 'next Tuesday at 2pm')
 into proper ISO datetime formats.
@@ -768,6 +779,8 @@ A supervisor agent coordinates specialized sub-agents (calendar and email)
 that are wrapped as tools.
 """
 
+from datetime import date
+
 from langchain.tools import tool
 from langchain.agents import create_agent
 from langchain.chat_models import init_chat_model
@@ -819,6 +832,7 @@ calendar_agent = create_agent(
     model,
     tools=[create_calendar_event, get_available_time_slots],
     system_prompt=(
+        f"Today's date is {date.today().isoformat()}. "
         "You are a calendar scheduling assistant. "
         "Parse natural language scheduling requests (e.g., 'next Tuesday at 2pm') "
         "into proper ISO datetime formats. "
@@ -1000,10 +1014,18 @@ const llm = new ChatAnthropic({
   model: "gpt-5.5",
 });
 
+const now = new Date();
+const today = [
+  now.getFullYear(),
+  String(now.getMonth() + 1).padStart(2, "0"),
+  String(now.getDate()).padStart(2, "0"),
+].join("-");
+
 const calendarAgent = createAgent({
   model: llm,
   tools: [createCalendarEvent, getAvailableTimeSlots],
   systemPrompt: `
+Today's date is ${today}.
 You are a calendar scheduling assistant.
 Parse natural language scheduling requests (e.g., 'next Tuesday at 2pm')
 into proper ISO datetime formats.


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

Add the runtime date to the Python and TypeScript calendar-agent prompts so relative scheduling requests such as "next Tuesday" are grounded in the current date instead of model knowledge.

## Type of change

**Type:** Update existing documentation / Fix bug

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue: Fixes langchain-ai/langchain#39074
- Feature PR: N/A

<!-- For LangChain employees, if applicable: -->
- Linear issue: N/A
- Slack thread: N/A

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->

- `make lint_prose VALE_BIN=/opt/homebrew/bin/vale FILES="src/oss/langchain/multi-agent/subagents-personal-assistant.mdx"` passes with no findings.
- The changed Python and TypeScript date/prompt construction was executed locally with `python3` and `node`.
- The full examples require configured model credentials and were not executed.
- This change was prepared with AI-agent assistance and reviewed and tested by the submitter.
