### PR TITLE
docs: use langchain (not langchain_core) imports in example code

### DIFF
--- a/src/langsmith/handle-model-rate-limiting.mdx
+++ b/src/langsmith/handle-model-rate-limiting.mdx
@@ -11,7 +11,7 @@ If you're using `langchain` Python chat models in your application or evaluators
 
 ```python
 from langchain.chat_models import init_chat_model
-from langchain_core.rate_limiters import InMemoryRateLimiter
+from langchain.rate_limiters import InMemoryRateLimiter
 
 rate_limiter = InMemoryRateLimiter(
     requests_per_second=0.1,  # <-- Super slow! We can only make a request once every 10 seconds!!

--- a/src/langsmith/run-backtests-new-agent.mdx
+++ b/src/langsmith/run-backtests-new-agent.mdx
@@ -65,7 +65,7 @@ For this example lets create a simple Tweet-writing application that has access 
 from langchain.chat_models import init_chat_model
 from langchain.agents import create_agent
 from langchain_community.tools import DuckDuckGoSearchRun, TavilySearchResults
-from langchain_core.rate_limiters import InMemoryRateLimiter
+from langchain.rate_limiters import InMemoryRateLimiter
 
 
 # We will use GPT-3.5 Turbo as the baseline and compare against GPT-4o

--- a/src/oss/langchain/models.mdx
+++ b/src/oss/langchain/models.mdx
@@ -1610,7 +1610,7 @@ To help manage rate limits, chat model integrations accept a `rate_limiter` para
     LangChain in comes with (an optional) built-in @[`InMemoryRateLimiter`]. This limiter is thread safe and can be shared by multiple threads in the same process.
 
     ```python Define a rate limiter
-    from langchain_core.rate_limiters import InMemoryRateLimiter
+    from langchain.rate_limiters import InMemoryRateLimiter
 
     rate_limiter = InMemoryRateLimiter(
         requests_per_second=0.1,  # 1 request every 10s

--- a/src/oss/python/integrations/providers/langfair.mdx
+++ b/src/oss/python/integrations/providers/langfair.mdx
@@ -31,7 +31,7 @@ Below are code samples illustrating how to use LangFair to assess bias and fairn
 To generate responses, we can use LangFair's `ResponseGenerator` class. First, we must create a `langchain` LLM object. Below we use `ChatVertexAI`, but **any of [LangChain’s LLM classes](https://js.langchain.com/docs/integrations/chat/) may be used instead**. Note that `InMemoryRateLimiter` is to used to avoid rate limit errors.
 ```python
 from langchain_google_vertexai import ChatVertexAI
-from langchain_core.rate_limiters import InMemoryRateLimiter
+from langchain.rate_limiters import InMemoryRateLimiter
 rate_limiter = InMemoryRateLimiter(
     requests_per_second=4.5, check_every_n_seconds=0.5, max_bucket_size=280,
 )

--- a/src/oss/python/integrations/retrievers/elasticsearch_retriever.mdx
+++ b/src/oss/python/integrations/retrievers/elasticsearch_retriever.mdx
@@ -55,7 +55,7 @@ from elasticsearch import Elasticsearch
 from elasticsearch.helpers import bulk
 from langchain_community.embeddings import DeterministicFakeEmbedding
 from langchain_core.documents import Document
-from langchain_core.embeddings import Embeddings
+from langchain.embeddings import Embeddings
 from langchain_elasticsearch import ElasticsearchRetriever
 ```
 


### PR DESCRIPTION
## Overview
This repo's own `scripts/check_pr_imports.py` (run in CI) flags new example code that imports symbols from `langchain_core` when `langchain` re-exports the same symbol. That check only looks at diff lines, so some pre-existing snippets in already-merged content still use the old `langchain_core` path. This PR fixes the 5 remaining cases found by running `scripts/check_import_mappings.py` against the current `langchain`/`langchain_core` releases:

- `InMemoryRateLimiter`: `langchain_core.rate_limiters` → `langchain.rate_limiters` (4 files)
- `Embeddings`: `langchain_core.embeddings` → `langchain.embeddings` (1 file)

## Type of change
Fix typo/bug/link/formatting

## Checklist
- [x] I have read the contributing guidelines, including the language policy
- [x] I have tested my changes locally (verified both symbols are exported by the installed `langchain` package, confirmed each import line is unique per file, ran `scripts/check_cross_refs.py` after the change, and confirmed `git apply --check` succeeds on a fresh clone of `main`)
- [x] All code examples have been tested and work correctly (import path only, no logic changed)
- [x] I have used root relative paths for internal links (not applicable — no links touched)
- [x] I have updated navigation in `src/docs.json` if needed (not applicable)