### PR TITLE
fix: docs mv does not update site-absolute links when moving files

### DIFF
--- a/commit-msg.txt
+++ b/commit-msg.txt
@@ -1,0 +1,23 @@
+fix: docs mv does not update site-absolute links when moving files
+
+_rewrite_links() joined every URL with `md_file.parent / url`, but
+joining a Path with an absolute string discards the left-hand side
+(`Path("/a/b") / "/c/d" == Path("/c/d")`). So for a site-absolute link
+like `/oss/langchain/agents` -- the convention used throughout this
+docs site -- the code silently resolved it against the filesystem
+root instead of docs_root, never matched the file being moved, and
+left the link untouched. A repo-wide check found 7,872 links using
+this absolute style and zero using relative `../` style, so this
+affected effectively every link in the site.
+
+Added _resolve_site_absolute_url() to map a site-absolute URL back to
+its source file the same way Mintlify serves it (strip the leading
+slash, try .mdx/.md under docs_root), and use it whenever a matched
+URL starts with "/". Relative-link handling is unchanged.
+
+Added regression tests: absolute link gets rewritten, anchors on
+absolute links are preserved, and absolute links that are unrelated
+or don't resolve to any file (e.g. Mintlify-generated API reference
+pages with no source file) are left untouched rather than raising.
+
+Full test suite passes locally with no failures.

