### PR TITLE
docs(langsmith): document the child_runs replacement in the SmithDB migration guide

### DIFF
--- a/src/code-samples/langsmith/smithdb-migration/runs-retrieve-child-runs-after.ts
+++ b/src/code-samples/langsmith/smithdb-migration/runs-retrieve-child-runs-after.ts
@@ -1,0 +1,102 @@
+// :remove-start:
+import { getCurrentRunTree, traceable } from "langsmith/traceable";
+
+process.env.LANGSMITH_TRACING = "true";
+
+// The `default` project holds no nested traces of its own, so the sample
+// creates one instead of depending on data it does not control.
+const seeded: { runId?: string; traceId?: string } = {};
+
+const leaf = traceable(async (index: number) => `leaf ${index}`, {
+  name: "leaf",
+  run_type: "llm",
+});
+const branch = traceable(
+  async () => {
+    await leaf(0);
+    return "branch";
+  },
+  { name: "branch" },
+);
+const seedRoot = traceable(
+  async () => {
+    const runTree = getCurrentRunTree();
+    seeded.runId = runTree.id;
+    seeded.traceId = runTree.trace_id;
+    await leaf(1);
+    await branch();
+    return "root";
+  },
+  { name: "docs-child-runs-example", project_name: "default" },
+);
+// :remove-end:
+
+// :snippet-start: runs-retrieve-child-runs-after-js
+// :codegroup-tab: After
+import { Client } from "langsmith";
+
+const client = new Client();
+const project = await client.readProject({ projectName: "default" });
+let runId = "<run-id>";
+// `traceId` is the run's trace ID. A root run is its own trace, so `traceId`
+// equals `runId`. For any other run, read `trace_id` from
+// `client.runs.retrieve()` first.
+let traceId = "<trace-id>";
+// :remove-start:
+await seedRoot();
+await client.awaitPendingTraceBatches();
+runId = seeded.runId!;
+traceId = seeded.traceId!;
+// The v2 read path becomes consistent a moment after ingestion, so poll until
+// the whole trace is visible.
+for (let attempt = 0; attempt < 30; attempt += 1) {
+  const seededTrace = await client.traces.listRuns(traceId, {
+    project_id: project.id,
+    selects: ["ID"],
+  });
+  if ((seededTrace.items ?? []).length === 4) break;
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+}
+// :remove-end:
+
+const traceRuns = await client.traces.listRuns(traceId, {
+  project_id: project.id,
+  selects: ["ID", "NAME", "RUN_TYPE", "PARENT_RUN_IDS", "START_TIME", "END_TIME"],
+});
+
+// `parent_run_ids` is the full ancestor chain, root first, closest parent last.
+// A run is a descendant of `runId` when `runId` appears anywhere in that chain,
+// at any depth, not only as the immediate parent. This flat list replaces
+// `child_run_ids`.
+const descendants = (traceRuns.items ?? []).filter((traceRun) =>
+  (traceRun.parent_run_ids ?? []).includes(runId),
+);
+console.log(descendants.length, "descendants");
+
+// Optional: group the runs by immediate parent to walk the trace as a tree,
+// which is the information `child_runs` used to carry.
+type TraceRun = NonNullable<typeof traceRuns.items>[number];
+const byParent = new Map<string, TraceRun[]>();
+for (const traceRun of traceRuns.items ?? []) {
+  const ancestors = traceRun.parent_run_ids ?? [];
+  if (ancestors.length === 0) continue;
+  // The last ancestor is the immediate parent.
+  const parentId = ancestors[ancestors.length - 1];
+  byParent.set(parentId, [...(byParent.get(parentId) ?? []), traceRun]);
+}
+
+const children = byParent.get(runId) ?? [];
+for (const child of children) {
+  console.log(child.name, child.run_type, (byParent.get(child.id!) ?? []).length);
+}
+// :snippet-end:
+
+// :remove-start:
+if (children.length !== 2) {
+  throw new Error(`expected 2 direct children, got ${children.length}`);
+}
+if (descendants.length !== 3) {
+  throw new Error(`expected 3 descendants, got ${descendants.length}`);
+}
+console.log("✓ runs-retrieve-child-runs-after validated");
+// :remove-end:

--- a/src/code-samples/langsmith/smithdb-migration/runs-retrieve-child-runs-after.ts
+++ b/src/code-samples/langsmith/smithdb-migration/runs-retrieve-child-runs-after.ts
@@ -5,7 +5,7 @@ process.env.LANGSMITH_TRACING = "true";
 
 // The `default` project holds no nested traces of its own, so the sample
 // creates one instead of depending on data it does not control.
