### PR TITLE
docs(langsmith): document the minimum CLI version for SmithDB

### DIFF
--- a/src/langsmith/langsmith-cli.mdx
+++ b/src/langsmith/langsmith-cli.mdx
@@ -44,6 +44,10 @@ langsmith self-update
 
 Use the `--dry-run` flag to preview the update without installing.
 
+<Note>
+Querying a [SmithDB](/langsmith/smithdb-sdk-migration)-backed deployment requires LangSmith CLI `v0.2.44` or later.
+</Note>
+
 ## Authenticate
 
 `langsmith auth login` requires LangSmith CLI `v0.2.30` or later. `langsmith profile` commands require LangSmith CLI `v0.2.26` or later.

--- a/src/langsmith/smithdb-sdk-migration.mdx
+++ b/src/langsmith/smithdb-sdk-migration.mdx
@@ -43,6 +43,8 @@ The new SDK methods are available starting at these SDK versions:
 | Java | `langsmith-java` | `0.1.0-beta.18` |
 | Go | `langsmith-go` | `v0.22.0` |
 
+The [LangSmith CLI](/langsmith/langsmith-cli) queries the same SmithDB-backed endpoints and requires `v0.2.44` or later.
+
 ## About self-hosted
 
 - The new methods documented in this guide require `>=0.16` self-hosted version, independent of the data store used.


### PR DESCRIPTION
## Summary

- The [LangSmith CLI](https://github.com/langchain-ai/langsmith-cli) auto-selects the SmithDB-backed v2 API for any deployment reporting self-hosted `>=0.16`, but nothing in the docs stated which CLI version can actually talk to it.
- `v0.2.44` is the first release whose v2 request paths resolve: [#216](https://github.com/langchain-ai/langsmith-cli/pull/216) bumped `langsmith-go` to `v0.25.2` so SDK-generated v2 paths carry the `/api` prefix, and [#217](https://github.com/langchain-ai/langsmith-cli/pull/217) fixed the paths the CLI hand-builds. Before that, the CLI would select v2 and then 404 on self-hosted.
- One sentence under **Minimum SDK version** in the SmithDB SDK migration guide, plus a `<Note>` in the CLI page's Install section so CLI readers see the floor without going through the migration guide.

Cloud accepted both the bare and `/api` path forms, so cloud users were never broken. The docs state a single floor of `v0.2.44` rather than splitting cloud from self-hosted, to avoid implying an older CLI is fine to run against cloud on purpose.

Verified with `make lint_prose` and `make broken-links` (no broken links).

[no screenshot]

🤖 Generated with [Claude Code](https://claude.com/claude-code)