### PR TITLE
docs: refresh the Scavio tools listing description

### DIFF
--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -33,7 +33,7 @@ The following table shows tools that execute online searches in some shape or fo
 | [Perplexity Search](/oss/integrations/tools/perplexity_search) | Paid (with monthly free tier) | URL, Title, Snippet, Date, Last Updated |
 | [Search1API Search](https://www.search1api.com/docs/integrations/langchain#search) | 100 free credits on sign up, no credit card | URL, Title, Snippet, Content, Images |
 | [SearchApi](https://www.searchapi.io/docs/google) | 100 free searches/month | URL, Snippet, Title, Answer Box, Knowledge Graph |
-| [Scavio](https://scavio.dev/docs/langchain) | 50 free credits to start | URL, Title, Snippet, Knowledge Graph, Products, Videos, Reddit posts, TikTok profiles and videos |
+| [Scavio](https://scavio.dev/docs/langchain) | 50 free credits to start | URL, Title, Snippet, Knowledge Graph, Products, Videos, Transcripts, Social posts and profiles |
 | [SERPdive](https://serpdive.com/docs) | 1000 free credits/month | URL, Title, Date, Page Content, Answer |
 | [TalorData SERP](https://www.talordata.com/docs) | Paid | Title, URL, snippet, position, knowledge graph, answer box, AI overview |
 | [Tavily Search](/oss/integrations/tools/tavily_search) | 1000 free searches/month | URL, Content, Title, Images, Answer |


### PR DESCRIPTION
One-line fix to the Scavio row in the tools index.

The description listed "Reddit posts, TikTok profiles and videos", which predates several platforms. `langchain-scavio` now covers Google and its verticals, YouTube, Amazon, Walmart, Reddit, TikTok, TikTok Shop, Instagram, X and LinkedIn, so the row now reads "Transcripts, Social posts and profiles" rather than naming a subset that goes stale each time we add a platform.

The linked page at https://scavio.dev/docs/langchain is live and has been updated with the full tool list, per the convention of hosting integration detail on the provider's own docs.