### PR TITLE
docs(self-host): fewer images to mirror from LangSmith 0.16.21

### DIFF
--- a/src/langsmith/self-host-fips.mdx
+++ b/src/langsmith/self-host-fips.mdx
@@ -21,12 +21,13 @@ Every LangChain-authored image has a `-fips` counterpart published at the same t
 | `langchain/langsmith-ace-backend` | `langchain/langsmith-ace-backend-fips` |
 | `langchain/langsmith-backend` | `langchain/langsmith-backend-fips` |
 | `langchain/langsmith-frontend` | `langchain/langsmith-frontend-fips` |
-| `langchain/langsmith-go-backend` | `langchain/langsmith-go-backend-fips` |
-| `langchain/langsmith-playground` | `langchain/langsmith-playground-fips` |
-| `langchain/hosted-langserve-backend` | `langchain/hosted-langserve-backend-fips` |
 | `langchain/langgraph-operator` | `langchain/langgraph-operator-fips` |
-| `langchain/agent-builder-tool-server` | `langchain/agent-builder-tool-server-fips` |
-| `langchain/agent-builder-trigger-server` | `langchain/agent-builder-trigger-server-fips` |
+
+<Note>
+  **Fewer images from LangSmith 0.16.21 (chart `0.16.0-rc.17`) onward.** The platform backend, playground, host backend, and the Fleet tool and trigger servers now all run from the single `langsmith-backend` image, so `langsmith-go-backend-fips`, `langsmith-playground-fips`, `hosted-langserve-backend-fips`, `agent-builder-tool-server-fips`, and `agent-builder-trigger-server-fips` are no longer needed. The corresponding `values.yaml` keys — `platformBackendImage`, `playgroundImage`, `hostBackendImage`, `fleetToolServerImage`, and `fleetTriggerServerImage` — have been removed from the chart; any values you still set for them are ignored.
+
+  On **earlier** versions those five images are published with `-fips` counterparts at the same tag as well; point each of those keys at its `-fips` repository too.
+</Note>
 
 PostgreSQL, Redis, and ClickHouse are not published as FIPS variants by LangChain. If your deployment requires FIPS for these components, bring your own FIPS-mode service and connect via [external Postgres](/langsmith/self-host-external-postgres), [external Redis](/langsmith/self-host-external-redis), or [external ClickHouse](/langsmith/self-host-external-clickhouse).
 
@@ -38,38 +39,26 @@ We consider this acceptable for regulated environments: FIPS governs the platfor
 
 ## Use FIPS images
 
-Update `values.yaml` in your LangSmith Helm installation to point each LangChain image repository at its `-fips` counterpart, keeping your existing tag. Replace `0.15.0` with the [LangSmith version](/langsmith/self-hosted-changelog) you want to deploy:
+Update `values.yaml` in your LangSmith Helm installation to point each LangChain image repository at its `-fips` counterpart, keeping your existing tag. Replace `0.16.21` with the [LangSmith version](/langsmith/self-hosted-changelog) you want to deploy:
 
 ```yaml
 images:
   aceBackendImage:
     repository: "langchain/langsmith-ace-backend-fips"
     pullPolicy: IfNotPresent
-    tag: "0.15.0"
+    tag: "0.16.21"
   backendImage:
     repository: "langchain/langsmith-backend-fips"
     pullPolicy: IfNotPresent
-    tag: "0.15.0"
+    tag: "0.16.21"
   frontendImage:
     repository: "langchain/langsmith-frontend-fips"
     pullPolicy: IfNotPresent
-    tag: "0.15.0"
-  hostBackendImage:
-    repository: "langchain/hosted-langserve-backend-fips"
-    pullPolicy: IfNotPresent
-    tag: "0.15.0"
+    tag: "0.16.21"
   operatorImage:
     repository: "langchain/langgraph-operator-fips"
     pullPolicy: IfNotPresent
-    tag: "0.15.0"
-  platformBackendImage:
-    repository: "langchain/langsmith-go-backend-fips"
-    pullPolicy: IfNotPresent
-    tag: "0.15.0"
-  playgroundImage:
-    repository: "langchain/langsmith-playground-fips"
-    pullPolicy: IfNotPresent
-    tag: "0.15.0"
+    tag: "0.16.21"
 ```
 
 Apply the change and upgrade following the [Upgrading LangSmith](/langsmith/self-host-upgrades) guide.
