### PR TITLE
Fix Uniswap V2 description: correct chain scope, mention write tools

### DIFF
--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -1999,7 +1999,7 @@ Browse the complete collection of integrations available for Python. LangChain P
         href="https://github.com/Conrad-sudo/langchain-uniswap-v2"
         icon="link"
     >
-        Live Uniswap V2 swap quotes and unsigned swap transactions for Ethereum and Base.
+        Live Uniswap V2 swap quotes and unsigned transactions for swaps, approvals, and liquidity, on any EVM chain.
     </Card>
 
     <Card

--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -109,7 +109,7 @@ The following table shows tools that can be used to execute financial transactio
 | [Ampersend](https://docs.ampersend.ai) | Paid | Pay for and use remote AI agent services with automatic x402 payment handling. |
 | [Delegare](https://docs.delegare.dev) | Paid | Authorize and execute multi-rail payments via AP2 mandates with built-in budget guardrails. |
 | [Privy](/oss/integrations/tools/privy) | Free | Create wallets with configurable permissions and execute transactions with speed. |
-| [Uniswap V2](https://github.com/Conrad-sudo/langchain-uniswap-v2) | Free | Get live Uniswap V2 swap quotes and prepare unsigned swap transactions for Ethereum and Base. |
+| [Uniswap V2](https://github.com/Conrad-sudo/langchain-uniswap-v2) | Free | Get live Uniswap V2 swap quotes and prepare unsigned transactions for swaps, approvals, and liquidity, on any EVM chain. |
 
 ## AI Workflow Optimization
 


### PR DESCRIPTION
The description in both summary entries said 'for Ethereum and Base,' but the package supports 13 built-in EVM chains plus any other Uniswap-V2-shaped DEX via explicit addresses. It also now ships write tools (unsigned transactions for swaps, approvals, and liquidity), not just quotes, as of langchain-uniswap-v2 v0.2.0.

## Overview

Small follow-up to #4810. Corrects an inaccurate chain-scope claim and updates the description to reflect write-tool capability shipped in `langchain-uniswap-v2` v0.2.0, across the two summary entries that link out to the package's own repo (per the "link out from overview tables" approach mentioned in review on #4810).

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue:
- Feature PR: #4810 (original entry this corrects)

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

- Both edits are single-line prose changes, no structural/JSX/markdown changes, verified against the current live source of each file before editing.
- No `docs dev` local test run for this PR — the diff is plain text inside an already-rendering `<Card>` and table row, no new components or links involved, so the risk of a rendering break is effectively nil. Happy to run it if you'd rather have that box checked for real.
- "All code examples tested" and "root-relative internal links" don't apply — no code examples or links were added or changed, only description text.
- `src/docs.json` navigation doesn't need updating — same as #4810, individual provider/tool entries aren't part of that nav; only the index pages (already unaffected) are.

**Exact before/after, both files:**

`tools/index.mdx`
- Before: *"Get live Uniswap V2 swap quotes and prepare unsigned swap transactions for Ethereum and Base."*
- After: *"Get live Uniswap V2 swap quotes and prepare unsigned transactions for swaps, approvals, and liquidity, on any EVM chain."*

`providers/all_providers.mdx`
- Before: *"Live Uniswap V2 swap quotes and unsigned swap transactions for Ethereum and Base."*
- After: *"Live Uniswap V2 swap quotes and unsigned transactions for swaps, approvals, and liquidity, on any EVM chain."*
