### PR TITLE
gateway: update langchain env var support in quickstart

### DIFF
--- a/src/langsmith/llm-gateway-quickstart.mdx
+++ b/src/langsmith/llm-gateway-quickstart.mdx
@@ -41,7 +41,7 @@ If your LangSmith account is on a regional instance, use the corresponding [regi
 
 ### Using LangChain and Deep Agents
 
-[LangChain](/oss/langchain/overview) chat models and [Deep Agents](/oss/deepagents/overview) support the gateway through two convenience environment variables:
+[LangChain](/oss/langchain/overview) chat models and [Deep Agents](/oss/deepagents/overview) (including [Deep Agents Code](/oss/deepagents/code/overview)) support the gateway through two convenience environment variables:
 
 ```bash
 export LANGSMITH_GATEWAY="true"
@@ -55,12 +55,17 @@ export LANGSMITH_GATEWAY="https://eu.gateway.smith.langchain.com"
 export LANGSMITH_GATEWAY_API_KEY="$LANGSMITH_API_KEY"
 ```
 
-See [more details](#more-details) below for provider support and interactions with provider-specific environment variables.
+You can also configure base URLs and API keys for individual providers as described in the [section above](#1-set-environment-variables). See [more details](#more-details) below for provider support and interactions with provider-specific environment variables.
 
 <Accordion title="More details">
 
 - Supported in Python only.
-- Supported chat models: [Anthropic](/oss/python/integrations/chat/anthropic) (`langchain-anthropic >= 1.5.1`), [Fireworks](/oss/python/integrations/chat/fireworks) (`langchain-fireworks >= 1.5.1`), and [OpenAI](/oss/python/integrations/chat/openai) (`langchain-openai >= 1.4.1`).
+- Supported chat models:
+  - [Anthropic](/oss/python/integrations/chat/anthropic) (`langchain-anthropic >= 1.5.1`)
+  - [Baseten](/oss/python/integrations/chat/baseten) (`langchain-baseten >= 0.2.3`)
+  - [Fireworks](/oss/python/integrations/chat/fireworks) (`langchain-fireworks >= 1.5.1`)
+  - [Google Gemini](/oss/python/integrations/chat/google_generative_ai) (`langchain-google-genai >= 4.3.2`)
+  - [OpenAI](/oss/python/integrations/chat/openai) (`langchain-openai >= 1.4.1`).
 - Provider-specific base URLs take precedence over the gateway, so you can still route an individual provider elsewhere. For example, with the gateway enabled, `OPENAI_API_BASE` sends OpenAI to that URL while every other provider continues to use the gateway:
 
   ```bash


### PR DESCRIPTION
Documents support for Baseten, Gemini, and dcode.