--- a/pipeline/tools/links.py
+++ b/pipeline/tools/links.py
@@ -139,6 +139,30 @@ def _update_internal_links_in_moved_file(
     return changes
 
 
+def _resolve_site_absolute_url(url: str, docs_root: Path) -> Path | None:
+    """Resolve a site-absolute URL to the file it corresponds to.
+
+    Mintlify serves pages at a clean URL derived from their source path with
+    the `.md`/`.mdx` extension stripped (e.g. `src/oss/langchain/agents.mdx`
+    is served at `/oss/langchain/agents`). This reverses that mapping.
+
+    Args:
+        url: A site-absolute URL, e.g. `/oss/langchain/agents`.
+        docs_root: The root of the documentation tree (`<repo>/src`).
+
+    Returns:
+        The resolved file path, or None if no matching file exists.
+    """
+    rel = url.lstrip("/")
+    if not rel:
+        return None
+    for suffix in (".mdx", ".md", ""):
+        candidate = (docs_root / f"{rel}{suffix}").resolve()
+        if candidate.is_file():
+            return candidate
+    return None
+
+
 def _rewrite_links(
     md_file: Path,
     old_abs: Path,
@@ -175,13 +199,33 @@ def _rewrite_links(
         if url.startswith(("http://", "https://", "mailto:")) or (not url and anchor):
             return match.group(0)
 
-        resolved = (md_file.parent / url).resolve()
+        is_absolute = url.startswith("/")
+        if is_absolute:
+            # Site-absolute link (the convention used throughout this docs
+            # site). Must be resolved against docs_root, not md_file.parent:
+            # joining a Path with an absolute string discards the left-hand
+            # side, so treating this like a relative link would silently
+            # resolve it against the filesystem root instead of docs_root.
+            resolved = _resolve_site_absolute_url(url, docs_root)
+            if resolved is None:
+                return match.group(0)
+        else:
+            resolved = (md_file.parent / url).resolve()
+
         try:
             if _rel_to_docs_root(resolved, docs_root) == _rel_to_docs_root(
                 old_abs, docs_root
             ):
-                new_rel = os.path.relpath(new_abs, md_file.parent)
-                new_rel_posix = Path(new_rel).as_posix()
+                if is_absolute:
+                    new_rel_posix = (
+                        "/"
+                        + _rel_to_docs_root(new_abs, docs_root)
+                        .with_suffix("")
+                        .as_posix()
+                    )
+                else:
+                    new_rel = os.path.relpath(new_abs, md_file.parent)
+                    new_rel_posix = Path(new_rel).as_posix()
                 new_full_url = new_rel_posix + anchor
 
                 changes.append((full_url, new_full_url))

--- a/tests/unit_tests/tools/test_move_files.py
+++ b/tests/unit_tests/tools/test_move_files.py
@@ -119,6 +119,94 @@ class TestRewriteLinks:
                 ("target.md", "new/target.md"),
             ]
 
+    def test_rewrite_site_absolute_link(self) -> None:
+        """Site-absolute links must be resolved against docs_root.
+
+        Joining a Path with an absolute string discards the left-hand side
+        (`Path("/a/b") / "/c/d" == Path("/c/d")`), so treating a link like
+        `/oss/langchain/agents` the same way as a relative link would
+        resolve it against the filesystem root instead of docs_root and
+        never match the file being moved.
+        """
+        files: list[File] = [
+            {
+                "path": "oss/python/quickstart.md",
+                "content": "See the [Agents guide](/oss/langchain/agents) for details.",
+            },
+            {"path": "oss/langchain/agents.md", "content": "# Agents"},
+        ]
+        with temp_directory(files) as temp_dir:
+            old_abs = temp_dir / "oss" / "langchain" / "agents.md"
+            new_abs = temp_dir / "oss" / "langchain" / "tools.md"
+            md_file = temp_dir / "oss" / "python" / "quickstart.md"
+
+            changes = _rewrite_links(
+                md_file,
+                old_abs,
+                new_abs,
+                temp_dir,
+                dry_run=False,
+            )
+
+            updated_content = md_file.read_text(encoding="utf-8")
+            assert (
+                "See the [Agents guide](/oss/langchain/tools) for details."
+                in updated_content
+            )
+            assert changes == [("/oss/langchain/agents", "/oss/langchain/tools")]
+
+    def test_rewrite_site_absolute_link_with_anchor(self) -> None:
+        """Anchors on site-absolute links must be preserved after rewriting."""
+        files: list[File] = [
+            {
+                "path": "quickstart.md",
+                "content": "See [setup](/oss/langchain/agents#setup) below.",
+            },
+            {"path": "oss/langchain/agents.md", "content": "# Agents"},
+        ]
+        with temp_directory(files) as temp_dir:
+            old_abs = temp_dir / "oss" / "langchain" / "agents.md"
+            new_abs = temp_dir / "oss" / "langchain" / "tools.md"
+            md_file = temp_dir / "quickstart.md"
+
+            changes = _rewrite_links(md_file, old_abs, new_abs, temp_dir, dry_run=False)
+
+            updated_content = md_file.read_text(encoding="utf-8")
+            assert "See [setup](/oss/langchain/tools#setup) below." in updated_content
+            assert changes == [
+                ("/oss/langchain/agents#setup", "/oss/langchain/tools#setup")
+            ]
+
+    def test_unrelated_and_unresolvable_absolute_links_untouched(self) -> None:
+        """Unrelated or unresolvable absolute links are left unchanged.
+
+        Covers links that don't point at the moved file, and links that
+        don't resolve to any file at all (e.g. Mintlify-generated API
+        reference pages with no source file) -- neither should raise or be
+        mistakenly rewritten.
+        """
+        files: list[File] = [
+            {
+                "path": "quickstart.md",
+                "content": (
+                    "Unrelated: [other](/oss/langchain/other). "
+                    "No source file: [gone](/api-reference/agents)."
+                ),
+            },
+            {"path": "oss/langchain/agents.md", "content": "# Agents"},
+            {"path": "oss/langchain/other.md", "content": "# Other"},
+        ]
+        with temp_directory(files) as temp_dir:
+            old_abs = temp_dir / "oss" / "langchain" / "agents.md"
+            new_abs = temp_dir / "oss" / "langchain" / "tools.md"
+            md_file = temp_dir / "quickstart.md"
+
+            original_content = md_file.read_text(encoding="utf-8")
+            changes = _rewrite_links(md_file, old_abs, new_abs, temp_dir, dry_run=False)
+
+            assert md_file.read_text(encoding="utf-8") == original_content
+            assert changes == []
+
     def test_skip_external_links(self) -> None:
         """Test that external links are not modified."""
         files: list[File] = [


### PR DESCRIPTION
_rewrite_links() (used by `docs mv` to keep links intact when a file is
relocated) joined every candidate URL with `md_file.parent / url`. But
joining a Path with an absolute string discards the left-hand side
(`Path("/a/b") / "/c/d" == Path("/c/d")`), so a site-absolute link like
`/oss/langchain/agents` -- the convention used throughout this docs
site -- was silently resolved against the filesystem root instead of
docs_root. It could never match the file being moved, so the link was
left untouched (and broken) after the move.

A repo-wide check found 7,872 links using this absolute `/oss/...` /
`/langsmith/...` style versus zero using relative `../file.mdx` style,
so this affected effectively every internal link in the site -- `docs
mv` was not actually keeping links intact for the link style the docs
actually use.

Added `_resolve_site_absolute_url()`, which maps a site-absolute URL
back to its source file the same way Mintlify serves it (strip the
leading slash, try `.mdx`/`.md` under docs_root), and use it whenever
a matched URL starts with `/`. Relative-link handling (`_rewrite_links`
for other cases, `_update_internal_links_in_moved_file`, `drop_suffix_
from_links`) is unchanged -- those already correctly skip absolute
links since their own resolution doesn't depend on the referencing
file's location.

Added three regression tests: an absolute link gets rewritten,
anchors on absolute links are preserved through the rewrite, and
absolute links that are unrelated to the moved file or don't resolve
to any file at all (e.g. Mintlify-generated API reference pages with
no corresponding source file) are left untouched rather than raising.

Verified: full test suite passes locally with no failures, plus ruff
format, ruff check, ty, and codespell all clean on the changed files.