-const seeded: { runId?: string; traceId?: string } = {};
+const seeded: { traceId?: string } = {};
 
 const leaf = traceable(async (index: number) => `leaf ${index}`, {
   name: "leaf",
@@ -20,9 +20,7 @@ const branch = traceable(
 );
 const seedRoot = traceable(
   async () => {
-    const runTree = getCurrentRunTree();
-    seeded.runId = runTree.id;
-    seeded.traceId = runTree.trace_id;
+    seeded.traceId = getCurrentRunTree().trace_id;
     await leaf(1);
     await branch();
     return "root";
@@ -37,15 +35,11 @@ import { Client } from "langsmith";
 
 const client = new Client();
 const project = await client.readProject({ projectName: "default" });
-let runId = "<run-id>";
-// `traceId` is the run's trace ID. A root run is its own trace, so `traceId`
-// equals `runId`. For any other run, read `trace_id` from
-// `client.runs.retrieve()` first.
+// A root run is its own trace, so `traceId` is also the run ID.
 let traceId = "<trace-id>";
 // :remove-start:
 await seedRoot();
 await client.awaitPendingTraceBatches();
-runId = seeded.runId!;
 traceId = seeded.traceId!;
 // The v2 read path becomes consistent a moment after ingestion, so poll until
 // the whole trace is visible.
@@ -65,11 +59,10 @@ const traceRuns = await client.traces.listRuns(traceId, {
 });
 
 // `parent_run_ids` is the full ancestor chain, root first, closest parent last.
-// A run is a descendant of `runId` when `runId` appears anywhere in that chain,
-// at any depth, not only as the immediate parent. This flat list replaces
-// `child_run_ids`.
+// A run is a descendant of any ID in that chain, at any depth, not only of the
+// immediate parent. This flat list replaces `child_run_ids`.
 const descendants = (traceRuns.items ?? []).filter((traceRun) =>
-  (traceRun.parent_run_ids ?? []).includes(runId),
+  (traceRun.parent_run_ids ?? []).includes(traceId),
 );
 console.log(descendants.length, "descendants");
 
@@ -85,7 +78,7 @@ for (const traceRun of traceRuns.items ?? []) {
   byParent.set(parentId, [...(byParent.get(parentId) ?? []), traceRun]);
 }
 
-const children = byParent.get(runId) ?? [];
+const children = byParent.get(traceId) ?? [];
 for (const child of children) {
   console.log(child.name, child.run_type, (byParent.get(child.id!) ?? []).length);
 }

--- a/src/code-samples/langsmith/smithdb-migration/runs-retrieve-child-runs-before.ts
+++ b/src/code-samples/langsmith/smithdb-migration/runs-retrieve-child-runs-before.ts
@@ -1,0 +1,73 @@
+// :remove-start:
+import { getCurrentRunTree, traceable } from "langsmith/traceable";
+
+process.env.LANGSMITH_TRACING = "true";
+
+// The `default` project holds no nested traces of its own, so the sample
+// creates one instead of depending on data it does not control.
+const seeded: { runId?: string } = {};
+
+const leaf = traceable(async (index: number) => `leaf ${index}`, {
+  name: "leaf",
+  run_type: "llm",
+});
+const branch = traceable(
+  async () => {
+    await leaf(0);
+    return "branch";
+  },
+  { name: "branch" },
+);
+const seedRoot = traceable(
+  async () => {
+    seeded.runId = getCurrentRunTree().id;
+    await leaf(1);
+    await branch();
+    return "root";
+  },
+  { name: "docs-child-runs-example", project_name: "default" },
+);
+// :remove-end:
+
+// :snippet-start: runs-retrieve-child-runs-before-js
+// :codegroup-tab: Before
+import { Client } from "langsmith";
+
+const client = new Client();
+let runId = "<run-id>";
+// :remove-start:
+await seedRoot();
+await client.awaitPendingTraceBatches();
+runId = seeded.runId!;
+// The v1 read path becomes consistent a moment after ingestion, so poll until
+// it returns the full child tree.
+for (let attempt = 0; attempt < 30; attempt += 1) {
+  try {
+    const seededRun = await client.readRun(runId, { loadChildRuns: true });
+    if ((seededRun.child_runs ?? []).length === 2) break;
+  } catch {
+    // Not ingested yet.
+  }
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+}
+// :remove-end:
+
+const run = await client.readRun(runId, { loadChildRuns: true });
+
+// `child_runs` holds the direct children, each with its own nested `child_runs`.
+// `child_run_ids` holds every descendant, at any depth.
+for (const child of run.child_runs ?? []) {
+  console.log(child.name, child.run_type, (child.child_runs ?? []).length);
+}
+console.log((run.child_run_ids ?? []).length, "descendants");
+// :snippet-end:
+
+// :remove-start:
+if ((run.child_runs ?? []).length !== 2) {
+  throw new Error(`expected 2 direct children, got ${(run.child_runs ?? []).length}`);
+}
+if ((run.child_run_ids ?? []).length !== 3) {
+  throw new Error(`expected 3 descendants, got ${(run.child_run_ids ?? []).length}`);
+}
+console.log("✓ runs-retrieve-child-runs-before validated");
+// :remove-end:

--- a/src/code-samples/langsmith/smithdb-migration/runs-retrieve-child-runs.py
+++ b/src/code-samples/langsmith/smithdb-migration/runs-retrieve-child-runs.py
@@ -1,0 +1,153 @@
+# :remove-start:
+import time
+
+from langsmith import Client as _SeedClient
+from langsmith import traceable
+from langsmith.run_helpers import get_current_run_tree, tracing_context
+
+_SEEDED: dict[str, str] = {}
+
+
+@traceable(run_type="llm")
+def _leaf(index: int) -> str:
+    return f"leaf {index}"
+
+
+@traceable
+def _branch() -> str:
+    _leaf(0)
+    return "branch"
+
+
+@traceable(name="docs-child-runs-example")
+def _root() -> str:
+    run_tree = get_current_run_tree()
+    assert run_tree is not None, "tracing is not enabled"
+    _SEEDED["run_id"] = str(run_tree.id)
+    _SEEDED["trace_id"] = str(run_tree.trace_id)
+    _leaf(1)
+    _branch()
+    return "root"
+
+
+def _seed_trace() -> tuple[str, str]:
+    """Trace a small nested call tree and wait until it is readable.
+
+    The `default` project holds no nested traces of its own, so the sample
+    creates one instead of depending on data it does not control. The v1 and v2
+    read paths become consistent at slightly different times, so poll until the
+    v1 path returns the full child tree.
+    """
+    client = _SeedClient()
+    with tracing_context(project_name="default", enabled=True):
+        _root()
+    client.flush()
+
+    run_id, trace_id = _SEEDED["run_id"], _SEEDED["trace_id"]
+    for _ in range(30):
+        try:
+            run = client.read_run(run_id, load_child_runs=True)
+        except Exception:  # noqa: BLE001 - not ingested yet
+            run = None
+        if run is not None and len(run.child_runs or []) == 2:
+            return run_id, trace_id
+        time.sleep(2)
+    raise AssertionError(f"seeded run {run_id} never became readable with children")
+
+
+_RUN_ID, _TRACE_ID = _seed_trace()
+# :remove-end:
+
+# :snippet-start: runs-retrieve-child-runs-before-py
+# :codegroup-tab: Before
+from langsmith import Client
+
+client = Client()
+run_id = "<run-id>"
+# :remove-start:
+run_id = _RUN_ID
+# :remove-end:
+
+run = client.read_run(run_id, load_child_runs=True)
+
+# `child_runs` holds the direct children, each with its own nested `child_runs`.
+# `child_run_ids` holds every descendant, at any depth.
+for child in run.child_runs or []:
+    print(child.name, child.run_type, len(child.child_runs or []))
+print(len(run.child_run_ids or []), "descendants")
+# :snippet-end:
+
+# :remove-start:
+_BEFORE_DIRECT = {str(child.id) for child in run.child_runs or []}
+_BEFORE_DESCENDANTS = {str(child_id) for child_id in run.child_run_ids or []}
+assert len(_BEFORE_DIRECT) == 2, _BEFORE_DIRECT
+assert len(_BEFORE_DESCENDANTS) == 3, _BEFORE_DESCENDANTS
+# :remove-end:
+
+# :snippet-start: runs-retrieve-child-runs-after-py
+# :codegroup-tab: After
+import asyncio
+from collections import defaultdict
+
+from langsmith import Client
+
+
+async def main():
+    client = Client()
+    project = await client.aread_project(project_name="default")
+    run_id = "<run-id>"
+    # `trace_id` is the run's trace ID. A root run is its own trace, so
+    # `trace_id` equals `run_id`. For any other run, read `trace_id` from
+    # `client.runs.retrieve()` first.
+    trace_id = "<trace-id>"
+    # :remove-start:
+    run_id, trace_id = _RUN_ID, _TRACE_ID
+    # :remove-end:
+
+    trace_runs = await client.traces.list_runs(
+        trace_id,
+        project_id=str(project.id),
+        selects=["ID", "NAME", "RUN_TYPE", "PARENT_RUN_IDS", "START_TIME", "END_TIME"],
+    )
+
+    # `parent_run_ids` is the full ancestor chain, root first, closest parent
+    # last. A run is a descendant of `run_id` when `run_id` appears anywhere in
+    # that chain, at any depth, not only as the immediate parent. This flat list
+    # replaces `child_run_ids`.
+    descendants = [
+        run for run in (trace_runs.items or []) if run_id in (run.parent_run_ids or [])
+    ]
+    print(len(descendants), "descendants")
+
+    # Optional: rebuild the nested `child_runs` shape instead of a flat list.
+    by_parent = defaultdict(list)
+    for run in trace_runs.items or []:
+        if run.parent_run_ids:
+            # The last ancestor is the immediate parent.
+            by_parent[run.parent_run_ids[-1]].append(run)
+
+    def attach(run):
+        run.child_runs = by_parent.get(run.id, [])
+        for child in run.child_runs:
+            attach(child)
+
+    for run in trace_runs.items or []:
+        attach(run)
+
+    children = by_parent.get(run_id, [])
+    for child in children:
+        print(child.name, child.run_type, len(child.child_runs))
+    # :remove-start:
+    assert {str(child.id) for child in children} == _BEFORE_DIRECT, (
+        f"direct children differ: {[str(c.id) for c in children]} != {_BEFORE_DIRECT}"
+    )
+    assert {str(run.id) for run in descendants} == _BEFORE_DESCENDANTS, (
+        f"descendants differ: {[str(r.id) for r in descendants]} "
+        f"!= {_BEFORE_DESCENDANTS}"
+    )
+    print("✓ runs-retrieve-child-runs validated")
+    # :remove-end:
+
+
+asyncio.run(main())
+# :snippet-end:

--- a/src/code-samples/langsmith/smithdb-migration/runs-retrieve-child-runs.py
+++ b/src/code-samples/langsmith/smithdb-migration/runs-retrieve-child-runs.py
@@ -95,13 +95,10 @@ from langsmith import Client
 async def main():
     client = Client()
     project = await client.aread_project(project_name="default")
-    run_id = "<run-id>"
-    # `trace_id` is the run's trace ID. A root run is its own trace, so
-    # `trace_id` equals `run_id`. For any other run, read `trace_id` from
-    # `client.runs.retrieve()` first.
+    # A root run is its own trace, so `trace_id` is also the run ID.
     trace_id = "<trace-id>"
     # :remove-start:
-    run_id, trace_id = _RUN_ID, _TRACE_ID
+    trace_id = _TRACE_ID
     # :remove-end:
 
     trace_runs = await client.traces.list_runs(
@@ -111,11 +108,10 @@ async def main():
     )
 
     # `parent_run_ids` is the full ancestor chain, root first, closest parent
-    # last. A run is a descendant of `run_id` when `run_id` appears anywhere in
-    # that chain, at any depth, not only as the immediate parent. This flat list
-    # replaces `child_run_ids`.
+    # last. A run is a descendant of any ID in that chain, at any depth, not
+    # only of the immediate parent. This flat list replaces `child_run_ids`.
     descendants = [
-        run for run in (trace_runs.items or []) if run_id in (run.parent_run_ids or [])
+        run for run in (trace_runs.items or []) if trace_id in (run.parent_run_ids or [])
     ]
     print(len(descendants), "descendants")
 
@@ -134,7 +130,7 @@ async def main():
     for run in trace_runs.items or []:
         attach(run)
 
-    children = by_parent.get(run_id, [])
+    children = by_parent.get(trace_id, [])
     for child in children:
         print(child.name, child.run_type, len(child.child_runs))
     # :remove-start:

--- a/src/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-after-js.mdx
@@ -1,0 +1,42 @@
+```ts After
+import { Client } from "langsmith";
+
+const client = new Client();
+const project = await client.readProject({ projectName: "default" });
+let runId = "<run-id>";
+// `traceId` is the run's trace ID. A root run is its own trace, so `traceId`
+// equals `runId`. For any other run, read `trace_id` from
+// `client.runs.retrieve()` first.
+let traceId = "<trace-id>";
+
+const traceRuns = await client.traces.listRuns(traceId, {
+  project_id: project.id,
+  selects: ["ID", "NAME", "RUN_TYPE", "PARENT_RUN_IDS", "START_TIME", "END_TIME"],
+});
+
+// `parent_run_ids` is the full ancestor chain, root first, closest parent last.
+// A run is a descendant of `runId` when `runId` appears anywhere in that chain,
+// at any depth, not only as the immediate parent. This flat list replaces
+// `child_run_ids`.
+const descendants = (traceRuns.items ?? []).filter((traceRun) =>
+  (traceRun.parent_run_ids ?? []).includes(runId),
+);
+console.log(descendants.length, "descendants");
+
+// Optional: group the runs by immediate parent to walk the trace as a tree,
+// which is the information `child_runs` used to carry.
+type TraceRun = NonNullable<typeof traceRuns.items>[number];
+const byParent = new Map<string, TraceRun[]>();
+for (const traceRun of traceRuns.items ?? []) {
+  const ancestors = traceRun.parent_run_ids ?? [];
+  if (ancestors.length === 0) continue;
+  // The last ancestor is the immediate parent.
+  const parentId = ancestors[ancestors.length - 1];
+  byParent.set(parentId, [...(byParent.get(parentId) ?? []), traceRun]);
+}
+
+const children = byParent.get(runId) ?? [];
+for (const child of children) {
+  console.log(child.name, child.run_type, (byParent.get(child.id!) ?? []).length);
+}
+```

--- a/src/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-after-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-after-js.mdx
@@ -3,10 +3,7 @@ import { Client } from "langsmith";
 
 const client = new Client();
 const project = await client.readProject({ projectName: "default" });
-let runId = "<run-id>";
-// `traceId` is the run's trace ID. A root run is its own trace, so `traceId`
-// equals `runId`. For any other run, read `trace_id` from
-// `client.runs.retrieve()` first.
+// A root run is its own trace, so `traceId` is also the run ID.
 let traceId = "<trace-id>";
 
 const traceRuns = await client.traces.listRuns(traceId, {
@@ -15,11 +12,10 @@ const traceRuns = await client.traces.listRuns(traceId, {
 });
 
 // `parent_run_ids` is the full ancestor chain, root first, closest parent last.
-// A run is a descendant of `runId` when `runId` appears anywhere in that chain,
-// at any depth, not only as the immediate parent. This flat list replaces
-// `child_run_ids`.
+// A run is a descendant of any ID in that chain, at any depth, not only of the
+// immediate parent. This flat list replaces `child_run_ids`.
 const descendants = (traceRuns.items ?? []).filter((traceRun) =>
-  (traceRun.parent_run_ids ?? []).includes(runId),
+  (traceRun.parent_run_ids ?? []).includes(traceId),
 );
 console.log(descendants.length, "descendants");
 
@@ -35,7 +31,7 @@ for (const traceRun of traceRuns.items ?? []) {
   byParent.set(parentId, [...(byParent.get(parentId) ?? []), traceRun]);
 }
 
-const children = byParent.get(runId) ?? [];
+const children = byParent.get(traceId) ?? [];
 for (const child of children) {
   console.log(child.name, child.run_type, (byParent.get(child.id!) ?? []).length);
 }

--- a/src/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-after-py.mdx
@@ -1,0 +1,53 @@
+```python After
+import asyncio
+from collections import defaultdict
+
+from langsmith import Client
+
+
+async def main():
+    client = Client()
+    project = await client.aread_project(project_name="default")
+    run_id = "<run-id>"
+    # `trace_id` is the run's trace ID. A root run is its own trace, so
+    # `trace_id` equals `run_id`. For any other run, read `trace_id` from
+    # `client.runs.retrieve()` first.
+    trace_id = "<trace-id>"
+
+    trace_runs = await client.traces.list_runs(
+        trace_id,
+        project_id=str(project.id),
+        selects=["ID", "NAME", "RUN_TYPE", "PARENT_RUN_IDS", "START_TIME", "END_TIME"],
+    )
+
+    # `parent_run_ids` is the full ancestor chain, root first, closest parent
+    # last. A run is a descendant of `run_id` when `run_id` appears anywhere in
+    # that chain, at any depth, not only as the immediate parent. This flat list
+    # replaces `child_run_ids`.
+    descendants = [
+        run for run in (trace_runs.items or []) if run_id in (run.parent_run_ids or [])
+    ]
+    print(len(descendants), "descendants")
+
+    # Optional: rebuild the nested `child_runs` shape instead of a flat list.
+    by_parent = defaultdict(list)
+    for run in trace_runs.items or []:
+        if run.parent_run_ids:
+            # The last ancestor is the immediate parent.
+            by_parent[run.parent_run_ids[-1]].append(run)
+
+    def attach(run):
+        run.child_runs = by_parent.get(run.id, [])
+        for child in run.child_runs:
+            attach(child)
+
+    for run in trace_runs.items or []:
+        attach(run)
+
+    children = by_parent.get(run_id, [])
+    for child in children:
+        print(child.name, child.run_type, len(child.child_runs))
+
+
+asyncio.run(main())
+```

--- a/src/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-after-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-after-py.mdx
@@ -8,10 +8,7 @@ from langsmith import Client
 async def main():
     client = Client()
     project = await client.aread_project(project_name="default")
-    run_id = "<run-id>"
-    # `trace_id` is the run's trace ID. A root run is its own trace, so
-    # `trace_id` equals `run_id`. For any other run, read `trace_id` from
-    # `client.runs.retrieve()` first.
+    # A root run is its own trace, so `trace_id` is also the run ID.
     trace_id = "<trace-id>"
 
     trace_runs = await client.traces.list_runs(
@@ -21,11 +18,10 @@ async def main():
     )
 
     # `parent_run_ids` is the full ancestor chain, root first, closest parent
-    # last. A run is a descendant of `run_id` when `run_id` appears anywhere in
-    # that chain, at any depth, not only as the immediate parent. This flat list
-    # replaces `child_run_ids`.
+    # last. A run is a descendant of any ID in that chain, at any depth, not
+    # only of the immediate parent. This flat list replaces `child_run_ids`.
     descendants = [
-        run for run in (trace_runs.items or []) if run_id in (run.parent_run_ids or [])
+        run for run in (trace_runs.items or []) if trace_id in (run.parent_run_ids or [])
     ]
     print(len(descendants), "descendants")
 
@@ -44,7 +40,7 @@ async def main():
     for run in trace_runs.items or []:
         attach(run)
 
-    children = by_parent.get(run_id, [])
+    children = by_parent.get(trace_id, [])
     for child in children:
         print(child.name, child.run_type, len(child.child_runs))
 

--- a/src/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-before-js.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-before-js.mdx
@@ -1,0 +1,15 @@
+```ts Before
+import { Client } from "langsmith";
+
+const client = new Client();
+let runId = "<run-id>";
+
+const run = await client.readRun(runId, { loadChildRuns: true });
+
+// `child_runs` holds the direct children, each with its own nested `child_runs`.
+// `child_run_ids` holds every descendant, at any depth.
+for (const child of run.child_runs ?? []) {
+  console.log(child.name, child.run_type, (child.child_runs ?? []).length);
+}
+console.log((run.child_run_ids ?? []).length, "descendants");
+```

--- a/src/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-before-py.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-before-py.mdx
@@ -1,0 +1,14 @@
+```python Before
+from langsmith import Client
+
+client = Client()
+run_id = "<run-id>"
+
+run = client.read_run(run_id, load_child_runs=True)
+
+# `child_runs` holds the direct children, each with its own nested `child_runs`.
+# `child_run_ids` holds every descendant, at any depth.
+for child in run.child_runs or []:
+    print(child.name, child.run_type, len(child.child_runs or []))
+print(len(run.child_run_ids or []), "descendants")
+```

--- a/src/snippets/langsmith/smithdb-migration/runs-retrieve.mdx
+++ b/src/snippets/langsmith/smithdb-migration/runs-retrieve.mdx
@@ -22,6 +22,10 @@ import SmithdbRunsRetrieveNotFoundBeforeGo from '/snippets/code-samples/smithdb-
 import SmithdbRunsRetrieveNotFoundAfterGo from '/snippets/code-samples/smithdb-migration/runs-retrieve-not-found-after-go.mdx';
 import SmithdbRunsRetrieveNotFoundBeforeSh from '/snippets/code-samples/smithdb-migration/runs-retrieve-not-found-before-sh.mdx';
 import SmithdbRunsRetrieveNotFoundAfterSh from '/snippets/code-samples/smithdb-migration/runs-retrieve-not-found-after-sh.mdx';
+import SmithdbRunsRetrieveChildRunsBeforePy from '/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-before-py.mdx';
+import SmithdbRunsRetrieveChildRunsAfterPy from '/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-after-py.mdx';
+import SmithdbRunsRetrieveChildRunsBeforeJs from '/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-before-js.mdx';
+import SmithdbRunsRetrieveChildRunsAfterJs from '/snippets/code-samples/smithdb-migration/runs-retrieve-child-runs-after-js.mdx';
 
 ## Runs: retrieve
 
@@ -84,7 +88,7 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
     | Before (`read_run`) | After (`runs.retrieve`) | Notes |
     |---|---|---|
     | `run_id` | `run_id` | Unchanged |
-    | `load_child_runs` | *(removed)* | No equivalent |
+    | `load_child_runs` | *(removed)* | Fetch the trace's runs with `traces.list_runs` and filter by `parent_run_ids`. See [Load a run's child runs](#load-a-runs-child-runs) |
     | *(not available)* | `project_id` | **Required**—UUID of the project that owns the run |
     | *(not available)* | `start_time` | Optional—run's start time (RFC3339); providing it speeds up retrieval |
     | *(all fields returned by default)* | `selects` | Field projection; defaults to `["ID"]` only; field names are uppercase |
@@ -97,7 +101,7 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
     | Before (`readRun`) | After (`client.runs.retrieve`) | Notes |
     |---|---|---|
     | `runId` | `runId` | Unchanged (positional parameter) |
-    | `options.loadChildRuns` | *(removed)* | No equivalent |
+    | `options.loadChildRuns` | *(removed)* | Fetch the trace's runs with `client.traces.listRuns` and filter by `parent_run_ids`. See [Load a run's child runs](#load-a-runs-child-runs) |
     | *(not available)* | `project_id` | **Required**—`snake_case`; UUID of the project that owns the run |
     | *(not available)* | `start_time` | Optional—`snake_case`; run's start time (RFC3339); providing it speeds up retrieval |
     | *(all fields returned by default)* | `selects` | Field projection; defaults to `["ID"]` only; field names are uppercase |
@@ -144,7 +148,6 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
     | Before (`GET /api/v1/runs/{run_id}` param) | After (`GET /v2/runs/{run_id}` param) | Notes |
     |---|---|---|
     | `run_id` (path) | `run_id` (path) | Unchanged |
-    | `load_child_runs` (query) | *(removed)* | No equivalent |
     | *(not available)* | `project_id` (query) | **Required**—UUID of the project that owns the run |
     | `start_time` (query) | `start_time` (query) | Still optional; providing it speeds up retrieval |
     | *(all fields returned by default)* | `selects` (query, repeatable) | Field projection; defaults to `["ID"]` only; field names are uppercase |
@@ -190,8 +193,8 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
     | `run.first_token_time` | `run.first_token_time` | Unchanged |
     | `run.latency` (property) | `run.latency_seconds` | Renamed; was a computed `timedelta` property, now a native `float` field |
     | `run.in_dataset` | `run.is_in_dataset` | Renamed |
-    | `run.child_run_ids` | *(removed)* | No equivalent |
-    | `run.child_runs` | *(removed)* | No equivalent |
+    | `run.child_run_ids` | *(removed)* | Filter the trace's runs on `parent_run_ids`. See [Load a run's child runs](#load-a-runs-child-runs) |
+    | `run.child_runs` | *(removed)* | Group the trace's runs by the last entry in `parent_run_ids`. See [Load a run's child runs](#load-a-runs-child-runs) |
     | `run.serialized` | *(removed)* | Use `run.manifest` |
     | `run.manifest_id` | *(removed)* | Use `run.manifest` |
     | *(not available)* | `run.is_root` | New |
@@ -243,8 +246,8 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
     | `run.firstTokenTime` | `run.first_token_time` | Renamed to `snake_case` |
     | `run.latency` | `run.latency_seconds` | Renamed; was a computed property, now a native `number` field (seconds) |
     | `run.inDataset` | `run.is_in_dataset` | Renamed |
-    | `run.childRunIds` | *(removed)* | No equivalent |
-    | `run.childRuns` | *(removed)* | No equivalent |
+    | `run.child_run_ids` | *(removed)* | Filter the trace's runs on `parent_run_ids`. See [Load a run's child runs](#load-a-runs-child-runs) |
+    | `run.child_runs` | *(removed)* | Group the trace's runs by the last entry in `parent_run_ids`. See [Load a run's child runs](#load-a-runs-child-runs) |
     | `run.serialized` | *(removed)* | Use `run.manifest` |
     | `run.manifestId` | *(removed)* | Use `run.manifest` |
     | `run.shareToken` | *(removed)* | Use `run.share_url` (full URL, only set when the run has been shared) |
@@ -736,6 +739,48 @@ curl "https://api.smith.langchain.com/api/v1/runs/$RUN_ID" \
         <SmithdbRunsRetrieveNotFoundAfterSh />
       </Tab>
     </Tabs>
+  </Tab>
+</Tabs>
+
+#### Load a run's child runs
+
+The `load_child_runs` flag and the nested `child_runs` field are removed. Fetch every run in the trace, then filter those runs by ancestry.
+
+`parent_run_ids` holds a run's full ancestor chain, root first and closest parent last. Filtering on it returns every descendant at any depth, which is what `child_run_ids` used to hold. Group the runs by the last entry in that chain to recover the direct children that `child_runs` used to hold.
+
+<Tabs>
+  <Tab title="Python">
+    `read_run` accepted `load_child_runs=True` and populated `run.child_runs`. Replace both with `client.traces.list_runs`, using the run's `trace_id` as the path parameter.
+
+    <Tabs sync={false}>
+      <Tab title="Before">
+        <SmithdbRunsRetrieveChildRunsBeforePy />
+      </Tab>
+      <Tab title="After">
+        <SmithdbRunsRetrieveChildRunsAfterPy />
+      </Tab>
+    </Tabs>
+  </Tab>
+  <Tab title="TypeScript">
+    `readRun` accepted a `loadChildRuns` option and populated `run.child_runs`. Replace both with `client.traces.listRuns`, using the run's `trace_id` as the path parameter.
+
+    <Tabs sync={false}>
+      <Tab title="Before">
+        <SmithdbRunsRetrieveChildRunsBeforeJs />
+      </Tab>
+      <Tab title="After">
+        <SmithdbRunsRetrieveChildRunsAfterJs />
+      </Tab>
+    </Tabs>
+  </Tab>
+  <Tab title="Java">
+    Nothing to migrate. Loading a run's children in one call was a convenience implemented in the Python and TypeScript SDKs, which issued a second query on the caller's behalf. The Java SDK never exposed it, and `client.runs().retrieve()` never returned nested child runs. To walk a trace's runs, use `client.traces().listRuns()`.
+  </Tab>
+  <Tab title="Go">
+    Nothing to migrate. Loading a run's children in one call was a convenience implemented in the Python and TypeScript SDKs, which issued a second query on the caller's behalf. The Go SDK never exposed it, and `client.Runs.Get()` never returned nested child runs. To walk a trace's runs, use `client.Traces.ListRuns()`.
+  </Tab>
+  <Tab title="cURL">
+    Nothing to migrate. Loading a run's children in one call was a convenience implemented in the Python and TypeScript SDKs, which issued a second query on the caller's behalf. `GET /api/v1/runs/{run_id}` never accepted a flag for it and never returned nested child runs. To walk a trace's runs, use `GET /v2/traces/{trace_id}/runs`.
   </Tab>
 </Tabs>
 

--- a/src/snippets/langsmith/smithdb-migration/runs-retrieve.mdx
+++ b/src/snippets/langsmith/smithdb-migration/runs-retrieve.mdx
@@ -744,13 +744,11 @@ curl "https://api.smith.langchain.com/api/v1/runs/$RUN_ID" \
 
 #### Load a run's child runs
 
-The `load_child_runs` flag and the nested `child_runs` field are removed. Fetch every run in the trace, then filter those runs by ancestry.
-
-`parent_run_ids` holds a run's full ancestor chain, root first and closest parent last. Filtering on it returns every descendant at any depth, which is what `child_run_ids` used to hold. Group the runs by the last entry in that chain to recover the direct children that `child_runs` used to hold.
+The `load_child_runs` flag and the nested `child_runs` field are removed. Fetch every run in the trace with `traces.list_runs`, then filter on `parent_run_ids`, which holds each run's full ancestor chain, root first and closest parent last.
 
 <Tabs>
   <Tab title="Python">
-    `read_run` accepted `load_child_runs=True` and populated `run.child_runs`. Replace both with `client.traces.list_runs`, using the run's `trace_id` as the path parameter.
+    Replace `read_run(run_id, load_child_runs=True)` with `client.traces.list_runs`.
 
     <Tabs sync={false}>
       <Tab title="Before">
@@ -762,7 +760,7 @@ The `load_child_runs` flag and the nested `child_runs` field are removed. Fetch 
     </Tabs>
   </Tab>
   <Tab title="TypeScript">
-    `readRun` accepted a `loadChildRuns` option and populated `run.child_runs`. Replace both with `client.traces.listRuns`, using the run's `trace_id` as the path parameter.
+    Replace the `loadChildRuns` option with `client.traces.listRuns`.
 
     <Tabs sync={false}>
       <Tab title="Before">
@@ -774,13 +772,13 @@ The `load_child_runs` flag and the nested `child_runs` field are removed. Fetch 
     </Tabs>
   </Tab>
   <Tab title="Java">
-    Nothing to migrate. Loading a run's children in one call was a convenience implemented in the Python and TypeScript SDKs, which issued a second query on the caller's behalf. The Java SDK never exposed it, and `client.runs().retrieve()` never returned nested child runs. To walk a trace's runs, use `client.traces().listRuns()`.
+    Nothing to migrate: the Java SDK never loaded child runs in one call, so use `client.traces().listRuns()` to walk a trace's runs.
   </Tab>
   <Tab title="Go">
-    Nothing to migrate. Loading a run's children in one call was a convenience implemented in the Python and TypeScript SDKs, which issued a second query on the caller's behalf. The Go SDK never exposed it, and `client.Runs.Get()` never returned nested child runs. To walk a trace's runs, use `client.Traces.ListRuns()`.
+    Nothing to migrate: the Go SDK never loaded child runs in one call, so use `client.Traces.ListRuns()` to walk a trace's runs.
   </Tab>
   <Tab title="cURL">
-    Nothing to migrate. Loading a run's children in one call was a convenience implemented in the Python and TypeScript SDKs, which issued a second query on the caller's behalf. `GET /api/v1/runs/{run_id}` never accepted a flag for it and never returned nested child runs. To walk a trace's runs, use `GET /v2/traces/{trace_id}/runs`.
+    Nothing to migrate: `GET /api/v1/runs/{run_id}` never returned child runs, so use `GET /v2/traces/{trace_id}/runs` to walk a trace's runs.
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Why

The SmithDB migration guide currently tells readers that `client.read_run(run_id, load_child_runs=True)`, `run.child_runs`, and `run.child_run_ids` have **No equivalent** in v2. They do have one: fetch every run in the trace with `traces.list_runs`, then filter on `parent_run_ids`. Anyone reading that table today concludes the capability was dropped and has no path forward.

## What changed

A new `#### Load a run's child runs` example in the runs-retrieve section, with tested before/after samples in Python and TypeScript, plus the three table rows now pointing at it instead of saying "No equivalent".

`parent_run_ids` is the full ancestor chain, so filtering on it yields every descendant at any depth (what `child_run_ids` held). Grouping by the last entry recovers the direct children (what `child_runs` held). Both shapes are shown.

Java, Go, and cURL get a tab explaining there is nothing to migrate, because loading children in one call was only ever a client-side fan-out in the Python and TypeScript SDKs.

## Areas needing careful review

**Two existing inaccuracies corrected.** Both were found while verifying this change, and both are the same underlying fact:

1. The cURL query-parameter table listed `load_child_runs` as a v1 param. It never was one: `GET /api/v1/runs/{run_id}` accepts `run_id, session_id, start_time, exclude_s3_stored_attributes, exclude_serialized, include_messages`, and `load_child_runs` appears zero times in `langsmith-platform-openapi.json`. The Python client sends no params on that GET and calls `_load_child_runs` separately (`langsmith/client.py:4017`). Row removed.
2. The TypeScript response table named the v1 fields `run.childRunIds` / `run.childRuns`. The actual properties are snake_case (`child_run_ids`, `child_runs`). Corrected.

**The samples seed their own data.** The `default` project holds no nested traces, so rather than depend on data they do not control, all three samples trace a small nested call tree in a hidden `:remove-start:` block and poll until it is readable. The Python sample then asserts the v2 result equals the v1 result on that same trace, so the documented replacement is verified equivalent rather than assumed.

**Placement.** The example sits after "Handle a not-found run". It documents a `runs.retrieve` migration but the replacement calls `traces.list_runs`, so an argument exists for putting it in the Traces section instead.

## Verification

- `make test-code-samples` on all three samples: 3/3 passed. Python run repeatedly to check for ingestion flakiness: 3/3 consecutive passes.
- Equivalence confirmed on the seeded trace: v1 reports 2 direct children and 3 descendants; v2 filtering reports the same 3 descendants and the same 2 direct children, matched by run ID.
- `make lint`: passed (ruff format, ruff check, ty, codespell).
- `make lint_prose`: 0 errors, 0 warnings, 0 suggestions.
- `make broken-links`: no broken links, including the new same-page anchors.
- `make lint_md`: no new findings (remaining ones in this file are pre-existing).

## AI disclosure

Written by Claude Opus 5 via Claude Code, under human direction and review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)