### PR TITLE
docs: prefix SmithDB migration v2 endpoints with /api

### DIFF
--- a/src/snippets/code-samples/smithdb-migration/experiment-runs-query-basic-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/experiment-runs-query-basic-after-sh.mdx
@@ -1,5 +1,5 @@
 ```bash After
-curl -X POST "https://api.smith.langchain.com/v2/datasets/$DATASET_ID/experiment-runs" \
+curl -X POST "https://api.smith.langchain.com/api/v2/datasets/$DATASET_ID/experiment-runs" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg eid "$EXPERIMENT_ID" '{

--- a/src/snippets/code-samples/smithdb-migration/experiment-runs-query-pagination-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/experiment-runs-query-pagination-after-sh.mdx
@@ -1,5 +1,5 @@
 ```bash After
-curl -X POST "https://api.smith.langchain.com/v2/datasets/$DATASET_ID/experiment-runs" \
+curl -X POST "https://api.smith.langchain.com/api/v2/datasets/$DATASET_ID/experiment-runs" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg eid "$EXPERIMENT_ID" --arg cursor "$NEXT_CURSOR" '{

--- a/src/snippets/code-samples/smithdb-migration/experiment-runs-query-sort-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/experiment-runs-query-sort-after-sh.mdx
@@ -1,5 +1,5 @@
 ```bash After
-curl -X POST "https://api.smith.langchain.com/v2/datasets/$DATASET_ID/experiment-runs" \
+curl -X POST "https://api.smith.langchain.com/api/v2/datasets/$DATASET_ID/experiment-runs" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg eid "$EXPERIMENT_ID" '{

--- a/src/snippets/code-samples/smithdb-migration/public-runs-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/public-runs-after-sh.mdx
@@ -1,19 +1,19 @@
 ```bash
 # Share a trace.
 curl --request POST \
-  "$API_URL/v2/runs/$RUN_ID/share" \
+  "$API_URL/api/v2/runs/$RUN_ID/share" \
   --header "X-API-Key: $LANGSMITH_API_KEY" \
   --header "Content-Type: application/json" \
   --data "{\"session_id\":\"$PROJECT_ID\",\"trace_id\":\"$TRACE_ID\"}"
 
 # Query the public trace.
 curl --request POST \
-  "$API_URL/v2/public/$SHARE_TOKEN/runs/v2/query" \
+  "$API_URL/api/v2/public/$SHARE_TOKEN/runs/v2/query" \
   --header "Content-Type: application/json" \
   --data '{"selects":["ID","NAME","RUN_TYPE","STATUS","START_TIME"]}'
 
 # Retrieve one public run using its exact start time from the query response.
-curl --get "$API_URL/v2/public/$SHARE_TOKEN/run/$RUN_ID" \
+curl --get "$API_URL/api/v2/public/$SHARE_TOKEN/run/$RUN_ID" \
   --data-urlencode "start_time=$START_TIME" \
   --data-urlencode "selects=ID" \
   --data-urlencode "selects=NAME" \
@@ -22,7 +22,7 @@ curl --get "$API_URL/v2/public/$SHARE_TOKEN/run/$RUN_ID" \
   --data-urlencode "selects=START_TIME"
 
 # Retrieve the deployment-aware public URL for an authenticated run.
-curl --get "$API_URL/v2/runs/$RUN_ID" \
+curl --get "$API_URL/api/v2/runs/$RUN_ID" \
   --header "X-API-Key: $LANGSMITH_API_KEY" \
   --data-urlencode "project_id=$PROJECT_ID" \
   --data-urlencode "start_time=$START_TIME" \
@@ -30,7 +30,7 @@ curl --get "$API_URL/v2/runs/$RUN_ID" \
 
 # Remove public access by root trace ID.
 curl --request DELETE \
-  "$API_URL/v2/runs/$TRACE_ID/share" \
+  "$API_URL/api/v2/runs/$TRACE_ID/share" \
   --header "X-API-Key: $LANGSMITH_API_KEY" \
   --header "Content-Type: application/json" \
   --data "{\"session_id\":\"$PROJECT_ID\"}"

--- a/src/snippets/code-samples/smithdb-migration/runs-geturl-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-geturl-after-sh.mdx
@@ -7,6 +7,6 @@ PROJECT_ID=$(echo "$RUN" | jq -r '.session_id')
 TRACE_ID=$(echo "$RUN" | jq -r '.trace_id')
 START_TIME=$(echo "$RUN" | jq -r '.start_time') # Optional, but speeds up retrieval
 
