### PR TITLE
ci: apply integration label to external integration PRs

### DIFF
--- a/.github/workflows/external-integration-pr-comment.yml
+++ b/.github/workflows/external-integration-pr-comment.yml
@@ -1,5 +1,5 @@
 # Post a patience comment on PRs from external contributors that add
-# new integration docs pages.
+# new integration docs pages, and apply the `integration` label to those PRs.
 #
 # NOTE: Uses `pull_request_target` so it can comment on PRs from forks.
 # The script only reads changed files from the GitHub API and checks org
@@ -65,7 +65,7 @@ jobs:
             });
 
             if (newIntegrationFiles.length === 0) {
-              console.log('No new integration files added; skipping comment');
+              console.log('No new integration files added; skipping');
               return;
             }
 
@@ -97,8 +97,24 @@ jobs:
             }
 
             if (!isExternal) {
-              console.log(`Author ${author} is internal; skipping comment`);
+              console.log(`Author ${author} is internal; skipping`);
               return;
+            }
+
+            const hasIntegrationLabel = pr.labels.some(
+              (label) => label.name === 'integration'
+            );
+
+            if (hasIntegrationLabel) {
+              console.log(`PR #${pr.number} already has the integration label; skipping labeling`);
+            } else {
+              await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pr.number,
+                labels: ['integration'],
+              });
+              console.log(`Added integration label to PR #${pr.number}`);
             }
 
             const marker = '<!-- external-integration-contribution -->';
@@ -110,7 +126,7 @@ jobs:
             });
 
             if (comments.some((comment) => comment.body.includes(marker))) {
-              console.log('Comment already posted; skipping');
+              console.log('Comment already posted; skipping comment');
               return;
             }
 


### PR DESCRIPTION
The `external-integration-pr-comment` workflow now applies the `integration` label to qualifying PRs, in addition to posting the patience comment.

Previously, a PR that qualified (non-draft, external non-bot author, adds a new file under `src/oss/{python,javascript}/integrations/` excluding `TEMPLATE.mdx`) only received the comment, and the whole script exited early if the comment had already been posted — so PRs opened before the comment existed never got any marker on `synchronize` events.

Now, once a PR qualifies:

- If the `integration` label isn't already present (checked against the PR payload's labels), the script adds it via the additive `issues.addLabels` endpoint and logs `Added integration label to PR #N`. If it's already applied, the script logs and skips the API call. Existing labels are never removed or overwritten.
- The comment is still posted only once, gated on the `<!-- external-integration-contribution -->` marker as before.

No trigger, token, or permission changes: `pull-requests: write` already covers labeling, and the workflow still never checks out or executes PR code.
