### PR TITLE
docs: add arXiv integration documentation and update providers list

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -912,3 +912,9 @@ packages:
   js: "n/a"
   downloads: 0
   downloads_updated_at: '2026-06-12T00:00:00.000000+00:00'
+- name: langchain-arxiv-retriever
+  name_title: arXiv
+  repo: j1c/langchain-arxiv-retriever
+  js: "n/a"
+  downloads: 0
+  downloads_updated_at: '2026-06-12T00:00:00.000000+00:00'

--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -735,6 +735,9 @@ python:
     docs_url: https://memstate.ai/docs/integrations/langchain
     self_host: false
     cloud_offering: true
+  - name: arXiv
+    pypi: langchain-arxiv-retriever
+    docs_url: https://j1c.github.io/langchain-arxiv-retriever
   embeddings:
   - name: NomicEmbeddings
     pypi: langchain-nomic

--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -210,6 +210,14 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
+        title="arXiv"
+        href="https://j1c.github.io/langchain-arxiv-retriever/"
+        icon="link"
+    >
+        Open-access archive for scholarly articles.
+    </Card>
+
+    <Card
         title="assistant-ui"
         icon="file-code"
         href="https://www.assistant-ui.com/docs/runtimes/langgraph"


### PR DESCRIPTION
## Overview
Adds documentation for the `langchain-arxiv-retriever` community tool integration, published to PyPI as [langchain-arxiv-retriever](https://pypi.org/project/langchain-arxiv-retriever/). The package updates the original implementation of the integrations to comply with the latest arXiv API. 

This PR:
- Added arXiv integration details to `packages.yml` and `integration_external_docs.yaml`.
- Included arXiv card in the providers documentation for better visibility.

I believe these reflect the latest changes in adding new external integrations.

## Type of change

**Type:**  New documentation page 

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue: N/A
- Feature PR: N/A

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
