### PR TITLE
fix: remove duplicated word in SQL agent system prompt

### DIFF
--- a/src/code-samples/langchain/sql-agent-studio.ts
+++ b/src/code-samples/langchain/sql-agent-studio.ts
@@ -101,7 +101,7 @@ ${await getSchema()}
 Rules:
 - Think step-by-step.
 - When you need data, call the tool \`execute_sql\` with ONE SELECT query.
-- Read-only only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
+- Read-only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
 - Limit to 5 rows unless user explicitly asks otherwise.
 - If the tool returns 'Error:', revise the SQL and try again.
 - Limit the number of attempts to 5.

--- a/src/code-samples/langchain/sql-agent.ts
+++ b/src/code-samples/langchain/sql-agent.ts
@@ -116,7 +116,7 @@ ${await getSchema()}
 Rules:
 - Think step-by-step.
 - When you need data, call the tool \`execute_sql\` with ONE SELECT query.
-- Read-only only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
+- Read-only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
 - Limit to 5 rows unless user explicitly asks otherwise.
 - If the tool returns 'Error:', revise the SQL and try again.
 - Limit the number of attempts to 5.

--- a/src/snippets/code-samples/sql-agent-studio-js.mdx
+++ b/src/snippets/code-samples/sql-agent-studio-js.mdx
@@ -100,7 +100,7 @@
     Rules:
     - Think step-by-step.
     - When you need data, call the tool \`execute_sql\` with ONE SELECT query.
-    - Read-only only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
+    - Read-only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
     - Limit to 5 rows unless user explicitly asks otherwise.
     - If the tool returns 'Error:', revise the SQL and try again.
     - Limit the number of attempts to 5.
@@ -216,7 +216,7 @@
     Rules:
     - Think step-by-step.
     - When you need data, call the tool \`execute_sql\` with ONE SELECT query.
-    - Read-only only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
+    - Read-only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
     - Limit to 5 rows unless user explicitly asks otherwise.
     - If the tool returns 'Error:', revise the SQL and try again.
     - Limit the number of attempts to 5.
@@ -332,7 +332,7 @@
     Rules:
     - Think step-by-step.
     - When you need data, call the tool \`execute_sql\` with ONE SELECT query.
-    - Read-only only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
+    - Read-only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
     - Limit to 5 rows unless user explicitly asks otherwise.
     - If the tool returns 'Error:', revise the SQL and try again.
     - Limit the number of attempts to 5.
@@ -448,7 +448,7 @@
     Rules:
     - Think step-by-step.
     - When you need data, call the tool \`execute_sql\` with ONE SELECT query.
-    - Read-only only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
+    - Read-only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
     - Limit to 5 rows unless user explicitly asks otherwise.
     - If the tool returns 'Error:', revise the SQL and try again.
     - Limit the number of attempts to 5.
@@ -564,7 +564,7 @@
     Rules:
     - Think step-by-step.
     - When you need data, call the tool \`execute_sql\` with ONE SELECT query.
-    - Read-only only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
+    - Read-only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
     - Limit to 5 rows unless user explicitly asks otherwise.
     - If the tool returns 'Error:', revise the SQL and try again.
     - Limit the number of attempts to 5.
@@ -680,7 +680,7 @@
     Rules:
     - Think step-by-step.
     - When you need data, call the tool \`execute_sql\` with ONE SELECT query.
-    - Read-only only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
+    - Read-only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
     - Limit to 5 rows unless user explicitly asks otherwise.
     - If the tool returns 'Error:', revise the SQL and try again.
     - Limit the number of attempts to 5.
@@ -796,7 +796,7 @@
     Rules:
     - Think step-by-step.
     - When you need data, call the tool \`execute_sql\` with ONE SELECT query.
-    - Read-only only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
+    - Read-only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
     - Limit to 5 rows unless user explicitly asks otherwise.
     - If the tool returns 'Error:', revise the SQL and try again.
     - Limit the number of attempts to 5.

--- a/src/snippets/code-samples/sql-agent-system-prompt-js.mdx
+++ b/src/snippets/code-samples/sql-agent-system-prompt-js.mdx
@@ -10,7 +10,7 @@ ${await getSchema()}
 Rules:
 - Think step-by-step.
 - When you need data, call the tool \`execute_sql\` with ONE SELECT query.
-- Read-only only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
+- Read-only; no INSERT/UPDATE/DELETE/ALTER/DROP/CREATE/REPLACE/TRUNCATE.
 - Limit to 5 rows unless user explicitly asks otherwise.
 - If the tool returns 'Error:', revise the SQL and try again.
 - Limit the number of attempts to 5.


### PR DESCRIPTION
## Overview
Small typo fix: "Read-only only; no INSERT/UPDATE/DELETE/ALTER/DROP/
CREATE/REPLACE/TRUNCATE." -> "Read-only; no INSERT/UPDATE/DELETE/
ALTER/DROP/CREATE/REPLACE/TRUNCATE." (duplicated "only").

Fixed in all 4 places it appears:
- src/code-samples/langchain/sql-agent.ts
- src/code-samples/langchain/sql-agent-studio.ts
- src/snippets/code-samples/sql-agent-system-prompt-js.mdx
- src/snippets/code-samples/sql-agent-studio-js.mdx (appears 7x, once per tutorial step)

The Python version of this system prompt doesn't have this typo, so
this looks like it was introduced when the JS/TS sample was ported.

## Type of change
**Type:** Fix typo/bug/link/formatting

## Checklist
- [x] I have read the contributing guidelines
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used root relative paths for internal links
- [ ] N/A - no navigation changes needed