### PR TITLE
docs(langsmith): publish the SmithDB SDK migration guide

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -1974,6 +1974,7 @@
                   "langsmith/smith-js-ts-sdk",
                   "langsmith/smith-go-sdk",
                   "langsmith/smith-java-sdk",
+                  "langsmith/smithdb-sdk-migration",
                   {
                     "group": "LangSmith REST API",
                     "openapi": {
@@ -2031,7 +2032,8 @@
                     "pages": [
                       "langsmith/changelog",
                       "langsmith/release-stages",
-                      "langsmith/endpoint-deprecation"
+                      "langsmith/endpoint-deprecation",
+                      "langsmith/smithdb-sdk-migration"
                     ]
                   }
                 ]
@@ -2170,7 +2172,8 @@
                     "pages": [
                       "langsmith/self-hosted-changelog",
                       "langsmith/release-versions",
-                      "langsmith/endpoint-deprecation"
+                      "langsmith/endpoint-deprecation",
+                      "langsmith/smithdb-sdk-migration"
                     ]
                   }
                 ]

--- a/src/langsmith/smithdb-sdk-migration.mdx
+++ b/src/langsmith/smithdb-sdk-migration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Migrate to SmithDB-backed SDK methods
+sidebarTitle: SmithDB SDK migration
 description: Migrate your existing LangSmith SDK methods to their SmithDB-backed equivalents for faster agent observability.
-noindex: true
 ---
 
 import SmithdbMigrationRunsQuery from '/snippets/langsmith/smithdb-migration/runs-query.mdx';


### PR DESCRIPTION
## Summary

- The SmithDB SDK migration guide was hidden (`noindex: true`, absent from `src/docs.json`). The cloud deprecation is now announced publicly, so the guide has to be discoverable.
- Removes `noindex`, adds a `sidebarTitle` (the full H1 is too long for the sidebar), and registers the page in three nav spots: Monitor → Reference (next to the SDK reference pages), Platform → Cloud → Reference, and Platform → Self-hosted → Reference (both next to the deprecation policy page, which is duplicated the same way).
- Content is unchanged and the URL is unchanged (`/langsmith/smithdb-sdk-migration`), so existing links from the support/GTM material and from the self-hosted Terraform architecture pages keep working.

Verified with `make lint_prose` and `make broken-links` (no broken links).

Closes LSDK-275.
