### PR TITLE
docs: list AproxPay in external integration tables

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -141,6 +141,9 @@ python:
   - name: ApifyActorsTool
     pypi: langchain-apify
     docs_url: https://docs.apify.com/platform/integrations/langchain
+  - name: AproxPayProxyGetTool
+    pypi: langchain-aproxpay
+    docs_url: https://github.com/aproxpay/langchain-aproxpay
   - name: SmartScraperTool
     pypi: langchain-scrapegraph
     docs_url: https://github.com/ScrapeGraphAI/langchain-scrapegraph
@@ -617,6 +620,9 @@ python:
 
 javascript:
   tools:
+  - name: AproxPay
+    npm: langchain-aproxpay
+    docs_url: https://github.com/aproxpay/langchain-aproxpay
   - name: Bilig WorkPaper
     npm: "@bilig/workpaper"
     docs_url: https://proompteng.github.io/bilig/

--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -154,6 +154,14 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
+        title="AproxPay"
+        href="https://github.com/aproxpay/langchain-aproxpay"
+        icon="link"
+    >
+        Residential proxy for agents with native x402 payments (USDC on Base).
+    </Card>
+
+    <Card
         title="assistant-ui"
         icon="file-code"
         href="https://www.assistant-ui.com/docs/runtimes/langgraph"

--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -57,6 +57,7 @@ The following table shows tools that can be used to automate tasks in web browse
 |-------------|---------|---------------------------------------|
 | [AgentQL Toolkit](https://docs.agentql.com/) | Free trial, with pay-as-you-go and flat rate plans after | ✅ |
 | [Amazon Bedrock AgentCore Browser](/oss/integrations/tools/bedrock_agentcore_browser) | Pay-per-use (AWS) | ✅ |
+| [AproxPay](https://github.com/aproxpay/langchain-aproxpay) | Pay-per-use via x402 (USDC on Base); no signup | ❌ (fetch + CONNECT session pass) |
 | [Browserless](https://browserless.io) | Free tier, with usage-based plans after | ✅ |
 | [Hyperbrowser Browser Agent Tools](https://docs.hyperbrowser.ai/) | Free trial, with flat rate plans and pre-paid credits after | ✅ |
 | [Hyperbrowser Web Scraping Tools](https://docs.hyperbrowser.ai/) | Free trial, with flat rate plans and pre-paid credits after | ❌ |


### PR DESCRIPTION
## Summary
- Add listing-only metadata for [`langchain-aproxpay`](https://pypi.org/project/langchain-aproxpay/) / [`langchain-aproxpay` on npm](https://www.npmjs.com/package/langchain-aproxpay) under the [new external-integration process](https://docs.langchain.com/oss/python/contributing/publish-langchain#make-your-integration-discoverable): one YAML row each in `python.tools` and `javascript.tools`, linking to the [GitHub README](https://github.com/aproxpay/langchain-aproxpay).
- Add AproxPay to the Python Tools → Web browsing table and the All providers card grid (external `href`s, no hosted guide pages).
- This is **listing metadata only** — usage docs stay in the package README. Related pre-policy hosted-guide submission: #5072.

## Test plan
- [ ] `uv run python scripts/refresh_integration_downloads.py --check-docs-urls`
- [ ] Confirm CI `check-external-docs-urls` passes
- [ ] After merge + weekly download refresh, AproxPay appears in Tools download tables with a link to GitHub
- [ ] Web browsing row and All providers card render with external links