### PR TITLE
chore: update to latest V2 public-run-query URL

### DIFF
--- a/src/snippets/code-samples/smithdb-migration/public-runs-after-sh.mdx
+++ b/src/snippets/code-samples/smithdb-migration/public-runs-after-sh.mdx
@@ -8,7 +8,7 @@ curl --request POST \
 
 # Query the public trace.
 curl --request POST \
-  "$API_URL/api/v2/public/$SHARE_TOKEN/runs/v2/query" \
+  "$API_URL/api/v2/public/$SHARE_TOKEN/runs/query" \
   --header "Content-Type: application/json" \
   --data '{"selects":["ID","NAME","RUN_TYPE","STATUS","START_TIME"]}'
 

--- a/src/snippets/langsmith/smithdb-migration/public-runs.mdx
+++ b/src/snippets/langsmith/smithdb-migration/public-runs.mdx
@@ -51,7 +51,7 @@ Public read methods do not require a LangSmith API key. Treat the share token as
     |---|---|---|
     | Share | `PUT /api/v1/runs/{run_id}/share` | `POST /api/v2/runs/{run_id}/share` |
     | Unshare | `DELETE /api/v1/runs/{run_id}/share` | `DELETE /api/v2/runs/{trace_id}/share` |
-    | Query public runs | `POST /api/v1/public/{share_token}/runs/query` | `POST /api/v2/public/{share_token}/runs/v2/query` |
+    | Query public runs | `POST /api/v1/public/{share_token}/runs/query` | `POST /api/v2/public/{share_token}/runs/query` |
     | Retrieve a public run | `GET /api/v1/public/{share_token}/run/{run_id}` | `GET /api/v2/public/{share_token}/run/{run_id}` |
     | Read share state | `GET /api/v1/runs/{run_id}/share` | `GET /api/v2/runs/{run_id}?selects=SHARE_URL` |
 


### PR DESCRIPTION
## Overview

Updates the two places in the SmithDB SDK migration docs that hardcode the public shared-trace runs query URL, following the upstream path fix in langchain-ai/langchainplus#32541 (merged, not yet in production).

The endpoint was served at `POST /api/v2/public/{share_token}/runs/v2/query` — `/v2` appeared twice because the route was registered under the `/v2` tree while keeping the versioned `runs/v2/query` suffix from the authenticated endpoint. The documented path is now:

```
POST /api/v2/public/{share_token}/runs/query
```

Changed:

- `src/snippets/langsmith/smithdb-migration/public-runs.mdx` — the "Query public runs" row of the cURL endpoint table.
- `src/snippets/code-samples/smithdb-migration/public-runs-after-sh.mdx` — the corresponding curl example.

Nothing else in the repo referenced the old path. The Python, TypeScript, Java, and Go tabs call SDK methods (`client.public.runs.query()` and equivalents), whose names and request/response shapes are unchanged, so the URL is internal to the generated clients.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue:
- Feature PR: langchainplus#32541

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev` — not run; the change is two string literals inside existing snippets, with no structural or navigation change
- [x] All code examples have been tested and work correctly — new path has been tested manually in preprod.
- [x] I have used **root relative** paths for internal links — no links changed
- [x] I have updated navigation in `src/docs.json` if needed — not needed, both files are existing snippets

## Additional notes

Verified with `grep` that no other source file referenced the old path, and confirmed no page links to the generated API reference page for this endpoint. Its Mintlify slug derives from the operation summary ("Query public shared trace runs"), which the backend PR does not change, so no redirect is required.

`make lint_prose` passes on both changed files.

**Follow-up, after the backend PR reaches production:** regenerate the vendored spec with `python scripts/process_langsmith_openapi.py --write`. `src/langsmith/langsmith-platform-openapi.json` still carries the old path key, and the regeneration also drops the `**Alpha:** The request and response contract may change;` prefix from both public shared-trace handler descriptions. Kept out of this PR because the script fetches the live spec from `api.smith.langchain.com`.

Drafted with Claude Code; updated by @emil-lc.