### PR TITLE
docs(langsmith): some improvements in the SDK migration guide

### DIFF
--- a/src/langsmith/smithdb-sdk-migration.mdx
+++ b/src/langsmith/smithdb-sdk-migration.mdx
@@ -17,20 +17,9 @@ import SmithdbMigrationTracesQuery from '/snippets/langsmith/smithdb-migration/t
 import SmithdbMigrationTracesListRuns from '/snippets/langsmith/smithdb-migration/traces-list-runs.mdx';
 
 ## Context
-
-<Warning>This migration guide, including the deprecation and removal dates below, is in **preview** and subject to change before general availability later this month.</Warning>
-
 In May 2026, we released [SmithDB](https://www.langchain.com/blog/introducing-smithdb?utm_source=docs), a new observability database built for modern AI agents. SmithDB delivers industry-leading performance across every key observability workload, making core LangSmith experiences dramatically faster.
 
-SmithDB-powered methods are now available to SDK users in eligible regions.
-
-## Deployment support
-
-| Deployment | Status |
-|---|---|
-| GCP `us-central` Cloud | Available. New methods are fully SmithDB-backed. |
-| Other Cloud regions | Available. SmithDB-backed later this year. |
-| Self-Hosted | New methods require version `>=v0.16` and SmithDB enabled. |
+New SDK methods are required to query your traces with SmithDB. This guide helps you migrate your codebase.
 
 ## Deprecation and removal
 
@@ -45,7 +34,7 @@ For details on how LangSmith deprecates and removes API endpoints and SDK method
 
 ## Minimum SDK version
 
-The SmithDB-backed methods require a minimum SDK version:
+The new SDK methods are available starting at these SDK versions:
 
 | Language | Package | Minimum version |
 |---|---|---|
@@ -54,11 +43,11 @@ The SmithDB-backed methods require a minimum SDK version:
 | Java | `langsmith-java` | `0.1.0-beta.18` |
 | Go | `langsmith-go` | `v0.22.0` |
 
-### SDK and self-hosted version compatibility
+## About self-hosted
 
-The SDK and self-hosted LangSmith instance upgrade independently, so their versions can drift out of alignment. If the SDK is too new or too old for the self-hosted version, a call to a new or changed endpoint, including the SmithDB-backed methods on this page, can fail.
-
-Where an SDK can detect this mismatch, it raises a warning identifying the compatible self-hosted or SDK version, rather than failing without explanation. Upgrade the self-hosted deployment or pin the SDK version accordingly.
+- The new methods documented in this guide require `>=0.16` self-hosted version, independent of the data store used.
+- The deprecated methods stop working once ClickHouse is disabled.
+- Where possible, the SDK raises a warning or error identifying the version to upgrade to, instead of failing without explanation.
 
 ## Migrate with an AI agent
 
@@ -82,6 +71,28 @@ parameters are affected, what replaces them, and deployment support.
 If a call site or parameter is not covered by the guide, stop and ask rather
 than guessing.
 ```
+
+<SmithdbMigrationRunsQuery />
+
+<SmithdbMigrationRunsRetrieve />
+
+<SmithdbMigrationRunsGetUrl />
+
+<SmithdbMigrationTracesQuery />
+
+<SmithdbMigrationTracesListRuns />
+
+<SmithdbMigrationThreadsQuery />
+
+<SmithdbMigrationThreadsListTraces />
+
+<SmithdbMigrationExperimentRunsQuery />
+
+<SmithdbMigrationRunsAddToAnnotationQueue />
+
+<SmithdbMigrationPublicRuns />
+
+<SmithdbMigrationFeedbackCreate />
 
 ## Exceptions
 
@@ -137,28 +148,6 @@ than guessing.
     No change. Error handling is unaffected by this migration.
   </Tab>
 </Tabs>
-
-<SmithdbMigrationRunsQuery />
-
-<SmithdbMigrationRunsRetrieve />
-
-<SmithdbMigrationRunsGetUrl />
-
-<SmithdbMigrationTracesQuery />
-
-<SmithdbMigrationTracesListRuns />
-
-<SmithdbMigrationThreadsQuery />
-
-<SmithdbMigrationThreadsListTraces />
-
-<SmithdbMigrationExperimentRunsQuery />
-
-<SmithdbMigrationRunsAddToAnnotationQueue />
-
-<SmithdbMigrationPublicRuns />
-
-<SmithdbMigrationFeedbackCreate />
 
 ## Discontinued
 


### PR DESCRIPTION
## Summary
Some improvements and simplification in the SDK migration guide.

## Test plan
- [x] `make lint_prose` on the changed file