### PR TITLE
chore: bring latest API/SDK updates to docs

### DIFF
--- a/src/langsmith/langsmith-platform-openapi.json
+++ b/src/langsmith/langsmith-platform-openapi.json
@@ -7074,6 +7074,7 @@
         "summary": "Read examples with runs",
         "description": "Fetch examples for a dataset, and fetch the runs for each example if they are associated with the given session_ids.",
         "operationId": "read_examples_with_runs_api_v1_datasets__dataset_id__runs_post",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -8754,6 +8755,7 @@
         "summary": "Read run",
         "description": "Get a specific run.",
         "operationId": "read_run_api_v1_runs__run_id__get",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -9002,6 +9004,7 @@
         "summary": "Read run share state",
         "description": "Get the state of sharing of a run.",
         "operationId": "read_run_share_state_api_v1_runs__run_id__share_get",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -9064,6 +9067,7 @@
         "summary": "Share run",
         "description": "Share a run.",
         "operationId": "share_run_api_v1_runs__run_id__share_put",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -9118,6 +9122,7 @@
         "summary": "Unshare run",
         "description": "Unshare a run.",
         "operationId": "unshare_run_api_v1_runs__run_id__share_delete",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -9246,6 +9251,7 @@
             }
           }
         },
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -9634,7 +9640,7 @@
             "Bearer Auth": []
           }
         ],
-        "description": "Ingests multiple runs, feedback objects, and binary attachments in a single `multipart/form-data` request.\n**Part‑name pattern**: `<event>.<run_id>[.<field>]` where `event` ∈ {`post`, `patch`, `feedback`, `attachment`}.\n* `post|patch.<run_id>` – JSON run payload.\n* `post|patch.<run_id>.<field>` – out‑of‑band run data (`inputs`, `outputs`, `events`, `error`, `extra`, `serialized`).\n* `feedback.<run_id>` – JSON feedback payload (must include `trace_id`).\n* `attachment.<run_id>.<filename>` – arbitrary binary attachment stored in S3.\n**Headers**: every part must set `Content-Type` **and** either a `Content-Length` header or `length` parameter. Per‑part `Content-Encoding` is **not** allowed; the top‑level request may be `Content-Encoding: gzip` or `Content-Encoding: zstd`.\n**Best performance** for high‑volume ingestion.",
+        "description": "Ingests multiple runs, feedback objects, and binary attachments in a single `multipart/form-data` request.\n**Part‑name pattern**: `<event>.<run_id>[.<field>]` where `event` ∈ {`post`, `patch`, `feedback`, `attachment`}.\n* `post|patch.<run_id>` – JSON run payload.\n* `post|patch.<run_id>.<field>` – out‑of‑band run data (`inputs`, `outputs`, `events`, `error`, `extra`, `serialized`).\n* `feedback.<run_id>` – JSON feedback payload (must include `trace_id` and `session_id`).\n* `attachment.<run_id>.<filename>` – arbitrary binary attachment stored in S3.\n**Headers**: every part must set `Content-Type` **and** either a `Content-Length` header or `length` parameter. Per‑part `Content-Encoding` is **not** allowed; the top‑level request may be `Content-Encoding: gzip` or `Content-Encoding: zstd`.\n**Best performance** for high‑volume ingestion.",
         "tags": [
           "runs"
         ],
@@ -9756,7 +9762,7 @@
                   "feedback.{run_id}": {
                     "type": "string",
                     "format": "binary",
-                    "description": "Feedback object (JSON) – must include trace_id"
+                    "description": "Feedback object (JSON) – must include trace_id and session_id"
                   },
                   "attachment.{run_id}.{filename}": {
                     "type": "string",
@@ -10900,7 +10906,7 @@
           "feedback"
         ],
         "summary": "Create feedback",
