### PR TITLE
fix: Command Literal type hint missing self-route in lookup_customer_history example

### DIFF
--- a/src/oss/langgraph/thinking-in-langgraph.mdx
+++ b/src/oss/langgraph/thinking-in-langgraph.mdx
@@ -396,7 +396,9 @@ Different errors need different handling strategies:
     from langgraph.types import Command
 
 
-    def lookup_customer_history(state: State) -> Command[Literal["draft_response"]]:
+    def lookup_customer_history(
+        state: State
+    ) -> Command[Literal["lookup_customer_history", "draft_response"]]:
         if not state.get('customer_id'):
             user_input = interrupt({
                 "message": "Customer ID needed",


### PR DESCRIPTION
The `lookup_customer_history` example in thinking-in-langgraph.mdx is
annotated as `Command[Literal["draft_response"]]`, but one branch
returns `Command(..., goto="lookup_customer_history")` -- routing back
to itself when the customer ID is missing. The type hint only
declares one of the two real destinations.

This directly contradicts what the same page teaches just above the
example: that `Command[Literal[...]]` should declare every possible
destination a node can route to, so the flow stays explicit and
traceable. Readers learning the pattern from this exact example would
copy an inconsistent annotation.

Fixed to `Command[Literal["lookup_customer_history", "draft_response"]]`,
matching both actual return paths. The TypeScript version of the same
example uses `GraphNode<typeof State>` rather than an explicit Literal
return type, so it isn't affected by the same issue.

Fixes #4676