### PR TITLE
docs(langsmith): document raw Gemini Live tracing

### DIFF
--- a/src/langsmith/trace-gemini-live.mdx
+++ b/src/langsmith/trace-gemini-live.mdx
@@ -109,31 +109,6 @@ async with (
 Transcription is opt-in. To show transcripts in the trace, set both `input_audio_transcription` and `output_audio_transcription` on `LiveConnectConfig`.
 </Note>
 
-### Trace tool calls
-
-Receive tool calls and send their responses through the wrapped session:
-
-```python
-async for message in session.receive():
-    if not message.tool_call:
-        continue
-
-    responses = []
-    for call in message.tool_call.function_calls:
-        result = await dispatch_tool(call.name, call.args)
-        responses.append(
-            types.FunctionResponse(
-                id=call.id,
-                name=call.name,
-                response=result,
-            )
-        )
-
-    await session.send_tool_response(function_responses=responses)
-```
-
-The integration correlates each inbound function call with its outbound response by call ID. It creates one `tool` span that contains the arguments and result, and spans the time from receiving the call through sending its response. Do not add `@traceable` solely to trace the same call, because doing so creates a second tool run.
-
 ### Group a conversation into a thread
 
 Each wrapped session is captured as its own trace with its own thread ID. To supply an ID, for example to group the conversation with related interactions in a LangSmith [thread](/langsmith/threads), pass `thread_id`:

--- a/src/langsmith/trace-gemini-live.mdx
+++ b/src/langsmith/trace-gemini-live.mdx
@@ -2,36 +2,63 @@
 title: Trace Gemini Live applications
 sidebarTitle: Gemini Live
 tag: Beta
-description: Trace Gemini Live voice agents built with the Google Agent Development Kit (ADK) in LangSmith.
+description: Trace Gemini Live voice agents in LangSmith using the LangSmith SDK.
 ---
 
 <Note>
 This integration is in beta, so its API may change.
 </Note>
 
-Gemini Live is a speech-to-speech model that ADK streams to your app as `run_live` events. The integration captures each conversation as a single LangSmith trace, with a span for every meaningful event (transcripts, tool calls, turn boundaries, and interruptions).
+Gemini Live is a speech-to-speech model that streams typed events over a WebSocket. Whether you build with a raw `google-genai` connection or the Google Agent Development Kit (ADK), the integration captures each conversation as a single LangSmith trace with spans for transcripts, model responses, tool calls, turn boundaries, and interruptions.
 
-Trace your [Gemini Live](https://ai.google.dev/gemini-api/docs/live-api) voice agents, built with the [Google Agent Development Kit (ADK)](https://google.github.io/adk-docs/streaming/), to LangSmith with the LangSmith ADK integration. For high-level conventions, see [Voice tracing fundamentals](/langsmith/trace-voice-fundamentals).
+Trace your [Gemini Live](https://ai.google.dev/gemini-api/docs/live-api) voice agents to LangSmith. For high-level conventions, see [Voice tracing fundamentals](/langsmith/trace-voice-fundamentals).
 
-<Note>
-The ADK Live integration requires `langsmith[google-adk-live]>=0.9.7` (separate from the `langsmith[google-adk]` batch integration).
-</Note>
+To trace non-live text agents, tools, and multi-agent workflows built with ADK, see [Trace Google ADK applications](/langsmith/trace-with-google-adk).
 
-To trace text agents, tools, and multi-agent workflows built with ADK, see [Trace Google ADK applications](/langsmith/trace-with-google-adk).
+## Choose an approach
+
+LangSmith provides a tracing integration for each way to connect to Gemini Live:
+
+- If you connect directly with `client.aio.live.connect(...)`, use `wrap_gemini_live`.
+- If you build with [Google ADK](https://google.github.io/adk-docs/streaming/), use `LangSmithGoogleADKLivePlugin`.
 
 ## Install
+
+### Use the Gemini Live client
+
+Install the `gemini-live` extra for a raw `google-genai` connection:
 
 <CodeGroup>
 
 ```bash pip
-pip install "langsmith[google-adk-live]" google-genai
+pip install "langsmith[gemini-live]"
 ```
 
 ```bash uv
-uv add "langsmith[google-adk-live]" google-genai
+uv add "langsmith[gemini-live]"
 ```
 
 </CodeGroup>
+
+### Use Google ADK
+
+Install the `google-adk-live` extra for an ADK application:
+
+<CodeGroup>
+
+```bash pip
+pip install "langsmith[google-adk-live]"
+```
+
+```bash uv
+uv add "langsmith[google-adk-live]"
+```
+
+</CodeGroup>
+
+<Note>
+The ADK Live integration requires `langsmith[google-adk-live]>=0.9.7`. This extra is separate from the `langsmith[google-adk]` batch integration.
+</Note>
 
 ## Set environment variables
 
@@ -40,11 +67,132 @@ LANGSMITH_API_KEY=<your-langsmith-api-key>
 LANGSMITH_TRACING=true
 LANGSMITH_PROJECT=<your-desired-langsmith-project>
 GOOGLE_API_KEY=<your-google-api-key>
+GEMINI_LIVE_MODEL=<your-gemini-live-model>
 ```
 
-## Set up tracing
+## Use the Gemini Live client
 
-Import `LangSmithGoogleADKLivePlugin` and register it on your `Runner`. It runs alongside your own `run_live` loop, so your loop only handles audio playback, barge-ins, and UI updates:
+Use this approach when your application opens the WebSocket with `client.aio.live.connect(...)` and owns the audio and tool loops.
+
+### Set up tracing
+
+Enable input and output transcription in the live configuration. `wrap_gemini_live` returns a transparent proxy for the connected session, so your existing receive loop, audio handling, and tool dispatch remain unchanged:
+
+```python
+import os
+
+from google import genai
+from google.genai import types
+from langsmith.integrations.gemini_live import wrap_gemini_live
+
+model = os.environ["GEMINI_LIVE_MODEL"]
+client = genai.Client()
+config = types.LiveConnectConfig(
+    response_modalities=[types.Modality.AUDIO],
+    input_audio_transcription=types.AudioTranscriptionConfig(),
+    output_audio_transcription=types.AudioTranscriptionConfig(),
+)
+
+async with (
+    client.aio.live.connect(model=model, config=config) as raw,
+    wrap_gemini_live(
+        raw,
+        model=model,
+        project_name="gemini-live-voice",
+    ) as session,
+):
+    async for message in session.receive():
+        ...  # play audio, run tools, handle barge-ins, and update the UI
+```
+
+<Note>
+Transcription is opt-in. To show transcripts in the trace, set both `input_audio_transcription` and `output_audio_transcription` on `LiveConnectConfig`.
+</Note>
+
+### Trace tool calls
+
+Receive tool calls and send their responses through the wrapped session:
+
+```python
+async for message in session.receive():
+    if not message.tool_call:
+        continue
+
+    responses = []
+    for call in message.tool_call.function_calls:
+        result = await dispatch_tool(call.name, call.args)
+        responses.append(
+            types.FunctionResponse(
+                id=call.id,
+                name=call.name,
+                response=result,
+            )
+        )
+
+    await session.send_tool_response(function_responses=responses)
+```
+
+The integration correlates each inbound function call with its outbound response by call ID. It creates one `tool` span that contains the arguments and result, and spans the time from receiving the call through sending its response. Do not add `@traceable` solely to trace the same call, because doing so creates a second tool run.
+
+### Group a conversation into a thread
+
+Each wrapped session is captured as its own trace with its own thread ID. To supply an ID, for example to group the conversation with related interactions in a LangSmith [thread](/langsmith/threads), pass `thread_id`:
+
+```python
+wrap_gemini_live(
+    raw,
+    model=model,
+    thread_id=thread_id,
+    project_name="gemini-live-voice",
+)
+```
+
+Create one wrapper per connected Gemini Live session. Each wrapper owns isolated tracing and transcript state, so concurrent conversations remain separate.
+
+### Record the conversation audio
+
+Feed microphone and playback audio to the wrapped session to attach a single stereo recording, with the user on the left channel and the agent on the right channel:
+
+```python
+RECORDING_SAMPLE_RATE = 24_000
+
+async with (
+    client.aio.live.connect(model=model, config=config) as raw,
+    wrap_gemini_live(
+        raw,
+        model=model,
+        sample_rate=RECORDING_SAMPLE_RATE,
+        is_agent_speaking=lambda: speaker.buffered_bytes() > 0,
+    ) as session,
+):
+    # Record audio after playback so discarded audio from a barge-in is omitted.
+    speaker.set_played_callback(session.record_agent_audio)
+
+    async def send_mic(mic_chunk):
+        await session.send_realtime_input(
+            audio=types.Blob(
+                data=mic_chunk,
+                mime_type=f"audio/pcm;rate={microphone.sample_rate}",
+            )
+        )
+        session.record_user_audio(
+            resample_pcm16(
+                mic_chunk,
+                microphone.sample_rate,
+                RECORDING_SAMPLE_RATE,
+            )
+        )
+```
+
+Record both channels as PCM16 at the wrapper's `sample_rate`. Record the agent's audio from the speaker so the attachment reflects only what the user heard. For the underlying attachment API, see [Upload files with traces](/langsmith/upload-files-with-traces).
+
+## Use Google ADK
+
+Use this approach when ADK owns the Gemini Live session and tool loop.
+
+### Set up tracing
+
+Import `LangSmithGoogleADKLivePlugin` and register it on your `Runner`. It runs alongside your `run_live` loop, so your loop only handles audio playback, barge-ins, and UI updates:
 
 ```python
 from google.adk.agents.run_config import RunConfig, StreamingMode
@@ -74,22 +222,22 @@ async for event in runner.run_live(
     live_request_queue=queue,
     run_config=run_config,
 ):
-    ...  # play audio, handle barge-in, update the UI
+    ...  # play audio, handle barge-ins, and update the UI
 ```
 
 <Note>
-Transcription is opt-in. To show transcripts, set both `input_audio_transcription` and `output_audio_transcription` on the `RunConfig`.
+Transcription is opt-in. To show transcripts, set both `input_audio_transcription` and `output_audio_transcription` on `RunConfig`.
 </Note>
 
 <Note>
-On a graceful end (the live request queue closing), ADK sends its `after_run` callback and the plugin finalizes the trace for you.
+On a graceful end, when the live request queue closes, ADK sends its `after_run` callback and the plugin finalizes the trace.
 
-On a cancelled run, such as a console app that stops `run_live` on Ctrl-C, ADK may not send that callback, so call `plugin.finalize(session_id=adk_session.id)` during teardown. Otherwise, you lose the trace and the audio attachment built at finalize. The call is idempotent, so it does nothing if ADK's callback already ran.
+On a cancelled run, such as a console app that stops `run_live` on Ctrl-C, ADK might not send that callback. Call `plugin.finalize(session_id=adk_session.id)` during teardown so the trace and audio attachment are finalized. The call is idempotent, so it does nothing if ADK's callback already ran.
 </Note>
 
-## Group a conversation into a thread
+### Group a conversation into a thread
 
-Each conversation is captured as its own trace with its own thread ID. To supply your own ID, for example to group the conversation with related interactions in a LangSmith [thread](/langsmith/threads), pass a `thread_id_provider` to the plugin:
+Each conversation is captured as its own trace with its own thread ID. To supply an ID, for example to group the conversation with related interactions in a LangSmith [thread](/langsmith/threads), pass a `thread_id_provider` to the plugin:
 
 ```python
 plugin = LangSmithGoogleADKLivePlugin(
@@ -98,18 +246,18 @@ plugin = LangSmithGoogleADKLivePlugin(
 )
 ```
 
-A single plugin instance is shared across every `run_live` call and it resolves the thread ID once, at the start of each conversation. The default keeps concurrent conversations separate. If you pass a `thread_id_provider` on a server handling concurrent conversations, it returns the ID for the current conversation rather than a fixed value; for example, by reading a `ContextVar` set at the start of each run.
+A single plugin instance is shared across every `run_live` call and resolves the thread ID once at the start of each conversation. The default keeps concurrent conversations separate. If you pass a `thread_id_provider` on a server handling concurrent conversations, return the ID for the current conversation, for example by reading a `ContextVar` set at the start of each run.
 
-## Record the conversation audio
+### Record the conversation audio
 
-If you feed your microphone and playback audio to the plugin, it attaches a single stereo recording (user left, agent right) to the trace:
+Feed microphone and playback audio to the plugin to attach a single stereo recording, with the user on the left channel and the agent on the right channel:
 
 ```python
 plugin.record_user_audio(mic_chunk)      # user mic PCM16
 plugin.record_agent_audio(played_chunk)  # agent PCM16 as played
 ```
 
-To accurately reflect what is heard, record the user's microphone capture before resampling it for ADK and tap the speaker for the agent's audio. Feed both channels at the same sample rate (the plugin's `sample_rate` is 24 kHz by default). For the underlying attachment API, see [Upload files with traces](/langsmith/upload-files-with-traces).
+Record the user's microphone capture before resampling it for ADK, and record the agent's audio from the speaker. Feed both channels at the same sample rate. The plugin's `sample_rate` is 24 kHz by default. For the underlying attachment API, see [Upload files with traces](/langsmith/upload-files-with-traces).
 
 ## Next steps
 


### PR DESCRIPTION
## Summary

- Document tracing direct Gemini Live WebSocket sessions with `wrap_gemini_live`.
- Separate raw `google-genai` and Google ADK setup, threading, and audio guidance.
- Keep existing application audio and tool handling unchanged behind the transparent wrapper.

## Why

The page previously covered only Google ADK. LangSmith now also traces applications that own the Gemini Live WebSocket, parallel to the raw and framework-based OpenAI Realtime integrations.

## Testing

- `make lint_prose VALE_BIN=/opt/homebrew/bin/vale FILES="src/langsmith/trace-gemini-live.mdx"`
- `.venv/bin/docs build`
- Parsed all six Python snippets with `ast.parse`
- Validated raw Gemini Live and ADK imports against the local SDK environments

## AI assistance

This PR was prepared with assistance from an AI coding agent.