### PR TITLE
docs: clarify gateway metadata-only trace billing

### DIFF
--- a/src/langsmith/llm-gateway-access.mdx
+++ b/src/langsmith/llm-gateway-access.mdx
@@ -24,6 +24,10 @@ Gateway-proxied calls are distinguishable from direct LLM calls by the project t
 - **Guard rule matches:** when redaction policies apply, the guard pipeline emits a `rule_id → count` map stamped onto the span as `policy.matched_rules`, `passed_rules`, and `violated_rules`. These are rule IDs, not PII or secret category labels.
 - **Cost data:** token counts and cost are computed inline and feed the same spend accumulator that spend-cap policies enforce against.
 
+### Trace content and billing
+
+When **Trace content** is disabled in a gateway data retention policy, request and response bodies are not stored. The gateway still emits a metadata-only trace that can include token usage, latency, status, and model information. Gateway-emitted metadata-only traces are excluded from trace-based billing. Model usage still contributes to gateway spend tracking.
+
 ## LangSmith Engine integration
 
 When a governance policy fires (such as when a spend limit is hit, PII is detected and redacted, or a secret is caught), the event is recorded as metadata on the trace. These policy violations surface as issues in LangSmith Engine.


### PR DESCRIPTION
## Description
Clarify that gateway metadata-only traces emitted when Trace content is disabled are excluded from trace-based billing, while model usage still contributes to gateway spend tracking.

## Test Plan
- [ ] Confirm the updated wording in the docs preview.

Made by [Open SWE](https://openswe.vercel.app/agents/7c4b9f37-27ea-db6b-fa37-3a24efef5acf)