### PR TITLE
docs: fix duplicate word in cratedb.mdx and llm-gateway-coding-agents.mdx

### DIFF
--- a/src/langsmith/llm-gateway-coding-agents.mdx
+++ b/src/langsmith/llm-gateway-coding-agents.mdx
@@ -37,7 +37,7 @@ claude
 Claude Code will use `ANTHROPIC_BASE_URL` and `ANTHROPIC_API_KEY` from your environment automatically.
 
 <Warning>
-Claude Desktop desktop plugins break when the gateway is configured. Claude users on a paid plan (Plus, Max) are not yet supported.
+Claude Desktop plugins break when the gateway is configured. Claude users on a paid plan (Plus, Max) are not yet supported.
 </Warning>
 
 ## Codex CLI

--- a/src/oss/python/integrations/providers/cratedb.mdx
+++ b/src/oss/python/integrations/providers/cratedb.mdx
@@ -95,7 +95,7 @@ docs_with_score = store.similarity_search_with_score(query)
 ```
 
 ### Document loader
-Load load documents from a CrateDB database table, using the document loader
+Load documents from a CrateDB database table, using the document loader
 `CrateDBLoader`, which is based on SQLAlchemy. See also [CrateDBLoader Tutorial].
 
 To use the document loader in your applications:


### PR DESCRIPTION
Two duplicate-word typos:
- "Load load documents" -> "Load documents" in the CrateDB document loader section
- "Claude Desktop desktop plugins" -> "Claude Desktop plugins" in the LLM Gateway coding agents guide

Docs-only, no behavior change. Same category as #5082-#5085.