### PR TITLE
LSE-2643: document prebuilt evaluator templates

### DIFF
--- a/src/langsmith/evaluators.mdx
+++ b/src/langsmith/evaluators.mdx
@@ -53,6 +53,89 @@ You can create an evaluator in the [LangSmith UI](https://smith.langchain.com) o
      | Image Evaluations | Evaluate image content quality and safety. |
      | Voice Evaluation | Evaluate voice and audio interaction quality. |
 
+     See the template details below.
+
+#### Prebuilt evaluator templates
+
+Prebuilt evaluator templates help you create common evaluators without starting from scratch. Each template is a starting point: edit the evaluator prompt and scoring schema before saving it to your workspace.
+
+**Security**
+
+Security templates detect leaks, injections, and adversarial inputs.
+
+| Template | What it scores |
+|----------|----------------|
+| PII Leakage | Whether inputs or outputs contain PII or privacy violations. |
+| Prompt Injection | Whether inputs contain prompt injection attempts. |
+| Code Injection | Whether inputs contain code injection attempts. |
+
+**Safety**
+
+Safety templates evaluate content safety and moderation.
+
+| Template | What it scores |
+|----------|----------------|
+| Toxicity | Whether outputs contain toxic elements, such as personal attacks or hate speech. |
+| Bias & Fairness | Whether outputs contain biased or unfair content. This template produces a `fairness` score. |
+
+**Quality**
+
+Quality templates measure output quality and accuracy.
+
+| Template | What it scores |
+|----------|----------------|
+| Hallucination | Whether an answer contains hallucinated facts or other information not supported by the input context. |
+| Correctness | Whether an answer is factually correct and complete compared with the reference output. |
+| Assertions | Whether the output satisfies every assertion in the reference output. This template produces an `assertions_passed` score. |
+| Conciseness | How efficiently the output conveys the required information without unnecessary elements. |
+| Code Checker | Whether the code solution correctly and completely solves the given problem. |
+| Answer Relevance | Whether the output answer is focused and directly addresses the original input question. |
+| Exact Match | Whether the output exactly matches the expected answer. |
+
+**Conversation**
+
+Conversation templates evaluate conversational quality and user experience.
+
+| Template | What it scores |
+|----------|----------------|
+| Perceived Error | Whether the user perceived the agent as making an error or going in the wrong direction. |
+| Language | The primary language used in a conversation. |
+| Support Intent | The primary intent of a support conversation, such as account and billing, order management, technical support, product inquiry, policy inquiry, status check, complaint and feedback, escalation, or other. |
+| User Satisfaction | Overall user satisfaction throughout a conversation. |
+| Tone | Whether the AI maintained an appropriate and consistent tone. This template produces an `agent_tone` score. |
+| Task Completion | Whether the agent fully completed all user requests. |
+| Knowledge Retention | Whether the agent retained and applied facts from earlier in the conversation. |
+
+**Trajectory**
+
+Trajectory templates evaluate agent tool use and decision paths.
+
+| Template | What it scores |
+|----------|----------------|
+| Plan Adherence | Whether an agent followed its declared plan during execution. |
+| Tool Selection | Whether the agent selected the right tools, including tool choice accuracy, order, and efficiency. |
+| Trajectory Accuracy | Whether the agent took a logical, progressive, and efficient path. |
+
+**Image**
+
+Image templates evaluate image content quality and safety.
+
+| Template | What it scores |
+|----------|----------------|
+| Explicit Content | Whether an image contains explicit or inappropriate content, such as nudity, sexual content, or graphic violence. |
+| Sensitive Imagery | Whether an image contains sensitive or potentially harmful content, such as harmful, offensive, or inappropriate symbols or depictions. |
+
+**Voice**
+
+Voice templates evaluate voice and audio interaction quality.
+
+| Template | What it scores |
+|----------|----------------|
+| Audio Quality | Whether audio contains clipping, distortion, or glitches that degrade the listening experience. |
+| Transcription Accuracy | Whether a transcription accurately reflects the spoken content. |
+| User Interrupts | Whether the agent handled user interruptions gracefully. |
+| Vocal Affect | Whether the agent's vocal affect was appropriate and natural. |
+
 You can also add an evaluator directly from a [tracing project](/langsmith/observability-concepts#projects) or [dataset](/langsmith/evaluation-concepts#datasets). In that flow, you can additionally **attach an existing evaluator** from your workspace, or create a [Composite](/langsmith/composite-evaluators-ui) evaluator. Refer to [Set up LLM-as-a-judge online evaluators](/langsmith/online-evaluations-llm-as-judge) and [Automatically run evaluators on experiments](/langsmith/bind-evaluator-to-dataset).
 
 ### Create an evaluator with the SDK


### PR DESCRIPTION
## Overview
Adds more detail to the existing LangSmith evaluator management docs about what each prebuilt evaluator template scores. The new section is nested under the “Create an evaluator in the UI” flow and organizes templates by category.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- Linear issue: LSE-2643 
- 
## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
None 
