### PR TITLE
ocs: fix a/an article reversal before 'unique'

### DIFF
--- a/src/langsmith/generative-ui-react.mdx
+++ b/src/langsmith/generative-ui-react.mdx
@@ -19,7 +19,7 @@ LangSmith supports colocating your React components with your graph code. This a
 
 ### 1. Define and configure UI components
 
-First, create your first UI component. For each component you need to provide an unique identifier that will be used to reference the component in your graph code.
+First, create your first UI component. For each component you need to provide a unique identifier that will be used to reference the component in your graph code.
 
 ```tsx title="src/agent/ui.tsx"
 const WeatherComponent = (props: { city: string }) => {

--- a/src/oss/python/integrations/vectorstores/vdms.mdx
+++ b/src/oss/python/integrations/vectorstores/vdms.mdx
@@ -462,7 +462,7 @@ It can be helpful to narrow down the collection before working with it.
 
 For example, collections can be filtered on metadata using the `get_by_constraints` method. A dictionary is used to filter metadata. Here we retrieve the document where `langchain_id = "2"` and remove it from the vector store.
 
-***NOTE:*** `id` was generated as additional metadata as an integer while `langchain_id` (the internal ID) is an unique string for each entry.
+***NOTE:*** `id` was generated as additional metadata as an integer while `langchain_id` (the internal ID) is a unique string for each entry.
 
 ```python
 response, response_array = db_FaissIVFFlat.get_by_constraints(


### PR DESCRIPTION
docs: fix a/an article reversal before 'unique'

'unique' starts with a consonant sound (y), so the correct article is
'a unique', not 'an unique'. Fixed in vdms.mdx and generative-ui-react.mdx.