### PR TITLE
gateway: (langchain OSS) document that `LANGSMITH_GATEWAY_API_KEY` falls back to `LANGSMITH_API_KEY`

### DIFF
--- a/src/langsmith/llm-gateway-quickstart.mdx
+++ b/src/langsmith/llm-gateway-quickstart.mdx
@@ -55,6 +55,10 @@ export LANGSMITH_GATEWAY="https://eu.gateway.smith.langchain.com"
 export LANGSMITH_GATEWAY_API_KEY="$LANGSMITH_API_KEY"
 ```
 
+<Note>
+If the Gateway is enabled but `LANGSMITH_GATEWAY_API_KEY` is unset, the Gateway will fall back to `LANGSMITH_API_KEY`.
+</Note>
+
 You can also configure base URLs and API keys for individual providers as described in the [section above](#1-set-environment-variables). See [more details](#more-details) below for provider support and interactions with provider-specific environment variables.
 
 <Accordion title="More details">


### PR DESCRIPTION
Following https://github.com/langchain-ai/langchain/pull/39115