### PR TITLE
Add LLM Gateway per-customer policies page

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -2265,6 +2265,7 @@
               "langsmith/llm-gateway-fallbacks",
               "langsmith/llm-gateway-spend-policies",
               "langsmith/llm-gateway-rate-limit-policies",
+              "langsmith/llm-gateway-header-policies",
               "langsmith/llm-gateway-redaction"
             ]
           },

--- a/src/langsmith/llm-gateway-header-policies.mdx
+++ b/src/langsmith/llm-gateway-header-policies.mdx
@@ -9,13 +9,13 @@ description: Split gateway spend caps and rate limits by a custom request header
 
 A [spend policy](/langsmith/llm-gateway-spend-policies) or [rate limit policy](/langsmith/llm-gateway-rate-limit-policies) can carry a condition on a custom request header, so traffic from a single subject splits into separate limits by header value. Use this to cap each of your own end customers, tenants, or teams without issuing a separate LangSmith API key for each one.
 
-For example, a policy scoped to a workspace with the condition `X-Gateway-Tenant-Id: acme` limits only the requests from that workspace that carry that header value. Requests from the same workspace carrying `X-Gateway-Tenant-Id: globex` count against a different policy.
+For example, a policy scoped to a workspace with the condition `X-Gateway-Customer-Id: acme` limits only the requests from that workspace that carry that header value. Requests from the same workspace carrying `X-Gateway-Customer-Id: globex` count against a different policy.
 
 ## Matchable headers
 
 The gateway matches on request headers prefixed with `X-Gateway-`, and on keys inside the `X-Gateway-Metadata` JSON header. No other request header is matchable.
 
-Header names are normalized before matching: the `X-Gateway-` prefix is stripped, the remainder is lowercased, and every character outside `a-z`, `0-9`, and `_` is replaced with `_`. The headers `X-Gateway-Tenant-Id`, `x-gateway-tenant_id`, and `X-Gateway-TENANT.ID` all resolve to the matcher key `tenant_id`. Header values are compared as exact, case-sensitive strings, with no wildcard or pattern matching.
+Header names are normalized before matching: the `X-Gateway-` prefix is stripped, the remainder is lowercased, and every character outside `a-z`, `0-9`, and `_` is replaced with `_`. The headers `X-Gateway-Customer-Id`, `x-gateway-customer_id`, and `X-Gateway-CUSTOMER.ID` all resolve to the matcher key `customer_id`. Header values are compared as exact, case-sensitive strings, with no wildcard or pattern matching.
 
 The gateway stamps caller identity itself and ignores client attempts to override it. Headers that resolve to `organization_id`, `workspace_id`, `workspace_handle`, `user_id`, `user_email`, `api_key_id`, `api_key_short`, `auth_mode`, `user_agent`, `applied_policy_ids`, or `applied_policy_names`, and any header whose normalized name starts with `gateway`, are discarded.
 
@@ -37,7 +37,7 @@ Creating and managing policies requires `organization:manage` permission. For th
 1. Go to **Settings → Gateway → LLM Gateway**.
 1. Click **Create policy**.
 1. Select the policy type and subject scope, then set the limits.
-1. Under **Custom header condition (optional)**, enter the **Header name** without its `X-Gateway-` prefix (for example, `Tenant-Id`) and the **Header value** to match (for example, `acme`).
+1. Under **Custom header condition (optional)**, enter the **Header name** without its `X-Gateway-` prefix (for example, `Customer-Id`) and the **Header value** to match (for example, `acme`).
 1. Save.
 
 The header condition cannot be edited in the UI after the policy is created. To change it, delete the policy and create a new one, or update `subject_matchers` through the API.
@@ -50,7 +50,7 @@ A reseller or multi-tenant application usually calls the gateway from its own ba
 The gateway trusts the `X-Gateway-*` headers on an incoming request. Set the header in your own backend after you authenticate the end user, and do not distribute the gateway API key to end users. A caller that controls both the key and the header can choose which cap to spend against.
 </Warning>
 
-### Step 1. Send a tenant header on every call
+### Step 1. Send a customer header on every call
 
 Attach the header to each request your backend makes on behalf of an end customer:
 
@@ -60,7 +60,7 @@ Attach the header to each request your backend makes on behalf of an end custome
 curl https://gateway.smith.langchain.com/openai/v1/chat/completions \
     -H "Authorization: Bearer $LANGSMITH_API_KEY" \
     -H "Content-Type: application/json" \
