### PR TITLE
docs: list Search1API toolkit integration

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -299,6 +299,9 @@ python:
   - name: Cosmergon
     pypi: langchain-cosmergon
     docs_url: https://cosmergon.com
+  - name: Search1APIToolkit
+    pypi: search1api-langchain
+    docs_url: https://github.com/superagents-lab/search1api-langchain
   middleware:
   - name: CopilotKit
     pypi: copilotkit


### PR DESCRIPTION
## Overview

List the official Search1API toolkit in the Python tools integration table under the new external-integration process.

The `search1api-langchain` package provides `Search1APIToolkit` with Search, News, and Crawl tools. Version 0.1.0 is published on PyPI and maintained by Search1API in the `superagents-lab` organization.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Package: https://pypi.org/project/search1api-langchain/
- Source and usage documentation: https://github.com/superagents-lab/search1api-langchain
- Release: https://github.com/superagents-lab/search1api-langchain/releases/tag/v0.1.0

## Validation

- `uv run --no-project --with requests --with pyyaml python scripts/refresh_integration_downloads.py --check-docs-urls`
- `PYTHONPATH=. uv run --no-project --with pytest --with requests --with pyyaml pytest -c /dev/null tests/unit_tests/test_refresh_integration_downloads.py` (17 passed)
- Verified the GitHub documentation URL and PyPI project URL return HTTP 200.

## Checklist

- [x] I have read the contributing guidelines.
- [x] All code examples have been tested and work correctly. No code examples are added by this PR.
- [x] I have used root-relative paths for internal links. No internal links are added by this PR.
- [x] I have updated navigation in `src/docs.json` if needed. No new page or navigation entry is required for an external YAML listing.

## Additional notes

This is a listing-only contribution for an integration below the hosted-guide download threshold. Usage documentation remains in the package repository.

An AI coding agent assisted with the YAML edit, validation, and PR preparation. The package implementation, published artifacts, links, and validation results were verified before submission.
