### PR TITLE
docs: add CKG (Compact Knowledge Graph) retriever integration

### DIFF
--- a/src/oss/python/integrations/providers/ckg.mdx
+++ b/src/oss/python/integrations/providers/ckg.mdx
@@ -1,0 +1,99 @@
+---
+title: "CKG (Compact Knowledge Graph)"
+description: "Integrate with Compact Knowledge Graphs (CKG) using LangChain Python."
+---
+
+## Overview
+
+[Graphify.md](https://graphifymd.com) builds **Compact Knowledge Graphs (CKGs)**—structured, typed dependency graphs of domain concepts served over MCP. CKGs replace vector-search retrieval with deterministic graph traversal. Every node carries a SHA-256 source hash for full audit provenance.
+
+**Benchmark (ckg-benchmark v0.6.2, 97 domains):**
+
+| System | Macro F1 | Tokens/query |
+|--------|:--------:|:------------:|
+| **CKG** | **0.471** | **269** |
+| RAG | 0.123 | 2,982 |
+| GraphRAG | 0.120 | 3,450 |
+
+97 domains available including NVIDIA AI, NemoClaw, Salesforce AgentForce, Nemotron, and Perplexity.
+
+## Installation and setup
+
+<CodeGroup>
+```bash pip
+pip install langchain-ckg
+```
+
+```bash uv
+uv add langchain-ckg
+```
+</CodeGroup>
+
+## Retrievers
+
+`CKGRetriever` implements `BaseRetriever` and traverses a CKG domain graph — returning prerequisite and dependent concept chains as structured `Document` objects.
+
+```python
+from langchain_ckg import CKGRetriever
+
+retriever = CKGRetriever(domain="nvidia-nemoclaw", depth=3)
+docs = retriever.invoke("CUDA kernel fusion")
+```
+
+### Parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `domain` | `str` | required | CKG domain name. See [available domains](https://pypi.org/project/ckg-mcp/). |
+| `depth` | `int` | `3` | Prerequisite traversal hops (1–5). |
+| `k` | `int` | `5` | Max concept matches returned. |
+
+### Use with RetrievalQA
+
+```python
+from langchain_ckg import CKGRetriever
+from langchain_openai import ChatOpenAI
+from langchain.chains import RetrievalQA
+
+retriever = CKGRetriever(domain="nvidia-nemoclaw", depth=3)
+qa = RetrievalQA.from_chain_type(llm=ChatOpenAI(), retriever=retriever)
+result = qa.invoke("How does NemoClaw handle CUDA kernel fusion?")
+```
+
+### Use in LCEL
+
+```python
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnablePassthrough
+from langchain_openai import ChatOpenAI
+from langchain_ckg import CKGRetriever
+
+retriever = CKGRetriever(domain="nvidia-nemoclaw", depth=3)
+
+prompt = ChatPromptTemplate.from_template(
+    "Answer using only this context:\n{context}\n\nQuestion: {question}"
+)
+
+chain = (
+    {"context": retriever, "question": RunnablePassthrough()}
+    | prompt
+    | ChatOpenAI()
+    | StrOutputParser()
+)
+
+chain.invoke("What are the prerequisites for NemoClaw kernel fusion?")
+```
+
+### Hosted retriever
+
+`CKGHostedRetriever` hits a managed endpoint with a rate-gate. Free: 50 calls/day. Upgrade at [graphifymd.com/pricing](https://graphifymd.com/pricing).
+
+```python
+from langchain_ckg import CKGHostedRetriever
+
+retriever = CKGHostedRetriever(
+    domain="nvidia-nemoclaw",
+    license_key="your-license-key",  # optional, unlocks unlimited calls
+)
+```

--- a/src/oss/python/integrations/providers/ckg.mdx
+++ b/src/oss/python/integrations/providers/ckg.mdx
@@ -15,7 +15,7 @@ description: "Integrate with Compact Knowledge Graphs (CKG) using LangChain Pyth
 | RAG | 0.123 | 2,982 |
 | GraphRAG | 0.120 | 3,450 |
 
-97 domains available including NVIDIA AI, NemoClaw, Salesforce AgentForce, Nemotron, and Perplexity.
+97 domains are available, including NVIDIA AI, NemoClaw, Salesforce AgentForce, Nemotron, and Perplexity.
 
 ## Installation and setup
 
@@ -31,7 +31,7 @@ uv add langchain-ckg
 
 ## Retrievers
 
-`CKGRetriever` implements `BaseRetriever` and traverses a CKG domain graph — returning prerequisite and dependent concept chains as structured `Document` objects.
+`CKGRetriever` implements `BaseRetriever` and traverses a CKG domain graph, returning prerequisite and dependent concept chains as structured `Document` objects.
 
 ```python
 from langchain_ckg import CKGRetriever
@@ -48,26 +48,14 @@ docs = retriever.invoke("CUDA kernel fusion")
 | `depth` | `int` | `3` | Prerequisite traversal hops (1–5). |
 | `k` | `int` | `5` | Max concept matches returned. |
 
-### Use with RetrievalQA
-
-```python
-from langchain_ckg import CKGRetriever
-from langchain_openai import ChatOpenAI
-from langchain.chains import RetrievalQA
-
-retriever = CKGRetriever(domain="nvidia-nemoclaw", depth=3)
-qa = RetrievalQA.from_chain_type(llm=ChatOpenAI(), retriever=retriever)
-result = qa.invoke("How does NemoClaw handle CUDA kernel fusion?")
-```
-
 ### Use in LCEL
 
 ```python
 from langchain_core.output_parsers import StrOutputParser
 from langchain_core.prompts import ChatPromptTemplate
 from langchain_core.runnables import RunnablePassthrough
-from langchain_openai import ChatOpenAI
 from langchain_ckg import CKGRetriever
+from langchain_openai import ChatOpenAI
 
 retriever = CKGRetriever(domain="nvidia-nemoclaw", depth=3)
 
@@ -87,13 +75,44 @@ chain.invoke("What are the prerequisites for NemoClaw kernel fusion?")
 
 ### Hosted retriever
 
-`CKGHostedRetriever` hits a managed endpoint with a rate-gate. Free: 50 calls/day. Upgrade at [graphifymd.com/pricing](https://graphifymd.com/pricing).
+`CKGHostedRetriever` queries a managed endpoint. A free tier is available; see [graphifymd.com/pricing](https://graphifymd.com/pricing) for upgrade options.
 
 ```python
 from langchain_ckg import CKGHostedRetriever
 
 retriever = CKGHostedRetriever(
     domain="nvidia-nemoclaw",
-    license_key="your-license-key",  # optional, unlocks unlimited calls
+    license_key="your-license-key",  # optional — unlocks unlimited calls
 )
+docs = retriever.invoke("NIM inference server architecture")
 ```
+
+#### Autonomous payment with x402
+
+`CKGHostedRetriever` supports autonomous USDC payment on Base L2 via the [x402 protocol](https://x402.org). When the endpoint returns a `402 Payment Required` response, the retriever signs a payment and retries automatically—no human approval required.
+
+<Note>
+Autonomous payment requires `pip install 'langchain-ckg[x402]'`.
+</Note>
+
+```python
+from langchain_ckg import CKGHostedRetriever
+
+retriever = CKGHostedRetriever(
+    domain="nvidia-nemoclaw",
+    x402_private_key="0x...",  # Base L2 EVM key — signs USDC payments on 402
+)
+docs = retriever.invoke("NIM inference server architecture")
+```
+
+#### Hosted retriever parameters
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `endpoint` | `str` | `"https://ckg-nvidia-ai.onrender.com"` | Base URL of the hosted CKG server. |
+| `domain` | `str` | required | CKG domain name. |
+| `license_key` | `str` | `""` | Polar license key for unlimited access. |
+| `x402_private_key` | `str` | `""` | EVM private key for autonomous USDC payment on Base L2. |
+| `lightning_invoice_id` | `str` | `""` | Pre-paid Lightning invoice ID for sats-based payment. |
+| `depth` | `int` | `3` | Prerequisite traversal hops (1–5). |
+| `k` | `int` | `5` | Max concept matches returned. |

--- a/src/oss/python/integrations/providers/ckg.mdx
+++ b/src/oss/python/integrations/providers/ckg.mdx
@@ -5,7 +5,7 @@ description: "Integrate with Compact Knowledge Graphs (CKG) using LangChain Pyth
 
 ## Overview
 
-[Graphify.md](https://graphifymd.com) builds **Compact Knowledge Graphs (CKGs)**—structured, typed dependency graphs of domain concepts served over MCP. CKGs replace vector-search retrieval with deterministic graph traversal. Every node carries a SHA-256 source hash for full audit provenance.
+[Graphify.md](https://graphifymd.com) builds **Compact Knowledge Graphs (CKGs)**: structured, typed dependency graphs of domain concepts served over MCP. CKGs replace vector-search retrieval with deterministic graph traversal. Every node carries a SHA-256 source hash for full audit provenance.
 
 **Benchmark (ckg-benchmark v0.6.2, 97 domains):**
 
@@ -30,6 +30,8 @@ uv add langchain-ckg
 </CodeGroup>
 
 ## Retrievers
+
+For full retriever documentation, including chain usage and all parameters, see the [CKGRetriever integration page](/oss/integrations/retrievers/ckg).
 
 `CKGRetriever` implements `BaseRetriever` and traverses a CKG domain graph, returning prerequisite and dependent concept chains as structured `Document` objects.
 
@@ -89,7 +91,7 @@ docs = retriever.invoke("NIM inference server architecture")
 
 #### Autonomous payment with x402
 
-`CKGHostedRetriever` supports autonomous USDC payment on Base L2 via the [x402 protocol](https://x402.org). When the endpoint returns a `402 Payment Required` response, the retriever signs a payment and retries automatically—no human approval required.
+`CKGHostedRetriever` supports autonomous USDC payment on Base L2 via the [x402 protocol](https://x402.org). When the endpoint returns a `402 Payment Required` response, the retriever signs a payment and retries automatically. No human approval is required.
 
 <Note>
 Autonomous payment requires `pip install 'langchain-ckg[x402]'`.

--- a/src/oss/python/integrations/providers/ckg.mdx
+++ b/src/oss/python/integrations/providers/ckg.mdx
@@ -5,7 +5,10 @@ description: "Integrate with Compact Knowledge Graphs (CKG) using LangChain Pyth
 
 ## Overview
 
-[Graphify.md](https://graphifymd.com) builds **Compact Knowledge Graphs (CKGs)**: structured, typed dependency graphs of domain concepts served over MCP. CKGs replace vector-search retrieval with deterministic graph traversal. Every node carries a SHA-256 source hash for full audit provenance.
+[Graphify.md](https://graphifymd.com) builds **Compact Knowledge Graphs (CKGs)**:
+structured, typed dependency graphs of domain concepts served over MCP. CKGs
+provide deterministic graph traversal instead of vector-search retrieval. Every
+node carries a SHA-256 source hash for audit provenance.
 
 **Benchmark (ckg-benchmark v0.6.2, 97 domains):**
 
@@ -31,9 +34,12 @@ uv add langchain-ckg
 
 ## Retrievers
 
-For full retriever documentation, including chain usage and all parameters, see the [CKGRetriever integration page](/oss/integrations/retrievers/ckg).
+For full retriever documentation, including chain usage and all parameters,
+see the [CKGRetriever integration page](/oss/integrations/retrievers/ckg).
 
-`CKGRetriever` implements `BaseRetriever` and traverses a CKG domain graph, returning prerequisite and dependent concept chains as structured `Document` objects.
+`CKGRetriever` implements `BaseRetriever` and traverses a CKG domain graph,
+returning prerequisite and dependent concept chains as structured `Document`
+objects.
 
 ```python
 from langchain_ckg import CKGRetriever
@@ -84,14 +90,17 @@ from langchain_ckg import CKGHostedRetriever
 
 retriever = CKGHostedRetriever(
     domain="nvidia-nemoclaw",
-    license_key="your-license-key",  # optional — unlocks unlimited calls
+    license_key="your-license-key",  # optional: unlocks unlimited calls
 )
 docs = retriever.invoke("NIM inference server architecture")
 ```
 
 #### Autonomous payment with x402
 
-`CKGHostedRetriever` supports autonomous USDC payment on Base L2 via the [x402 protocol](https://x402.org). When the endpoint returns a `402 Payment Required` response, the retriever signs a payment and retries automatically. No human approval is required.
+`CKGHostedRetriever` supports autonomous USDC payment on Base L2 via the
+[x402 protocol](https://x402.org). When the endpoint returns a
+`402 Payment Required` response, the retriever signs a payment and retries
+automatically. No human approval is required.
 
 <Note>
 Autonomous payment requires `pip install 'langchain-ckg[x402]'`.
@@ -102,7 +111,7 @@ from langchain_ckg import CKGHostedRetriever
 
 retriever = CKGHostedRetriever(
     domain="nvidia-nemoclaw",
-    x402_private_key="0x...",  # Base L2 EVM key — signs USDC payments on 402
+    x402_private_key="0x...",  # Base L2 EVM key: signs USDC payments on 402
 )
 docs = retriever.invoke("NIM inference server architecture")
 ```

--- a/src/oss/python/integrations/retrievers/ckg.mdx
+++ b/src/oss/python/integrations/retrievers/ckg.mdx
@@ -1,0 +1,145 @@
+---
+title: CKGRetriever integration
+description: Integrate with the CKGRetriever using LangChain Python.
+integration:
+  name: CKGRetriever
+  pypi: langchain-ckg
+  self_host: true
+  cloud_offering: true
+  package_md: '[`langchain-ckg`](https://pypi.org/project/langchain-ckg/)'
+---
+
+`CKGRetriever` and `CKGHostedRetriever` are LangChain retrievers backed by
+[Compact Knowledge Graphs (CKG)](https://graphifymd.com)—pre-built, typed
+dependency graphs of domain concepts. CKG traversal is deterministic: the
+retriever follows declared edges rather than performing vector similarity search.
+Every node carries a SHA-256 source hash for audit provenance.
+
+**Benchmark (ckg-benchmark v0.6.2, 97 domains):**
+
+| System | Macro F1 | Tokens/query |
+|--------|:--------:|:------------:|
+| **CKG** | **0.471** | **269** |
+| RAG | 0.123 | 2,982 |
+| GraphRAG | 0.120 | 3,450 |
+
+## Overview
+
+### Integration details
+
+| Class | Package | Local | Cloud | JS support | Downloads | Version |
+| :--- | :--- | :---: | :---: | :---: | :---: | :---: |
+| `CKGRetriever` | [`langchain-ckg`](https://pypi.org/project/langchain-ckg/) | ✅ | ❌ | ❌ | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_ckg?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain_ckg?style=flat-square&label=%20) |
+| `CKGHostedRetriever` | [`langchain-ckg`](https://pypi.org/project/langchain-ckg/) | ❌ | ✅ | ❌ | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain_ckg?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain_ckg?style=flat-square&label=%20) |
+
+## Setup
+
+### Installation
+
+<CodeGroup>
+```bash pip
+pip install langchain-ckg
+```
+
+```bash uv
+uv add langchain-ckg
+```
+</CodeGroup>
+
+For autonomous x402 payment support:
+
+```bash
+pip install 'langchain-ckg[x402]'
+```
+
+### Credentials
+
+`CKGRetriever` runs locally and requires no credentials. `CKGHostedRetriever`
+connects to a managed endpoint. A free tier is available; see
+[graphifymd.com/pricing](https://graphifymd.com/pricing) for rate limits and
+upgrade options.
+
+## Instantiation
+
+### Local retriever
+
+```python
+from langchain_ckg import CKGRetriever
+
+retriever = CKGRetriever(domain="nvidia-nemoclaw", depth=3)
+```
+
+### Hosted retriever
+
+```python
+from langchain_ckg import CKGHostedRetriever
+
+retriever = CKGHostedRetriever(
+    domain="nvidia-nemoclaw",
+    license_key="your-license-key",  # optional: unlocks unlimited calls
+)
+```
+
+## Invocation
+
+```python
+docs = retriever.invoke("CUDA kernel fusion")
+for doc in docs:
+    print(doc.page_content)
+```
+
+Each returned `Document` contains the prerequisite and dependent concept chain
+for a matched node, with source provenance in `metadata`.
+
+## Use within a chain
+
+```python
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.prompts import ChatPromptTemplate
+from langchain_core.runnables import RunnablePassthrough
+from langchain_ckg import CKGRetriever
+from langchain_openai import ChatOpenAI
+
+retriever = CKGRetriever(domain="nvidia-nemoclaw", depth=3)
+
+prompt = ChatPromptTemplate.from_template(
+    "Answer using only this context:\n{context}\n\nQuestion: {question}"
+)
+
+chain = (
+    {"context": retriever, "question": RunnablePassthrough()}
+    | prompt
+    | ChatOpenAI()
+    | StrOutputParser()
+)
+
+chain.invoke("What are the prerequisites for NemoClaw kernel fusion?")
+```
+
+## Parameters
+
+### CKGRetriever
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `domain` | `str` | required | CKG domain name. Run `uvx ckg-mcp list_domains` to see all available domains. |
+| `depth` | `int` | `3` | Upstream prerequisite hops to traverse (1-5). |
+| `k` | `int` | `5` | Maximum number of concept matches to return. |
+
+### CKGHostedRetriever
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `endpoint` | `str` | `"https://ckg-nvidia-ai.onrender.com"` | Base URL of the hosted CKG server. |
+| `domain` | `str` | required | CKG domain name. |
+| `license_key` | `str` | `""` | License key for unlimited access. |
+| `x402_private_key` | `str` | `""` | EVM private key for autonomous USDC payment on Base L2 when a 402 is received. |
+| `lightning_invoice_id` | `str` | `""` | Pre-paid Lightning invoice ID. |
+| `depth` | `int` | `3` | Prerequisite traversal hops (1-5). |
+| `k` | `int` | `5` | Max concept matches. |
+
+## Related topics
+
+- [CKG provider page](/oss/integrations/providers/ckg)
+- [langchain-ckg on PyPI](https://pypi.org/project/langchain-ckg/)
+- [ckg-benchmark results](https://github.com/Yarmoluk/ckg-benchmark/blob/main/paper/main.pdf)

--- a/src/oss/python/integrations/retrievers/ckg.mdx
+++ b/src/oss/python/integrations/retrievers/ckg.mdx
@@ -10,7 +10,7 @@ integration:
 ---
 
 `CKGRetriever` and `CKGHostedRetriever` are LangChain retrievers backed by
-[Compact Knowledge Graphs (CKG)](https://graphifymd.com): pre-built, typed
+[Compact Knowledge Graphs (CKG)](https://graphifymd.com): prebuilt, typed
 dependency graphs of domain concepts. CKG traversal is deterministic. The
 retriever follows declared edges rather than performing vector similarity search.
 Every node carries a SHA-256 source hash for audit provenance.

--- a/src/oss/python/integrations/retrievers/ckg.mdx
+++ b/src/oss/python/integrations/retrievers/ckg.mdx
@@ -10,8 +10,8 @@ integration:
 ---
 
 `CKGRetriever` and `CKGHostedRetriever` are LangChain retrievers backed by
-[Compact Knowledge Graphs (CKG)](https://graphifymd.com)—pre-built, typed
-dependency graphs of domain concepts. CKG traversal is deterministic: the
+[Compact Knowledge Graphs (CKG)](https://graphifymd.com): pre-built, typed
+dependency graphs of domain concepts. CKG traversal is deterministic. The
 retriever follows declared edges rather than performing vector similarity search.
 Every node carries a SHA-256 source hash for audit provenance.
 
@@ -55,7 +55,7 @@ pip install 'langchain-ckg[x402]'
 ### Credentials
 
 `CKGRetriever` runs locally and requires no credentials. `CKGHostedRetriever`
-connects to a managed endpoint. A free tier is available; see
+connects to a managed endpoint. A free tier is available. See
 [graphifymd.com/pricing](https://graphifymd.com/pricing) for rate limits and
 upgrade options.
 
@@ -122,7 +122,7 @@ chain.invoke("What are the prerequisites for NemoClaw kernel fusion?")
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
-| `domain` | `str` | required | CKG domain name. Run `uvx ckg-mcp list_domains` to see all available domains. |
+| `domain` | `str` | required | CKG domain name. Run `uvx ckg-mcp list_domains` to list available domains. |
 | `depth` | `int` | `3` | Upstream prerequisite hops to traverse (1-5). |
 | `k` | `int` | `5` | Maximum number of concept matches to return. |
 
@@ -133,7 +133,7 @@ chain.invoke("What are the prerequisites for NemoClaw kernel fusion?")
 | `endpoint` | `str` | `"https://ckg-nvidia-ai.onrender.com"` | Base URL of the hosted CKG server. |
 | `domain` | `str` | required | CKG domain name. |
 | `license_key` | `str` | `""` | License key for unlimited access. |
-| `x402_private_key` | `str` | `""` | EVM private key for autonomous USDC payment on Base L2 when a 402 is received. |
+| `x402_private_key` | `str` | `""` | EVM private key for autonomous USDC payment on Base L2. |
 | `lightning_invoice_id` | `str` | `""` | Pre-paid Lightning invoice ID. |
 | `depth` | `int` | `3` | Prerequisite traversal hops (1-5). |
 | `k` | `int` | `5` | Max concept matches. |

--- a/src/oss/python/integrations/retrievers/index.mdx
+++ b/src/oss/python/integrations/retrievers/index.mdx
@@ -22,6 +22,7 @@ The below retrievers allow you to index and search a custom corpus of documents.
 
 | Retriever | Self-host | Cloud offering | Package |
 |-----------|-----------|----------------|---------|
+| [`CKGRetriever`](/oss/integrations/retrievers/ckg) | ✅ | ✅ | [`langchain-ckg`](https://pypi.org/project/langchain-ckg/) |
 | [`AmazonKnowledgeBasesRetriever`](/oss/integrations/retrievers/bedrock) | ❌ | ✅ | [`langchain-aws`](https://reference.langchain.com/python/langchain-aws/retrievers/bedrock/AmazonKnowledgeBasesRetriever) |
 | [`ElasticsearchRetriever`](/oss/integrations/retrievers/elasticsearch_retriever) | ✅ | ✅ | [`langchain-elasticsearch`](https://reference.langchain.com/python/langchain-elasticsearch/retrievers/ElasticsearchRetriever) |
 | [`NVIDIARAGRetriever`](/oss/integrations/retrievers/nvidia) | ✅ | ❌ | [`langchain-nvidia-ai-endpoints`](https://reference.langchain.com/python/langchain-nvidia-ai-endpoints/retrievers/NVIDIARAGRetriever) |


### PR DESCRIPTION
## Summary

Adds a provider page and overview table entry for [`langchain-ckg`](https://pypi.org/project/langchain-ckg/) — a LangChain `BaseRetriever` backed by Compact Knowledge Graphs (CKG).

### What is CKG?

CKGs are pre-built, structured dependency graphs of domain concepts — a deterministic alternative to vector search retrieval. Every node carries a SHA-256 source hash for audit provenance.

**Benchmark results (ckg-benchmark v0.6.2, 97 domains):**

| System | Macro F1 | Tokens/query |
|--------|:--------:|:------------:|
| **CKG** | **0.471** | **269** |
| RAG | 0.123 | 2,982 |
| GraphRAG | 0.120 | 3,450 |

### Changes

- `src/oss/python/integrations/providers/ckg.mdx` — new provider page with installation, LCEL usage example, hosted retriever docs, and x402 autonomous payment
- `src/oss/python/integrations/providers/overview.mdx` — added row to the providers table alongside `langchain-graph-retriever`

### Package

- PyPI: https://pypi.org/project/langchain-ckg/
- GitHub: https://github.com/Yarmoluk/langchain-ckg
- Implements `BaseRetriever` from `langchain-core`
- 97 domains available including NVIDIA AI, NemoClaw, Salesforce AgentForce