-    -H "X-Gateway-Tenant-Id: acme" \
+    -H "X-Gateway-Customer-Id: acme" \
     -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}'
 ```
 
@@ -75,12 +75,12 @@ client = OpenAI(
 )
 
 
-def answer(tenant_id: str, question: str) -> str:
+def answer(customer_id: str, question: str) -> str:
     """Call the gateway on behalf of one end customer."""
     response = client.chat.completions.create(
         model="gpt-4o-mini",
         messages=[{"role": "user", "content": question}],
-        extra_headers={"X-Gateway-Tenant-Id": tenant_id},
+        extra_headers={"X-Gateway-Customer-Id": customer_id},
     )
     return response.choices[0].message.content
 ```
@@ -96,18 +96,18 @@ curl -X POST "https://api.smith.langchain.com/v1/platform/gateway-policies" \
     -H "X-Api-Key: $LANGSMITH_API_KEY" \
     -H "Content-Type: application/json" \
     -d '{
-          "name": "tenant-acme-monthly-cap",
+          "name": "customer-acme-monthly-cap",
           "policy_type": "spend_cap",
           "action": "block",
           "subject_matchers": [
             {"key": "workspace_id", "value": "0b1c2d3e-4f56-7890-abcd-ef1234567890"},
-            {"key": "tenant_id", "value": "acme"}
+            {"key": "customer_id", "value": "acme"}
           ],
           "config": {"window": "monthly", "limit_usd": 250}
         }'
 ```
 
-The matcher key is the normalized name `tenant_id`, not the header name `X-Gateway-Tenant-Id`. The policy belongs to the organization that owns the API key.
+The matcher key is the normalized name `customer_id`, not the header name `X-Gateway-Customer-Id`. The policy belongs to the organization that owns the API key.
 
 Posting a policy whose `subject_matchers` already exist updates that policy instead of adding a duplicate, so this call is safe to repeat.
 
@@ -124,28 +124,28 @@ API_URL = "https://api.smith.langchain.com/v1/platform/gateway-policies"
 WORKSPACE_ID = os.environ["LANGSMITH_WORKSPACE_ID"]
 
 # Your source of truth: end customer identifier mapped to a monthly cap in USD.
-TENANT_CAPS = {"acme": 250.0, "globex": 1000.0, "initech": 50.0}
+CUSTOMER_CAPS = {"acme": 250.0, "globex": 1000.0, "initech": 50.0}
 
 
-def matchers_for(tenant: str) -> list[dict[str, str]]:
+def matchers_for(customer: str) -> list[dict[str, str]]:
     return [
         {"key": "workspace_id", "value": WORKSPACE_ID},
-        {"key": "tenant_id", "value": tenant},
+        {"key": "customer_id", "value": customer},
     ]
 
 
 def existing_caps(client: httpx.Client) -> dict[str, dict]:
-    """Return the current per-tenant spend caps, keyed by tenant identifier."""
+    """Return the current per-customer spend caps, keyed by customer identifier."""
     response = client.get(
         API_URL,
-        params={"policy_type": "spend_cap", "subject_matcher_key": "tenant_id"},
+        params={"policy_type": "spend_cap", "subject_matcher_key": "customer_id"},
     )
     response.raise_for_status()
     return {
         matcher["value"]: policy
         for policy in response.json()
         for matcher in policy["subject_matchers"]
-        if matcher["key"] == "tenant_id"
+        if matcher["key"] == "customer_id"
     }
 
 
@@ -156,20 +156,20 @@ def sync() -> None:
 
         # Posting an existing matcher set updates that policy, so this both
         # creates caps for new customers and corrects caps that changed.
-        for tenant, limit_usd in TENANT_CAPS.items():
+        for customer, limit_usd in CUSTOMER_CAPS.items():
             client.post(
                 API_URL,
                 json={
-                    "name": f"tenant-{tenant}-monthly-cap",
+                    "name": f"customer-{customer}-monthly-cap",
                     "policy_type": "spend_cap",
                     "action": "block",
-                    "subject_matchers": matchers_for(tenant),
+                    "subject_matchers": matchers_for(customer),
                     "config": {"window": "monthly", "limit_usd": limit_usd},
                 },
             ).raise_for_status()
 
-        for tenant, policy in existing.items():
-            if tenant not in TENANT_CAPS:
+        for customer, policy in existing.items():
+            if customer not in CUSTOMER_CAPS:
                 client.delete(f"{API_URL}/{policy['id']}").raise_for_status()
 
 
@@ -187,7 +187,7 @@ Every spend policy returned by the API carries `current_spend_usd`, the spend ac
 curl -G "https://api.smith.langchain.com/v1/platform/gateway-policies" \
     -H "X-Api-Key: $LANGSMITH_API_KEY" \
     --data-urlencode "policy_type=spend_cap" \
-    --data-urlencode "subject_matcher_key=tenant_id"
+    --data-urlencode "subject_matcher_key=customer_id"
 ```
 
 ## Limit throughput per end customer
