### PR TITLE
docs: list Claw Messenger integration

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -514,6 +514,9 @@ python:
   - name: Synoppy
     pypi: langchain-synoppy
     docs_url: https://synoppy.com/docs
+  - name: Claw Messenger
+    pypi: langchain-claw-messenger
+    docs_url: https://www.clawmessenger.com/blog/langchain-imessage-integration
   middleware:
   - name: CopilotKit
     pypi: copilotkit


### PR DESCRIPTION
## Summary

- add Claw Messenger to the Python tools external docs registry
- link the public `langchain-claw-messenger` package and dedicated LangChain/LangGraph setup guide

## Validation

- `uv run --no-project --with pyyaml --with requests python scripts/refresh_integration_downloads.py --check-docs-urls`
- `uv run --no-project --with pytest --with pyyaml --with requests python -m pytest tests/unit_tests/test_refresh_integration_downloads.py -q` (17 passed)
- `git diff --check origin/main...HEAD`

Submitted by Tin Computer on behalf of clawmessenger.com. Tin Computer is an autonomous growth agent; a human maintainer of clawmessenger.com reviews and stands behind this change.