-curl "https://api.smith.langchain.com/v2/runs/$RUN_ID/url?project_id=$PROJECT_ID&trace_id=$TRACE_ID&start_time=$START_TIME" \
+curl "https://api.smith.langchain.com/api/v2/runs/$RUN_ID/url?project_id=$PROJECT_ID&trace_id=$TRACE_ID&start_time=$START_TIME" \
   -H "x-api-key: $LANGSMITH_API_KEY"
 ```

--- a/src/snippets/code-samples/smithdb-migration/runs-query-boolean-filters-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-boolean-filters-after-sh.mdx
@@ -4,7 +4,7 @@ PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=defau
 
 FILTER='and(gt(start_time, "2023-07-15T12:34:56Z"), or(neq(status, "error"), and(eq(feedback_key, "Correctness"), eq(feedback_score, 0.0))))'
 
-curl -X POST "https://api.smith.langchain.com/v2/runs/query" \
+curl -X POST "https://api.smith.langchain.com/api/v2/runs/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pid "$PROJECT_ID" --arg f "$FILTER" '{"project_ids": [$pid], "filter": $f}')"

--- a/src/snippets/code-samples/smithdb-migration/runs-query-fetch-by-id-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-fetch-by-id-after-sh.mdx
@@ -5,7 +5,7 @@ PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=defau
 RUN_ID_1="<run-id-1>"
 RUN_ID_2="<run-id-2>"
 
-curl -X POST "https://api.smith.langchain.com/v2/runs/query" \
+curl -X POST "https://api.smith.langchain.com/api/v2/runs/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pid "$PROJECT_ID" --arg r1 "$RUN_ID_1" --arg r2 "$RUN_ID_2" '{"project_ids": [$pid], "ids": [$r1, $r2]}')"

--- a/src/snippets/code-samples/smithdb-migration/runs-query-filter-errors-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-filter-errors-after-sh.mdx
@@ -2,7 +2,7 @@
 PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=default&limit=1" \
   -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
 
-curl -X POST "https://api.smith.langchain.com/v2/runs/query" \
+curl -X POST "https://api.smith.langchain.com/api/v2/runs/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pid "$PROJECT_ID" '{"project_ids": [$pid], "has_error": true}')"

--- a/src/snippets/code-samples/smithdb-migration/runs-query-filter-metadata-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-filter-metadata-after-sh.mdx
@@ -4,7 +4,7 @@ PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=defau
 
 FILTER='and(eq(metadata_key, "user_id"), eq(metadata_value, "u_123"))'
 
-curl -X POST "https://api.smith.langchain.com/v2/runs/query" \
+curl -X POST "https://api.smith.langchain.com/api/v2/runs/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pid "$PROJECT_ID" --arg f "$FILTER" '{"project_ids": [$pid], "filter": $f}')"

--- a/src/snippets/code-samples/smithdb-migration/runs-query-filter-root-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-filter-root-after-sh.mdx
@@ -2,7 +2,7 @@
 PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=default&limit=1" \
   -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
 
-curl -X POST "https://api.smith.langchain.com/v2/runs/query" \
+curl -X POST "https://api.smith.langchain.com/api/v2/runs/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pid "$PROJECT_ID" '{"project_ids": [$pid], "is_root": true}')"

--- a/src/snippets/code-samples/smithdb-migration/runs-query-filter-time-range-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-filter-time-range-after-sh.mdx
@@ -2,7 +2,7 @@
 PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=default&limit=1" \
   -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
 
-curl -X POST "https://api.smith.langchain.com/v2/runs/query" \
+curl -X POST "https://api.smith.langchain.com/api/v2/runs/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pid "$PROJECT_ID" '{"project_ids": [$pid], "run_type": "LLM", "min_start_time": "2025-01-01T00:00:00Z"}')"

--- a/src/snippets/code-samples/smithdb-migration/runs-query-list-all-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-list-all-after-sh.mdx
@@ -2,7 +2,7 @@
 PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=default&limit=1" \
   -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
 
-curl -X POST "https://api.smith.langchain.com/v2/runs/query" \
+curl -X POST "https://api.smith.langchain.com/api/v2/runs/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pid "$PROJECT_ID" '{"project_ids": [$pid]}')"

--- a/src/snippets/code-samples/smithdb-migration/runs-query-list-root-as-traces-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-list-root-as-traces-after-sh.mdx
@@ -2,7 +2,7 @@
 PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=default&limit=1" \
   -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
 
-curl -X POST "https://api.smith.langchain.com/v2/traces/query" \
+curl -X POST "https://api.smith.langchain.com/api/v2/traces/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pid "$PROJECT_ID" '{

--- a/src/snippets/code-samples/smithdb-migration/runs-query-pagination-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-pagination-after-sh.mdx
@@ -9,7 +9,7 @@ CURSOR=""
 while :; do
   BODY=$(jq -n --arg pid "$PROJECT_ID" --arg cursor "$CURSOR" \
     'if $cursor == "" then {"project_ids": [$pid]} else {"project_ids": [$pid], "cursor": $cursor} end')
-  RESPONSE=$(curl -s -X POST "https://api.smith.langchain.com/v2/runs/query" \
+  RESPONSE=$(curl -s -X POST "https://api.smith.langchain.com/api/v2/runs/query" \
     -H "x-api-key: $LANGSMITH_API_KEY" \
     -H "Content-Type: application/json" \
     -d "$BODY")

--- a/src/snippets/code-samples/smithdb-migration/runs-query-scoped-filters-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-scoped-filters-after-sh.mdx
@@ -6,7 +6,7 @@ FILTER='eq(name, "RetrieveDocs")'
 TRACE_FILTER='and(eq(feedback_key, "user_score"), eq(feedback_score, 1))'
 TREE_FILTER='eq(name, "ExpandQuery")'
 
-curl -X POST "https://api.smith.langchain.com/v2/runs/query" \
+curl -X POST "https://api.smith.langchain.com/api/v2/runs/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n \

--- a/src/snippets/code-samples/smithdb-migration/runs-query-selecting-fields-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-query-selecting-fields-after-sh.mdx
@@ -2,7 +2,7 @@
 PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=default&limit=1" \
   -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
 
-curl -X POST "https://api.smith.langchain.com/v2/runs/query" \
+curl -X POST "https://api.smith.langchain.com/api/v2/runs/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pid "$PROJECT_ID" '{"project_ids": [$pid], "selects": ["ID", "NAME", "RUN_TYPE", "STATUS", "START_TIME", "INPUTS", "ERROR"]}')"

--- a/src/snippets/code-samples/smithdb-migration/runs-retrieve-basic-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-retrieve-basic-after-sh.mdx
@@ -5,6 +5,6 @@ PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=defau
 RUN_ID="<run-id>"
 START_TIME="2026-06-01T12:00:00Z"
 
-curl "https://api.smith.langchain.com/v2/runs/$RUN_ID?project_id=$PROJECT_ID&start_time=$START_TIME&selects=NAME&selects=STATUS&selects=TOTAL_TOKENS" \
+curl "https://api.smith.langchain.com/api/v2/runs/$RUN_ID?project_id=$PROJECT_ID&start_time=$START_TIME&selects=NAME&selects=STATUS&selects=TOTAL_TOKENS" \
   -H "x-api-key: $LANGSMITH_API_KEY"
 ```