-        "description": "Create a new feedback.",
+        "description": "Create a new feedback.\n\n`session_id` is required: it identifies the tracing project the feedback\nbelongs to.",
         "operationId": "create_feedback_api_v1_feedback_post",
         "security": [
           {
@@ -11383,6 +11389,7 @@
         "summary": "Get shared run by ID",
         "description": "Get the shared run.",
         "operationId": "get_shared_run_by_id_api_v1_public__share_token__run__id__get",
+        "deprecated": true,
         "parameters": [
           {
             "name": "id",
@@ -11448,6 +11455,7 @@
         "summary": "Query shared runs",
         "description": "Get run by ids or the shared run if not specifed.",
         "operationId": "query_shared_runs_api_v1_public__share_token__runs_query_post",
+        "deprecated": true,
         "parameters": [
           {
             "name": "share_token",
@@ -13617,6 +13625,7 @@
         ],
         "summary": "Add runs to annotation queue",
         "operationId": "add_runs_to_annotation_queue_api_v1_annotation_queues__queue_id__runs_post",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -13715,6 +13724,7 @@
         ],
         "summary": "Get runs from annotation queue",
         "operationId": "get_runs_from_annotation_queue_api_v1_annotation_queues__queue_id__runs_get",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -13849,7 +13859,9 @@
           "annotation-queues"
         ],
         "summary": "Add runs to annotation queue by key",
+        "description": "Self-hosted deployments require LangSmith `v0.16` or later.",
         "operationId": "add_runs_to_annotation_queue_by_key_api_v1_annotation_queues__queue_id__runs_by_key_post",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -13997,6 +14009,7 @@
         "summary": "Get run from annotation queue",
         "description": "Get a run from an annotation queue",
         "operationId": "get_run_from_annotation_queue_api_v1_annotation_queues__queue_id__run__index__get",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -14130,6 +14143,7 @@
         ],
         "summary": "Update run in annotation queue",
         "operationId": "update_run_in_annotation_queue_api_v1_annotation_queues__queue_id__runs__queue_run_id__patch",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -14201,6 +14215,7 @@
         ],
         "summary": "Delete run from annotation queue",
         "operationId": "delete_run_from_annotation_queue_api_v1_annotation_queues__queue_id__runs__queue_run_id__delete",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -14264,6 +14279,7 @@
         ],
         "summary": "Delete runs from annotation queue",
         "operationId": "delete_runs_from_annotation_queue_api_v1_annotation_queues__queue_id__runs_delete_post",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -14327,6 +14343,7 @@
         ],
         "summary": "Get total size from annotation queue",
         "operationId": "get_total_size_from_annotation_queue_api_v1_annotation_queues__queue_id__total_size_get",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -14382,6 +14399,7 @@
         ],
         "summary": "Get total archived from annotation queue",
         "operationId": "get_total_archived_from_annotation_queue_api_v1_annotation_queues__queue_id__total_archived_get",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -14471,6 +14489,7 @@
         ],
         "summary": "Get size from annotation queue",
         "operationId": "get_size_from_annotation_queue_api_v1_annotation_queues__queue_id__size_get",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -14547,6 +14566,7 @@
         ],
         "summary": "Create identity annotation queue run status",
         "operationId": "create_identity_annotation_queue_run_status_api_v1_annotation_queues_status__annotation_queue_run_id__post",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -14611,6 +14631,7 @@
         "summary": "Resolve annotation queue run",
         "description": "Resolve a queue run ID to its section and run data for deep linking.",
         "operationId": "resolve_annotation_queue_run_api_v1_annotation_queues__queue_id__runs_resolve__queue_run_id__get",
+        "deprecated": true,
         "security": [
           {
             "API Key": []
@@ -25961,8 +25982,8 @@
             "name": "include_stats",
             "in": "query",
             "schema": {
-              "default": true,
               "type": "boolean",
+              "default": true,
               "title": "Include Stats"
             }
           },
@@ -25971,10 +25992,10 @@
             "name": "limit",
             "in": "query",
             "schema": {
-              "default": 20,
               "type": "integer",
-              "minimum": 1,
+              "default": 20,
               "maximum": 100,
+              "minimum": 1,
               "title": "Limit"
             }
           },
@@ -25983,8 +26004,8 @@
             "name": "offset",
             "in": "query",
             "schema": {
-              "default": 0,
               "type": "integer",
+              "default": 0,
               "minimum": 0,
               "title": "Offset"
             }
@@ -26195,8 +26216,8 @@
             "name": "get_examples",
             "in": "query",
             "schema": {
-              "default": false,
               "type": "boolean",
+              "default": false,
               "title": "Get Examples"
             }
           },
@@ -26214,8 +26235,8 @@
             "name": "include_model",
             "in": "query",
             "schema": {
-              "default": false,
               "type": "boolean",
+              "default": false,
               "title": "Include Model"
             }
           },
