### PR TITLE
docs: document reasoning_effort param for ChatBedrockConverse

### DIFF
--- a/src/oss/langchain/models.mdx
+++ b/src/oss/langchain/models.mdx
@@ -1503,10 +1503,10 @@ Depending on the model, you can sometimes specify the level of effort it should 
 
 :::python
 <Note>
-    `reasoning_effort` as a standard parameter requires `langchain-core>=1.5.2`, plus the corresponding partner package version: `langchain-anthropic>=1.5.3`, `langchain-openai>=1.4.1`, `langchain-fireworks>=1.5.2`, `langchain-xai>=1.3.0`, or `langchain-google-genai>=4.3.1`.
+    `reasoning_effort` as a standard parameter requires `langchain-core>=1.5.2`, plus the corresponding partner package version: `langchain-anthropic>=1.5.3`, `langchain-openai>=1.4.1`, `langchain-fireworks>=1.5.2`, `langchain-xai>=1.3.0`, `langchain-google-genai>=4.3.1`, or `langchain-aws>=1.6.5`.
 </Note>
 
-@[`ChatOpenAI`], @[`ChatAnthropic`], @[`ChatFireworks`], @[`ChatXAI`], and @[`ChatGoogleGenerativeAI`] support a standard `reasoning_effort` parameter. Like `temperature`, it can be set at model construction or per invocation, and each provider translates it into its own API format:
+@[`ChatOpenAI`], @[`ChatAnthropic`], @[`ChatFireworks`], @[`ChatXAI`], @[`ChatGoogleGenerativeAI`], and [`ChatBedrockConverse`](https://reference.langchain.com/python/langchain-aws/chat_models/bedrock_converse/ChatBedrockConverse) support a standard `reasoning_effort` parameter. Like `temperature`, it can be set at model construction or per invocation, and each provider translates it into its own API format:
 
 ```python
 from langchain_anthropic import ChatAnthropic

--- a/src/oss/python/integrations/chat/bedrock.mdx
+++ b/src/oss/python/integrations/chat/bedrock.mdx
@@ -218,6 +218,40 @@ ai_msg.content_blocks
  {'type': 'text', 'text': "J'aime l'IA."}]
 ```
 
+## Reasoning effort
+
+<Note>
+    `reasoning_effort` requires `langchain-aws>=1.6.5`.
+</Note>
+
+[`ChatBedrockConverse`](https://reference.langchain.com/python/langchain-aws/chat_models/bedrock_converse/ChatBedrockConverse) supports the standard [`reasoning_effort`](/oss/langchain/models#reasoning) parameter for models with configurable reasoning. Like `temperature`, it can be set at model construction or per invocation, and it is translated into the request format for the underlying model family:
+
+| Model family | Request shape |
+| :--- | :--- |
+| Claude (Opus 5, Sonnet 5) | `{"thinking": {"type": "adaptive"}, "output_config": {"effort": ...}}` |
+| Amazon Nova 2 | `{"reasoningConfig": {"type": "enabled", "maxReasoningEffort": ...}}` |
+| OpenAI (gpt-oss), Moonshot Kimi K2 | `{"reasoning_effort": ...}` |
+
+```python
+from langchain_aws import ChatBedrockConverse
+
+llm = ChatBedrockConverse(
+    model="us.anthropic.claude-sonnet-5",
+    region_name="us-west-2",
+    reasoning_effort="high",
+)
+
+response = llm.invoke("What is the cube root of 50.653?")
+```
+
+Supported effort levels vary by model. Check a model's [profile](/oss/langchain/models#model-profiles) for the levels it supports:
+
+```python
+llm.profile["reasoning_effort_levels"]  # e.g. ['low', 'medium', 'high', 'xhigh', 'max']
+```
+
+An explicit `additional_model_request_fields` value takes precedence over the fields derived from `reasoning_effort`. Models without a known translation ignore `reasoning_effort` and emit a warning.
+
 ## Prompt caching
 
 Bedrock supports [caching](https://docs.aws.amazon.com/bedrock/latest/userguide/prompt-caching.html) of elements of your prompts, including messages and tools. This allows you to reuse large documents, instructions, [few-shot documents](/langsmith/create-few-shot-evaluators), and other data to reduce latency and costs.

--- a/src/oss/python/integrations/chat/bedrock.mdx
+++ b/src/oss/python/integrations/chat/bedrock.mdx
@@ -224,13 +224,7 @@ ai_msg.content_blocks
     `reasoning_effort` requires `langchain-aws>=1.6.5`.
 </Note>
 
-[`ChatBedrockConverse`](https://reference.langchain.com/python/langchain-aws/chat_models/bedrock_converse/ChatBedrockConverse) supports the standard [`reasoning_effort`](/oss/langchain/models#reasoning) parameter for models with configurable reasoning. Like `temperature`, it can be set at model construction or per invocation, and it is translated into the request format for the underlying model family:
-
-| Model family | Request shape |
-| :--- | :--- |
-| Claude (Opus 5, Sonnet 5) | `{"thinking": {"type": "adaptive"}, "output_config": {"effort": ...}}` |
-| Amazon Nova 2 | `{"reasoningConfig": {"type": "enabled", "maxReasoningEffort": ...}}` |
-| OpenAI (gpt-oss), Moonshot Kimi K2 | `{"reasoning_effort": ...}` |
+[`ChatBedrockConverse`](https://reference.langchain.com/python/langchain-aws/chat_models/bedrock_converse/ChatBedrockConverse) supports the standard [`reasoning_effort`](/oss/langchain/models#reasoning) parameter for models with configurable reasoning, including Claude (Opus 5, Sonnet 5), Amazon Nova 2, and OpenAI gpt-oss and Moonshot Kimi K2 models on Bedrock. Like `temperature`, it can be set at model construction or per invocation, and it is translated into the request format for the underlying model family:
 
 ```python
 from langchain_aws import ChatBedrockConverse


### PR DESCRIPTION
## Description
langchain-ai/langchain-aws#1188 added a standard `reasoning_effort` parameter to `ChatBedrockConverse`. Document it in the standard reasoning-effort provider list and add a dedicated "Reasoning effort" section to the Bedrock chat integration page.

## Test Plan
- [x] `make lint_prose FILES="src/oss/python/integrations/chat/bedrock.mdx src/oss/langchain/models.mdx"`
- [x] `make broken-links`

Opened collaboratively by Nishitha Madhu and open-swe