### PR TITLE
docs: point RelayShield provider card at developer docs

### DIFF
--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -1146,7 +1146,7 @@ Browse the complete collection of integrations available for Python. LangChain P
 
     <Card
         title="RelayShield"
-        href="https://relayshield.net"
+        href="https://api.relayshield.net/developers"
         icon="link"
     >
         Identity and agentic-attack-surface threat intelligence.


### PR DESCRIPTION
Small follow-up to #5188.

That PR updated the security tools table and both `integration_external_docs.yaml` entries, but the provider card in `all_providers.mdx` still points at `https://relayshield.net` (the marketing page) rather than the developer documentation.

The two generated snippets (`python-tools-downloads.mdx`, `python-middleware-downloads.mdx`) will pick up the corrected URL automatically on the next `refresh_integration_downloads.py` run, so this is the last hand-maintained reference.

URL only.

cc @npentrel

🤖 Generated with [Claude Code](https://claude.com/claude-code)