### PR TITLE
docs: add OpenTTT to callbacks integrations

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -1022,6 +1022,9 @@ python:
     docs_url: https://docs.thecontextcompany.com/frameworks/langchain-langgraph
   - name: Work Ledger
     docs_url: https://github.com/metawake/work-ledger/blob/main/docs/integrations.md
+  - name: OpenTTT
+    pypi: langchain-openttt
+    docs_url: https://github.com/Helm-Protocol/OpenTTT/tree/main/integrations/langchain
 
 javascript:
   chat:


### PR DESCRIPTION
Adds `langchain-openttt` (PyPI: https://pypi.org/project/langchain-openttt/0.2.0/) to the callbacks integrations table.

`langchain-openttt` provides `TTTPSTimestampCallbackHandler`, a `BaseCallbackHandler` that attaches a cryptographic Proof-of-Time timestamp (draft-helmprotocol-tttps, https://datatracker.ietf.org/doc/draft-helmprotocol-tttps/) to each LLM generation via `on_llm_end`, for tamper-evident audit-trail timestamping. Fail-open by design: any timestamping failure degrades to a `status: degraded` receipt rather than raising, so it never breaks the caller's LLM pipeline.

Contributed by the OpenTTT / Helm-Protocol team (maintainers of `langchain-openttt`).

Following the process at https://docs.langchain.com/oss/python/contributing/integrations-langchain — this is a docs-only PR adding a row to `integration_external_docs.yaml` per that guide, since new integrations are published as independent PyPI packages rather than core PRs.