@@ -199,12 +199,12 @@ curl -X POST "https://api.smith.langchain.com/v1/platform/gateway-policies" \
     -H "X-Api-Key: $LANGSMITH_API_KEY" \
     -H "Content-Type: application/json" \
     -d '{
-          "name": "tenant-acme-rate-limit",
+          "name": "customer-acme-rate-limit",
           "policy_type": "rate_limit",
           "action": "block",
           "subject_matchers": [
             {"key": "workspace_id", "value": "0b1c2d3e-4f56-7890-abcd-ef1234567890"},
-            {"key": "tenant_id", "value": "acme"}
+            {"key": "customer_id", "value": "acme"}
           ],
           "config": {
             "version": 1,

--- a/src/langsmith/llm-gateway-header-policies.mdx
+++ b/src/langsmith/llm-gateway-header-policies.mdx
@@ -50,6 +50,10 @@ A reseller or multi-tenant application usually calls the gateway from its own ba
 The gateway trusts the `X-Gateway-*` headers on an incoming request. Set the header in your own backend after you authenticate the end user, and do not distribute the gateway API key to end users. A caller that controls both the key and the header can choose which cap to spend against.
 </Warning>
 
+<Note>
+These examples use the GCP US hosts. On a regional instance, substitute both: the gateway host your application calls in step 1, and the `api.smith.langchain.com` host that serves the policy endpoints. GCP EU, for example, uses `https://eu.gateway.smith.langchain.com` and `https://eu.api.smith.langchain.com`. For the full list of gateway hosts, refer to [Regional gateways](/langsmith/llm-gateway#regional-gateways).
+</Note>
+
 ### Step 1. Send a customer header on every call
 
 Attach the header to each request your backend makes on behalf of an end customer:

--- a/src/langsmith/llm-gateway-header-policies.mdx
+++ b/src/langsmith/llm-gateway-header-policies.mdx
@@ -164,8 +164,6 @@ def matchers_for(customer: str) -> list[dict[str, str]]:
 
 def existing_caps(client: httpx.Client) -> dict[str, dict]:
     """Return the current per-customer spend caps, keyed by customer identifier."""
-    # A matcher key narrows the list only when paired with a value, so the
-    # per-customer caps are selected below rather than by the query.
     response = client.get(API_URL, params={"policy_type": "spend_cap"})
     response.raise_for_status()
     return {
@@ -195,6 +193,8 @@ def sync() -> None:
                 },
             ).raise_for_status()
 
+        # Deletes any per-customer cap missing from CUSTOMER_CAPS, including
+        # caps created outside this script.
         for customer, policy in existing.items():
             if customer not in CUSTOMER_CAPS:
                 client.delete(f"{API_URL}/{policy['id']}").raise_for_status()

--- a/src/langsmith/llm-gateway-header-policies.mdx
+++ b/src/langsmith/llm-gateway-header-policies.mdx
@@ -212,14 +212,46 @@ Run the script whenever a customer signs up, churns, or moves to a different pla
 
 ### Step 4. Read spend per customer
 
-Every spend policy returned by the API carries `current_spend_usd`, the spend accumulated in the policy's active window. Use it to show each end customer their usage, or to warn them before they reach the cap:
+Each spend policy returned by the API reports `current_spend_usd`, the spend accumulated in the policy's active window. Use it to show each end customer their usage, or to warn them before they reach the cap. The field is omitted when the spend lookup fails, so treat a missing value as unknown rather than as zero:
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -G "https://api.smith.langchain.com/v1/platform/gateway-policies" \
     -H "X-Api-Key: $LANGSMITH_API_KEY" \
     --data-urlencode "policy_type=spend_cap" \
     --data-urlencode "subject_matcher_key=customer_id"
 ```
+
+```python Python
+import os
+
+import httpx
+
+response = httpx.get(
+    "https://api.smith.langchain.com/v1/platform/gateway-policies",
+    headers={"X-Api-Key": os.environ["LANGSMITH_API_KEY"]},
+    params={"policy_type": "spend_cap", "subject_matcher_key": "customer_id"},
+    timeout=30.0,
+)
+response.raise_for_status()
+
+for policy in response.json():
+    customer = next(
+        matcher["value"]
+        for matcher in policy["subject_matchers"]
+        if matcher["key"] == "customer_id"
+    )
+    limit_usd = policy["config"]["limit_usd"]
+    spent_usd = policy.get("current_spend_usd")
+    if spent_usd is None:
+        print(f"{customer}: spend unavailable, cap ${limit_usd:,.2f}")
+        continue
+    flag = " (80% of cap reached)" if spent_usd >= 0.8 * limit_usd else ""
+    print(f"{customer}: ${spent_usd:,.2f} of ${limit_usd:,.2f}{flag}")
+```
+
+</CodeGroup>
 
 ## Limit throughput per end customer
 

--- a/src/langsmith/llm-gateway-header-policies.mdx
+++ b/src/langsmith/llm-gateway-header-policies.mdx
@@ -1,0 +1,225 @@
+---
+title: Per-customer policies
+description: Split gateway spend caps and rate limits by a custom request header so each of your end customers gets its own limit under a single API key.
+---
+
+<Note>
+**Private beta:** The LLM Gateway is in private [beta](/langsmith/release-stages). [Sign up for the waitlist](https://www.langchain.com/langsmith-llm-gateway-waitlist) to get access.
+</Note>
+
+A [spend policy](/langsmith/llm-gateway-spend-policies) or [rate limit policy](/langsmith/llm-gateway-rate-limit-policies) can carry a condition on a custom request header, so traffic from a single subject splits into separate limits by header value. Use this to cap each of your own end customers, tenants, or teams without issuing a separate LangSmith API key for each one.
+
+For example, a policy scoped to a workspace with the condition `X-Gateway-Tenant-Id: acme` limits only the requests from that workspace that carry that header value. Requests from the same workspace carrying `X-Gateway-Tenant-Id: globex` count against a different policy.
+
+## Matchable headers
+
+The gateway matches on request headers prefixed with `X-Gateway-`, and on keys inside the `X-Gateway-Metadata` JSON header. No other request header is matchable.
+
+Header names are normalized before matching: the `X-Gateway-` prefix is stripped, the remainder is lowercased, and every character outside `a-z`, `0-9`, and `_` is replaced with `_`. The headers `X-Gateway-Tenant-Id`, `x-gateway-tenant_id`, and `X-Gateway-TENANT.ID` all resolve to the matcher key `tenant_id`. Header values are compared as exact, case-sensitive strings, with no wildcard or pattern matching.
+
+The gateway stamps caller identity itself and ignores client attempts to override it. Headers that resolve to `organization_id`, `workspace_id`, `workspace_handle`, `user_id`, `user_email`, `api_key_id`, `api_key_short`, `auth_mode`, `user_agent`, `applied_policy_ids`, or `applied_policy_names`, and any header whose normalized name starts with `gateway`, are discarded.
+
+## Header condition rules
+
+- **One condition per policy**: A policy accepts a single header key with a single value.
+- **Pairs with one subject scope**: Combine a header condition with an organization, workspace, user, or API key scope. The subject side accepts several values and matches any of them. The header side accepts exactly one value.
+- **Spend caps and rate limits only**: Default policies cannot carry a header condition, so the gateway never creates per-header policies on its own. To limit many header values, create one policy for each.
+- **A missing header matches nothing**: A request that does not carry the header does not match the policy. Pair per-header policies with a broader policy on the subject itself so untagged traffic is still limited.
+- **Every matching policy is enforced**: A request that matches both a plain subject policy and a policy with a header condition counts against both, and either one can block it.
+- **At most 10 conditions**: A policy carries no more than 10 subject conditions in total.
+
+## Add a header condition
+
+<Warning>
+Creating and managing policies requires `organization:manage` permission. For the full permissions breakdown, refer to [Traces, Engine, and access control](/langsmith/llm-gateway-access).
+</Warning>
+
+1. Go to **Settings → Gateway → LLM Gateway**.
+1. Click **Create policy**.
+1. Select the policy type and subject scope, then set the limits.
+1. Under **Custom header condition (optional)**, enter the **Header name** without its `X-Gateway-` prefix (for example, `Tenant-Id`) and the **Header value** to match (for example, `acme`).
+1. Save.
+
+The header condition cannot be edited in the UI after the policy is created. To change it, delete the policy and create a new one, or update `subject_matchers` through the API.
+
+## Cap spend per end customer
+
+A reseller or multi-tenant application usually calls the gateway from its own backend, using one workspace-scoped API key on behalf of many end customers. Header conditions give each of those end customers a separate cap under that single key.
+
+<Warning>
+The gateway trusts the `X-Gateway-*` headers on an incoming request. Set the header in your own backend after you authenticate the end user, and do not distribute the gateway API key to end users. A caller that controls both the key and the header can choose which cap to spend against.
+</Warning>
+
+### Step 1. Send a tenant header on every call
+
+Attach the header to each request your backend makes on behalf of an end customer:
+
+<CodeGroup>
+
+```bash curl
+curl https://gateway.smith.langchain.com/openai/v1/chat/completions \
+    -H "Authorization: Bearer $LANGSMITH_API_KEY" \
+    -H "Content-Type: application/json" \
+    -H "X-Gateway-Tenant-Id: acme" \
+    -d '{"model":"gpt-4o-mini","messages":[{"role":"user","content":"ping"}]}'
+```
+
+```python OpenAI SDK
+import os
+
+from openai import OpenAI
+
+client = OpenAI(
+    base_url=os.environ["OPENAI_BASE_URL"],
+    api_key=os.environ["LANGSMITH_API_KEY"],
+)
+
+
+def answer(tenant_id: str, question: str) -> str:
+    """Call the gateway on behalf of one end customer."""
+    response = client.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[{"role": "user", "content": question}],
+        extra_headers={"X-Gateway-Tenant-Id": tenant_id},
+    )
+    return response.choices[0].message.content
+```
+
+</CodeGroup>
+
+### Step 2. Create a cap for one customer
+
+Create one spend policy per end customer through the [LangSmith REST API](/langsmith/smith-api-ref):
+
+```bash
+curl -X POST "https://api.smith.langchain.com/v1/platform/gateway-policies" \
+    -H "X-Api-Key: $LANGSMITH_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{
+          "name": "tenant-acme-monthly-cap",
+          "policy_type": "spend_cap",
+          "action": "block",
+          "subject_matchers": [
+            {"key": "workspace_id", "value": "0b1c2d3e-4f56-7890-abcd-ef1234567890"},
+            {"key": "tenant_id", "value": "acme"}
+          ],
+          "config": {"window": "monthly", "limit_usd": 250}
+        }'
+```
+
+The matcher key is the normalized name `tenant_id`, not the header name `X-Gateway-Tenant-Id`. The policy belongs to the organization that owns the API key.
+
+Posting a policy whose `subject_matchers` already exist updates that policy instead of adding a duplicate, so this call is safe to repeat.
+
+### Step 3. Sync policies with your customer list
+
+Because each end customer needs its own policy, keep the policy set in step with your customer list. The following script creates or updates a cap for every current customer, then deletes the caps of customers that are gone:
+
+```python
+import os
+
+import httpx
+
+API_URL = "https://api.smith.langchain.com/v1/platform/gateway-policies"
+WORKSPACE_ID = os.environ["LANGSMITH_WORKSPACE_ID"]
+
+# Your source of truth: end customer identifier mapped to a monthly cap in USD.
+TENANT_CAPS = {"acme": 250.0, "globex": 1000.0, "initech": 50.0}
+
+
+def matchers_for(tenant: str) -> list[dict[str, str]]:
+    return [
+        {"key": "workspace_id", "value": WORKSPACE_ID},
+        {"key": "tenant_id", "value": tenant},
+    ]
+
+
+def existing_caps(client: httpx.Client) -> dict[str, dict]:
+    """Return the current per-tenant spend caps, keyed by tenant identifier."""
+    response = client.get(
+        API_URL,
+        params={"policy_type": "spend_cap", "subject_matcher_key": "tenant_id"},
+    )
+    response.raise_for_status()
+    return {
+        matcher["value"]: policy
+        for policy in response.json()
+        for matcher in policy["subject_matchers"]
+        if matcher["key"] == "tenant_id"
+    }
+
+
+def sync() -> None:
+    headers = {"X-Api-Key": os.environ["LANGSMITH_API_KEY"]}
+    with httpx.Client(headers=headers, timeout=30.0) as client:
+        existing = existing_caps(client)
+
+        # Posting an existing matcher set updates that policy, so this both
+        # creates caps for new customers and corrects caps that changed.
+        for tenant, limit_usd in TENANT_CAPS.items():
+            client.post(
+                API_URL,
+                json={
+                    "name": f"tenant-{tenant}-monthly-cap",
+                    "policy_type": "spend_cap",
+                    "action": "block",
+                    "subject_matchers": matchers_for(tenant),
+                    "config": {"window": "monthly", "limit_usd": limit_usd},
+                },
+            ).raise_for_status()
+
+        for tenant, policy in existing.items():
+            if tenant not in TENANT_CAPS:
+                client.delete(f"{API_URL}/{policy['id']}").raise_for_status()
+
+
+if __name__ == "__main__":
+    sync()
+```
+
+Run the script whenever a customer signs up, churns, or moves to a different plan.
+
+### Step 4. Read spend per customer
+
+Every spend policy returned by the API carries `current_spend_usd`, the spend accumulated in the policy's active window. Use it to show each end customer their usage, or to warn them before they reach the cap:
+
+```bash
+curl -G "https://api.smith.langchain.com/v1/platform/gateway-policies" \
+    -H "X-Api-Key: $LANGSMITH_API_KEY" \
+    --data-urlencode "policy_type=spend_cap" \
+    --data-urlencode "subject_matcher_key=tenant_id"
+```
+
+## Limit throughput per end customer
+
+Rate limits use the same subject matchers. Swap `policy_type` and `config` to give an end customer its own request and token allowance:
+
+```bash
+curl -X POST "https://api.smith.langchain.com/v1/platform/gateway-policies" \
+    -H "X-Api-Key: $LANGSMITH_API_KEY" \
+    -H "Content-Type: application/json" \
+    -d '{
+          "name": "tenant-acme-rate-limit",
+          "policy_type": "rate_limit",
+          "action": "block",
+          "subject_matchers": [
+            {"key": "workspace_id", "value": "0b1c2d3e-4f56-7890-abcd-ef1234567890"},
+            {"key": "tenant_id", "value": "acme"}
+          ],
+          "config": {
+            "version": 1,
+            "limits": [
+              {"metric": "requests", "window": "minute", "value": 100},
+              {"metric": "tokens", "window": "hour", "value": 1000000}
+            ]
+          }
+        }'
+```
+
+The sync script in step 3 applies to rate limits with the same two substitutions. Spend caps and rate limits are separate families, so an end customer can hold one of each on the same header value.
+
+## Next steps
+
+- [Spend policies](/langsmith/llm-gateway-spend-policies): set cost caps for organizations, workspaces, users, and API keys.
+- [Rate limit policies](/langsmith/llm-gateway-rate-limit-policies): limit requests and tokens in a rolling window.
+- [Traces and access control](/langsmith/llm-gateway-access): understand where gateway traces land and who can configure policies.

--- a/src/langsmith/llm-gateway-header-policies.mdx
+++ b/src/langsmith/llm-gateway-header-policies.mdx
@@ -95,7 +95,9 @@ If your LangSmith account is on a regional instance, use the corresponding [regi
 
 Create one spend policy per end customer through the [LangSmith REST API](/langsmith/smith-api-ref):
 
-```bash
+<CodeGroup>
+
+```bash curl
 curl -X POST "https://api.smith.langchain.com/v1/platform/gateway-policies" \
     -H "X-Api-Key: $LANGSMITH_API_KEY" \
     -H "Content-Type: application/json" \
@@ -110,6 +112,31 @@ curl -X POST "https://api.smith.langchain.com/v1/platform/gateway-policies" \
           "config": {"window": "monthly", "limit_usd": 250}
         }'
 ```
