### PR TITLE
docs: document exact-match `delete` permission behavior

### DIFF
--- a/src/oss/deepagents/permissions.mdx
+++ b/src/oss/deepagents/permissions.mdx
@@ -114,7 +114,7 @@ Set `mode="interrupt"` to pause for human approval instead of allowing or denyin
 Interrupt-mode rules are wired into the agent's human-in-the-loop middleware automatically and merge with any `interrupt_on` you pass, so you handle and resume them the same way as tool-call interrupts. See [Human-in-the-loop](/oss/deepagents/human-in-the-loop) for the resume flow.
 
 <Note>
-Deleting a directory is all-or-nothing: `delete` checks the `write` permission on the target and every descendant path, and refuses the entire operation if any of them is denied, rather than removing part of the tree. This conservative check also applies to an existing empty directory, since directories can gain descendants.
+Deleting a directory is all-or-nothing: `delete` checks the `write` permission on the target and every descendant path, and refuses the entire operation if any of them is denied, rather than removing part of the tree. `delete` applies this same conservative check to an existing empty directory, since it is still a directory rather than a confirmed leaf target.
 
 Deleting a plain file is an exact-match case instead: `delete` resolves the target the same way `write_file` and `edit_file` do, using first-match-wins evaluation, so an earlier, narrower `allow` rule wins over a later catch-all `deny`. `deepagents>=0.7.3` is required for this exact-match behavior.
 </Note>

--- a/src/oss/deepagents/permissions.mdx
+++ b/src/oss/deepagents/permissions.mdx
@@ -114,7 +114,9 @@ Set `mode="interrupt"` to pause for human approval instead of allowing or denyin
 Interrupt-mode rules are wired into the agent's human-in-the-loop middleware automatically and merge with any `interrupt_on` you pass, so you handle and resume them the same way as tool-call interrupts. See [Human-in-the-loop](/oss/deepagents/human-in-the-loop) for the resume flow.
 
 <Note>
-Deleting a directory is all-or-nothing: `delete` checks the `write` permission on the target and every descendant path, and refuses the entire operation if any of them is denied, rather than removing part of the tree.
+Deleting a directory is all-or-nothing: `delete` checks the `write` permission on the target and every descendant path, and refuses the entire operation if any of them is denied, rather than removing part of the tree. This conservative check also applies to an existing empty directory, since directories can gain descendants.
+
+Deleting a plain file is an exact-match case instead: `delete` resolves the target the same way `write_file` and `edit_file` do, using first-match-wins evaluation, so an earlier, narrower `allow` rule wins over a later catch-all `deny`. `deepagents>=0.7.3` is required for this exact-match behavior.
 </Note>
 
 <Tip>


### PR DESCRIPTION
## Description
`deepagents` [#5229](https://github.com/langchain-ai/deepagents/pull/5229) changed `delete` to resolve a confirmed plain-file target with the same first-match-wins evaluation as `write_file`/`edit_file`, instead of the conservative all-or-nothing subtree check used for directories. This documents both behaviors in the Deep Agents permissions page.

## Test Plan
- [ ] `make lint_prose FILES="src/oss/deepagents/permissions.mdx"` passes

Made by [Open SWE](https://openswe.vercel.app/agents/112f6585-47d9-2e81-f81c-b184008ab0ab)