### PR TITLE
chore: clarify bulk export plan eligibility

### DIFF
--- a/src/langsmith/big-query-bulk-export.mdx
+++ b/src/langsmith/big-query-bulk-export.mdx
@@ -7,7 +7,7 @@ description: Load LangSmith trace data into BigQuery using bulk export to GCS.
 <Info>
 **Plan restrictions apply**
 
-For customers who signed up after August 3, 2026, bulk export is only available on the [LangSmith Enterprise plan](https://www.langchain.com/pricing-langsmith). Customers who signed up on or before August 3, 2026, can use bulk export on Plus or Enterprise plans.
+For customers who signed up after August 3, 2026, bulk export is only available on the [LangSmith Enterprise plan](https://www.langchain.com/pricing-langsmith). Customers who signed up on or before August 3, 2026, can use bulk export on Plus or Enterprise plans until February 1, 2027.
 </Info>
 
 LangSmith can export trace data to a Google Cloud Storage (GCS) bucket in Parquet format. From there, you can load it into BigQuery as an external table (queried in place from GCS) or as a native table (copied into BigQuery storage).

--- a/src/langsmith/big-query-bulk-export.mdx
+++ b/src/langsmith/big-query-bulk-export.mdx
@@ -7,7 +7,7 @@ description: Load LangSmith trace data into BigQuery using bulk export to GCS.
 <Info>
 **Plan restrictions apply**
 
-Bulk export is only available on [LangSmith Plus or Enterprise tiers](https://www.langchain.com/pricing-langsmith).
+For customers who signed up after August 3, 2026, bulk export is only available on the [LangSmith Enterprise plan](https://www.langchain.com/pricing-langsmith). Customers who signed up on or before August 3, 2026, can use bulk export on Plus or Enterprise plans.
 </Info>
 
 LangSmith can export trace data to a Google Cloud Storage (GCS) bucket in Parquet format. From there, you can load it into BigQuery as an external table (queried in place from GCS) or as a native table (copied into BigQuery storage).

--- a/src/langsmith/data-export.mdx
+++ b/src/langsmith/data-export.mdx
@@ -7,7 +7,7 @@ description: Export LangSmith trace data to an S3-compatible bucket in Parquet f
 <Info>
 **Plan restrictions apply**
 
-For customers who signed up after August 3, 2026, bulk export is only available on the [LangSmith Enterprise plan](https://www.langchain.com/pricing-langsmith). Customers who signed up on or before August 3, 2026, can use bulk export on Plus or Enterprise plans.
+For customers who signed up after August 3, 2026, bulk export is only available on the [LangSmith Enterprise plan](https://www.langchain.com/pricing-langsmith). Customers who signed up on or before August 3, 2026, can use bulk export on Plus or Enterprise plans until February 1, 2027.
 </Info>
 
 LangSmith's bulk data export lets you export trace data from a specific project and date range to an S3-compatible bucket in [Parquet](https://parquet.apache.org/docs/overview/) format, matching the fields in the [Run data format](/langsmith/run-data-format). This is useful for offline analysis in tools like BigQuery, Snowflake, Redshift, or Jupyter Notebooks.

--- a/src/langsmith/data-export.mdx
+++ b/src/langsmith/data-export.mdx
@@ -7,7 +7,7 @@ description: Export LangSmith trace data to an S3-compatible bucket in Parquet f
 <Info>
 **Plan restrictions apply**
 
-Please note that the Data Export functionality is only supported for [LangSmith Plus or Enterprise tiers](https://www.langchain.com/pricing-langsmith).
+For customers who signed up after August 3, 2026, bulk export is only available on the [LangSmith Enterprise plan](https://www.langchain.com/pricing-langsmith). Customers who signed up on or before August 3, 2026, can use bulk export on Plus or Enterprise plans.
 </Info>
 
 LangSmith's bulk data export lets you export trace data from a specific project and date range to an S3-compatible bucket in [Parquet](https://parquet.apache.org/docs/overview/) format, matching the fields in the [Run data format](/langsmith/run-data-format). This is useful for offline analysis in tools like BigQuery, Snowflake, Redshift, or Jupyter Notebooks.


### PR DESCRIPTION
## Description
Clarifies bulk export availability for customers signing up after August 3, 2026, while documenting the existing Plus eligibility cutoff. Applies the same wording to the primary and BigQuery bulk export guides.

## Test Plan
- [x] Run scoped Vale prose lint on both updated pages
- [x] Verify the plan restriction callouts use the same cutoff wording

Made by [Open SWE](https://openswe.vercel.app/agents/e1c8bfbe-dd33-295e-faae-0080e2871803)