@@ -26223,8 +26244,8 @@
             "name": "is_view",
             "in": "query",
             "schema": {
-              "default": false,
               "type": "boolean",
+              "default": false,
               "title": "Is View"
             }
           }
@@ -27302,8 +27323,8 @@
             "name": "page_size",
             "in": "query",
             "schema": {
-              "default": 20,
               "type": "integer",
+              "default": 20,
               "title": "Page Size"
             }
           },
@@ -27334,8 +27355,8 @@
             "name": "direction",
             "in": "query",
             "schema": {
-              "default": "forward",
               "type": "string",
+              "default": "forward",
               "enum": [
                 "forward",
                 "backward"
@@ -28523,8 +28544,8 @@
             "name": "limit",
             "in": "query",
             "schema": {
-              "default": 100,
               "type": "integer",
+              "default": 100,
               "title": "Limit"
             }
           },
@@ -28533,8 +28554,8 @@
             "name": "offset",
             "in": "query",
             "schema": {
-              "default": 0,
               "type": "integer",
+              "default": 0,
               "title": "Offset"
             }
           }
@@ -30634,6 +30655,8 @@
               "type": "string",
               "enum": [
                 "open",
+                "fixing",
+                "watching",
                 "completed",
                 "ignored"
               ],
@@ -35115,7 +35138,7 @@
     },
     "/api/v2/datasets/public/{share_token}/experiment-runs": {
       "post": {
-        "description": "Public share-token variant of POST /v2/datasets/{dataset_id}/experiment-runs.\nReturns a paginated page of dataset examples with runs from the requested experiments.",
+        "description": "Public share-token variant of POST /v2/datasets/{dataset_id}/experiment-runs.\nReturns a paginated page of dataset examples with runs from the requested experiments.\n\nSelf-hosted deployments require LangSmith `v0.16` or later.",
         "tags": [
           "datasets"
         ],
@@ -35218,7 +35241,7 @@
             "Tenant ID": []
           }
         ],
-        "description": "Returns a paginated page of dataset examples with runs from the requested experiments.\nResponse uses the canonical `{items, next_cursor}` envelope.",
+        "description": "Returns a paginated page of dataset examples with runs from the requested experiments.\nResponse uses the canonical `{items, next_cursor}` envelope.\n\nSelf-hosted deployments require LangSmith `v0.16` or later.",
         "tags": [
           "datasets"
         ],
@@ -35321,7 +35344,7 @@
     },
     "/api/v2/public/{share_token}/run/{run_id}": {
       "get": {
-        "description": "**Alpha:** The request and response contract may change;\nReturns one run within the trace identified by the share token. The request supplies only the run ID and that run's exact start_time coordinate.",
+        "description": "Returns one run within the trace identified by the share token. The request supplies only the run ID and that run's exact start_time coordinate.\n\nSelf-hosted deployments require LangSmith `v0.16` or later.",
         "tags": [
           "runs"
         ],
@@ -35457,9 +35480,9 @@
         "x-public": true
       }
     },
-    "/api/v2/public/{share_token}/runs/v2/query": {
+    "/api/v2/public/{share_token}/runs/query": {
       "post": {
-        "description": "**Alpha:** The request and response contract may change;\nReturns all runs within the trace identified by the share token. The share token supplies the tenant, project, and trace scope.",
+        "description": "Returns all runs within the trace identified by the share token. The share token supplies the tenant, project, and trace scope.\n\nSelf-hosted deployments require LangSmith `v0.16` or later.",
         "tags": [
           "runs"
         ],
@@ -35589,7 +35612,7 @@
             "Tenant ID": []
           }
         ],
-        "description": "**Alpha:** The request and response contract may change;\nReturns a paginated list of runs for the given projects within min/max start_time. Supports filters, cursor pagination, and `selects` to select fields to return.",
+        "description": "Returns a paginated list of runs for the given projects within min/max start_time. Supports filters, cursor pagination, and `selects` to select fields to return.\n\nSelf-hosted deployments require LangSmith `v0.16` or later.",
         "tags": [
           "runs"
         ],
@@ -35729,7 +35752,7 @@
             "Tenant ID": []
           }
         ],
-        "description": "**Alpha:** The request and response contract may change;\nReturns one run by ID for the given session. Use the `selects` query parameter (repeatable) to select fields to return.",
+        "description": "Returns one run by ID for the given session. Use the `selects` query parameter (repeatable) to select fields to return.\n\nSelf-hosted deployments require LangSmith `v0.16` or later.",
         "tags": [
           "runs"
         ],