@@ -106,7 +95,7 @@ Locate applicable CMVP certificate(s) at: CMVP #4985
 You can also verify an image outside Kubernetes:
 
 ```bash
-docker run --rm --entrypoint openssl-fips-test langchain/langsmith-go-backend-fips:0.15.0
+docker run --rm --entrypoint openssl-fips-test langchain/langsmith-backend-fips:0.16.21
 ```
 
 For more detail on interpreting the output, see [Chainguard's FIPS verification guide](https://edu.chainguard.dev/chainguard/fips/verify-fips/).

--- a/src/langsmith/self-host-fips.mdx
+++ b/src/langsmith/self-host-fips.mdx
@@ -24,7 +24,7 @@ Every LangChain-authored image has a `-fips` counterpart published at the same t
 | `langchain/langgraph-operator` | `langchain/langgraph-operator-fips` |
 
 <Note>
-  **Fewer images from LangSmith 0.16.21 (chart `0.16.0-rc.17`) onward.** The platform backend, playground, host backend, and the Fleet tool and trigger servers now all run from the single `langsmith-backend` image, so `langsmith-go-backend-fips`, `langsmith-playground-fips`, `hosted-langserve-backend-fips`, `agent-builder-tool-server-fips`, and `agent-builder-trigger-server-fips` are no longer needed. The corresponding `values.yaml` keys — `platformBackendImage`, `playgroundImage`, `hostBackendImage`, `fleetToolServerImage`, and `fleetTriggerServerImage` — have been removed from the chart; any values you still set for them are ignored.
+  **Fewer images from LangSmith 0.16.21 (chart `0.16.0-rc.17`) onward.** The platform backend, playground, host backend, and the Fleet tool and trigger servers now all run from the single `langsmith-backend` image, so `langsmith-go-backend-fips`, `langsmith-playground-fips`, `hosted-langserve-backend-fips`, `agent-builder-tool-server-fips`, and `agent-builder-trigger-server-fips` are no longer needed. The corresponding `values.yaml` keys: `platformBackendImage`, `playgroundImage`, `hostBackendImage`, `fleetToolServerImage`, and `fleetTriggerServerImage`, have been removed from the chart; any values you still set for them are ignored.
 
   On **earlier** versions those five images are published with `-fips` counterparts at the same tag as well; point each of those keys at its `-fips` repository too.
 </Note>

--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -13,6 +13,12 @@ By default, LangSmith will pull images from our public Docker registry. However,
 
 ## Mirroring the images
 
+<Note>
+  **Fewer images from LangSmith 0.16.21 (chart `0.16.0-rc.17`) onward.** The platform backend, playground, host backend, and the Fleet tool and trigger servers now all run from the single `langsmith-backend` image, so you no longer need to mirror `langsmith-go-backend`, `langsmith-playground`, `hosted-langserve-backend`, `agent-builder-tool-server`, or `agent-builder-trigger-server` (or their `-fips` variants). The corresponding `values.yaml` keys — `platformBackendImage`, `playgroundImage`, `hostBackendImage`, `fleetToolServerImage`, and `fleetTriggerServerImage` — have been removed from the chart; any values you still set for them are ignored.
+
+  If you are installing an **earlier** version, keep mirroring those images and setting those keys as before.
+</Note>
+
 For your convenience, we have provided a script that will mirror the images for you. You can find the script in the [LangSmith Helm Chart repository](https://github.com/langchain-ai/helm/blob/main/charts/langsmith/scripts/mirror_langsmith_images.sh)
 
 To use the script, you will need to run the script with the following command specifying your registry and platform:
@@ -46,7 +52,7 @@ You will need to repeat this for each image that you want to mirror.
 
 ## Configuration
 
-Once the images are mirrored, you will need to configure your LangSmith installation to use the mirrored images. You can do this by modifying the `values.yaml` file for your LangSmith Helm Chart installation. Replace tag with the version you want to use, e.g. `0.10.66` for the latest version at the time of writing.
+Once the images are mirrored, you will need to configure your LangSmith installation to use the mirrored images. You can do this by modifying the `values.yaml` file for your LangSmith Helm Chart installation. Replace tag with the [LangSmith version](/langsmith/self-hosted-changelog) you want to deploy — the example below uses `0.16.21`.
 
 ```yaml
 images:
@@ -55,31 +61,19 @@ images:
   aceBackendImage:
     repository: "(your-registry)/langchain/langsmith-ace-backend"
     pullPolicy: IfNotPresent
-    tag: "0.10.66"
+    tag: "0.16.21"
   backendImage:
     repository: "(your-registry)/langchain/langsmith-backend"
     pullPolicy: IfNotPresent
-    tag: "0.10.66"
+    tag: "0.16.21"
   frontendImage:
     repository: "(your-registry)/langchain/langsmith-frontend"
     pullPolicy: IfNotPresent
-    tag: "0.10.66"
-  hostBackendImage:
-    repository: "(your-registry)/langchain/hosted-langserve-backend"
-    pullPolicy: IfNotPresent
-    tag: "0.10.66"
+    tag: "0.16.21"
   operatorImage:
     repository: "(your-registry)/langchain/langgraph-operator"
     pullPolicy: IfNotPresent
     tag: "6cc83a8"
-  platformBackendImage:
-    repository: "(your-registry)/langchain/langsmith-go-backend"
-    pullPolicy: IfNotPresent
-    tag: "0.10.66"
-  playgroundImage:
-    repository: "(your-registry)/langchain/langsmith-playground"
-    pullPolicy: IfNotPresent
-    tag: "0.10.66"
   postgresImage:
     repository: "(your-registry)/postgres"
     pullPolicy: IfNotPresent

--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -52,7 +52,7 @@ You will need to repeat this for each image that you want to mirror.
 
 ## Configuration
 
-Once the images are mirrored, you will need to configure your LangSmith installation to use the mirrored images. You can do this by modifying the `values.yaml` file for your LangSmith Helm Chart installation. Replace tag with the [LangSmith version](/langsmith/self-hosted-changelog) you want to deploy — the example below uses `0.16.21`.
+Once the images are mirrored, you will need to configure your LangSmith installation to use the mirrored images. You can do this by modifying the `values.yaml` file for your LangSmith Helm Chart installation. Replace tag with the [LangSmith version](/langsmith/self-hosted-changelog) you want to deploy. The following example uses `0.16.21`.
 
 ```yaml
 images:

--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -14,7 +14,7 @@ By default, LangSmith will pull images from our public Docker registry. However,
 ## Mirroring the images
 
 <Note>
-  **Fewer images from LangSmith 0.16.21 (chart `0.16.0-rc.17`) onward.** The platform backend, playground, host backend, and the Fleet tool and trigger servers now all run from the single `langsmith-backend` image, so you no longer need to mirror `langsmith-go-backend`, `langsmith-playground`, `hosted-langserve-backend`, `agent-builder-tool-server`, or `agent-builder-trigger-server` (or their `-fips` variants). The corresponding `values.yaml` keys — `platformBackendImage`, `playgroundImage`, `hostBackendImage`, `fleetToolServerImage`, and `fleetTriggerServerImage` — have been removed from the chart; any values you still set for them are ignored.
+  **Fewer images from LangSmith 0.16.21 (chart `0.16.0-rc.17`) onward.** The platform backend, playground, host backend, and the Fleet tool and trigger servers now all run from the single `langsmith-backend` image, so you no longer need to mirror `langsmith-go-backend`, `langsmith-playground`, `hosted-langserve-backend`, `agent-builder-tool-server`, or `agent-builder-trigger-server` (or their `-fips` variants). The corresponding `values.yaml` keys: `platformBackendImage`, `playgroundImage`, `hostBackendImage`, `fleetToolServerImage`, and `fleetTriggerServerImage`, have been removed from the chart; any values you still set for them are ignored.
 
   If you are installing an **earlier** version, keep mirroring those images and setting those keys as before.
 </Note>


### PR DESCRIPTION
## What

Document that self-hosted installs no longer need the five standalone service images, as of **LangSmith 0.16.21** (chart `0.16.0-rc.17`).

The platform backend, playground, host backend, and the Fleet tool and trigger servers all run from the single `langsmith-backend` image now, and the corresponding `values.yaml` keys were removed from the chart in langchain-ai/helm#828.

No longer needed to mirror or configure:

- `langsmith-go-backend`
- `langsmith-playground`
- `hosted-langserve-backend`
- `agent-builder-tool-server`
- `agent-builder-trigger-server`

…plus their `-fips` variants. Removed keys: `platformBackendImage`, `playgroundImage`, `hostBackendImage`, `fleetToolServerImage`, `fleetTriggerServerImage`.

## Changes

**`self-host-mirroring-images.mdx`**
- Version note at the top of "Mirroring the images" stating what's no longer needed from 0.16.21, and that values still set for the removed keys are ignored.
- Dropped the removed keys from the Configuration example.
- Refreshed the stale example tag (`0.10.66` → `0.16.21`) and linked the changelog instead of saying "latest at the time of writing".

**`self-host-fips.mdx`**
- Trimmed the non-FIPS → FIPS image table to the images that still ship separately.
- Same version note, with the added detail that on earlier versions those five *do* have `-fips` counterparts and should still be set.
- Dropped the removed keys from the "Use FIPS images" example and normalized its tags (`0.15.0` → `0.16.21`).
- The `openssl-fips-test` example referenced `langsmith-go-backend-fips`, which is consolidated away — switched to `langsmith-backend-fips`.

## Note on earlier versions

Both notes are explicitly version-conditional: customers installing anything **before** 0.16.21 still need to mirror those images and set those keys, so the guidance stays correct for the older supported line. Already-published tags are unaffected.

Version verified against the chart tags: the consolidation first shipped in `langsmith-0.16.0-rc.17` (appVersion `0.16.21rc1`).
