### PR TITLE
fix: clarify TTL behavior for existing threads

### DIFF
--- a/src/langsmith/configure-ttl.mdx
+++ b/src/langsmith/configure-ttl.mdx
@@ -40,7 +40,7 @@ Add a `checkpointer.ttl` configuration to your `langgraph.json` file:
 - `sweep_limit`: (_Agent server v0.8+_) Sets how many threads the sweeper processes in a single iteration. Defaults to `10000` (Agent server v0.12+) or `1000` (Agent server v0.8-0.11).
 
 <Note>
-TTLs are applied to threads and checkpoints when they are created. They do not apply to existing threads and checkpoints. To clear older data, delete it explicitly.
+After you deploy a checkpoint TTL configuration, it applies to new threads when they are created and to existing threads when a new run is created on them. Existing threads with no subsequent runs do not receive the TTL. To clear their older data, delete it explicitly.
 </Note>
 
 ## Configuring store item TTL


### PR DESCRIPTION
## Description
Clarifies when checkpoint TTL configuration reaches existing threads. The note now explains that a new run applies the configured TTL, while inactive existing threads remain unaffected.

## Test Plan
- [x] Run Vale against `src/langsmith/configure-ttl.mdx`

Made by [Open SWE](https://openswe.vercel.app/agents/79d4133c-7299-80a7-bf04-ec14bab774b8)