--- a/src/snippets/code-samples/smithdb-migration/runs-retrieve-by-id-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-retrieve-by-id-after-sh.mdx
@@ -5,6 +5,6 @@ PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=defau
 RUN_ID="<run-id>"
 START_TIME="2025-01-01T12:00:00Z" # Optional, but speeds up retrieval
 
-curl "https://api.smith.langchain.com/v2/runs/$RUN_ID?project_id=$PROJECT_ID&start_time=$START_TIME" \
+curl "https://api.smith.langchain.com/api/v2/runs/$RUN_ID?project_id=$PROJECT_ID&start_time=$START_TIME" \
   -H "x-api-key: $LANGSMITH_API_KEY"
 ```

--- a/src/snippets/code-samples/smithdb-migration/runs-retrieve-not-found-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/runs-retrieve-not-found-after-sh.mdx
@@ -6,7 +6,7 @@ RUN_ID="<run-id>"
 START_TIME="2025-01-01T12:00:00Z"
 
 HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-  "https://api.smith.langchain.com/v2/runs/$RUN_ID?project_id=$PROJECT_ID&start_time=$START_TIME" \
+  "https://api.smith.langchain.com/api/v2/runs/$RUN_ID?project_id=$PROJECT_ID&start_time=$START_TIME" \
   -H "x-api-key: $LANGSMITH_API_KEY")
 
 if [ "$HTTP_STATUS" = "404" ]; then

--- a/src/snippets/code-samples/smithdb-migration/threads-list-traces-basic-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/threads-list-traces-basic-after-sh.mdx
@@ -3,7 +3,7 @@ PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=defau
   -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
 THREAD_ID="<thread-id>"
 
-curl -G "https://api.smith.langchain.com/v2/threads/$THREAD_ID/traces" \
+curl -G "https://api.smith.langchain.com/api/v2/threads/$THREAD_ID/traces" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   --data-urlencode "project_id=$PROJECT_ID" \
   --data-urlencode "selects=START_TIME"

--- a/src/snippets/code-samples/smithdb-migration/threads-list-traces-selecting-fields-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/threads-list-traces-selecting-fields-after-sh.mdx
@@ -3,7 +3,7 @@ PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=defau
   -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
 THREAD_ID="<thread-id>"
 
-curl -G "https://api.smith.langchain.com/v2/threads/$THREAD_ID/traces" \
+curl -G "https://api.smith.langchain.com/api/v2/threads/$THREAD_ID/traces" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   --data-urlencode "project_id=$PROJECT_ID" \
   --data-urlencode "selects=TRACE_ID" \

--- a/src/snippets/code-samples/smithdb-migration/threads-query-filter-status-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/threads-query-filter-status-after-sh.mdx
@@ -2,7 +2,7 @@
 PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=default&limit=1" \
   -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
 
-curl -X POST "https://api.smith.langchain.com/v2/threads/query" \
+curl -X POST "https://api.smith.langchain.com/api/v2/threads/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pid "$PROJECT_ID" '{

--- a/src/snippets/code-samples/smithdb-migration/threads-query-list-all-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/threads-query-list-all-after-sh.mdx
@@ -2,7 +2,7 @@
 PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=default&limit=1" \
   -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
 
-curl -X POST "https://api.smith.langchain.com/v2/threads/query" \
+curl -X POST "https://api.smith.langchain.com/api/v2/threads/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pid "$PROJECT_ID" '{

--- a/src/snippets/code-samples/smithdb-migration/traces-list-runs-basic-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/traces-list-runs-basic-after-sh.mdx
@@ -3,7 +3,7 @@ PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=defau
   -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
 TRACE_ID="<trace-id>"
 
-curl -G "https://api.smith.langchain.com/v2/traces/$TRACE_ID/runs" \
+curl -G "https://api.smith.langchain.com/api/v2/traces/$TRACE_ID/runs" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   --data-urlencode "project_id=$PROJECT_ID" \
   --data-urlencode "selects=NAME" \

--- a/src/snippets/code-samples/smithdb-migration/traces-list-runs-filter-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/traces-list-runs-filter-after-sh.mdx
@@ -3,7 +3,7 @@ PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=defau
   -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
 TRACE_ID="<trace-id>"
 
-curl -G "https://api.smith.langchain.com/v2/traces/$TRACE_ID/runs" \
+curl -G "https://api.smith.langchain.com/api/v2/traces/$TRACE_ID/runs" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   --data-urlencode "project_id=$PROJECT_ID" \
   --data-urlencode "filter=eq(run_type, \"llm\")" \

--- a/src/snippets/code-samples/smithdb-migration/traces-query-filters-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/traces-query-filters-after-sh.mdx
@@ -3,7 +3,7 @@ PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=defau
   -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
 
 # trace_filter is implicitly root-run-only — no is_root needed.
-curl -s -X POST "https://api.smith.langchain.com/v2/traces/query" \
+curl -s -X POST "https://api.smith.langchain.com/api/v2/traces/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pid "$PROJECT_ID" '{
@@ -16,7 +16,7 @@ curl -s -X POST "https://api.smith.langchain.com/v2/traces/query" \
 
 # trace_ids is a fast-path when you already know which traces you want.
 TRACE_ID="<trace-id>"
-curl -s -X POST "https://api.smith.langchain.com/v2/traces/query" \
+curl -s -X POST "https://api.smith.langchain.com/api/v2/traces/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pid "$PROJECT_ID" --arg tid "$TRACE_ID" '{

--- a/src/snippets/code-samples/smithdb-migration/traces-query-totals-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/traces-query-totals-after-sh.mdx
@@ -2,7 +2,7 @@
 PROJECT_ID=$(curl -s "https://api.smith.langchain.com/api/v1/sessions?name=default&limit=1" \
   -H "x-api-key: $LANGSMITH_API_KEY" | jq -r '.[0].id')
 
-curl -X POST "https://api.smith.langchain.com/v2/traces/query" \
+curl -X POST "https://api.smith.langchain.com/api/v2/traces/query" \
   -H "x-api-key: $LANGSMITH_API_KEY" \
   -H "Content-Type: application/json" \
   -d "$(jq -n --arg pid "$PROJECT_ID" '{

--- a/src/snippets/langsmith/smithdb-migration/experiment-runs-query.mdx
+++ b/src/snippets/langsmith/smithdb-migration/experiment-runs-query.mdx
@@ -73,7 +73,7 @@ Query dataset examples together with the experiment runs recorded against each e
   <Tab title="cURL">
     | Before | After |
     |--------|-------|
-    | `POST /api/v1/datasets/{dataset_id}/runs` | `POST /v2/datasets/{dataset_id}/experiment-runs` |
+    | `POST /api/v1/datasets/{dataset_id}/runs` | `POST /api/v2/datasets/{dataset_id}/experiment-runs` |
 
     See the [API doc](/langsmith/smith-api/datasets/fetch-experiment-runs-for-dataset-examples) for the full parameter and field list.
   </Tab>
@@ -158,7 +158,7 @@ Query dataset examples together with the experiment runs recorded against each e
     `experiment_ids` is required and replaces `session_ids`. Values are still experiment tracing-project UUIDs—if you only know the experiment's name, resolve it first: `GET /api/v1/sessions?name=my-experiment` and take `.[0].id`.
     </Warning>
 
-    | Before (`POST /api/v1/datasets/{dataset_id}/runs` body) | After (`POST /v2/datasets/{dataset_id}/experiment-runs` body) | Notes |
+    | Before (`POST /api/v1/datasets/{dataset_id}/runs` body) | After (`POST /api/v2/datasets/{dataset_id}/experiment-runs` body) | Notes |
     |---|---|---|
     | `session_ids` | `experiment_ids` | Renamed; required and non-empty |
     | `limit` | *(removed)* | Use `page_size` for per-request batch size |
@@ -240,7 +240,7 @@ Each page item is a dataset example paired with the runs produced for it—not a
     | `Runs` | This example's runs—see [Querying runs](#response-fields) |
   </Tab>
   <Tab title="cURL">
-    `POST /api/v1/datasets/{dataset_id}/runs` returned a JSON array. `POST /v2/datasets/{dataset_id}/experiment-runs` returns `{ "items": [...], "next_cursor": "..." }`; each item has:
+    `POST /api/v1/datasets/{dataset_id}/runs` returned a JSON array. `POST /api/v2/datasets/{dataset_id}/experiment-runs` returns `{ "items": [...], "next_cursor": "..." }`; each item has:
 
     | Field | Notes |
     |---|---|

--- a/src/snippets/langsmith/smithdb-migration/public-runs.mdx
+++ b/src/snippets/langsmith/smithdb-migration/public-runs.mdx
@@ -49,11 +49,11 @@ Public read methods do not require a LangSmith API key. Treat the share token as
   <Tab title="cURL">
     | Operation | Before | After |
     |---|---|---|
-    | Share | `PUT /api/v1/runs/{run_id}/share` | `POST /v2/runs/{run_id}/share` |
-    | Unshare | `DELETE /api/v1/runs/{run_id}/share` | `DELETE /v2/runs/{trace_id}/share` |
-    | Query public runs | `POST /api/v1/public/{share_token}/runs/query` | `POST /v2/public/{share_token}/runs/v2/query` |
-    | Retrieve a public run | `GET /api/v1/public/{share_token}/run/{run_id}` | `GET /v2/public/{share_token}/run/{run_id}` |
-    | Read share state | `GET /api/v1/runs/{run_id}/share` | `GET /v2/runs/{run_id}?selects=SHARE_URL` |
+    | Share | `PUT /api/v1/runs/{run_id}/share` | `POST /api/v2/runs/{run_id}/share` |
+    | Unshare | `DELETE /api/v1/runs/{run_id}/share` | `DELETE /api/v2/runs/{trace_id}/share` |
+    | Query public runs | `POST /api/v1/public/{share_token}/runs/query` | `POST /api/v2/public/{share_token}/runs/v2/query` |
+    | Retrieve a public run | `GET /api/v1/public/{share_token}/run/{run_id}` | `GET /api/v2/public/{share_token}/run/{run_id}` |
+    | Read share state | `GET /api/v1/runs/{run_id}/share` | `GET /api/v2/runs/{run_id}?selects=SHARE_URL` |
 
     The legacy `GET /api/v1/public/{share_token}/run` endpoint without a run ID has no direct v2 equivalent.
   </Tab>

--- a/src/snippets/langsmith/smithdb-migration/runs-geturl.mdx
+++ b/src/snippets/langsmith/smithdb-migration/runs-geturl.mdx
@@ -56,7 +56,7 @@ Get the LangSmith UI URL for a run.
 
     | Before | After |
     |--------|-------|
-    | *(no legacy endpoint)* | `GET /v2/runs/{run_id}/url` |
+    | *(no legacy endpoint)* | `GET /api/v2/runs/{run_id}/url` |
   </Tab>
 </Tabs>
 
@@ -108,7 +108,7 @@ Get the LangSmith UI URL for a run.
     | *(no legacy method)* | `StartTime` | Optional; run's start time (RFC3339); omit if unknown |
   </Tab>
   <Tab title="cURL">
-    | Before | After (`GET /v2/runs/{run_id}/url`) | Notes |
+    | Before | After (`GET /api/v2/runs/{run_id}/url`) | Notes |
     |---|---|---|
     | *(no legacy endpoint)* | `run_id` (path) | **Required** |
     | *(no legacy endpoint)* | `project_id` (query) | **Required**; the project (session) UUID |
@@ -187,7 +187,7 @@ Get the LangSmith UI URL for a run.
     <SmithdbRunsGetUrlAfterGo />
   </Tab>
   <Tab title="cURL">
-    The REST API has no legacy equivalent. `GET /v2/runs/{run_id}/url` needs the run's `project_id` and `trace_id` query parameters, with `start_time` optional.
+    The REST API has no legacy equivalent. `GET /api/v2/runs/{run_id}/url` needs the run's `project_id` and `trace_id` query parameters, with `start_time` optional.
 
     <SmithdbRunsGetUrlAfterSh />
   </Tab>

--- a/src/snippets/langsmith/smithdb-migration/runs-query.mdx
+++ b/src/snippets/langsmith/smithdb-migration/runs-query.mdx
@@ -143,7 +143,7 @@ Query runs from a project with optional filtering and field projection. Returns 
   <Tab title="cURL">
     | Before | After |
     |--------|-------|
-    | `POST /api/v1/runs/query` | `POST /v2/runs/query` |
+    | `POST /api/v1/runs/query` | `POST /api/v2/runs/query` |
 
     See the [API doc](/langsmith/smith-api/runs/query-runs) for the full parameter and field list.
   </Tab>
@@ -279,10 +279,10 @@ Query runs from a project with optional filtering and field projection. Returns 
   <Tab title="cURL">
 
     <Warning>
-    `min_start_time` defaults to **1 day ago** when omitted. `POST /api/v1/runs/query` with no `start_time` returned all historical runs; `POST /v2/runs/query` without `min_start_time` silently scopes the query to the last 24 hours. Pass an explicit `min_start_time` if you need a wider window.
+    `min_start_time` defaults to **1 day ago** when omitted. `POST /api/v1/runs/query` with no `start_time` returned all historical runs; `POST /api/v2/runs/query` without `min_start_time` silently scopes the query to the last 24 hours. Pass an explicit `min_start_time` if you need a wider window.
     </Warning>
 
-    | Before (v1 `POST /api/v1/runs/query` body field) | After (v2 `POST /v2/runs/query` body field) | Notes |
+    | Before (v1 `POST /api/v1/runs/query` body field) | After (v2 `POST /api/v2/runs/query` body field) | Notes |
     |---|---|---|
     | `session` | `project_ids` | Renamed; both take an array of project UUIDs. `project_ids` is mutually exclusive with `reference_dataset_id` |
     | `run_type` | `run_type` | Values must now be uppercase: `"LLM"`, `"CHAIN"`, `"TOOL"`, `"RETRIEVER"`, `"EMBEDDING"`, `"PROMPT"`, `"PARSER"` |
@@ -681,7 +681,7 @@ Query runs from a project with optional filtering and field projection. Returns 
 
   </Tab>
   <Tab title="cURL">
-    `POST /v2/runs/query` does not accept a project name directly. Resolve the project UUID with a `GET /api/v1/sessions` request first, then pass it as a string in `project_ids`.
+    `POST /api/v2/runs/query` does not accept a project name directly. Resolve the project UUID with a `GET /api/v1/sessions` request first, then pass it as a string in `project_ids`.
 
 <Tabs sync={false}>
   <Tab title="Before">
@@ -751,7 +751,7 @@ Query runs from a project with optional filtering and field projection. Returns 
 
   </Tab>
   <Tab title="cURL">
-    `POST /api/v1/runs/query` returns a default set of fields with no selection needed. `POST /v2/runs/query` returns only `id` by default—pass `selects` with the uppercase field names you need (e.g. `"NAME"`).
+    `POST /api/v1/runs/query` returns a default set of fields with no selection needed. `POST /api/v2/runs/query` returns only `id` by default—pass `selects` with the uppercase field names you need (e.g. `"NAME"`).
 
 <Tabs sync={false}>
   <Tab title="Before">

--- a/src/snippets/langsmith/smithdb-migration/runs-retrieve.mdx
+++ b/src/snippets/langsmith/smithdb-migration/runs-retrieve.mdx
@@ -71,7 +71,7 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
   <Tab title="cURL">
     | Before | After |
     |--------|-------|
-    | `GET /api/v1/runs/{run_id}` | `GET /v2/runs/{run_id}` |
+    | `GET /api/v1/runs/{run_id}` | `GET /api/v2/runs/{run_id}` |
 
     See the [API doc](/langsmith/smith-api/runs/get-a-single-run) for the full parameter and field list.
   </Tab>
@@ -142,10 +142,10 @@ Fetch a single run by ID. Returns only the run ID by default—specify a field s
     `run_id` remains in the URL path. All other parameters are query string values with `snake_case` names.
 
     <Warning>
-    `GET /v2/runs/{run_id}` requires a new `project_id` query param. `start_time` remains optional—providing it speeds up retrieval but is not required.
+    `GET /api/v2/runs/{run_id}` requires a new `project_id` query param. `start_time` remains optional—providing it speeds up retrieval but is not required.
     </Warning>
 
-    | Before (`GET /api/v1/runs/{run_id}` param) | After (`GET /v2/runs/{run_id}` param) | Notes |
+    | Before (`GET /api/v1/runs/{run_id}` param) | After (`GET /api/v2/runs/{run_id}` param) | Notes |
     |---|---|---|
     | `run_id` (path) | `run_id` (path) | Unchanged |
     | *(not available)* | `project_id` (query) | **Required**—UUID of the project that owns the run |
@@ -556,7 +556,7 @@ asyncio.run(main())
 
   </Tab>
   <Tab title="cURL">
-    `GET /v2/runs/{run_id}` requires an additional `project_id` (UUID) query parameter that `GET /api/v1/runs/{run_id}` did not need. It also accepts an optional `start_time`—providing it speeds up retrieval but is not required. Resolve the project UUID via a `GET /api/v1/sessions` request first.
+    `GET /api/v2/runs/{run_id}` requires an additional `project_id` (UUID) query parameter that `GET /api/v1/runs/{run_id}` did not need. It also accepts an optional `start_time`—providing it speeds up retrieval but is not required. Resolve the project UUID via a `GET /api/v1/sessions` request first.
 
 <Tabs sync={false}>
   <Tab title="Before">
@@ -659,7 +659,7 @@ asyncio.run(main())
     </Tabs>
   </Tab>
   <Tab title="cURL">
-    `GET /api/v1/runs/{run_id}` returns a full run object with no selection needed. `GET /v2/runs/{run_id}` returns only `id` by default—pass `selects` query parameters for the fields you need.
+    `GET /api/v1/runs/{run_id}` returns a full run object with no selection needed. `GET /api/v2/runs/{run_id}` returns only `id` by default—pass `selects` query parameters for the fields you need.
 
     <Tabs sync={false}>
       <Tab title="Before">
@@ -729,7 +729,7 @@ curl "https://api.smith.langchain.com/api/v1/runs/$RUN_ID" \
     </Tabs>
   </Tab>
   <Tab title="cURL">
-    Both `GET /api/v1/runs/{run_id}` and `GET /v2/runs/{run_id}` return HTTP 404 for a missing run. Check the response status code.
+    Both `GET /api/v1/runs/{run_id}` and `GET /api/v2/runs/{run_id}` return HTTP 404 for a missing run. Check the response status code.
 
     <Tabs sync={false}>
       <Tab title="Before">
@@ -778,7 +778,7 @@ The `load_child_runs` flag and the nested `child_runs` field are removed. Fetch 
     Nothing to migrate: the Go SDK never loaded child runs in one call, so use `client.Traces.ListRuns()` to walk a trace's runs.
   </Tab>
   <Tab title="cURL">
-    Nothing to migrate: `GET /api/v1/runs/{run_id}` never returned child runs, so use `GET /v2/traces/{trace_id}/runs` to walk a trace's runs.
+    Nothing to migrate: `GET /api/v1/runs/{run_id}` never returned child runs, so use `GET /api/v2/traces/{trace_id}/runs` to walk a trace's runs.
   </Tab>
 </Tabs>
 

--- a/src/snippets/langsmith/smithdb-migration/threads-list-traces.mdx
+++ b/src/snippets/langsmith/smithdb-migration/threads-list-traces.mdx
@@ -67,7 +67,7 @@ Retrieve all traces belonging to a specific thread within a project.
   <Tab title="cURL">
     | Before | After |
     |--------|-------|
-    | `POST /api/v1/runs/query` (`filter=eq(thread_id, ...)`) | `GET /v2/threads/{thread_id}/traces` |
+    | `POST /api/v1/runs/query` (`filter=eq(thread_id, ...)`) | `GET /api/v2/threads/{thread_id}/traces` |
 
     See the [API doc](/langsmith/smith-api/threads/query-thread-traces) for the full parameter and field list.
   </Tab>
@@ -109,7 +109,7 @@ Retrieve all traces belonging to a specific thread within a project.
     No query parameters to map. There was no dedicated method. `ListTraces(ctx, threadID, params)` takes `ProjectID`, `Filter`, `PageSize`, `Cursor`, `Selects` (24-value enum). Results are always sorted by `StartTime` ascending, a fixed server-side order.
   </Tab>
   <Tab title="cURL">
-    `GET /v2/threads/{thread_id}/traces` query params: `project_id`, `filter`, `page_size`, `cursor`, `selects` (repeatable), all `snake_case`. Results are always sorted by `start_time` ascending, a fixed server-side order.
+    `GET /api/v2/threads/{thread_id}/traces` query params: `project_id`, `filter`, `page_size`, `cursor`, `selects` (repeatable), all `snake_case`. Results are always sorted by `start_time` ascending, a fixed server-side order.
   </Tab>
 </Tabs>
 

--- a/src/snippets/langsmith/smithdb-migration/threads-query.mdx
+++ b/src/snippets/langsmith/smithdb-migration/threads-query.mdx
@@ -67,7 +67,7 @@ Query threads within a project, with cursor-based pagination. Returns threads ma
   <Tab title="cURL">
     | Before | After |
     |--------|-------|
-    | `POST /api/v1/runs/query` (`is_root=true`, grouped client-side) | `POST /v2/threads/query` |
+    | `POST /api/v1/runs/query` (`is_root=true`, grouped client-side) | `POST /api/v2/threads/query` |
 
     See the [API doc](/langsmith/smith-api/threads/query-threads) for the full parameter and field list.
   </Tab>
@@ -99,7 +99,7 @@ Query threads within a project, with cursor-based pagination. Returns threads ma
     No query parameters to map. There was no dedicated method. The old approach used the generic run query (`IsRoot: true`, manual grouping by `thread_id` metadata). `Threads.Query()` takes `ProjectID`, `MinStartTime`, `MaxStartTime` (both optional, defaulting to a 1-day window ending now), `Filter`, `PageSize`, `Cursor`.
   </Tab>
   <Tab title="cURL">
-    `POST /v2/threads/query` body fields: `project_id`, `min_start_time` (optional), `max_start_time` (optional), `filter`, `page_size`, `cursor` (all `snake_case`). `min_start_time`/`max_start_time` default to a 1-day window ending now when omitted.
+    `POST /api/v2/threads/query` body fields: `project_id`, `min_start_time` (optional), `max_start_time` (optional), `filter`, `page_size`, `cursor` (all `snake_case`). `min_start_time`/`max_start_time` default to a 1-day window ending now when omitted.
   </Tab>
 </Tabs>
 

--- a/src/snippets/langsmith/smithdb-migration/traces-list-runs.mdx
+++ b/src/snippets/langsmith/smithdb-migration/traces-list-runs.mdx
@@ -63,7 +63,7 @@ Returns runs for a trace ID within min/max start time. Optional `filter`; repeat
   <Tab title="cURL">
     | Before | After |
     |--------|-------|
-    | `POST /api/v1/runs/query` (`trace` field) | `GET /v2/traces/{trace_id}/runs` |
+    | `POST /api/v1/runs/query` (`trace` field) | `GET /api/v2/traces/{trace_id}/runs` |
   </Tab>
 </Tabs>
 

--- a/src/snippets/langsmith/smithdb-migration/traces-query.mdx
+++ b/src/snippets/langsmith/smithdb-migration/traces-query.mdx
@@ -77,7 +77,7 @@ Supports filters (`trace_filter`, `tree_filter`) and field projection (`selects`
   <Tab title="cURL">
     | Before | After |
     |--------|-------|
-    | `POST /api/v1/runs/query` (`is_root=true`) | `POST /v2/traces/query` |
+    | `POST /api/v1/runs/query` (`is_root=true`) | `POST /api/v2/traces/query` |
   </Tab>
 </Tabs>
 


### PR DESCRIPTION
## Problem

The SmithDB SDK migration guide documents the new v2 REST endpoints as `/v2/...`, but they are actually served under `/api/v2/...`. Confirmed against [`smith-backend/static/openapi.json`](https://github.com/langchain-ai/langchainplus/blob/main/smith-backend/static/openapi.json) on `main`, which lists `/api/v2/runs/query`, `/api/v2/runs/{run_id}`, `/api/v2/runs/{run_id}/url`, `/api/v2/runs/{run_id}/share`, `/api/v2/traces/query`, `/api/v2/traces/{trace_id}/runs`, `/api/v2/threads/query`, `/api/v2/threads/{thread_id}/traces`, `/api/v2/datasets/{dataset_id}/experiment-runs`, `/api/v2/public/{share_token}/run/{run_id}` and `/api/v2/public/{share_token}/runs/v2/query`.

As written, every "after" cURL example in the guide returns a 404.

## Change

Rewrote `/v2/` → `/api/v2/` in:

- `src/snippets/langsmith/smithdb-migration/*.mdx` — the before/after endpoint mapping tables and prose
- `src/snippets/code-samples/smithdb-migration/*-after-sh.mdx` — the cURL examples

The trailing `runs/v2/query` segment of the public-runs query endpoint is part of the path itself, not the API prefix, so it is left unchanged (`/api/v2/public/{share_token}/runs/v2/query`).

Every `/api/v2/...` path in the guide after this change matches a path in the OpenAPI spec.