### PR TITLE
docs(langsmith): add API and SDK deprecation policy page

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -2023,7 +2023,8 @@
                     "group": "Reference",
                     "pages": [
                       "langsmith/changelog",
-                      "langsmith/release-stages"
+                      "langsmith/release-stages",
+                      "langsmith/endpoint-deprecation"
                     ]
                   }
                 ]
@@ -2161,7 +2162,8 @@
                     "group": "Reference",
                     "pages": [
                       "langsmith/self-hosted-changelog",
-                      "langsmith/release-versions"
+                      "langsmith/release-versions",
+                      "langsmith/endpoint-deprecation"
                     ]
                   }
                 ]
@@ -2558,10 +2560,6 @@
     },
     {
       "source": "/langsmith/api-v1-v2-overview",
-      "destination": "/langsmith/trace-with-api"
-    },
-    {
-      "source": "/langsmith/endpoint-deprecation",
       "destination": "/langsmith/trace-with-api"
     },
     {

--- a/src/langsmith/endpoint-deprecation.mdx
+++ b/src/langsmith/endpoint-deprecation.mdx
@@ -1,0 +1,46 @@
+---
+title: API and SDK deprecation policy
+sidebarTitle: Deprecation policy
+description: How LangSmith deprecates and removes API endpoints and SDK methods in cloud and self-hosted deployments.
+---
+
+LangSmith deprecates API endpoints and SDK methods before removing them, so you have time to migrate to a replacement. This page describes how deprecations are announced and how long they stay supported.
+
+## Deprecation lifecycle
+
+Every deprecation follows the same stages:
+
+1. **Announced**: the deprecation is published in the [changelog](/langsmith/changelog) with the removal date, once known, and, where call-site changes are needed, in a migration guide that documents the replacement.
+2. **Marked**: the deprecated API endpoint returns `Deprecation: true` and `Sunset: <date>` response headers, so you can detect deprecated usage without watching the changelog. Deprecated SDK methods are marked in the SDK release notes and, where supported, raise a deprecation warning at call time.
+3. **Supported**: the deprecated endpoint or method continues to function for a minimum window that depends on your deployment. See [Deprecation window by deployment](#deprecation-window-by-deployment).
+4. **Removed**: after the support window ends, the endpoint or method is removed. Requests to a removed endpoint fail, and a removed SDK method no longer exists.
+
+In Cloud, if active consumers remain close to the removal date, LangSmith may apply rate limits and increased latency to the deprecated endpoint, and return an explicit error message on a portion of requests, as a last resort to catch the attention of remaining usage before removal. Affected customers are contacted directly beforehand.
+
+## Deprecation window by deployment
+
+| Deployment | Minimum support window |
+|---|---|
+| Cloud | 6 months from announcement to removal |
+| Self-hosted | At least one release. Removal happens no earlier than the following major release |
+
+Self-hosted major releases ship on a roughly six-week cadence. For details, see [Release policy](/langsmith/release-versions).
+
+## SDK method deprecation
+
+Most SDK methods are thin wrappers around an API endpoint, so a method deprecates on the same timeline as the endpoint it calls, and is removed from the SDK when the endpoint is removed.
+
+A method that does not map one-to-one to an endpoint, or is deprecated independently of any endpoint change, can have a different deprecation timeline. It is announced explicitly in both places: in the SDK, through documentation and a deprecation warning, and in the API, through the process described above.
+
+## Field-level deprecation
+
+A deprecated field is removed at a version boundary, not on a date:
+
+- **API fields and parameters**: a deprecated response field, request body field, or query parameter continues to work within the same endpoint version. Removal is a breaking change, so it ships only with the next endpoint version, for example v1 to v2.
+- **SDK method fields and parameters**: continue working within the current major SDK version. Removal requires a new major SDK version, independent of the API's own versioning.
+
+## See also
+
+- [Changelog](/langsmith/changelog) for recent LangSmith updates
+- [Release stages](/langsmith/release-stages) for how features move from alpha to GA
+- [Release policy](/langsmith/release-versions) for self-hosted release channels, cadence, and version support

--- a/src/langsmith/endpoint-deprecation.mdx
+++ b/src/langsmith/endpoint-deprecation.mdx
@@ -11,9 +11,9 @@ LangSmith deprecates API endpoints and SDK methods before removing them, so you 
 Every deprecation follows the same stages:
 
 1. **Announced**: the deprecation is published in the [changelog](/langsmith/changelog) with the removal date, once known, and, where call-site changes are needed, in a migration guide that documents the replacement.
-2. **Marked**: the deprecated API endpoint returns `Deprecation: true` and `Sunset: <date>` response headers, so you can detect deprecated usage without watching the changelog. Deprecated SDK methods are marked in the SDK release notes and, where supported, raise a deprecation warning at call time.
-3. **Supported**: the deprecated endpoint or method continues to function for a minimum window that depends on your deployment. See [Deprecation window by deployment](#deprecation-window-by-deployment).
-4. **Removed**: after the support window ends, the endpoint or method is removed. Requests to a removed endpoint fail, and a removed SDK method no longer exists.
+2. **Marked**: the deprecated API endpoint returns `Deprecation: true` and `Sunset: <date>` response headers. Deprecated SDK methods are marked in the documentation and, where supported, raise a deprecation warning at call time.
+3. **Supported**: the deprecated endpoint continues to function for a minimum window that depends on your deployment. See [Deprecation window by deployment](#deprecation-window-by-deployment).
+4. **Removed**: after the support window ends, the endpoint is removed.
 
 In Cloud, if active consumers remain close to the removal date, LangSmith may apply rate limits and increased latency to the deprecated endpoint, and return an explicit error message on a portion of requests, as a last resort to catch the attention of remaining usage before removal. Affected customers are contacted directly beforehand.
 
@@ -22,7 +22,7 @@ In Cloud, if active consumers remain close to the removal date, LangSmith may ap
 | Deployment | Minimum support window |
 |---|---|
 | Cloud | 6 months from announcement to removal |
-| Self-hosted | At least one release. Removal happens no earlier than the following major release |
+| Self-hosted | At least one major release |
 
 Self-hosted major releases ship on a roughly six-week cadence. For details, see [Release policy](/langsmith/release-versions).
 

--- a/src/langsmith/endpoint-deprecation.mdx
+++ b/src/langsmith/endpoint-deprecation.mdx
@@ -6,6 +6,8 @@ description: How LangSmith deprecates and removes API endpoints and SDK methods 
 
 LangSmith deprecates API endpoints and SDK methods before removing them, so you have time to migrate to a replacement. This page describes how deprecations are announced and how long they stay supported.
 
+<Note>This policy applies only to public endpoints documented in the [LangSmith API reference](/langsmith/smith-api-ref) and the [Agent Server API reference](/langsmith/server-api-ref). Internal, undocumented endpoints are not covered and can change, including with breaking changes, at any time.</Note>
+
 ## Deprecation lifecycle
 
 Every deprecation follows the same stages:

--- a/src/langsmith/release-stages.mdx
+++ b/src/langsmith/release-stages.mdx
@@ -57,4 +57,5 @@ Any feature that is not marked alpha or beta is GA, and is supported immediately
 ## See also
 
 - [Release policy](/langsmith/release-versions) for self-hosted release channels, cadence, and version support
+- [API and SDK deprecation policy](/langsmith/endpoint-deprecation) for how deprecated endpoints and methods are removed
 - [Changelog](/langsmith/changelog) for recent LangSmith updates

--- a/src/langsmith/release-versions.mdx
+++ b/src/langsmith/release-versions.mdx
@@ -67,3 +67,8 @@ LangSmith supports the current stable major version and the two previous stable 
 ## Current version
 
 To check the current stable and preview versions, refer to the [self-hosted changelog](/langsmith/self-hosted-changelog).
+
+## See also
+
+- [Release stages](/langsmith/release-stages) for how features move from alpha to GA
+- [API and SDK deprecation policy](/langsmith/endpoint-deprecation) for how deprecated endpoints and methods are removed

--- a/src/langsmith/smithdb-sdk-migration.mdx
+++ b/src/langsmith/smithdb-sdk-migration.mdx
@@ -38,9 +38,9 @@ Each SDK method and its underlying endpoint share the same deprecation date.
 | Deployment | Deprecation | Removal |
 |---|---|---|
 | All Cloud regions | End of July 2026 | 31 Jan 2027 |
-| Self-Hosted | `>=v0.16` | `>=v0.18` |
+| Self-Hosted | `v0.16` | `v0.18` |
 
-A detailed deprecation process will be linked here before the general availability of this guide.
+For details on how LangSmith deprecates and removes API endpoints and SDK methods, see [API and SDK deprecation policy](/langsmith/endpoint-deprecation).
 
 ## Minimum SDK version
 
@@ -52,6 +52,12 @@ The SmithDB-backed methods require a minimum SDK version:
 | TypeScript | `langsmith` | `>=0.8.4` |
 | Java | `langsmith-java` | `0.1.0-beta.18` |
 | Go | `langsmith-go` | `v0.22.0` |
+
+### SDK and self-hosted version compatibility
+
+The SDK and self-hosted LangSmith instance upgrade independently, so their versions can drift out of alignment. If the SDK is too new or too old for the self-hosted version, a call to a new or changed endpoint, including the SmithDB-backed methods on this page, can fail.
+
+Where an SDK can detect this mismatch, it raises a warning identifying the compatible self-hosted or SDK version, rather than failing without explanation. Upgrade the self-hosted deployment or pin the SDK version accordingly.
 
 ## Migrate with an AI agent
 


### PR DESCRIPTION
## Summary
- Adds a general API and SDK deprecation policy page (`/langsmith/endpoint-deprecation`), covering the deprecation lifecycle, cloud/self-hosted support windows, brownout, SDK method deprecation, and field-level deprecation.
- Links it from the SmithDB SDK migration guide's deprecation section and cross-links it from Release stages / Release policy.
- Reclaims the `/langsmith/endpoint-deprecation` slug (previously redirecting to `/trace-with-api` from a reverted, unrelated PR).

## Test plan
- [x] `make lint_prose` on changed files
- [x] `make broken-links`