### PR TITLE
docs: clarify self-hosted version support as N and N-1

### DIFF
--- a/src/langsmith/release-versions.mdx
+++ b/src/langsmith/release-versions.mdx
@@ -43,11 +43,21 @@ Service additions, service removals, and breaking changes only land in a new maj
 
 ## Version numbering
 
-Self-hosted LangSmith uses the following scheme:
+Every self-hosted release has two version numbers:
 
-- `v0.X.0`: Major version (stable GA release)
-- `v0.X.Y`: Stable patch release (critical fixes only)
-- `v0.X.0-rc1`, `v0.X.0-rc2`, ...: Preview builds (release candidates) for the next major version, with an incrementing build number
+- The **chart version** is the Helm chart version you install and pin. Releases are named after it, both in the [self-hosted changelog](/langsmith/self-hosted-changelog) and as [Helm repository](https://github.com/langchain-ai/helm/releases) release tags, for example `langsmith-0.15.17`.
+- The **LangSmith version** is the application version the chart deploys, recorded as `appVersion` in the chart.
+
+|  | Chart version | LangSmith version |
+|--|--|--|
+| Stable | `0.15.17` | `0.15.24` |
+| Preview (release candidate) | `0.16.0-rc.15` | `0.16.19rc1` |
+
+- Stable chart versions are `0.X.Y`, where `X` is the major version and `Y` increments with each patch release.
+- Preview chart versions are `0.X.0-rc.N`, where `N` increments with each release candidate.
+- The two numbers advance independently. The chart patch number and the LangSmith patch number are not expected to match.
+
+The `vX` shorthand used for release trains (`v15`, `v16`) refers to the major version, so `v15` means chart version `0.15.Y`.
 
 ## Version support
 
@@ -59,7 +69,7 @@ LangSmith supports the current stable major version (`N`) and the previous stabl
 
 Because a new major version ships approximately every 6 weeks, a version reaches end of life roughly 6 weeks after it is superseded as stable. Fixes are not backported to a version once it is end of life; upgrade to a supported major version to pick them up.
 
-Alongside the two supported stable versions, the next major version (`N+1`) is available on the preview channel as a series of release candidates (`v0.X.0-rc1`, `v0.X.0-rc2`, ...). Preview builds are published continuously and always carry the newest fixes, but they are intended for evaluation in test and staging environments rather than production. Running preview in a non-production environment is the recommended way to validate `N+1` before it becomes stable.
+Alongside the two supported stable versions, the next major version is available on the preview channel as a series of release candidates, for example `0.16.0-rc.15`. Preview builds are published continuously and always carry the newest fixes, but they are intended for evaluation in test and staging environments rather than production. Running preview in a non-production environment is the recommended way to validate the next major version before it becomes stable.
 
 ## Recommendations
 

--- a/src/langsmith/release-versions.mdx
+++ b/src/langsmith/release-versions.mdx
@@ -12,7 +12,7 @@ Self-hosted LangSmith ships on two release channels: a stable channel that custo
 
 The current generally available major version. LangSmith recommends this channel for production. Stable receives weekly patch releases containing critical bug fixes and security patches only. No new features, data migrations, or infrastructure changes land on stable between major versions.
 
-At any given time, the latest major version (N) is the preview channel and the previous major version (N-1) is stable.
+Throughout this page, `N` refers to the current stable major version. Preview tracks the next major version, `N+1`.
 
 ### Preview
 
@@ -47,15 +47,19 @@ Self-hosted LangSmith uses the following scheme:
 
 - `v0.X.0`: Major version (stable GA release)
 - `v0.X.Y`: Stable patch release (critical fixes only)
-- `v0.X.0-rcN`: Preview build (release candidate) for the next major version, where `N` is an incrementing build number
+- `v0.X.0-rc1`, `v0.X.0-rc2`, ...: Preview builds (release candidates) for the next major version, with an incrementing build number
 
 ## Version support
 
-LangSmith supports the current stable major version and the two previous stable major versions. When `N` represents the current stable major version:
+LangSmith supports the current stable major version (`N`) and the previous stable major version (`N-1`):
 
-- `N` receives active support, including critical bug fixes, security patches, and new patch releases.
-- `N-1` and `N-2` receive critical support, including critical bug fixes and security patches.
-- Versions older than `N-2` are end of life and do not receive new patch releases, bug fixes, or security updates.
+- `N` receives active support: critical bug fixes, security patches, and weekly patch releases.
+- `N-1` receives critical support only: critical bug fixes and security patches, released ad hoc rather than weekly.
+- Versions older than `N-1` are end of life and do not receive new patch releases, bug fixes, or security updates.
+
+Because a new major version ships approximately every 6 weeks, a version reaches end of life roughly 6 weeks after it is superseded as stable. Fixes are not backported to a version once it is end of life; upgrade to a supported major version to pick them up.
+
+Alongside the two supported stable versions, the next major version (`N+1`) is available on the preview channel as a series of release candidates (`v0.X.0-rc1`, `v0.X.0-rc2`, ...). Preview builds are published continuously and always carry the newest fixes, but they are intended for evaluation in test and staging environments rather than production. Running preview in a non-production environment is the recommended way to validate `N+1` before it becomes stable.
 
 ## Recommendations
 


### PR DESCRIPTION
## Why

The [release policy page](https://docs.langchain.com/langsmith/release-versions) used `N` inconsistently: one section defined `N` as the preview channel and `N-1` as stable, while the version support section defined `N` as the current stable major and promised support for `N-1` **and** `N-2`. Read together, that says we support three stable majors — more than we actually do.

This came up when a self-hosted customer asked whether the previous stable release is abandoned once a new stable ships, and requested 6–12 month long-term support.

The version numbering section also did not match the Helm chart. It described a single `v0.X.Y` scheme, but a release has two independent version numbers, and neither uses a `v` prefix.

## Changes

**Version support**

- Define `N` as the current stable major version throughout the page; preview tracks the next major.
- State the supported window as `N` (active support, weekly patches) and `N-1` (critical fixes and security patches only). Older majors are end of life.
- Note that at a ~6 week major cadence, a version reaches end of life roughly 6 weeks after it is superseded as stable, and fixes are not backported past that point.
- Add that the next major is available on the preview channel as release candidates, for evaluation in test/staging ahead of GA.

**Version numbering**

Documented the chart version and `appVersion` separately, with the formats actually used in [langchain-ai/helm](https://github.com/langchain-ai/helm):

|  | Chart version | LangSmith version (`appVersion`) |
|--|--|--|
| Stable | `0.15.17` | `0.15.24` |
| Preview (release candidate) | `0.16.0-rc.15` | `0.16.19rc1` |

The chart uses a dotted SemVer prerelease (`0.X.0-rc.N`) while `appVersion` uses a PEP 440 style suffix with no separator on an already-incremented patch (`0.16.19rc1`). The page previously implied both were `v0.X.0-rcN`, and that a GA major was `0.X.0` — true of the chart, but at v15 GA `appVersion` was `0.15.8`. Also noted that the `v15`/`v16` shorthand refers to the major version.

## Note for reviewers

The `N-1` window is the one substantive policy decision here, not just a wording fix. It means a superseded stable version still receives critical backports for roughly 6 weeks. If the intent is that a stable version receives nothing at all once its successor GAs, the `N-1` bullet and the 6-week paragraph should change accordingly.