+
+```python Python
+import os
+
+import httpx
+
+response = httpx.post(
+    "https://api.smith.langchain.com/v1/platform/gateway-policies",
+    headers={"X-Api-Key": os.environ["LANGSMITH_API_KEY"]},
+    json={
+        "name": "customer-acme-monthly-cap",
+        "policy_type": "spend_cap",
+        "action": "block",
+        "subject_matchers": [
+            {"key": "workspace_id", "value": "0b1c2d3e-4f56-7890-abcd-ef1234567890"},
+            {"key": "customer_id", "value": "acme"},
+        ],
+        "config": {"window": "monthly", "limit_usd": 250},
+    },
+    timeout=30.0,
+)
+response.raise_for_status()
+```
+
+</CodeGroup>
 
 The matcher key is the normalized name `customer_id`, not the header name `X-Gateway-Customer-Id`. The policy belongs to the organization that owns the API key.
 

--- a/src/langsmith/llm-gateway-header-policies.mdx
+++ b/src/langsmith/llm-gateway-header-policies.mdx
@@ -164,10 +164,9 @@ def matchers_for(customer: str) -> list[dict[str, str]]:
 
 def existing_caps(client: httpx.Client) -> dict[str, dict]:
     """Return the current per-customer spend caps, keyed by customer identifier."""
