### PR TITLE
docs: correct AI Identity wording to tamper-evident

### DIFF
--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -118,7 +118,7 @@ Browse the complete collection of integrations available for Python. LangChain P
         href="https://ai-identity.co/docs"
         icon="link"
     >
-        Per-agent identity, scoped API access, and tamper-proof audit logging for LangChain agents.
+        Per-agent identity, scoped API access, and tamper-evident audit logging for LangChain agents.
     </Card>
 
     <Card

--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -134,7 +134,7 @@ The following table shows tools that can be used for security-related tasks:
 | Tool/Toolkit | Pricing | Capabilities |
 |-------------|---------|--------------|
 | [URLCheck](https://urlcheck.dev) | 100 free requests/day | Verify URL safety before agent navigation. Supports optional intent-aware risk analysis. Returns actionable access directives (ALLOW/DENY/RETRY_LATER). |
-| [AI Identity](https://ai-identity.co/docs) | Free tier available | Per-agent cryptographic API keys, scoped policy enforcement, and tamper-proof audit logging via a gateway in front of tools and LLM calls. |
+| [AI Identity](https://ai-identity.co/docs) | Free tier available | Per-agent cryptographic API keys, scoped policy enforcement, and tamper-evident audit logging via a gateway in front of tools and LLM calls. |
 | [RelayShield](https://api.relayshield.net/developers) | Paid | MCP server registry-risk and prompt-injection-breach checks before high-impact agent actions. |
 | [SidClaw](https://docs.sidclaw.com/docs/integrations/langchain) | Free hosted tier available | Policy evaluation, human approval workflows, and tamper-evident audit trails for LangChain tool calls. |
 | [Tonic Textual](https://textual.tonic.ai) | Requires account | Detect, extract, synthesize, or tokenize PII in text, JSON, HTML, and files. |


### PR DESCRIPTION
Small wording correction to my own AI Identity entries, added in #3405.

Both entries described the audit logging as "tamper-proof". The property is that alteration is **detectable**, not prevented, so "tamper-evident" is the accurate term — and it matches the wording already used by other entries on these same pages.

Two lines, no other changes.