### PR TITLE
docs: correct the Model Activation Date description

### DIFF
--- a/src/langsmith/cost-tracking.mdx
+++ b/src/langsmith/cost-tracking.mdx
@@ -372,7 +372,7 @@ Here, you can specify the following fields:
 - **Input Price Breakdown** (Optional): The breakdown of price for each different type of input token, e.g., `cache_read`, `video`, `audio`.
 - **Output Price**: The cost per 1M output tokens for the model. This number is multiplied by the number of tokens in the completion to calculate the completion cost.
 - **Output Price Breakdown** (Optional): The breakdown of price for each different type of output token, e.g., `reasoning`, `image`, etc.
-- **Model Activation Date** (Optional): The date from which the pricing is applicable. Only runs after this date will apply this model price.
+- **Model Activation Date** (Optional): The date from which the pricing applies. LangSmith compares this date against each run's own start time, so the price is eligible for a matching run that starts on or after it. Because the comparison is per run, child runs on either side of the date can price differently. The date must be today or later. Leave the field empty to apply the price to every matching run regardless of start time.
 - **Match Pattern**: A regex pattern to match the model name. This is used to match the value for `ls_model_name` in the run metadata.
 - **Provider** (Optional): The provider of the model. If specified, this is matched against `ls_provider` in the run metadata.
 


### PR DESCRIPTION
## Why

The **Model Activation Date** bullet on `/langsmith/cost-tracking` read:

> The date from which the pricing is applicable. Only runs after this date will apply this model price.

That is wrong in three ways, and a change now in review on `langchainplus` ([#32275](https://github.com/langchain-ai/langchainplus/pull/32275)) makes the omission worse by adding a constraint the page does not mention.

## What the code actually does

All three points come from `smith-go/queue/ingest/token_cost.go:376`, the only place the activation date gates pricing:

```go
if pm.StartTime != nil && !run.StartTime.IsZero() && run.StartTime.Before(*pm.StartTime) {
```

1. **The boundary is inclusive, not exclusive.** The entry is skipped only when the run starts *before* the activation date, so a run starting exactly on it does match. "Only runs after this date" says the opposite.
2. **The comparison is against each run's own start time.** Not ingest time, and not one timestamp for a whole trace. Child runs on either side of the date can therefore price differently, which the page never said.
3. **An empty field applies the price to every matching run.** When `StartTime` is `nil` the gate is skipped entirely. The page documented the field as optional without saying what omitting it does.

Separately, the activation date must now be today or later. That is the behavior change in langchainplus#32275.

## Review notes

- The claims above are verified against `token_cost.go`, not inferred from the previous copy. The inclusive boundary in particular contradicts what the page said, so it is worth a second look.
- I deliberately did **not** touch the `<Note>` a few lines above about backfilling ("LangSmith does not reflect updates to the model pricing map in the costs for traces **already** logged"). That claim is in tension with reinsert behavior — a qualifying reinsert recomputes stored cost — but whether trace-tier upgrades should re-cost completed runs is an open question on the source ticket. Documenting it now would mean documenting an undecided behavior.
- No links, pages, or nav entries were added or renamed, so `make broken-links` does not apply. `make lint_prose FILES="src/langsmith/cost-tracking.mdx"` reports 0 errors, 0 warnings, 0 suggestions.

## AI agent involvement

Written with Claude Code. The behavioral claims were verified by reading `smith-go/queue/ingest/token_cost.go` in `langchainplus`; the prose was checked with Vale.