-    response = client.get(
-        API_URL,
-        params={"policy_type": "spend_cap", "subject_matcher_key": "customer_id"},
-    )
+    # A matcher key narrows the list only when paired with a value, so the
+    # per-customer caps are selected below rather than by the query.
+    response = client.get(API_URL, params={"policy_type": "spend_cap"})
     response.raise_for_status()
     return {
         matcher["value"]: policy
@@ -209,18 +208,11 @@ Run the script whenever a customer signs up, churns, or moves to a different pla
 
 ### Step 4. Read spend per customer
 
-Each spend policy returned by the API reports `current_spend_usd`, the spend accumulated in the policy's active window. Use it to show each end customer their usage, or to warn them before they reach the cap. The field is omitted when the spend lookup fails, so treat a missing value as unknown rather than as zero:
+Each spend policy returned by the API reports `current_spend_usd`, the spend accumulated in the policy's active window. Use it to show each end customer their usage, or to warn them before they reach the cap. The field is omitted when the spend lookup fails, so treat a missing value as unknown rather than as zero.
 
-<CodeGroup>
+The list endpoint narrows by a subject matcher key only when that key is paired with a value, so list the spend caps and select the per-customer ones in your own code:
 
-```bash curl
-curl -G "https://api.smith.langchain.com/v1/platform/gateway-policies" \
-    -H "X-Api-Key: $LANGSMITH_API_KEY" \
-    --data-urlencode "policy_type=spend_cap" \
-    --data-urlencode "subject_matcher_key=customer_id"
-```
-
-```python Python
+```python
 import os
 
 import httpx
@@ -228,19 +220,21 @@ import httpx
 response = httpx.get(
     "https://api.smith.langchain.com/v1/platform/gateway-policies",
     headers={"X-Api-Key": os.environ["LANGSMITH_API_KEY"]},
-    params={"policy_type": "spend_cap", "subject_matcher_key": "customer_id"},
+    params={"policy_type": "spend_cap"},
     timeout=30.0,
 )
 response.raise_for_status()
 
 for policy in response.json():
-    matchers = policy["subject_matchers"]
-    customer = next(m["value"] for m in matchers if m["key"] == "customer_id")
+    customer = next(
+        (m["value"] for m in policy["subject_matchers"] if m["key"] == "customer_id"),
+        None,
+    )
+    if customer is None:
+        continue  # A cap on the workspace itself, not on one end customer.
     # current_spend_usd is absent when the spend lookup fails.
     print(customer, policy.get("current_spend_usd"), policy["config"]["limit_usd"])
 ```
-
-</CodeGroup>
 
 ## Limit throughput per end customer
 

--- a/src/langsmith/llm-gateway-header-policies.mdx
+++ b/src/langsmith/llm-gateway-header-policies.mdx
@@ -50,10 +50,6 @@ A reseller or multi-tenant application usually calls the gateway from its own ba
 The gateway trusts the `X-Gateway-*` headers on an incoming request. Set the header in your own backend after you authenticate the end user, and do not distribute the gateway API key to end users. A caller that controls both the key and the header can choose which cap to spend against.
 </Warning>
 
-<Note>
-These examples use the GCP US hosts. On a regional instance, substitute both: the gateway host your application calls in step 1, and the `api.smith.langchain.com` host that serves the policy endpoints. GCP EU, for example, uses `https://eu.gateway.smith.langchain.com` and `https://eu.api.smith.langchain.com`. For the full list of gateway hosts, refer to [Regional gateways](/langsmith/llm-gateway#regional-gateways).
-</Note>
-
 ### Step 1. Send a customer header on every call
 
 Attach the header to each request your backend makes on behalf of an end customer:
@@ -90,6 +86,10 @@ def answer(customer_id: str, question: str) -> str:
 ```
 
 </CodeGroup>
+
+<Note>
+If your LangSmith account is on a regional instance, use the corresponding [regional gateway](/langsmith/llm-gateway#regional-gateways).
+</Note>
 
 ### Step 2. Create a cap for one customer
 

--- a/src/langsmith/llm-gateway-header-policies.mdx
+++ b/src/langsmith/llm-gateway-header-policies.mdx
@@ -73,16 +73,13 @@ client = OpenAI(
     base_url=os.environ["OPENAI_BASE_URL"],
     api_key=os.environ["LANGSMITH_API_KEY"],
 )
-
-
-def answer(customer_id: str, question: str) -> str:
-    """Call the gateway on behalf of one end customer."""
-    response = client.chat.completions.create(
-        model="gpt-4o-mini",
-        messages=[{"role": "user", "content": question}],
-        extra_headers={"X-Gateway-Customer-Id": customer_id},
-    )
-    return response.choices[0].message.content
+customer_id = "acme"
+response = client.chat.completions.create(
+    model="gpt-4o-mini",
+    messages=[{"role": "user", "content": "ping"}],
+    extra_headers={"X-Gateway-Customer-Id": customer_id},
+)
+print(response.choices[0].message.content)
 ```
 
 </CodeGroup>
@@ -237,18 +234,10 @@ response = httpx.get(
 response.raise_for_status()
 
 for policy in response.json():
-    customer = next(
-        matcher["value"]
-        for matcher in policy["subject_matchers"]
-        if matcher["key"] == "customer_id"
-    )
-    limit_usd = policy["config"]["limit_usd"]
-    spent_usd = policy.get("current_spend_usd")
-    if spent_usd is None:
-        print(f"{customer}: spend unavailable, cap ${limit_usd:,.2f}")
-        continue
-    flag = " (80% of cap reached)" if spent_usd >= 0.8 * limit_usd else ""
-    print(f"{customer}: ${spent_usd:,.2f} of ${limit_usd:,.2f}{flag}")
+    matchers = policy["subject_matchers"]
+    customer = next(m["value"] for m in matchers if m["key"] == "customer_id")
+    # current_spend_usd is absent when the spend lookup fails.
+    print(customer, policy.get("current_spend_usd"), policy["config"]["limit_usd"])
 ```
 
 </CodeGroup>

--- a/src/langsmith/llm-gateway-rate-limit-policies.mdx
+++ b/src/langsmith/llm-gateway-rate-limit-policies.mdx
@@ -71,7 +71,10 @@ Creating and managing policies requires `organization:manage` permission. For th
 
 Policies take effect immediately.
 
+A rate limit policy can also carry a condition on a custom request header, so traffic from a single subject splits into separate limits by header value. Use this to give each of your own end customers its own throughput allowance under one API key. For more information, see [Per-customer policies](/langsmith/llm-gateway-header-policies).
+
 ## Next steps
 
 - [Spend policies](/langsmith/llm-gateway-spend-policies): set cost caps alongside rate limits.
+- [Per-customer policies](/langsmith/llm-gateway-header-policies): split a limit by a custom request header so each end customer gets its own allowance.
 - [PII and secrets redaction](/langsmith/llm-gateway-redaction): add data protection policies.

--- a/src/langsmith/llm-gateway-spend-policies.mdx
+++ b/src/langsmith/llm-gateway-spend-policies.mdx
@@ -63,6 +63,8 @@ Creating and managing policies requires `organization:manage` permission. For th
 
 Policies take effect immediately. The gateway evaluates them on every incoming request with sub-second enforcement latency.
 
+A spend policy can also carry a condition on a custom request header, so traffic from a single subject splits into separate caps by header value. Use this to cap each of your own end customers under one API key. For more information, see [Per-customer policies](/langsmith/llm-gateway-header-policies).
+
 ## View spend
 
 The spend visibility dashboard shows real-time cost rollups so you can understand where your LLM budget is going before you reach the limit.
@@ -77,5 +79,6 @@ This is useful for diagnosing whether a blocked request represents a genuine cos
 
 ## Next steps
 
+- [Per-customer policies](/langsmith/llm-gateway-header-policies): split a cap by a custom request header so each end customer gets its own limit.
 - [PII and secrets redaction](/langsmith/llm-gateway-redaction): add data protection policies alongside cost controls.
 


### PR DESCRIPTION
## Overview

Documents scoping LLM Gateway spend caps and rate limits by a custom `X-Gateway-*` request header. This is the capability shipped in langchainplus #31373/#31378 and generalized to org, workspace, and user scopes in #32030/#32031. It had no customer-facing docs.

The reader this is written for is a reseller or multi-tenant application that calls the gateway from its own backend with one workspace-scoped API key on behalf of many end customers, and wants a separate limit per end customer.

The page is standalone rather than a section on the two existing policy pages, because the capability spans both spend caps and rate limits, and the worked example is long enough that duplicating it across both pages would be worse than one shared page.

Because default policies cannot carry a header condition, the gateway never creates per-header limits on its own. Per-customer limits therefore require programmatic policy management, so the page walks through it end to end: send the header from your backend, create a cap, reconcile the policy set against your customer list, and read per-customer spend.

## Type of change

**Type:** New documentation page

## Related issues/PRs

- Feature PR: langchain-ai/langchainplus#31373, langchain-ai/langchainplus#32030
- Linear issue: ENT-1416

## Areas needing careful review

- **The API reference contradicts this page.** `smith-go/gateway_policies/handler.go:233-238` documents `subject_matchers.key` as one of `organization_id`, `workspace_id`, `user_id`, `api_key_id`, or `run_rule_id`, and never mentions the custom-header form. That annotation feeds `langsmith-platform-openapi.json`. A separate smith-go PR is needed; this page should not merge far ahead of it.
- **Security framing.** The gateway trusts client-supplied `X-Gateway-*` headers, so the page carries a warning that the header must be set by your own backend and the gateway API key must not be distributed to end users. Worth a second opinion on whether that is stated strongly enough.
- **Code examples are not executed.** The request/response shapes, matcher validation rules, normalization, reserved header names, and the create-is-idempotent behavior were all read out of the implementation rather than exercised against a live gateway. Specifically worth confirming: `POST` with an existing matcher set updates rather than duplicates (`gateway_policies/admin.go:587-597`), and `GET` returns a bare array with no pagination.
- **Model identifier.** Examples use `gpt-4o-mini` to match the existing gateway pages. The style guide asks for latest-GA models, so the whole gateway section may be due a refresh separately.

## Checklist

- [x] I have read the contributing guidelines, including the language policy
- [ ] I have tested my changes locally using `docs dev` — ran `make build` and `mint broken-links` instead
- [x] All code examples have been tested and work correctly — see above
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

`make lint_prose` is clean on all three files. `mint broken-links` reports no broken links originating from them. Note that `make broken-links` currently reports a false pass on this repo: the filter script can die mid-run and the Makefile treats empty filter output as success, so it printed a green result while `mint` had found 1,681 broken links. Those are pre-existing, almost all links to `/use-these-docs` from OSS provider pages, and unrelated to this change, but the target itself is worth fixing.

Written with Claude Code.