### PR TITLE
docs: point RelayShield integration links at developer docs

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -326,7 +326,7 @@ python:
     docs_url: https://urlcheck.dev
   - name: RelayShield
     pypi: langchain-relayshield
-    docs_url: https://relayshield.net
+    docs_url: https://api.relayshield.net/developers
   - name: Scalekit
     pypi: scalekit-sdk-python
     docs_url: https://docs.scalekit.com/agentkit/overview/
@@ -416,7 +416,7 @@ python:
     source: "[`IngmarVG-IB/langchain-dns-aid`](https://github.com/IngmarVG-IB/langchain-dns-aid)"
   - name: RelayShield
     pypi: langchain-relayshield
-    docs_url: https://relayshield.net
+    docs_url: https://api.relayshield.net/developers
     available: Mandatory pre-execution gate that blocks connect_mcp_server and install_mcp_package tool calls when RelayShield reports risk.
     source: "[`nzdsf2-gif/langchain-relayshield`](https://github.com/nzdsf2-gif/langchain-relayshield)"
   sandboxes:

--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -105,7 +105,7 @@ The following table shows tools that can be used for security-related tasks:
 | Tool/Toolkit | Pricing | Capabilities |
 |-------------|---------|--------------|
 | [URLCheck](https://urlcheck.dev) | 100 free requests/day | Verify URL safety before agent navigation. Supports optional intent-aware risk analysis. Returns actionable access directives (ALLOW/DENY/RETRY_LATER). |
-| [RelayShield](https://relayshield.net) | Paid | MCP server registry-risk and prompt-injection-breach checks before high-impact agent actions. |
+| [RelayShield](https://api.relayshield.net/developers) | Paid | MCP server registry-risk and prompt-injection-breach checks before high-impact agent actions. |
 
 ## All tools and toolkits
 


### PR DESCRIPTION
Follow-up to #5047.

The RelayShield entries currently link to `https://relayshield.net`, which is the product marketing page rather than documentation. With the move to linking out to external docs from the overview tables instead of hosting integration pages, that link is now the only entry point — and developers arriving from the integrations table land on consumer-facing copy with no setup instructions.

This points the three references at `https://api.relayshield.net/developers`, which documents the endpoints, authentication, and usage the `langchain-relayshield` integration relies on.

Changed:
- `src/oss/python/integrations/tools/index.mdx` — security tools table
- `scripts/data/integration_external_docs.yaml` — tools entry
- `scripts/data/integration_external_docs.yaml` — middleware entry

URL only, no content or wording changes.

cc @npentrel

🤖 Generated with [Claude Code](https://claude.com/claude-code)