@@ -35954,7 +35977,7 @@
             "Bearer Auth": []
           }
         ],
-        "description": "Creates or returns a share token for a run. Child runs share their trace root.",
+        "description": "Creates or returns a share token for a run. Child runs share their trace root.\n\nSelf-hosted deployments require LangSmith `v0.16` or later.",
         "tags": [
           "runs"
         ],
@@ -36068,7 +36091,7 @@
             "Tenant ID": []
           }
         ],
-        "description": "Returns the URL to view a specific run in the LangSmith UI. The caller must supply the\nrun's project_id and trace_id as query parameters; start_time is optional.",
+        "description": "Returns the URL to view a specific run in the LangSmith UI. The caller must supply the\nrun's project_id and trace_id as query parameters; start_time is optional.\n\nSelf-hosted deployments require LangSmith `v0.16` or later.",
         "tags": [
           "runs"
         ],
@@ -36182,7 +36205,7 @@
             "Bearer Auth": []
           }
         ],
-        "description": "Deletes the share token for the trace identified by trace_id and session_id. Idempotent: returns 204 whether or not a share token existed.",
+        "description": "Deletes the share token for the trace identified by trace_id and session_id. Idempotent: returns 204 whether or not a share token existed.\n\nSelf-hosted deployments require LangSmith `v0.16` or later.",
         "tags": [
           "runs"
         ],
@@ -36294,8 +36317,8 @@
             "name": "limit",
             "in": "query",
             "schema": {
-              "default": 50,
               "type": "integer",
+              "default": 50,
               "title": "Limit"
             }
           },
@@ -36304,8 +36327,8 @@
             "name": "offset",
             "in": "query",
             "schema": {
-              "default": 0,
               "type": "integer",
+              "default": 0,
               "title": "Offset"
             }
           },
@@ -36355,8 +36378,8 @@
             "name": "sort_by",
             "in": "query",
             "schema": {
-              "default": "created_at",
               "type": "string",
+              "default": "created_at",
               "title": "Sort By"
             }
           },
@@ -36365,8 +36388,8 @@
             "name": "sort_direction",
             "in": "query",
             "schema": {
-              "default": "desc",
               "type": "string",
+              "default": "desc",
               "title": "Sort Direction"
             }
           }
@@ -37690,8 +37713,8 @@
             "name": "limit",
             "in": "query",
             "schema": {
-              "default": 50,
               "type": "integer",
+              "default": 50,
               "title": "Limit"
             }
           },
@@ -37700,8 +37723,8 @@
             "name": "offset",
             "in": "query",
             "schema": {
-              "default": 0,
               "type": "integer",
+              "default": 0,
               "title": "Offset"
             }
           },
@@ -37751,8 +37774,8 @@
             "name": "sort_by",
             "in": "query",
             "schema": {
-              "default": "created_at",
               "type": "string",
+              "default": "created_at",
               "title": "Sort By"
             }
           },
@@ -37761,8 +37784,8 @@
             "name": "sort_direction",
             "in": "query",
             "schema": {
-              "default": "desc",
               "type": "string",
+              "default": "desc",
               "title": "Sort Direction"
             }
           }
@@ -38271,6 +38294,214 @@
         }
       }
     },
