### PR TITLE
docs(langsmith): document self-hosted auth for the CLI

### DIFF
--- a/src/langsmith/langsmith-cli.mdx
+++ b/src/langsmith/langsmith-cli.mdx
@@ -55,7 +55,7 @@ Querying a [SmithDB](/langsmith/smithdb-sdk-migration)-backed deployment require
 The recommended local setup is to authenticate with OAuth:
 
 <Note>
-`langsmith auth login` also works against self-hosted instances from LangSmith CLI `v0.2.46` and later, provided the deployment serves the OAuth authorization server under `/api` (LangSmith `0.16` and later). See [Self-hosted instances](#self-hosted-instances). On earlier deployments, authenticate with an API key or create an API-key profile.
+`langsmith auth login` also works against self-hosted instances from LangSmith CLI `v0.2.46` and later, provided the deployment is on LangSmith `0.16` or later with the OAuth authorization server enabled (requires a signing JWKS to be configured). See [Self-hosted instances](#self-hosted-instances). On earlier deployments, or without a signing JWKS, authenticate with an API key or create an API-key profile.
 </Note>
 
 ```bash
@@ -118,7 +118,9 @@ Point the CLI at your instance with `--api-url`, or with `LANGSMITH_ENDPOINT`. B
 
 <Tabs>
 <Tab title="OAuth">
-Requires LangSmith CLI `v0.2.46` or later and a deployment on LangSmith `0.16` or later, which serves the OAuth authorization server under `/api`.
+Requires LangSmith CLI `v0.2.46` or later and a deployment on LangSmith `0.16` or later, with the OAuth authorization server enabled.
+
+The OAuth authorization server is enabled automatically when `config.hostname` is set in your Helm chart **and** a signing JWKS is configured (via `config.signingJwks`, or the key `langsmith_signing_jwks` in `config.existingSecretName`). Without the signing JWKS, the OAuth endpoints are inactive and the CLI will receive a `404` — use the API key tab instead.
 
 ```bash
 langsmith auth login --api-url https://langsmith.example.com --profile self-hosted

--- a/src/langsmith/langsmith-cli.mdx
+++ b/src/langsmith/langsmith-cli.mdx
@@ -55,7 +55,7 @@ Querying a [SmithDB](/langsmith/smithdb-sdk-migration)-backed deployment require
 The recommended local setup is to authenticate with OAuth:
 
 <Note>
-`langsmith auth login` also works against self-hosted instances from LangSmith CLI `v0.2.46` and later, provided the deployment is on LangSmith `0.16` or later with the OAuth authorization server enabled (requires a signing JWKS to be configured). See [Self-hosted instances](#self-hosted-instances). On earlier deployments, or without a signing JWKS, authenticate with an API key or create an API-key profile.
+`langsmith auth login` also works against self-hosted instances from LangSmith CLI `v0.2.46` and newer, provided the deployment is on LangSmith `0.16` or later with the OAuth authorization server enabled (requires a signing JWKS to be configured). See [Self-hosted instances](#self-hosted-instances). On earlier deployments, or without a signing JWKS, authenticate with an API key or create an API-key profile.
 </Note>
 
 ```bash
@@ -118,7 +118,7 @@ Point the CLI at your instance with `--api-url`, or with `LANGSMITH_ENDPOINT`. B
 
 <Tabs>
 <Tab title="OAuth">
-Requires LangSmith CLI `v0.2.46` or later and a deployment on LangSmith `0.16` or later, with the OAuth authorization server enabled.
+Requires LangSmith CLI `v0.2.46` or later and a deployment on LangSmith `0.16` or later, with the OAuth authorization server enabled. The chart exposes the OAuth authorization server under `/api`, but those endpoints stay inert until you configure a signing JWKS. For setup steps, see [Enabling Remote MCP](/langsmith/langsmith-remote-mcp#enabling-remote-mcp).
 
 The OAuth authorization server is enabled automatically when `config.hostname` is set in your Helm chart **and** a signing JWKS is configured (via `config.signingJwks`, or the key `langsmith_signing_jwks` in `config.existingSecretName`). Without the signing JWKS, the OAuth endpoints are inactive and the CLI will receive a `404` — use the API key tab instead.
 

--- a/src/langsmith/langsmith-cli.mdx
+++ b/src/langsmith/langsmith-cli.mdx
@@ -55,7 +55,7 @@ Querying a [SmithDB](/langsmith/smithdb-sdk-migration)-backed deployment require
 The recommended local setup is to authenticate with OAuth:
 
 <Note>
-`langsmith auth login` currently supports LangSmith Cloud (SaaS) only. For self-hosted or other non-SaaS LangSmith endpoints, authenticate with an API key or create an API-key profile.
+`langsmith auth login` also works against self-hosted instances from LangSmith CLI `v0.2.46` and later, provided the deployment serves the OAuth authorization server under `/api` (LangSmith `0.16` and later). See [Self-hosted instances](#self-hosted-instances). On earlier deployments, authenticate with an API key or create an API-key profile.
 </Note>
 
 ```bash
@@ -111,6 +111,50 @@ Or, pass them as flags per command:
 ```bash
 langsmith --api-key lsv2_... trace list --project my-app
 ```
+
+### Self-hosted instances
+
+Point the CLI at your instance with `--api-url`, or with `LANGSMITH_ENDPOINT`. Both the browser-based login and API keys are supported.
+
+<Tabs>
+<Tab title="OAuth">
+Requires LangSmith CLI `v0.2.46` or later and a deployment on LangSmith `0.16` or later, which serves the OAuth authorization server under `/api`.
+
+```bash
+langsmith auth login --api-url https://langsmith.example.com --profile self-hosted
+```
+
+Pass your instance's base URL. The CLI reads the deployment's authorization server metadata to find the OAuth endpoints, so `https://langsmith.example.com` and `https://langsmith.example.com/api` both work.
+
+Tokens are stored under the named profile, so later commands only need `--profile`:
+
+```bash
+langsmith --profile self-hosted project list
+```
+</Tab>
+
+<Tab title="API key">
+Works on every LangSmith version.
+
+```bash
+export LANGSMITH_ENDPOINT="https://langsmith.example.com"
+export LANGSMITH_API_KEY="lsv2_..."
+
+langsmith project list
+```
+
+To save the endpoint and key as a reusable profile instead:
+
+```bash
+LANGSMITH_API_KEY="lsv2_..." langsmith profile create self-hosted \
+  --api-url https://langsmith.example.com --set-current
+```
+</Tab>
+</Tabs>
+
+<Warning>
+`LANGSMITH_ENDPOINT` takes precedence over a profile's `api_url`. If it is set in your shell, every profile you select resolves to that endpoint — a common cause of commands unexpectedly reaching LangSmith Cloud while a self-hosted profile is active. Unset it when working with profiles, or pass `--api-url` explicitly.
+</Warning>
 
 ## Quickstart
 

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -144,7 +144,7 @@ langsmith --format pretty profile list
 Run `langsmith auth login` to authenticate with OAuth instead of manually creating an API-key profile. The command starts a browser-based device authorization flow, stores OAuth tokens in the selected profile, and sets that profile as current.
 
 <Note>
-`langsmith auth login` also works against self-hosted instances from LangSmith CLI `v0.2.46` and later, provided the deployment serves the OAuth authorization server under `/api` (LangSmith `0.16` and later). On earlier deployments, create an API-key profile instead.
+`langsmith auth login` also works against self-hosted instances from LangSmith CLI `v0.2.46` and later, provided the deployment is on LangSmith `0.16` or later with the OAuth authorization server enabled. The OAuth authorization server is enabled automatically when `config.hostname` is set in your Helm chart **and** a signing JWKS is configured (`config.signingJwks` or key `langsmith_signing_jwks` in `config.existingSecretName`). On earlier deployments, or if no signing JWKS is configured, create an API-key profile instead.
 </Note>
 
 ```shell

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -162,6 +162,7 @@ For a self-hosted instance, pass its base URL. The CLI reads the deployment's au
 ```shell
 langsmith auth login --api-url https://langsmith.example.com --profile self-hosted
 ```
+Self-hosted OAuth login requires Helm chart `0.16.0` or later with a signing JWKS. For configuration, see [Enabling Remote MCP](/langsmith/langsmith-remote-mcp#enabling-remote-mcp). Otherwise create an API-key profile.
 
 For a headless environment, suppress automatic browser opening and pass a workspace ID:
 

--- a/src/langsmith/profile-configuration.mdx
+++ b/src/langsmith/profile-configuration.mdx
@@ -144,7 +144,7 @@ langsmith --format pretty profile list
 Run `langsmith auth login` to authenticate with OAuth instead of manually creating an API-key profile. The command starts a browser-based device authorization flow, stores OAuth tokens in the selected profile, and sets that profile as current.
 
 <Note>
-`langsmith auth login` currently supports LangSmith Cloud (SaaS) only. For self-hosted or other non-SaaS LangSmith endpoints, create an API-key profile instead.
+`langsmith auth login` also works against self-hosted instances from LangSmith CLI `v0.2.46` and later, provided the deployment serves the OAuth authorization server under `/api` (LangSmith `0.16` and later). On earlier deployments, create an API-key profile instead.
 </Note>
 
 ```shell
@@ -155,6 +155,12 @@ Choose the profile with `--profile` or `LANGSMITH_PROFILE`:
 
 ```shell
 langsmith auth login --profile dev
+```
+
+For a self-hosted instance, pass its base URL. The CLI reads the deployment's authorization server metadata to find the OAuth endpoints:
+
+```shell
+langsmith auth login --api-url https://langsmith.example.com --profile self-hosted
 ```
 
 For a headless environment, suppress automatic browser opening and pass a workspace ID:


### PR DESCRIPTION
## What

`langsmith auth login` no longer works only against LangSmith Cloud. From CLI `v0.2.46` (langchain-ai/langsmith-cli#244) it resolves the OAuth endpoints from the deployment's authorization server metadata, so it also authenticates against a self-hosted instance that serves the authorization server under `/api`.

Both the CLI page and the profile configuration page still told readers the opposite.

- Replace the "LangSmith Cloud (SaaS) only" note on both pages with the actual version requirements.
- Add a **Self-hosted instances** section to the CLI page, with tabs for the OAuth and API-key paths.
- Document that `LANGSMITH_ENDPOINT` takes precedence over a profile's `api_url` — it otherwise quietly routes commands to Cloud while a self-hosted profile is active.

## Version requirements stated

- CLI `v0.2.46` or later — confirmed the fix is an ancestor of that tag.
- LangSmith `0.16` or later on the server, which is what serves the authorization server under `/api` (langchain-ai/helm#762). Worth flagging for review: **no stable chart contains it yet** — the latest stable is `0.15.17` and the change is currently only in `0.16.0-rc.*`. The wording says `0.16` and later so it is accurate once 0.16 ships, and the API-key tab covers everyone on 0.15.x today.

## Test plan

- [x] `make build` passes; both pages render, and the new section appears in the build output. The only build INFO lines are the pre-existing `deepagents/fault-tolerance.mdx` link warnings
- [x] Every documented command run against the released `v0.2.46` binary: `auth login --api-url <host> --profile <name>` reaches the device-code prompt against a real self-hosted deployment, and `profile create --api-url ... --set-current` stores the endpoint and key as shown
- [x] `<Tabs>`, `<Tab>` and `<Warning>` all already used elsewhere under `src/langsmith/`; the `#self-hosted-instances` anchor matches the new heading

No `src/docs.json` change — this adds a section to an existing page rather than a new page.

A claim about subpath deployments was deliberately left out: the CLI handles them by construction, but it has not been verified against a live subpath install.