### PR TITLE
docs: add LangSmith Gateway guidance to quickstarts

### DIFF
--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -149,6 +149,19 @@ export HUGGINGFACEHUB_API_TOKEN="hf_..."
   </Tab>
 </Tabs>
 
+<Tip>
+    **Using LangSmith Gateway**
+
+    If using the [LangSmith Gateway](/langsmith/llm-gateway-quickstart#using-langchain-and-deep-agents), most major providers are supported via your LangSmith API key:
+
+    ```bash
+    export LANGSMITH_GATEWAY="true"
+    export LANGSMITH_GATEWAY_API_KEY="$LANGSMITH_API_KEY"
+    ```
+
+    See [details](/langsmith/llm-gateway-quickstart#more-details) for supported providers and configuration.
+</Tip>
+
 ## Build a basic agent
 
 Start by creating a simple agent that can answer questions and call tools. The agent in this example uses the chosen language model, a basic weather function as a tool, and a simple prompt to guide its behavior:

--- a/src/oss/langgraph/quickstart.mdx
+++ b/src/oss/langgraph/quickstart.mdx
@@ -18,7 +18,7 @@ This quickstart demonstrates how to build a calculator agent using the LangGraph
 For conceptual information, see [Graph API overview](/oss/langgraph/graph-api) and [Functional API overview](/oss/langgraph/functional-api).
 
 <Info>
-For this example, you will need to set up a [Claude (Anthropic)](https://www.anthropic.com/) account and get an API key. Then, set the `ANTHROPIC_API_KEY` environment variable in your terminal.
+For this example, you will need to set up a [Claude (Anthropic)](https://www.anthropic.com/) account and get an API key. Then, set the `ANTHROPIC_API_KEY` environment variable in your terminal. See [chat model integrations](/oss/integrations/chat) for all available providers. If you use LangSmith Gateway, see [the LangSmith Gateway quickstart](/langsmith/llm-gateway-quickstart) for API key configuration.
 </Info>
 
 <Tabs>


### PR DESCRIPTION
## Description
Add LangSmith Gateway guidance to the LangChain API-key setup and link provider and Gateway configuration from the LangGraph quickstart.

## Test Plan
- [x] Run scoped Vale prose lint on both changed quickstarts
- [x] Run the broken-link checker

Made by [Open SWE](https://openswe.vercel.app/agents/c9c5f67f-eb68-4f10-324e-707dd0aa137d)