+    "/api/v2/sandboxes/{sandbox_id}/execute/stream/resume": {
+      "post": {
+        "security": [
+          {
+            "API Key": []
+          },
+          {
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": []
+          }
+        ],
+        "description": "Continue streaming a command started by the stream start endpoint. The offsets are also the ack for everything below them, which frees the sandbox's output buffer and unpauses a command waiting for room. Attaches only: a command the sandbox no longer has returns 404 rather than running again.",
+        "tags": [
+          "sandboxes"
+        ],
+        "summary": "Resume a streamed sandbox command",
+        "parameters": [
+          {
+            "description": "Sandbox ID or name",
+            "name": "sandbox_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SSE event stream",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sandboxes.ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sandboxes.ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sandboxes.ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sandboxes.ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sandboxes.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/sandboxes.ExecStreamResumeRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/sandboxes/{sandbox_id}/execute/stream/start": {
+      "post": {
+        "security": [
+          {
+            "API Key": []
+          },
+          {
+            "Tenant ID": []
+          },
+          {
+            "Bearer Auth": []
+          }
+        ],
+        "description": "Execute a command inside a sandbox and stream stdout/stderr as Server-Sent Events with base64 payloads. Requires a sandbox on the v2 runtime. Passing a command_id reuses a running command instead of starting a second one. The response ends with an ack_required event when the sandbox's output buffer needs an ack; continue from the reported offsets with the resume endpoint.",
+        "tags": [
+          "sandboxes"
+        ],
+        "summary": "Start a streamed sandbox command",
+        "parameters": [
+          {
+            "description": "Sandbox ID or name",
+            "name": "sandbox_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "SSE event stream",
+            "content": {
+              "text/event-stream": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sandboxes.ErrorResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sandboxes.ErrorResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sandboxes.ErrorResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Conflict",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sandboxes.ErrorResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/sandboxes.ErrorResponse"
+                }
+              }
+            }
+          }
+        },
+        "x-public": true,
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/sandboxes.ExecStreamRequest"
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/v2/sandboxes/{sandbox_id}/execute/ws": {
       "get": {
         "security": [
@@ -38747,7 +38978,7 @@
             "Tenant ID": []
           }
         ],
-        "description": "**Alpha:** The request and response contract may change;\nQuery threads within a project (session), with cursor-based pagination.\nReturns threads matching the given time range and optional filter.",
+        "description": "Query threads within a project (session), with cursor-based pagination.\nReturns threads matching the given time range and optional filter.\n\nSelf-hosted deployments require LangSmith `v0.16` or later.",
         "tags": [
           "threads"
         ],
@@ -38870,7 +39101,7 @@
             "Tenant ID": []
           }
         ],
-        "description": "**Alpha:** The request and response contract may change;\nCompute aggregate stats for a single thread (turn count, latency percentiles, token/cost sums, and detail breakdowns) within a project.",
+        "description": "Compute aggregate stats for a single thread (turn count, latency percentiles, token/cost sums, and detail breakdowns) within a project.\n\nSelf-hosted deployments require LangSmith `v0.16` or later.",
         "tags": [
           "threads"
         ],
@@ -39051,7 +39282,7 @@
             "Tenant ID": []
           }
         ],
-        "description": "**Alpha:** The request and response contract may change;\nRetrieve all traces belonging to a specific thread within a project.",
+        "description": "Retrieve all traces belonging to a specific thread within a project.\n\nSelf-hosted deployments require LangSmith `v0.16` or later.",
         "tags": [
           "threads"
         ],
@@ -39090,10 +39321,10 @@
             "name": "page_size",
             "in": "query",
             "schema": {
-              "default": 20,
               "type": "integer",
-              "minimum": 1,
+              "default": 20,
               "maximum": 100,
+              "minimum": 1,
               "title": "Page Size"
             }
           },
@@ -39260,7 +39491,7 @@
             "Tenant ID": []
           }
         ],
-        "description": "Returns a paginated list of traces (root runs) for a single tracing project. Each item carries the trace's root run plus optional trace-wide aggregates (`total_tokens`, `total_cost`, `first_token_time`) under `trace_aggregates`, so clients never have to merge by `trace_id`.\n\nTraces are scanned within a `start_time` window: `min_start_time` defaults to 24 hours before the request, `max_start_time` defaults to the request time. Set either explicitly to widen or narrow the window.\n\nSupports filters (`trace_filter`, `tree_filter`), cursor pagination (`cursor`), and field projection (`selects`).",
+        "description": "Returns a paginated list of traces (root runs) for a single tracing project. Each item carries the trace's root run plus optional trace-wide aggregates (`total_tokens`, `total_cost`, `first_token_time`) under `trace_aggregates`, so clients never have to merge by `trace_id`.\n\nTraces are scanned within a `start_time` window: `min_start_time` defaults to 24 hours before the request, `max_start_time` defaults to the request time. Set either explicitly to widen or narrow the window.\n\nSupports filters (`trace_filter`, `tree_filter`), cursor pagination (`cursor`), and field projection (`selects`).\n\nSelf-hosted deployments require LangSmith `v0.16` or later.",
         "tags": [
           "runs"
         ],
@@ -39392,7 +39623,7 @@
             "Tenant ID": []
           }
         ],
