### PR TITLE
docs(sandbox): remove unsatisfiable vcpu/memory pairs from CLI examples

### DIFF
--- a/src/langsmith/sandbox-cli.mdx
+++ b/src/langsmith/sandbox-cli.mdx
@@ -33,10 +33,7 @@ langsmith --format pretty sandbox list
 Create a sandbox, then run commands inside it:
 
 ```bash
-langsmith sandbox create my-vm \
-  --vcpus 2 \
-  --memory 1gb \
-  --wait
+langsmith sandbox create my-vm --wait
 
 langsmith sandbox exec my-vm -- python --version
 ```
@@ -90,8 +87,6 @@ Create a sandbox with the default runtime. Add `--snapshot-id` only when you wan
 
 ```bash
 langsmith sandbox create my-vm \
-  --vcpus 4 \
-  --memory 1gb \
   --rootfs-capacity 8gb \
   --wait
 ```
@@ -114,7 +109,7 @@ langsmith sandbox start my-vm --wait
 Update resources or proxy configuration:
 
 ```bash
-langsmith sandbox update my-vm --vcpus 8 --memory 2gb
+langsmith sandbox update my-vm --rootfs-capacity 16gb
 langsmith sandbox update my-vm --proxy-config @proxy.json
 ```
 


### PR DESCRIPTION
The sandbox API validates `vcpus` and `mem_bytes` together: `mem_bytes` must be within 50% of 4 GiB per vCPU. Every sizing example in `sandbox-cli.mdx` predates that check and is now rejected outright:

| example | ratio | allowed |
|---|---|---|
| `create --vcpus 2 --memory 1gb` | 0.5 GiB/vCPU | 2–6 GiB/vCPU |
| `create --vcpus 4 --memory 1gb` | 0.25 GiB/vCPU | 2–6 GiB/vCPU |
| `update --vcpus 8 --memory 2gb` | 0.25 GiB/vCPU | 2–6 GiB/vCPU |

Copy-pasting any of them fails. This drops the explicit flags so the examples use platform defaults; the update example now demonstrates `--rootfs-capacity`, which has no paired constraint.

Surfaced by a customer report (Pylon #28308) — they were sizing at 0.5 GiB/vCPU, squarely inside the range our docs showed.

## Test Plan
- [x] none — documentation only