### PR TITLE
docs: align tools.mdx store recommendation with rest of docs (add MongoDBStore, RedisStore)

### DIFF
--- a/src/oss/langchain/tools.mdx
+++ b/src/oss/langchain/tools.mdx
@@ -327,7 +327,7 @@ The @[`BaseStore`] provides persistent storage that survives across conversation
 Access the store through `runtime.store`. The store uses a namespace/key pattern to organize data:
 
 <Tip>
-    For production deployments, use a persistent store implementation like @[`PostgresStore`] instead of `InMemoryStore`. See the [memory documentation](/oss/langgraph/add-memory) for setup details.
+    For production deployments, use a persistent store implementation like @[`PostgresStore`], `MongoDBStore`, or `RedisStore` instead of `InMemoryStore`. See the [memory documentation](/oss/langgraph/add-memory) for setup details.
 </Tip>
 
 ```python expandable


### PR DESCRIPTION
## Overview
The persistent-store tip in `tools.mdx` only mentions `PostgresStore`, while the equivalent tip in `stores.mdx`, `add-memory.mdx`, and `checkpointers.mdx` consistently lists `PostgresStore`, `MongoDBStore`, and `RedisStore`. This one-line change brings `tools.mdx` in line with the rest of the docs.

## Type of change
Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue: none — found via inconsistency while reading the docs
- Feature PR: n/a

## Checklist
- [x] I have read the contributing guidelines, including the language policy
- [x] I have tested my changes locally (verified string match + clean `git apply` on a fresh clone of `main`)
- [x] All code examples have been tested and work correctly (no code examples changed)
- [x] I have used root relative paths for internal links (no new links added)
- [x] I have updated navigation in `src/docs.json` if needed (not applicable — no new pages)

## Additional notes
Single-line prose change, no links added or modified.