### PR TITLE
chore: document opt-in feedbacks [closes SDB-940]

### DIFF
--- a/src/langsmith/data-export.mdx
+++ b/src/langsmith/data-export.mdx
@@ -194,7 +194,11 @@ If a scheduled bulk export is created with `start_time=2025-07-16T00:00:00Z` and
 Requires LangSmith Helm version >= `0.12.11` (application version >= `0.12.42`). Supported in both one-time and scheduled exports.
 </Note>
 
-You can improve export speed and reduce file size by limiting which fields are included using the `export_fields` parameter. When omitted, all fields are included.
+You can improve export speed and reduce file size by limiting which fields are included using the `export_fields` parameter. If you omit `export_fields`, `feedbacks` is not included.
+
+<Note>
+Feedback comments are opt-in. To include them, explicitly add `feedbacks` to `export_fields`.
+</Note>
 
 ```bash
 curl --request POST \
@@ -271,6 +275,7 @@ By default, bulk exports include the following fields for each run:
 |-------|-------------|
 | `tags` | List of tags |
 | `feedback_stats` | Feedback statistics (JSON). Refer to the following note for aggregation limitations. |
+| `feedbacks` | Feedback comments and keys (JSON) |
 
 <Note>
 **`feedback_stats` aggregation limitation**

--- a/src/langsmith/data-export.mdx
+++ b/src/langsmith/data-export.mdx
@@ -194,11 +194,9 @@ If a scheduled bulk export is created with `start_time=2025-07-16T00:00:00Z` and
 Requires LangSmith Helm version >= `0.12.11` (application version >= `0.12.42`). Supported in both one-time and scheduled exports.
 </Note>
 
-You can improve export speed and reduce file size by limiting which fields are included using the `export_fields` parameter. If you omit `export_fields`, `feedbacks` is not included.
+You can improve export speed and reduce file size by limiting which fields are included using the `export_fields` parameter. If you omit `export_fields`, all fields except `feedbacks` are included.
 
-<Note>
-Feedback comments are opt-in. To include them, explicitly add `feedbacks` to `export_fields`.
-</Note>
+Feedback comments are opt-in. To include them, explicitly add `feedbacks` to `export_fields` along with the other relevant fields.
 
 ```bash
 curl --request POST \


### PR DESCRIPTION
## Description
Document that bulk export feedback comments are opt-in and must be requested through `export_fields`, and add `feedbacks` to the exportable fields table.

## Release Note
none

## Test Plan
- [x] Run focused Vale prose lint on `src/langsmith/data-export.mdx`.

Made by [Open SWE](https://openswe.vercel.app/agents/fcd59d40-8bfb-c47f-3972-2f712f314df9)