### PR TITLE
Use models that support embeddings; fix for #5109

### DIFF
--- a/src/oss/python/integrations/vectorstores/index.mdx
+++ b/src/oss/python/integrations/vectorstores/index.mdx
@@ -208,7 +208,7 @@ pip install -qU langchain-ollama
 ```python
 from langchain_ollama import OllamaEmbeddings
 
-embeddings = OllamaEmbeddings(model="llama3")
+embeddings = OllamaEmbeddings(model="nomic-embed-text")
 ```
 </Accordion>
 <Accordion title="Cohere">


### PR DESCRIPTION
## Overview

Per #5109, this code example needs a model that supports embeddings. This PR changes the example from `llama3` (a chat model) to `nomic-embed-text`. This seems to work; my updated example code is here:

https://github.com/timothymcmackin/langchain-test/blob/5ad44990804c8193e67ac533cce41c3f5d8a057a/langchain-semantic-tutorial.py


## Type of change

**Type:** Update existing documentation 

## Related issues/PRs

Resolves #5109.

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [X] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [X] I have tested my changes locally using `docs dev`
- [X] All code examples have been tested and work correctly
- [X] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
