### PR TITLE
docs (langchain): use contentBlocks in JS LangChain quickstart

### DIFF
--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -1101,9 +1101,9 @@ Along the way you will explore the following concepts:
 
             const agentMessages = agentResult.messages;
             const deepMessages = deepAgentResult.messages;
-            console.log(agentMessages[agentMessages.length - 1]!.content_blocks);
+            console.log(agentMessages[agentMessages.length - 1]!.contentBlocks);
             console.log("\n");
-            console.log(deepMessages[deepMessages.length - 1]!.content_blocks);
+            console.log(deepMessages[deepMessages.length - 1]!.contentBlocks);
         }
 
         main().catch((err) => {


### PR DESCRIPTION
## Overview
The JavaScript/TypeScript snippets in `src/oss/langchain/quickstart.mdx` access the last message with `.content_blocks`. That is the Python API. In JS/TS, `BaseMessage` / `AIMessage` expose `.contentBlocks`, so the documented examples resolve to `undefined` at runtime.

This PR updates the four JS occurrences to `.contentBlocks`.

## Type of change

**Type:** Fix typo

## Related issues/PRs
None

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes
Verified the example by running locally