-        "description": "**Alpha:** The request and response contract may change;\nReturns runs for a trace ID within min/max start time. Optional `filter`; repeatable `selects` to select fields to return.",
+        "description": "Returns runs for a trace ID within min/max start time. Optional `filter`; repeatable `selects` to select fields to return.\n\nSelf-hosted deployments require LangSmith `v0.16` or later.",
         "tags": [
           "runs"
         ],
@@ -41276,7 +41507,7 @@
             }
           },
           "409": {
-            "description": "Data plane is already in a terminal status",
+            "description": "Data plane is not active",
             "content": {
               "application/json": {
                 "schema": {
@@ -41355,10 +41586,10 @@
             "name": "limit",
             "in": "query",
             "schema": {
-              "default": 50,
               "type": "integer",
-              "minimum": 1,
+              "default": 50,
               "maximum": 100,
+              "minimum": 1,
               "title": "Limit"
             }
           },
@@ -41366,8 +41597,8 @@
             "name": "offset",
             "in": "query",
             "schema": {
-              "default": 0,
               "type": "integer",
+              "default": 0,
               "minimum": 0,
               "title": "Offset"
             }
@@ -53283,7 +53514,8 @@
                 "type": "null"
               }
             ],
-            "title": "Session Id"
+            "title": "Session Id",
+            "description": "Required. The ID of the tracing project (session) the feedback belongs to."
           },
           "trace_id": {
             "anyOf": [
@@ -58553,6 +58785,17 @@
             "title": "Max Workspaces",
             "default": 1
           },
+          "code_evaluator_execution_batch_size": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Code Evaluator Execution Batch Size"
+          },
           "can_use_rbac": {
             "type": "boolean",
             "title": "Can Use Rbac",
@@ -58848,6 +59091,11 @@
             "title": "Fleet Builtin Models Enabled",
             "default": false
           },
+          "models_connect_via_langsmith_enabled": {
+            "type": "boolean",
+            "title": "Models Connect Via Langsmith Enabled",
+            "default": false
+          },
           "dev_zero_deployments_enabled": {
             "type": "boolean",
             "title": "Dev Zero Deployments Enabled",
@@ -58863,6 +59111,17 @@
               }
             ],
             "title": "Fleet Lcu Spend Limit Monthly"
+          },
+          "langchain_provider_spend_limit_monthly": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Langchain Provider Spend Limit Monthly"
           },
           "max_agent_builder_assistants": {
             "type": "integer",
@@ -75106,6 +75365,10 @@
             "description": "CLIOEnabled indicates whether CLIO is enabled for this org.",
             "type": "boolean"
           },
+          "code_evaluator_execution_batch_size": {
+            "description": "CodeEvaluatorExecutionBatchSize is a per-org override for how many code-evaluator\nexecutions are grouped into a single ACE /execute request. nil uses the global\ndefault (RUN_RULES_CODE_EXECUTE_BATCH_SIZE). Consumed only by smith-backend; carried\nhere so the value survives the org-config JSON round-trip into the Python auth payload.",
+            "type": "integer"
+          },
           "datadog_rum_session_sample_rate": {
             "description": "DatadogRumSessionSampleRate indicates the sampling rate for datadog RUM sessions.",
             "type": "integer"
@@ -79845,6 +80108,67 @@
           },
           "stdout": {
             "type": "string"
+          }
+        }
+      },
+      "sandboxes.ExecStreamRequest": {
+        "type": "object",
+        "properties": {
+          "command": {
+            "description": "Command accepts either a shell command string or an argv string array.",
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          },
+          "command_id": {
+            "description": "CommandID makes the request idempotent: a known ID attaches to that\nrunning command instead of starting a second one.",
+            "type": "string"
+          },
+          "cwd": {
+            "type": "string"
+          },
+          "env": {
+            "type": "object",
+            "additionalProperties": {
+              "type": "string"
+            }
+          },
+          "idle_timeout_seconds": {
+            "description": "0 = default, -1 = never idle-kill",
+            "type": "integer"
+          },
+          "shell": {
+            "type": "string"
+          },
+          "stdin": {
+            "description": "Stdin is the process's entire standard input, base64 on the wire. It is\nwritten once when the command is spawned and then closed, so the process\nreads EOF; there is no stdin streaming on this endpoint.",
+            "type": "string",
+            "format": "byte"
+          },
+          "timeout_seconds": {
+            "description": "0 = no timeout",
+            "type": "integer"
+          },
+          "ttl_seconds": {
+            "description": "0 = default, -1 = keep forever",
+            "type": "integer"
+          }
+        }
+      },
+      "sandboxes.ExecStreamResumeRequest": {
+        "type": "object",
+        "properties": {
+          "command_id": {
+            "description": "CommandID names the command to attach to.",
+            "type": "string"
+          },
+          "stderr_offset": {
+            "type": "integer"
+          },
+          "stdout_offset": {
+            "description": "StdoutOffset and StderrOffset are where to continue from, and are also the\nack for every buffered byte below them. Zero replays from the beginning,\nwhich is what a retry sends when the stream broke before any output arrived.",
+            "type": "integer"
           }
         }
       },


