### PR TITLE
docs: update Gateway Credits guidance

### DIFF
--- a/src/langsmith/llm-gateway-langchain-provider.mdx
+++ b/src/langsmith/llm-gateway-langchain-provider.mdx
@@ -1,13 +1,13 @@
 ---
-title: LangChain managed models
-description: Call LangChain-managed models through the LLM Gateway with no provider key or account of your own. Authenticate with your LangSmith API key.
+title: Gateway Credits
+description: Use Gateway Credits to call models through the LLM Gateway without provider keys. Authenticate with your LangSmith API key.
 ---
 
 <Note>
 **Private beta:** The LLM Gateway is in private [beta](/langsmith/release-stages). APIs and features may change as we iterate. Sign up for [the waitlist](https://www.langchain.com/langsmith-llm-gateway-waitlist) to get access.
 </Note>
 
-The `/langchain` provider serves **LangChain-managed models** through the LLM Gateway. With the [other providers](/langsmith/llm-gateway#supported-providers), you bring your own account and key. With managed models, LangChain owns the upstream provider credential, so you can start calling a model immediately with only your [LangSmith API key](/langsmith/create-account-api-key). No [provider secret](/langsmith/llm-gateway-admin-setup#2-add-provider-secrets) setup is required.
+Bring your own provider keys with no token surcharge, or use Gateway Credits for instant access to models with no keys needed. The `/langchain` provider lets you call models with Gateway Credits through the LLM Gateway using only your [LangSmith API key](/langsmith/create-account-api-key). No [provider secret](/langsmith/llm-gateway-admin-setup#2-add-provider-secrets) setup is required.
 
 <Card title="Base URL" icon="link">
 Point any OpenAI-compatible client at:
@@ -23,11 +23,12 @@ For regional base URLs, see [Regional gateways](/langsmith/llm-gateway#regional-
 
 ## Available models
 
-The provider is OpenAI-compatible and advertises branded model IDs. Select a model by name in the request body, and the gateway routes it to the managed upstream model. Model IDs are case-insensitive.
+The provider is OpenAI-compatible. Select a model by ID in the request body. Model IDs are case-insensitive.
 
 | Model ID | Description |
 | --- | --- |
-| `LangSmith:pro` | A high-capability general-purpose managed model. |
+| `moonshotai/Kimi-K2.6` | Moonshot AI Kimi K2.6, hosted by Fireworks. |
+| `moonshotai/Kimi-K3` | Moonshot AI Kimi K3, hosted by Fireworks. |
 
 You can also list the available models programmatically:
 
@@ -36,7 +37,7 @@ curl https://gateway.smith.langchain.com/langchain/v1/models \
     -H "Authorization: Bearer $LANGSMITH_API_KEY"
 ```
 
-The response is the standard OpenAI `/v1/models` list containing only the managed model IDs above.
+The response is the standard OpenAI `/v1/models` list containing only the Gateway Credits model IDs above.
 
 ## Prerequisites
 
@@ -55,7 +56,7 @@ Point any OpenAI-compatible client at `https://gateway.smith.langchain.com/langc
 curl https://gateway.smith.langchain.com/langchain/v1/chat/completions \
     -H "Authorization: Bearer $LANGSMITH_API_KEY" \
     -H "Content-Type: application/json" \
-    -d '{"model":"LangSmith:pro","messages":[{"role":"user","content":"ping"}]}'
+    -d '{"model":"moonshotai/Kimi-K2.6","messages":[{"role":"user","content":"ping"}]}'
 ```
 
 ```python OpenAI SDK
@@ -68,7 +69,7 @@ client = OpenAI(
     api_key=os.environ["LANGSMITH_API_KEY"],
 )
 response = client.chat.completions.create(
-    model="LangSmith:pro",
+    model="moonshotai/Kimi-K2.6",
     messages=[{"role": "user", "content": "ping"}],
 )
 print(response.choices[0].message.content)
@@ -80,7 +81,7 @@ import os
 from langchain.chat_models import init_chat_model
 
 model = init_chat_model(
-    model="LangSmith:pro",
+    model="moonshotai/Kimi-K2.6",
     model_provider="openai",
     base_url="https://gateway.smith.langchain.com/langchain/v1",
     api_key=os.environ["LANGSMITH_API_KEY"],
@@ -98,22 +99,22 @@ The `/langchain` provider forwards two OpenAI-compatible prompt endpoints and se
 | --- | --- |
 | `POST /langchain/v1/chat/completions` | Chat completions, including streaming. |
 | `POST /langchain/v1/responses` | OpenAI Responses API. |
-| `GET /langchain/v1/models` | Lists the managed model IDs. |
+| `GET /langchain/v1/models` | Lists the Gateway Credits model IDs. |
 
-Any other path returns `404`. A request for a model that isn't advertised also returns `404` with a message listing the available model IDs.
+Any other path returns `404`. A request for a model that is not advertised also returns `404` with a message listing the available model IDs.
 
 ## Pricing
 
-Invocations are billed to your account.
+Gateway Credits are prepaid model usage, billed as LCUs. Tokens are priced at face value. Gateway Credits purchased have a processing fee. See our [pricing page](https://www.langchain.com/pricing) for more details.
 
-Standard gateway [spend policies](/langsmith/llm-gateway-spend-policies) still apply on top of the managed-model cap, so you can add tighter per-key or per-user limits.
+Standard gateway [spend policies](/langsmith/llm-gateway-spend-policies) apply to Gateway Credits usage, so you can add tighter per-key or per-user limits.
 
 ## Tracing
 
-Like all gateway traffic, managed-model calls are traced to LangSmith. See [Traces, Engine, and access control](/langsmith/llm-gateway-access) for where traces land and how to control access to them.
+Like all gateway traffic, calls made with Gateway Credits are traced to LangSmith. See [Traces, Engine, and access control](/langsmith/llm-gateway-access) for where traces land and how to control access to them.
 
 ## Next steps
 
 - [Quickstart](/langsmith/llm-gateway-quickstart): make your first gateway-proxied call.
-- [Spend policies](/langsmith/llm-gateway-spend-policies): add cost limits on top of the managed-model cap.
+- [Spend policies](/langsmith/llm-gateway-spend-policies): add cost limits to Gateway Credits usage.
 - [Custom model providers](/langsmith/llm-gateway-custom-providers): route to your own OpenAI-compatible endpoints.

--- a/src/langsmith/llm-gateway.mdx
+++ b/src/langsmith/llm-gateway.mdx
@@ -46,7 +46,7 @@ Every gateway-proxied call appears as a [trace](/langsmith/observability-concept
 | Google Vertex AI | `/vertex` | `VERTEX_SERVICE_ACCOUNT_JSON` |
 | OpenAI | `/openai` | `OPENAI_API_KEY` |
 
-In addition to the providers above, LangChain offers [managed models](/langsmith/llm-gateway-langchain-provider) through the `/langchain` path. These require no provider secret of your own: you authenticate with your LangSmith API key and LangChain owns the upstream credential.
+Bring your own provider keys with no token surcharge, or use [Gateway Credits](/langsmith/llm-gateway-langchain-provider) for instant access to models with no keys needed. Gateway Credits models use the `/langchain` path and authenticate with your LangSmith API key.
 
 ## Regional gateways
 


### PR DESCRIPTION
## Description
Reframes the LLM Gateway offering around Gateway Credits instead of LangChain-managed models. Updates the available Fireworks-hosted Kimi model IDs, request examples, and pricing language.

## Test Plan
- [ ] Verify the page copy, model table, and examples in the docs preview.

Made by [Open SWE](https://openswe.vercel.app/agents/b5f1541b-3116-d260-3740-814159226c35)