### PR TITLE
docs: recommend Microsoft Foundry

### DIFF
--- a/src/oss/python/integrations/providers/microsoft.mdx
+++ b/src/oss/python/integrations/providers/microsoft.mdx
@@ -7,9 +7,11 @@ sidebarTitle: "Microsoft"
 This page covers all LangChain integrations with [Microsoft Azure](https://portal.azure.com) and other [Microsoft](https://www.microsoft.com) products.
 
 <Tip>
-    **Recommended: Azure OpenAI and Microsoft Foundry**
+    **Recommended: Microsoft Foundry**
 
-    We recommend using @[Azure OpenAI][AzureOpenAI] across [chat models](#chat-models), [LLMs](#llms), and [embedding models](#embedding-models). With the [v1 API](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/api-version-lifecycle?tabs=python) (Generally Available as of August 2025), you can use your Azure endpoint and API keys directly with the @[`langchain-openai`] package to call any model deployed in [Microsoft Foundry](https://learn.microsoft.com/en-us/azure/ai-foundry/) (including OpenAI, Llama, DeepSeek, Mistral, and Phi) through a single interface. You also get native support for Microsoft Entra ID authentication and access to the latest features including the [Responses API](#responses-api) and [reasoning models](/oss/integrations/chat/azure_chat_openai). [Get started here](#azure-openai).
+    We recommend using [Microsoft Foundry](https://learn.microsoft.com/en-us/azure/foundry/) across [chat models](#chat-models), [LLMs](#llms), and [embedding models](#embedding-models). The Foundry resource type is a superset of the Azure OpenAI resource type, with access to a broader model catalog, agent service, and evaluation capabilities while retaining Azure OpenAI APIs. If you use an Azure OpenAI resource, [upgrade it to a Foundry resource](https://learn.microsoft.com/en-us/azure/foundry/how-to/upgrade-azure-openai) to keep your existing API endpoint, state, and security configurations while gaining access to Foundry capabilities.
+
+    With the [Azure OpenAI v1 API](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/api-version-lifecycle?tabs=python) (generally available as of August 2025), you can use your Azure endpoint and API keys directly with the @[`langchain-openai`] package to call any model deployed in Microsoft Foundry (including OpenAI, Llama, DeepSeek, Mistral, and Phi) through a single interface. You also get native support for Microsoft Entra ID authentication and access to the latest features including the [Responses API](#responses-api) and [reasoning models](/oss/integrations/chat/azure_chat_openai). [Get started here](#azure-openai).
 
     For agent hosting, use [Microsoft Foundry hosted agents](#microsoft-foundry-hosted-agents) to deploy custom LangGraph code on a managed agent platform with built-in runtime, sessions, scaling, identity, and protocol endpoints.
 


### PR DESCRIPTION
## Overview

Update the Microsoft integrations recommendation to recommend Microsoft Foundry rather than Azure OpenAI. Clarify that the Foundry resource type is a superset of Azure OpenAI, and direct existing Azure OpenAI users to Microsoft's upgrade guide so they can preserve their endpoint, state, and security configuration while gaining Foundry capabilities.

This change reduces ambiguity between the two resource types and aligns the recommendation with current Microsoft guidance.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: N/A
- Feature PR: N/A
- Linear issue: N/A
- Slack thread: N/A

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

Please review the Foundry and Azure OpenAI relationship wording carefully. The superset and resource-preservation statements follow Microsoft's official upgrade documentation.

This change was drafted with GitHub Copilot assistance and reviewed by the author.