### PR TITLE
Add Fidacy action firewall to external tool integrations

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -538,6 +538,9 @@ python:
   - name: Toolstem
     pypi: langchain-toolstem
     docs_url: https://toolstem.com
+  - name: FidacyActionFirewall
+    pypi: langchain-fidacy
+    docs_url: https://github.com/fidacy/fidacy-open
   middleware:
   - name: CopilotKit
     pypi: copilotkit
@@ -1138,6 +1141,9 @@ javascript:
   - name: The Context Company
     npm: "@contextcompany/langchain"
     docs_url: https://docs.thecontextcompany.com/frameworks/langchain-langgraph
+  - name: Fidacy Action Firewall
+    npm: "@fidacy/langchain"
+    docs_url: https://github.com/fidacy/fidacy-open
   llm_caching:
   - name: BetterDB Agent Cache
     npm: "@betterdb/agent-cache"


### PR DESCRIPTION
Adds Fidacy to the external tool rows, Python and JS. Fidacy wraps a LangChain tool so the call is judged before it runs: a denied call never executes, and every allow and deny is Ed25519-signed so a third party can verify the decision offline. Works with any model driving the graph. Packages: langchain-fidacy on PyPI and @fidacy/langchain on npm, both published and tested from clean environments. I build and maintain it at https://github.com/fidacy/fidacy-open.