### PR TITLE
docs: point Search1API at partner docs and list it by capability

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -305,9 +305,9 @@ python:
   - name: Cosmergon
     pypi: langchain-cosmergon
     docs_url: https://cosmergon.com
-  - name: Search1APIToolkit
+  - name: Search1API Toolkit
     pypi: search1api-langchain
-    docs_url: https://github.com/superagents-lab/search1api-langchain
+    docs_url: https://www.search1api.com/docs/integrations/langchain
   middleware:
   - name: CopilotKit
     pypi: copilotkit

--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -25,6 +25,7 @@ The following table shows tools that execute online searches in some shape or fo
 | [Nimble Search](https://docs.nimbleway.com/nimble-sdk/web-tools/search) | Free trial available | URL, Content, Title |
 | [Parallel Search](/oss/integrations/tools/parallel_search) | Paid | URL, Title, Excerpts |
 | [Perplexity Search](/oss/integrations/tools/perplexity_search) | Paid (with monthly free tier) | URL, Title, Snippet, Date, Last Updated |
+| [Search1API Search](https://www.search1api.com/docs/integrations/langchain#search) | 100 free credits on sign up, no credit card | URL, Title, Snippet, Content, Images |
 | [Tavily Search](/oss/integrations/tools/tavily_search) | 1000 free searches/month | URL, Content, Title, Images, Answer |
 | [Apify](https://docs.apify.com/platform/integrations/langchain) | Free tier, pay-per-use (varies by Actor) | Actor output (varies by Actor) |
 | [You.com Search](/oss/integrations/tools/you) | $100 in credits on sign up | URL, Title, Page Content |
@@ -64,6 +65,7 @@ The following table shows tools that can be used to automate tasks in web browse
 | [Manifest](https://omfang.io/manifest-docs) | Free tier available | ❌ |
 | [Nimble Extract](https://docs.nimbleway.com/nimble-sdk/web-tools/extract) | Free trial available | ❌ |
 | [Oxylabs Web Scraper API](https://github.com/oxylabs/langchain-oxylabs) | Free trial, with flat rate plans and pre-paid credits after | ❌ |
+| [Search1API Crawl](https://www.search1api.com/docs/integrations/langchain#crawl) | 100 free credits on sign up, no credit card | ❌ |
 
 ## Database
 


### PR DESCRIPTION
## Overview

Two follow-ups to #5173, which listed `search1api-langchain` in the Python tools table.

**1. `docs_url` now points at partner docs.** The original entry used the GitHub repository because no dedicated partner page existed. That page now exists, and the listing guidance prefers partner docs over a repository link:

> **`docs_url`**: Link for the name column. Prefer partner docs, then the GitHub repo, then the PyPI or npm page.

The display name is also changed from the class name to `Search1API Toolkit` to match the surrounding entries.

**2. Listed by capability in two category tables.** The package ships three tools — `search1api_search`, `search1api_news`, and `search1api_crawl`. The search tool belongs in **Search** and the crawl tool in **Web browsing**, which is the same split Nimble uses for Nimble Search and Nimble Extract. Each row links to the section of the partner page that documents that tool.

`Search1API Crawl` fetches and extracts page content rather than driving a browser session, so **Supports Interacting with the Browser** is `❌`, consistent with Nimble Extract, Oxylabs Web Scraper API, and Hyperbrowser Web Scraping Tools.

Column values:

- **Free/Paid, Pricing** — new accounts receive 100 credits with no credit card and no expiration ([Credits and limits](https://www.search1api.com/docs/essentials/credits-and-limits)).
- **Return Data** — `results[]` carries `title`, `link`, `snippet`, and `content`, plus an `images` list ([Search](https://www.search1api.com/docs/basic/search)).

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Follows #5173
- Partner page: https://www.search1api.com/docs/integrations/langchain
- Package: https://pypi.org/project/search1api-langchain/

## Validation

- `uv run --no-project --with requests --with pyyaml python scripts/refresh_integration_downloads.py --check-docs-urls` — all `docs_url` values safe
- `PYTHONPATH=. uv run --no-project --with pytest --with requests --with pyyaml pytest -c /dev/null tests/unit_tests/test_refresh_integration_downloads.py` — 17 passed
- Verified the partner page and both anchor targets return HTTP 200

## Checklist

- [x] I have read the contributing guidelines.
- [x] All code examples have been tested and work correctly. No code examples are added by this PR.
- [x] I have used root-relative paths for internal links. No internal links are added by this PR.
- [x] I have updated navigation in `src/docs.json` if needed. No new page or navigation entry is required.

## Additional notes

Happy to drop either category row if you would rather keep those tables curated by maintainers — the `docs_url` change stands on its own.