### PR TITLE
docs: point Nimble at partner LangChain connector docs

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -242,13 +242,13 @@ python:
     docs_url: https://docs.delegare.dev/introduction
   - name: NimbleExtractTool
     pypi: langchain-nimble
-    docs_url: https://docs.nimbleway.com/nimble-sdk/web-tools/extract/quickstart
+    docs_url: https://docs.nimbleway.com/integrations/connectors/langchain
   - name: NodeProxyMarkdownTool
     pypi: nodeproxy-tools
     docs_url: https://github.com/pgalyen1987/NodeProxy/tree/main/integrations
   - name: NimbleSearchTool
     pypi: langchain-nimble
-    docs_url: https://docs.nimbleway.com/nimble-sdk/web-tools/search
+    docs_url: https://docs.nimbleway.com/integrations/connectors/langchain
   - name: Salesforce
     pypi: langchain-salesforce
     docs_url: https://github.com/colesmcintosh/langchain-salesforce
@@ -660,10 +660,10 @@ python:
     docs_url: https://docs.tokenfactory.nebius.com/quickstart
   - name: Nimble Extract
     pypi: langchain-nimble
-    docs_url: https://docs.nimbleway.com/nimble-sdk/web-tools/extract/quickstart
+    docs_url: https://docs.nimbleway.com/integrations/connectors/langchain
   - name: Nimble Search
     pypi: langchain-nimble
-    docs_url: https://docs.nimbleway.com/nimble-sdk/web-tools/search
+    docs_url: https://docs.nimbleway.com/integrations/connectors/langchain
   - name: Contextual AI reranker
     pypi: langchain-contextual
     docs_url: https://docs.contextual.ai/

--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -26,7 +26,8 @@ The following table shows tools that execute online searches in some shape or fo
 | [Octen](https://docs.octen.ai) | Paid | Title, URL, highlight, authors, time_published |
 | [Mixpeek](https://docs.mixpeek.com/agent-integrations/langchain) | Free tier available | Multimodal search results (video, image, audio, document) |
 | [Nia Toolkit](https://github.com/nozomio-labs/nia-langchain) | Free tier available | Code, Docs, Metadata, Sources |
-| [Nimble Search](https://docs.nimbleway.com/nimble-sdk/web-tools/search) | Free trial available | URL, Content, Title |
+| [Nimble Search](https://docs.nimbleway.com/integrations/connectors/langchain) | Free trial available | URL, Content, Title |
+| [Nimble Web Search Agents](https://docs.nimbleway.com/integrations/connectors/langchain#agent-api-v2-web-search-agents) | Free trial available | Research answer, Sources |
 | [Parallel Search](/oss/integrations/tools/parallel_search) | Paid | URL, Title, Excerpts |
 | [Perplexity Search](/oss/integrations/tools/perplexity_search) | Paid (with monthly free tier) | URL, Title, Snippet, Date, Last Updated |
 | [Search1API Search](https://www.search1api.com/docs/integrations/langchain#search) | 100 free credits on sign up, no credit card | URL, Title, Snippet, Content, Images |
@@ -80,7 +81,9 @@ The following table shows tools that can be used to automate tasks in web browse
 | [Manifest](https://omfang.io/manifest-docs) | Free tier available | ❌ |
 | [MrScraper](https://docs.mrscraper.com) | Paid | ❌ |
 | [W2A](https://w2a-protocol.org/docs) | Free (public endpoints) | ❌ |
-| [Nimble Extract](https://docs.nimbleway.com/nimble-sdk/web-tools/extract) | Free trial available | ❌ |
+| [Nimble Extract](https://docs.nimbleway.com/integrations/connectors/langchain) | Free trial available | ❌ |
+| [Nimble Extract Templates](https://docs.nimbleway.com/integrations/connectors/langchain#extract-templates) | Free trial available | ❌ |
+| [Nimble Crawl and Map](https://docs.nimbleway.com/integrations/connectors/langchain#crawl-and-map) | Free trial available | ❌ |
 | [NodeProxy](https://github.com/pgalyen1987/NodeProxy/tree/main/integrations) | ~$0.002 USDC per parse (x402 on Base) | ❌ |
 | [Oxylabs Web Scraper API](https://github.com/oxylabs/langchain-oxylabs) | Free trial, with flat rate plans and pre-paid credits after | ❌ |
 | [ProxyClaw](https://docs.proxyclaw.ai) | Free tier available | ❌ |


### PR DESCRIPTION
## Overview

Point existing `langchain-nimble` listings at Nimble's partner LangChain connector docs, and list the package by capability the same way Search1API does.

**1. `docs_url` now points at partner docs.** The tools and retrievers entries previously linked to product Search/Extract quickstarts. The preferred listing guidance is partner docs when available:

> **`docs_url`**: Link for the name column. Prefer partner docs, then the GitHub repo, then the PyPI or npm page.

Partner page: https://docs.nimbleway.com/integrations/connectors/langchain

**2. Listed by capability in category tables.** In addition to updating Nimble Search and Nimble Extract links, add rows for:

- **Nimble Web Search Agents** (Search) → Agent API V2 section
- **Nimble Extract Templates** (Web browsing) → Extract Templates section
- **Nimble Crawl and Map** (Web browsing) → Crawl and Map section

Extract Templates / Crawl and Map fetch or structure page content rather than driving a browser session, so **Supports Interacting with the Browser** is `❌`, consistent with Nimble Extract and Search1API Crawl.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Partner page: https://docs.nimbleway.com/integrations/connectors/langchain
- Package: https://pypi.org/project/langchain-nimble/ (`>=4.0.0`)
- Similar prior change: #5182

## Validation

- `uv run --no-project --with requests --with pyyaml python scripts/refresh_integration_downloads.py --check-docs-urls` — all `docs_url` values safe
- Verified the partner page and capability anchor targets return HTTP 200

## Checklist

- [x] I have read the contributing guidelines.
- [x] All code examples have been tested and work correctly. No code examples are added by this PR.
- [x] I have used root-relative paths for internal links. No internal links are added by this PR.
- [x] I have updated navigation in `src/docs.json` if needed. No new page or navigation entry is required.

## Additional notes

Happy to drop any of the new category rows if you would rather keep those tables curated by maintainers — the `docs_url` change stands on its own.


Made with [Cursor](https://cursor.com)