### PR TITLE
fix: clarify production standalone deployment safeguards

### DIFF
--- a/src/langsmith/deploy-standalone-server.mdx
+++ b/src/langsmith/deploy-standalone-server.mdx
@@ -46,25 +46,35 @@ Do not run standalone servers in serverless environments. Scale-to-zero may caus
 - **Kubernetes**: Use the LangSmith Helm chart to run Agent Servers in a Kubernetes cluster. This is the recommended option for production-grade deployments.
 - **Docker**: Run in any Docker-supported compute platform (local dev machine, VM, ECS, etc.). This is best suited for development or small-scale workloads.
 
+<Warning>
+For production deployments, use Kubernetes with the maintained LangSmith Helm chart when possible. If you deploy to another orchestrator, such as ECS, you must implement and maintain equivalent production safeguards:
+
+- **Independent queue autoscaling**: Configure scaling policies and queue metrics for bursty, write-heavy workloads.
+- **Graceful run draining**: Configure shutdown draining and sufficient termination windows so in-flight runs can finish during deployments and scale-down events.
+- **Split-mode wiring**: Provision and connect separate API and queue services. The Helm chart handles this when `queue.enabled` is `true`.
+- **Reference scaling configuration**: Translate the [Agent Server scaling](/langsmith/agent-server-scale) settings, including `api.replicas`, `queue.replicas`, `numberOfJobsPerWorker`, and read replicas, into your orchestrator's task definitions and scaling policies.
+- **Version upgrades and support**: Maintain task definitions and apply version updates. LangChain tests and ships supported Helm chart version updates.
+</Warning>
+
 ## Prerequisites
 
 1. Use the [LangGraph CLI](/langsmith/cli) to [test your application locally](/langsmith/local-dev-testing).
 2. Use the [LangGraph CLI](/langsmith/cli) to build a Docker image (i.e. `langgraph build`).
 3. The following environment variables are needed for a data plane deployment.
   1. `REDIS_URI`: Connection details to a Redis instance. Redis will be used as a pub-sub broker to enable streaming real time output from background runs. The value of `REDIS_URI` must be a valid [Redis connection URI](https://redis-py.readthedocs.io/en/stable/connections.html#redis.Redis.from_url).
-        <Warning>
+        <Note>
         **Shared Redis Instance**
         Multiple self-hosted deployments can share the same Redis instance. For example, for `Deployment A`, `REDIS_URI` can be set to `redis://<hostname_1>:<port>/1` and for `Deployment B`, `REDIS_URI` can be set to `redis://<hostname_1>:<port>/2`.
 
         `1` and `2` are different database numbers within the same instance, but `<hostname_1>` is shared. **The same database number cannot be used for separate deployments**.
-        </Warning>
+        </Note>
   2. `DATABASE_URI`: Postgres connection details. Postgres will be used to store assistants, threads, runs, persist thread state and long term memory, and to manage the state of the background task queue with 'exactly once' semantics. The value of `DATABASE_URI` must be a valid [Postgres connection URI](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS).
-        <Warning>
+        <Note>
         **Shared Postgres Instance**
         Multiple self-hosted deployments can share the same Postgres instance. For example, for `Deployment A`, `DATABASE_URI` can be set to `postgres://<user>:<password>@/<database_name_1>?host=<hostname_1>` and for `Deployment B`, `DATABASE_URI` can be set to `postgres://<user>:<password>@/<database_name_2>?host=<hostname_1>`.
 
         `<database_name_1>` and `database_name_2` are different databases within the same instance, but `<hostname_1>` is shared. **The same database cannot be used for separate deployments**.
-        </Warning>
+        </Note>
         <Tip>
         You can optionally store checkpoint data in MongoDB instead of PostgreSQL. PostgreSQL is still required for all other server data. See [Configure checkpointer backend](/langsmith/configure-checkpointer) for details.
         </Tip>
@@ -82,7 +92,9 @@ The Helm chart (v0.2.6+) supports MongoDB checkpointing with a bundled instance 
 
 ## Docker
 
-This `docker` example is intended for local development and testing.
+<Warning>
+This Docker example is intended for local development and testing. For production, use the Kubernetes deployment or implement the equivalent autoscaling, run draining, split-mode wiring, scaling configuration, and upgrade safeguards described above.
+</Warning>
 
 Run the following `docker` command:
 
@@ -106,7 +118,9 @@ and you should provide appropriate values for `REDIS_URI`, `DATABASE_URI`, and `
 
 ## Docker Compose
 
-This Docker Compose example is intended for local development and testing.
+<Warning>
+This Docker Compose example is intended for local development and testing. For production, use the Kubernetes deployment or implement the equivalent autoscaling, run draining, split-mode wiring, scaling configuration, and upgrade safeguards described above.
+</Warning>
 
 Use the following Docker Compose file:
 

--- a/src/langsmith/deploy-standalone-server.mdx
+++ b/src/langsmith/deploy-standalone-server.mdx
@@ -52,19 +52,19 @@ Do not run standalone servers in serverless environments. Scale-to-zero may caus
 2. Use the [LangGraph CLI](/langsmith/cli) to build a Docker image (i.e. `langgraph build`).
 3. The following environment variables are needed for a data plane deployment.
   1. `REDIS_URI`: Connection details to a Redis instance. Redis will be used as a pub-sub broker to enable streaming real time output from background runs. The value of `REDIS_URI` must be a valid [Redis connection URI](https://redis-py.readthedocs.io/en/stable/connections.html#redis.Redis.from_url).
-        <Note>
+        <Warning>
         **Shared Redis Instance**
         Multiple self-hosted deployments can share the same Redis instance. For example, for `Deployment A`, `REDIS_URI` can be set to `redis://<hostname_1>:<port>/1` and for `Deployment B`, `REDIS_URI` can be set to `redis://<hostname_1>:<port>/2`.
 
         `1` and `2` are different database numbers within the same instance, but `<hostname_1>` is shared. **The same database number cannot be used for separate deployments**.
-        </Note>
+        </Warning>
   2. `DATABASE_URI`: Postgres connection details. Postgres will be used to store assistants, threads, runs, persist thread state and long term memory, and to manage the state of the background task queue with 'exactly once' semantics. The value of `DATABASE_URI` must be a valid [Postgres connection URI](https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING-URIS).
-        <Note>
+        <Warning>
         **Shared Postgres Instance**
         Multiple self-hosted deployments can share the same Postgres instance. For example, for `Deployment A`, `DATABASE_URI` can be set to `postgres://<user>:<password>@/<database_name_1>?host=<hostname_1>` and for `Deployment B`, `DATABASE_URI` can be set to `postgres://<user>:<password>@/<database_name_2>?host=<hostname_1>`.
 
         `<database_name_1>` and `database_name_2` are different databases within the same instance, but `<hostname_1>` is shared. **The same database cannot be used for separate deployments**.
-        </Note>
+        </Warning>
         <Tip>
         You can optionally store checkpoint data in MongoDB instead of PostgreSQL. PostgreSQL is still required for all other server data. See [Configure checkpointer backend](/langsmith/configure-checkpointer) for details.
         </Tip>

--- a/src/langsmith/deploy-standalone-server.mdx
+++ b/src/langsmith/deploy-standalone-server.mdx
@@ -47,7 +47,9 @@ Do not run standalone servers in serverless environments. Scale-to-zero may caus
 - **Docker**: Run in any Docker-supported compute platform (local dev machine, VM, ECS, etc.). This is best suited for development or small-scale workloads.
 
 <Warning>
-For production deployments, use Kubernetes with the maintained LangSmith Helm chart when possible. If you deploy to another orchestrator, such as ECS, you must implement and maintain equivalent production safeguards:
+For production deployments, use Kubernetes with the maintained LangSmith Helm chart. This is the production path that LangChain regularly tests. LangChain does not regularly test other orchestrators, including ECS.
+
+Non-Kubernetes deployments have known gaps that you must implement and maintain yourself. These deployments may diverge further from the tested production path as the Helm chart evolves:
 
 - **Independent queue autoscaling**: Configure scaling policies and queue metrics for bursty, write-heavy workloads.
 - **Graceful run draining**: Configure shutdown draining and sufficient termination windows so in-flight runs can finish during deployments and scale-down events.

--- a/src/langsmith/deploy-standalone-server.mdx
+++ b/src/langsmith/deploy-standalone-server.mdx
@@ -47,7 +47,7 @@ Do not run standalone servers in serverless environments. Scale-to-zero may caus
 - **Docker**: Run in any Docker-supported compute platform (local dev machine, VM, ECS, etc.). This is best suited for development or small-scale workloads.
 
 <Warning>
-For production deployments, use Kubernetes with the maintained LangSmith Helm chart. This is the production path that LangChain regularly tests. LangChain does not regularly test other orchestrators, including ECS.
+For production deployments, use Kubernetes with the maintained LangSmith Helm chart. This is the production path that LangChain regularly tests. LangChain does not regularly test other orchestrators.
 
 Non-Kubernetes deployments have known gaps that you must implement and maintain yourself. These deployments may diverge further from the tested production path as the Helm chart evolves:
 

--- a/src/langsmith/deploy-standalone-server.mdx
+++ b/src/langsmith/deploy-standalone-server.mdx
@@ -95,7 +95,7 @@ The Helm chart (v0.2.6+) supports MongoDB checkpointing with a bundled instance 
 ## Docker
 
 <Warning>
-This Docker example is intended for local development and testing. For production, use the Kubernetes deployment or implement the equivalent autoscaling, run draining, split-mode wiring, scaling configuration, and upgrade safeguards described above.
+This Docker example is intended for local development and testing. For production, use the Kubernetes deployment.
 </Warning>
 
 Run the following `docker` command:
@@ -121,7 +121,7 @@ and you should provide appropriate values for `REDIS_URI`, `DATABASE_URI`, and `
 ## Docker Compose
 
 <Warning>
-This Docker Compose example is intended for local development and testing. For production, use the Kubernetes deployment or implement the equivalent autoscaling, run draining, split-mode wiring, scaling configuration, and upgrade safeguards described above.
+This Docker Compose example is intended for local development and testing. For production, use the Kubernetes deployment.
 </Warning>
 
 Use the following Docker Compose file:


### PR DESCRIPTION
## Description
Make the Kubernetes recommendation prescriptive by identifying the maintained Helm chart as the regularly tested production path. Warn that other orchestrators are not regularly tested, require users to address known operational gaps, and may diverge as the chart evolves. The Docker examples remain explicitly development-only.

## Test Plan
- [x] Run focused Vale prose lint on the updated page

Made by [Open SWE](https://openswe.vercel.app/agents/3937565d-3b47-1ee6-342b-3276a65d5e97)