### PR DESCRIPTION
## Overview

Refreshes the vendored LangSmith OpenAPI spec from production. Regenerated with:

```bash
python scripts/process_langsmith_openapi.py --write
```

Result: 541 operations, 8 hidden, 533 public. Only `src/langsmith/langsmith-platform-openapi.json` changes (+368/-44). No hand edits.

The trigger was the public shared-trace runs query path fix (langchain-ai/langchainplus#32541). That accounts for three entries below; the rest is upstream drift since the last refresh (#5205).

### Public shared-trace runs query

- `POST /api/v2/public/{share_token}/runs/v2/query` → `POST /api/v2/public/{share_token}/runs/query`. The duplicated `/v2` is gone.
- The `**Alpha:** The request and response contract may change;` prefix is dropped from both public shared-trace handler descriptions, including `GET /api/v2/public/{share_token}/run/{run_id}`, whose path is unchanged.
- The operation summary ("Query public shared trace runs") is unchanged, so the generated page slug is stable and no redirect is needed. No page in `src/` links to it.

The prose and curl snippets for this endpoint were already updated in #5237. The old path remains registered on the backend for deploy safety but is no longer advertised in the spec.

### Other upstream changes in this refresh

- **Deprecations: 20 → 40 operations.** Upstream set `deprecated: true` across the v1 run, share, and annotation-queue endpoints (`/api/v1/runs/query`, `/api/v1/runs/{run_id}`, `/api/v1/runs/{run_id}/share`, `/api/v1/public/{share_token}/runs/query`, `/api/v1/public/{share_token}/run/{id}`, `/api/v1/datasets/{dataset_id}/runs`, and the `/api/v1/annotation-queues/*` run operations). These render as "Deprecated" in the API reference. Consistent with the SmithDB migration, but it is the most reader-visible change here.
- **`POST /api/v1/feedback`** now documents `session_id` as required: "it identifies the tracing project the feedback belongs to." The `/api/v1/runs/multipart` feedback part description likewise changes from "must include trace_id" to "must include trace_id and session_id".
- **Alpha prefix dropped** from the remaining v2 endpoint descriptions: `/api/v2/runs/query`, `/api/v2/runs/{run_id}`, `/api/v2/threads/query`, `/api/v2/threads/{thread_id}/stats`, `/api/v2/threads/{thread_id}/traces`, `/api/v2/traces/{trace_id}/runs`.
- **Self-hosted version notes** appended to many v2 descriptions: "Self-hosted deployments require LangSmith `v0.16` or later."
- **Two new sandbox operations:** `POST /api/v2/sandboxes/{sandbox_id}/execute/stream/start` and `.../resume`, with schemas `sandboxes.ExecStreamRequest` and `sandboxes.ExecStreamResumeRequest`. Tagged `sandboxes`, which is already public (20 → 22 visible sandbox operations), so no `x-hidden` change is needed.
- `/orgs/current/data-planes/{id}`: a response description changes from "Data plane is already in a terminal status" to "Data plane is not active".

No tags were added or removed, and no schemas were removed.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue:
- Feature PR: langchain-ai/langchainplus#32541
- Docs PR for the matching prose and curl snippets: #5237


## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev` — not run; this is generated spec output with no MDX or navigation change
- [x] All code examples have been tested and work correctly — no code examples in this PR
- [x] I have used **root relative** paths for internal links — no links changed
- [x] I have updated navigation in `src/docs.json` if needed — not needed; the spec is already wired up as the `LangSmith REST API` group with directory `langsmith/smith-api`

## Additional notes

Spec refresh run and description drafted with Claude Code; reviewed by @emil-lc.
