### PR TITLE
docs(langsmith): document enabling Engine on self-hosted 

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -2712,6 +2712,10 @@
       "destination": "/langsmith/deploy-self-hosted-full-platform#enable-sandboxes"
     },
     {
+      "source": "/langsmith/self-host-engine",
+      "destination": "/langsmith/deploy-self-hosted-full-platform#enable-engine"
+    },
+    {
       "source": "/langsmith/fleet/self-hosted",
       "destination": "/langsmith/deploy-self-hosted-full-platform#enable-fleet-insights-and-chat"
     },

--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -1189,7 +1189,11 @@ Engine also adds configuration to `platform-backend` and `ingest-queue`, which d
   </Step>
 
   <Step title="Allow egress to LangSmith Intelligence">
-    Allow outbound HTTPS from the cluster to the LangSmith Intelligence gateway for your cloud. On AWS that host is `beacon.aws.langchain.com`; on other clouds, get the hostname from your account team.
+    Allow outbound HTTPS from the cluster to the LangSmith Intelligence gateway. For AWS US deployments that host is `beacon.aws.langchain.com`, which is the value of `engine.intelligenceBaseUrl` below.
+
+    <Note>
+    Engine is currently available for self-hosted deployments in **AWS US**. AWS EU and GCP US are coming soon, and Azure is planned. Check [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region) and confirm coverage with your account team before planning a rollout.
+    </Note>
 
     Add it as a specific allowlist entry rather than opening general egress. Requests are authenticated with your LangSmith license key. This is separate from the billing and operational telemetry egress described in [Configure egress](/langsmith/self-host-egress).
 

--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -152,7 +152,7 @@ Fleet additionally provisions:
 <Warning>
 As of chart `0.16.0`, Insights runs on `langsmith-insights-engine`, a combined image that serves both the `insights` and `engine` graphs, and the chart uses it by default. The previous Insights-only image, `langsmith-clio`, is retired.
 
-If your values pin `images.engineInsightsAgentImage.repository` to `langsmith-clio`, remove or update that pin before upgrading; the chart rejects it. If you mirror images to a private registry, mirror `langsmith-insights-engine` and point the repository at your copy — see [Mirroring images](/langsmith/self-host-mirroring-images#additional-images-for-engine).
+If your values pin `images.engineInsightsAgentImage.repository` to `langsmith-clio`, remove or update that pin before upgrading. The chart rejects it. If you mirror images to a private registry, mirror `langsmith-insights-engine` and point the repository at your copy. See [Mirroring images](/langsmith/self-host-mirroring-images#additional-images-for-engine).
 </Warning>
 
 ### Generate encryption keys
@@ -1153,12 +1153,12 @@ Self-hosted Engine requires LangSmith Helm chart `0.16.0` or later and a license
 
 [Engine](/langsmith/engine-overview) watches a tracing project, clusters recurring failures into issues, diagnoses each one, and proposes a fix. Engine is disabled by default.
 
-Engine builds on two other features on this page:
+Engine requires Sandboxes and shares a runtime with Insights:
 
-- **[Sandboxes](#enable-sandboxes)** — every Engine run executes in one. Enable Sandboxes first; the chart refuses to render when `engine.enabled` is set without them.
-- **[Insights](#enable-fleet-insights-and-chat)** — Engine and Insights are served by the same image and share one deployment. On an install that already runs Insights, enabling Engine adds configuration rather than new pods.
+- **[Sandboxes](#enable-sandboxes):** Every Engine run executes in one. Enable Sandboxes first. The chart refuses to render when `engine.enabled` is set without them.
+- **[Insights](#enable-fleet-insights-and-chat):** Engine and Insights are served by the same image and share one deployment. Insights is not an Engine prerequisite. On an install that already runs Insights, enabling Engine adds configuration rather than new pods.
 
-Unlike the other features on this page, Engine does not run models in your cluster. It routes model calls to LangSmith Intelligence, a LangChain-managed zero data retention inference service, authenticating with your license key. See [Engine on self-hosted](/langsmith/engine-self-hosted) for that architecture and what it means for your data.
+Unlike the other features on this page, Engine does not run models in your cluster. It routes model calls to LangSmith Intelligence, a LangChain-managed zero data retention inference service in AWS, and authenticates with a short-lived license JWT obtained during LangSmith license verification. See [Engine on self-hosted](/langsmith/engine-self-hosted) for the data flow and retained billing metadata.
 
 ### Components
 
@@ -1180,9 +1180,9 @@ Engine also adds configuration to `platform-backend` and `ingest-queue`, which d
     Engine's sandboxes are owned by a single workspace. By default LangSmith resolves the install's own workspace, which works when there is exactly one non-personal organization; with more than one it declines rather than guess, and you must set `engine.sandboxTenantId`.
 
     <Warning>
-    Prefer a workspace reserved for Engine. Engine's sandboxes are not billed on the Sandboxes product — Engine meters its own usage in LCUs — but they do count against that workspace's concurrent sandbox, CPU, and memory quotas. A workspace already near its cap can push an Engine run into a quota error, and Engine's own sandboxes can crowd out interactive ones.
+    Prefer a workspace reserved for Engine. Engine's sandboxes are not billed on the Sandboxes product because Engine meters its own usage in LCUs. They do count against that workspace's concurrent sandbox, CPU, and memory quotas. A workspace already near its cap can push an Engine run into a quota error, and Engine's own sandboxes can crowd out interactive ones.
 
-    Those sandboxes are also listed in that workspace and can be stopped by anyone with access to it, while each one runs agent-generated code and holds a GitHub token for the repository under analysis.
+    Those sandboxes are also listed in that workspace and can be stopped by anyone with access to it. Each one runs agent-generated code. Repository credentials are held by the sandbox auth proxy and are not readable inside the sandbox.
     </Warning>
   </Step>
 
@@ -1197,7 +1197,7 @@ Engine also adds configuration to `platform-backend` and `ingest-queue`, which d
     Engine is currently available for self-hosted deployments in **AWS US**. AWS EU and GCP US are coming soon, and Azure is planned. Check [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region) and confirm coverage with your account team before planning a rollout.
     </Note>
 
-    Add it as a specific allowlist entry rather than opening general egress. Requests are authenticated with your LangSmith license key. This is separate from the billing and operational telemetry egress described in [Configure egress](/langsmith/self-host-egress).
+    Add it as a specific allowlist entry rather than opening general egress. Requests use a short-lived license JWT obtained during LangSmith license verification. This is separate from the billing and operational telemetry egress described in [Configure egress](/langsmith/self-host-egress).
 
     <Note>
     Offline (air-gapped) installs cannot run Engine. There is no in-cluster model for it to fall back on.
@@ -1205,9 +1205,9 @@ Engine also adds configuration to `platform-backend` and `ingest-queue`, which d
   </Step>
 
   <Step title="Verify your hostname is externally reachable">
-    Engine's sandboxes call your LangSmith install from outside the cluster using the `langsmith` CLI, so `config.hostname` must be reachable from the sandbox network. The chart rejects `localhost` and in-cluster `*.svc` addresses.
+    Engine's sandboxes call your LangSmith install using the `langsmith` CLI, so `config.hostname` must be reachable from the sandbox network. The chart rejects `localhost` and in-cluster `*.svc` addresses.
 
-    Serve that hostname through your ingress with TLS, as described in [Set up an ingress](/langsmith/self-host-ingress). Engine does not require you to expose anything beyond the address your own users already reach. Sandbox egress is allowlisted to your LangSmith hostname, `github.com`, `api.github.com`, and the Python package registries, and per-run credentials are injected by a proxy outside the sandbox rather than being readable inside it.
+    Serve that hostname through your ingress with TLS, as described in [Set up an ingress](/langsmith/self-host-ingress). Engine does not require you to expose anything beyond the address your own users already reach. Sandbox egress is allowlisted to your LangSmith hostname, `github.com`, `api.github.com`, and the Python package registries. Per-run credentials are injected by a proxy outside the sandbox rather than being readable inside it.
   </Step>
 
   <Step title="Generate the Engine encryption key">
@@ -1234,7 +1234,7 @@ Add the following to your [`langsmith_config.yaml`](/langsmith/kubernetes#config
     ```yaml
     config:
       existingSecretName: "<your-secret-name>"
-      # Must be externally reachable — Engine's sandboxes call it from outside the cluster.
+      # Must be reachable from the sandbox network.
       hostname: "https://langsmith.example.com"
 
     engine:
@@ -1268,7 +1268,7 @@ Add the following to your [`langsmith_config.yaml`](/langsmith/kubernetes#config
 </Tabs>
 
 <Warning>
-Engine runs on `langsmith-insights-engine`, the combined image serving both the `engine` and `insights` graphs. The chart uses it by default, so a new install needs no image configuration. If you are upgrading an install whose values pin `images.engineInsightsAgentImage.repository` to the retired `langsmith-clio` image, remove or update that pin — `langsmith-clio` serves Insights only, and the chart rejects it.
+Engine runs on `langsmith-insights-engine`, the combined image serving both the `engine` and `insights` graphs. The chart uses it by default, so a new install needs no image configuration. If you are upgrading an install whose values pin `images.engineInsightsAgentImage.repository` to the retired `langsmith-clio` image, remove or update that pin. `langsmith-clio` serves Insights only, and the chart rejects it.
 </Warning>
 
 If your install has more than one non-personal organization, also set the workspace that owns Engine's sandboxes:
@@ -1308,6 +1308,8 @@ kubectl rollout status deployment/langsmith-platform-backend -n <namespace>
 
 If Engine does not appear in the LangSmith UI after this, the most common causes are a license without the Engine entitlement and the organization-level toggle described below.
 
+After completing the in-product setup, start an Engine analysis and confirm that results appear for the tracing project. This verifies the complete path through Engine, Sandboxes, and LangSmith Intelligence. Running pods alone does not verify model inference.
+
 ### Turn on Engine in LangSmith
 
 Enabling Engine in Helm makes the feature available; it does not start any scans. Two in-product steps remain, both covered in [Find and fix issues](/langsmith/engine):
@@ -1315,7 +1317,7 @@ Enabling Engine in Helm makes the feature available; it does not start any scans
 1. An [Organization Admin](/langsmith/rbac#organization-admin) turns Engine on for the organization under **Settings > Engine enablement**.
 2. Any user sets Engine up for a tracing project from the project's **Engine** tab.
 
-Connecting a GitHub repository is optional and improves Engine's diagnosis and fixes. Without one, Engine still detects and diagnoses issues and proposes prompt fixes, but it cannot read your source code or open pull requests. Repository connection depends on a GitHub App registered against `host-backend`, which the chart does not yet expose as Helm values — contact technical support via the [Support Portal](https://support.langchain.com) to set it up.
+Connecting a GitHub repository is optional and improves Engine's diagnosis and fixes. Without one, Engine still detects and diagnoses issues and proposes prompt fixes, but it cannot read your source code or open pull requests. Repository connection depends on a GitHub App registered against `host-backend`, which the chart does not yet expose as Helm values. Contact technical support through the [Support Portal](https://support.langchain.com) to set it up.
 
 ### Disable Engine
 

--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -1158,7 +1158,7 @@ Engine requires Sandboxes and shares a runtime with Insights:
 - **[Sandboxes](#enable-sandboxes):** Every Engine run executes in one. Enable Sandboxes first. The chart refuses to render when `engine.enabled` is set without them.
 - **[Insights](#enable-fleet-insights-and-chat):** Engine and Insights are served by the same image and share one deployment. Insights is not an Engine prerequisite. On an install that already runs Insights, enabling Engine adds configuration rather than new pods.
 
-Unlike the other features on this page, Engine does not run models in your cluster. It routes model calls to LangSmith Intelligence, a LangChain-managed zero data retention inference service in AWS, and authenticates with a short-lived license JWT obtained during LangSmith license verification. See [Engine on self-hosted](/langsmith/engine-self-hosted) for the data flow and retained billing metadata.
+Unlike the other features on this page, Engine cannot run entirely inside your cluster. It depends on LangSmith Intelligence, a LangChain-managed zero data retention service in AWS, and authenticates with a short-lived license JWT obtained during LangSmith license verification. See [Engine on self-hosted](/langsmith/engine-self-hosted) for the data flow and retained billing metadata.
 
 ### Components
 
@@ -1308,7 +1308,7 @@ kubectl rollout status deployment/langsmith-platform-backend -n <namespace>
 
 If Engine does not appear in the LangSmith UI after this, the most common causes are a license without the Engine entitlement and the organization-level toggle described below.
 
-After completing the in-product setup, start an Engine analysis and confirm that results appear for the tracing project. This verifies the complete path through Engine, Sandboxes, and LangSmith Intelligence. Running pods alone does not verify model inference.
+After completing the in-product setup, start an Engine analysis and confirm that results appear for the tracing project. This verifies the complete path through Engine, Sandboxes, and LangSmith Intelligence. Running pods alone does not verify that path.
 
 ### Turn on Engine in LangSmith
 

--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -1180,7 +1180,9 @@ Engine also adds configuration to `platform-backend` and `ingest-queue`, which d
     Engine's sandboxes are owned by a single workspace. By default LangSmith resolves the install's own workspace, which works when there is exactly one non-personal organization; with more than one it declines rather than guess, and you must set `engine.sandboxTenantId`.
 
     <Warning>
-    Prefer a workspace reserved for Engine. Its sandboxes count against that workspace's sandbox quota, so an Engine run can be refused when the workspace is at its cap, and Engine sandboxes consume capacity bought for other work. They are also listed in that workspace and can be stopped by anyone with access to it, while each one runs agent-generated code and holds a GitHub token for the repository under analysis.
+    Prefer a workspace reserved for Engine. Engine's sandboxes are not billed on the Sandboxes product — Engine meters its own usage in LCUs — but they do count against that workspace's concurrent sandbox, CPU, and memory quotas. A workspace already near its cap can push an Engine run into a quota error, and Engine's own sandboxes can crowd out interactive ones.
+
+    Those sandboxes are also listed in that workspace and can be stopped by anyone with access to it, while each one runs agent-generated code and holds a GitHub token for the repository under analysis.
     </Warning>
   </Step>
 

--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -1,7 +1,7 @@
 ---
-title: Enable LangSmith Deployment, Fleet, Insights, Chat, and Sandboxes
+title: Enable LangSmith Deployment, Fleet, Insights, Chat, Sandboxes, and Engine
 sidebarTitle: Enable additional features
-description: Enable LangSmith Deployment, Fleet, Insights, Chat, and Sandboxes on a self-hosted LangSmith instance.
+description: Enable LangSmith Deployment, Fleet, Insights, Chat, Sandboxes, and Engine on a self-hosted LangSmith instance.
 ---
 
 In addition to the base [LangSmith](/langsmith/self-hosted) platform, you can enable the following features:
@@ -19,6 +19,8 @@ In addition to the base [LangSmith](/langsmith/self-hosted) platform, you can en
 - **[Chat](/langsmith/chat)** provides an in-workspace chat experience to help you analyze traces, threads, prompts, and experiment results.
 
 - **[Sandboxes](/langsmith/sandboxes)** let users run code, expose temporary services, and create memory snapshots from LangSmith.
+
+- **[Engine](/langsmith/engine-overview)** finds recurring issues in a tracing project, diagnoses them against your source code, and proposes fixes. Engine requires Sandboxes.
 
 <Info>
 These features require an [Enterprise](https://langchain.com/pricing) plan. [Get a demo](https://www.langchain.com/contact-sales) to learn more.
@@ -146,6 +148,12 @@ Enabling these features provisions the following components in your cluster for 
 Fleet additionally provisions:
 - `toolServer`: Provides MCP tool execution for agents.
 - `triggerServer`: Handles webhooks and scheduled triggers.
+
+<Warning>
+As of chart `0.16.0`, Insights runs on `langsmith-insights-engine`, a combined image that serves both the `insights` and `engine` graphs, and the chart uses it by default. The previous Insights-only image, `langsmith-clio`, is retired.
+
+If your values pin `images.engineInsightsAgentImage.repository` to `langsmith-clio`, remove or update that pin before upgrading; the chart rejects it. If you mirror images to a private registry, mirror `langsmith-insights-engine` and point the repository at your copy — see [Mirroring images](/langsmith/self-host-mirroring-images#additional-images-for-engine).
+</Warning>
 
 ### Generate encryption keys
 
@@ -1136,6 +1144,183 @@ Sandbox runtime image changes roll out through the `sandbox-host` Kubernetes Dep
 During a normal Helm upgrade, a terminating host stops accepting new Sandboxes, attempts to save each running Sandbox's VM memory to JuiceFS, and then stops those VMs before the pod exits. This shutdown is bounded by the `sandbox-host` pod termination grace period, which defaults to 300 seconds. This is not live migration: Sandboxes on that host are interrupted during the restart.
 
 Sandboxes are not proactively restarted. They start again when a user or API action starts the Sandbox, or when a request path wakes it. LangSmith then places the Sandbox on an available host and restores from the saved memory image if the shutdown capture completed. If the memory image is absent or incomplete, the Sandbox starts from the saved root filesystem.
+
+## Enable Engine
+
+<Info>
+Self-hosted Engine requires LangSmith Helm chart `0.16.0` or later and a license that includes the Engine entitlement. [Contact your account team](https://www.langchain.com/contact-sales) to have it added to your order.
+</Info>
+
+[Engine](/langsmith/engine-overview) watches a tracing project, clusters recurring failures into issues, diagnoses each one, and proposes a fix. Engine is disabled by default.
+
+Engine builds on two other features on this page:
+
+- **[Sandboxes](#enable-sandboxes)** — every Engine run executes in one. Enable Sandboxes first; the chart refuses to render when `engine.enabled` is set without them.
+- **[Insights](#enable-fleet-insights-and-chat)** — Engine and Insights are served by the same image and share one deployment. On an install that already runs Insights, enabling Engine adds configuration rather than new pods.
+
+Unlike the other features on this page, Engine does not run models in your cluster. It routes model calls to LangSmith Intelligence, a LangChain-managed zero data retention inference service, authenticating with your license key. See [Engine on self-hosted](/langsmith/engine-self-hosted) for that architecture and what it means for your data.
+
+### Components
+
+Enabling Engine provisions or reuses:
+
+- `standalone-insights-api-server`: serves both the `engine` and `insights` graphs.
+- `standalone-insights-queue`: background run processing for Engine and Insights.
+- A dedicated PostgreSQL and Redis instance for the shared deployment, each replaceable with an external instance.
+- The sandbox components described under [Enable Sandboxes](#enable-sandboxes).
+
+Engine also adds configuration to `platform-backend` and `ingest-queue`, which dispatch and schedule its runs.
+
+### Prerequisites
+
+<Steps>
+  <Step title="Enable Sandboxes">
+    Complete [Enable Sandboxes](#enable-sandboxes) first, including the KVM-capable node pool and JuiceFS storage.
+
+    Engine's sandboxes are owned by a single workspace. By default LangSmith resolves the install's own workspace, which works when there is exactly one non-personal organization; with more than one it declines rather than guess, and you must set `engine.sandboxTenantId`.
+
+    <Warning>
+    Prefer a workspace reserved for Engine. Its sandboxes count against that workspace's sandbox quota, so an Engine run can be refused when the workspace is at its cap, and Engine sandboxes consume capacity bought for other work. They are also listed in that workspace and can be stopped by anyone with access to it, while each one runs agent-generated code and holds a GitHub token for the repository under analysis.
+    </Warning>
+  </Step>
+
+  <Step title="Confirm the license entitlement">
+    Engine is licensed separately, in the same way as Sandboxes. Your license must carry the Engine entitlement. LangSmith validates your license key against `https://beacon.langchain.com` at startup and periodically thereafter, so the entitlement takes effect without you changing any configuration once it is added to your order.
+  </Step>
+
+  <Step title="Allow egress to LangSmith Intelligence">
+    Allow outbound HTTPS from the cluster to the LangSmith Intelligence gateway for your cloud. On AWS that host is `beacon.aws.langchain.com`; on other clouds, get the hostname from your account team.
+
+    Add it as a specific allowlist entry rather than opening general egress. Requests are authenticated with your LangSmith license key. This is separate from the billing and operational telemetry egress described in [Configure egress](/langsmith/self-host-egress).
+
+    <Note>
+    Offline (air-gapped) installs cannot run Engine. There is no in-cluster model for it to fall back on.
+    </Note>
+  </Step>
+
+  <Step title="Verify your hostname is externally reachable">
+    Engine's sandboxes call your LangSmith install from outside the cluster using the `langsmith` CLI, so `config.hostname` must be reachable from the sandbox network. The chart rejects `localhost` and in-cluster `*.svc` addresses.
+
+    Serve that hostname through your ingress with TLS, as described in [Set up an ingress](/langsmith/self-host-ingress). Engine does not require you to expose anything beyond the address your own users already reach. Sandbox egress is allowlisted to your LangSmith hostname, `github.com`, `api.github.com`, and the Python package registries, and per-run credentials are injected by a proxy outside the sandbox rather than being readable inside it.
+  </Step>
+
+  <Step title="Generate the Engine encryption key">
+    Engine uses its own Fernet key to encrypt the run payloads LangSmith passes to it, which carry short-lived credentials. Generate one:
+
+    ```bash
+    python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+    ```
+
+    Store it in your predefined Kubernetes Secret as `engine_encryption_key` rather than in your config file. See [Use an existing secret](/langsmith/self-host-using-an-existing-secret#parameters).
+
+    To rotate the key later, copy the current value to `engine_encryption_key_previous` and set the new key as `engine_encryption_key`. The previous key is accepted for decryption only, so runs encrypted just before the swap still complete.
+  </Step>
+</Steps>
+
+### Enable with Helm
+
+Add the following to your [`langsmith_config.yaml`](/langsmith/kubernetes#configure-your-helm-charts), alongside the Sandboxes values from [Enable Sandboxes](#enable-sandboxes):
+
+<Tabs>
+  <Tab title="Using Kubernetes secrets (recommended)">
+    Reference your existing Secret by name. The chart reads `engine_encryption_key` from it automatically.
+
+    ```yaml
+    config:
+      existingSecretName: "<your-secret-name>"
+      # Must be externally reachable — Engine's sandboxes call it from outside the cluster.
+      hostname: "https://langsmith.example.com"
+
+    engine:
+      enabled: true
+      intelligenceBaseUrl: "https://beacon.aws.langchain.com/intelligence"
+
+    sandboxes:
+      enabled: true
+    ```
+  </Tab>
+  <Tab title="Using inline values">
+    Set the encryption key directly in your config file.
+
+    <Warning>
+    This puts a live credential in your config file. Do not commit it to version control; prefer the Kubernetes Secret above.
+    </Warning>
+
+    ```yaml
+    config:
+      hostname: "https://langsmith.example.com"
+
+    engine:
+      enabled: true
+      intelligenceBaseUrl: "https://beacon.aws.langchain.com/intelligence"
+      encryptionKey: "<engine-encryption-key>"
+
+    sandboxes:
+      enabled: true
+    ```
+  </Tab>
+</Tabs>
+
+<Warning>
+Engine runs on `langsmith-insights-engine`, the combined image serving both the `engine` and `insights` graphs. The chart uses it by default, so a new install needs no image configuration. If you are upgrading an install whose values pin `images.engineInsightsAgentImage.repository` to the retired `langsmith-clio` image, remove or update that pin — `langsmith-clio` serves Insights only, and the chart rejects it.
+</Warning>
+
+If your install has more than one non-personal organization, also set the workspace that owns Engine's sandboxes:
+
+```yaml
+engine:
+  sandboxTenantId: "<workspace-id>"
+```
+
+Apply the updated chart:
+
+```bash
+helm upgrade -i langsmith langchain/langsmith \
+  --values langsmith_config.yaml \
+  --version <version> \
+  --namespace <namespace> \
+  --wait
+```
+
+<Tip>
+The chart validates the Engine configuration at render time and fails with a message naming the missing value, so `helm template` catches a misconfiguration before it reaches your cluster.
+</Tip>
+
+### Verify the installation
+
+Confirm the shared Engine and Insights deployment is running:
+
+```bash
+kubectl get pods -n <namespace> | grep standalone-insights
+```
+
+Both the API server and queue pods should be `Running`. Then confirm `platform-backend` is healthy, since it dispatches Engine runs:
+
+```bash
+kubectl rollout status deployment/langsmith-platform-backend -n <namespace>
+```
+
+If Engine does not appear in the LangSmith UI after this, the most common causes are a license without the Engine entitlement and the organization-level toggle described below.
+
+### Turn on Engine in LangSmith
+
+Enabling Engine in Helm makes the feature available; it does not start any scans. Two in-product steps remain, both covered in [Find and fix issues](/langsmith/engine):
+
+1. An [Organization Admin](/langsmith/rbac#organization-admin) turns Engine on for the organization under **Settings > Engine enablement**.
+2. Any user sets Engine up for a tracing project from the project's **Engine** tab.
+
+Connecting a GitHub repository is optional and improves Engine's diagnosis and fixes. Without one, Engine still detects and diagnoses issues and proposes prompt fixes, but it cannot read your source code or open pull requests. Repository connection depends on a GitHub App registered against `host-backend`, which the chart does not yet expose as Helm values — contact technical support via the [Support Portal](https://support.langchain.com) to set it up.
+
+### Disable Engine
+
+Set `engine.enabled` to `false` and re-apply:
+
+```yaml
+engine:
+  enabled: false
+```
+
+Engine stops dispatching runs. Existing issues remain in the database and reappear if you re-enable it. Because Insights shares the same deployment, the `standalone-insights` pods keep running when `insights.enabled` is `true`.
 
 ## Optional configuration
 

--- a/src/langsmith/engine-self-hosted.mdx
+++ b/src/langsmith/engine-self-hosted.mdx
@@ -29,7 +29,7 @@ Engine depends on LSI coverage. That coverage is expanding, so availability vari
 | AWS | US | Available |
 | AWS | EU | Coming soon |
 | GCP | US | Coming soon |
-| Azure | — | Planned |
+| Azure | n/a | Planned |
 
 Contact your account team to confirm coverage for your region and for current timing. The GCP and Azure sections below describe future availability, not deployments you can enable today.
 

--- a/src/langsmith/engine-self-hosted.mdx
+++ b/src/langsmith/engine-self-hosted.mdx
@@ -1,7 +1,7 @@
 ---
 title: LangSmith Engine on self-hosted
 sidebarTitle: Self-hosted
-description: How LangSmith Engine runs in a self-hosted deployment, how it reaches managed inference over a private link, and what that means for your data.
+description: How LangSmith Engine runs in a self-hosted deployment, reaches managed inference in AWS, and handles your data.
 ---
 
 <Info>
@@ -18,11 +18,11 @@ Engine works with three kinds of data:
 - **Traces:** runtime data from your agents, which can include user messages, tool outputs, and PII.
 - **Model:** the LLM calls Engine makes to run diagnosis, generate fixes, and write evaluators.
 
-In a self-hosted deployment, Engine's orchestration runs inside your VPC as part of LangSmith: reading traces, reading code, and running its detect, fix, and verify loop. The models it calls are the exception. Rather than run them locally, Engine reaches a LangChain-managed, zero data retention (ZDR) inference service over a private network connection. Traces are the sensitive data type, and the architecture below keeps trace data on private networks inside your cloud service provider (CSP).
+In a self-hosted deployment, Engine's orchestration runs inside your VPC as part of LangSmith: reading traces, reading code, and running its detect, fix, and verify loop. The models it calls are the exception. Rather than run them locally, Engine sends the content required for each model call to LangSmith Intelligence (LSI), a LangChain-managed zero data retention (ZDR) inference service hosted in AWS.
 
 ## Availability by cloud and region
 
-Engine depends on a LangSmith Intelligence deployment in your cloud and region. That coverage is expanding, so availability is narrower than the architectures described below:
+Engine depends on LSI coverage. That coverage is expanding, so availability varies by cloud and region:
 
 | Cloud | Region | Status |
 | --- | --- | --- |
@@ -31,54 +31,45 @@ Engine depends on a LangSmith Intelligence deployment in your cloud and region. 
 | GCP | US | Coming soon |
 | Azure | — | Planned |
 
-Contact your account team to confirm coverage for your region and for current timing. The GCP and Azure sections below describe the intended architecture for those clouds, not deployments you can enable today.
+Contact your account team to confirm coverage for your region and for current timing. The GCP and Azure sections below describe future availability, not deployments you can enable today.
 
 ## How inference works
 
-Engine's inference is delivered through a LangChain-managed service, LangSmith Intelligence. The service is fully isolated from LangSmith and does not trace, store, or persist any customer data.
+Engine's inference is delivered through LSI.
 
 The flow:
 
-- Your self-hosted deployment connects to LangSmith Intelligence over a private link (PrivateLink on AWS and Azure, Private Service Connect on GCP).
-- LangSmith Intelligence runs models hosted within your cloud provider's environment (Bedrock, Vertex, or Foundry), so no data leaves your CSP.
-- The service records only request metadata for billing, plus telemetry needed to keep the service reliable.
+- Your self-hosted Engine sends an HTTPS request to `https://beacon.aws.langchain.com/intelligence`.
+- Engine authenticates with a short-lived license JWT obtained during LangSmith license verification. You do not provide separate model-provider credentials.
+- LSI validates the JWT and routes the request to AWS Bedrock through private AWS networking in LangChain's environment.
+- LSI returns the model response to your self-hosted Engine.
 
-{/* TODO(author): For security review, enumerate exactly what "request metadata" includes (for example, token counts, timestamps, model ID) and confirm that no request payload is recorded. Do not ship vague wording. */}
+Each inference request carries the trace content, code, and intermediate outputs the model needs to reason. LSI and AWS Bedrock process that content for inference. LSI does not persist prompt or completion bodies.
 
-Each inference request carries the trace content, code, and intermediate outputs the model needs to reason. The request is processed by a model running inside your cloud provider and is never stored. No copy of your data is persisted outside your CSP.
+Your cluster must allow outbound HTTPS to `beacon.aws.langchain.com`. This documentation does not assume that the connection from your environment to LSI uses AWS PrivateLink. If your security policy requires private connectivity, contact your account team to confirm availability and setup before enabling Engine.
 
-{/* TODO(author): State data residency: which region(s) the models run in, whether the customer selects the region, and whether any cross-region inference can occur. */}
+If the connection to LSI is unavailable, Engine fails closed. There is no in-cluster model and no secondary provider to fall back on, so the affected run ends with an error rather than degrading to lower-quality output. The rest of your LangSmith deployment is unaffected, and Engine tries again on its next scheduled scan.
 
-If the connection to LangSmith Intelligence is unavailable, Engine fails closed: there is no in-cluster model and no secondary provider to fall back to, so the affected run ends with an error rather than degrading to lower-quality output. The rest of your LangSmith deployment is unaffected, and Engine tries again on its next scheduled scan.
+## What LangSmith Intelligence retains
 
-{/* TODO(author): Link or list the specific models served on each platform so customers can validate against approved-model policies. */}
+LSI does not persist prompt or completion bodies. It retains the following metadata for usage attribution and billing:
+
+- Account, workspace, and project identifiers used to attribute usage.
+- Model and token-usage metadata used for billing.
+
+For model-provider retention and training commitments, see [Engine security](/langsmith/engine-security).
 
 ### AWS (available in US)
 
-<Frame caption="AWS: private link to LangSmith Intelligence, models served by Bedrock">
-  <img
-    src="/langsmith/images/engine-self-hosted-aws.png"
-    alt="Architecture diagram showing a self-hosted LangSmith deployment on AWS connecting to LangSmith Intelligence over PrivateLink, with inference served by Bedrock inside the customer's account"
-  />
-</Frame>
+Self-hosted Engine sends model requests through the LSI gateway. LSI routes them to AWS Bedrock in LangChain's AWS environment.
 
 ### GCP (coming soon)
 
-<Frame caption="GCP: Private Service Connect to LangSmith Intelligence, models served by Vertex">
-  <img
-    src="/langsmith/images/engine-self-hosted-gcp.png"
-    alt="Architecture diagram showing a self-hosted LangSmith deployment on GCP connecting to LangSmith Intelligence over Private Service Connect, with inference served by Vertex inside the customer's project"
-  />
-</Frame>
+Self-hosted Engine support on GCP is coming soon. Contact your account team for current timing.
 
 ### Azure (planned)
 
-<Frame caption="Azure: private link to LangSmith Intelligence, models served by Foundry">
-  <img
-    src="/langsmith/images/engine-self-hosted-azure.png"
-    alt="Architecture diagram showing a self-hosted LangSmith deployment on Azure connecting to LangSmith Intelligence over PrivateLink, with inference served by Foundry inside the customer's environment"
-  />
-</Frame>
+Self-hosted Engine support on Azure is planned. Contact your account team for current timing.
 
 ## Model selection and quality
 
@@ -88,10 +79,10 @@ Managed inference makes that possible. Because Engine always runs the model Lang
 
 ## What this means for your data
 
-In a self-hosted deployment, Engine adds two data-locality guarantees on top of the controls common to every deployment:
+In a self-hosted deployment, Engine separates data handling between your environment and LangChain's AWS environment:
 
-- **Private networks only:** all data transit happens over private link, never the public internet.
-- **In-CSP:** models run inside your CSP, so data never leaves it.
+- **Your environment:** Engine orchestration and LangSmith-stored traces remain in your self-hosted deployment.
+- **LangChain's AWS environment:** Content required for model inference is processed by LSI and AWS Bedrock. LSI retains the billing metadata listed above, but it does not persist prompt or completion bodies.
 
 Engine's deployment-independent data handling, including zero data retention with every model provider and no use of customer data to train or fine-tune models, is described in [Engine security](/langsmith/engine-security).
 

--- a/src/langsmith/engine-self-hosted.mdx
+++ b/src/langsmith/engine-self-hosted.mdx
@@ -20,6 +20,19 @@ Engine works with three kinds of data:
 
 In a self-hosted deployment, Engine's orchestration runs inside your VPC as part of LangSmith: reading traces, reading code, and running its detect, fix, and verify loop. The models it calls are the exception. Rather than run them locally, Engine reaches a LangChain-managed, zero data retention (ZDR) inference service over a private network connection. Traces are the sensitive data type, and the architecture below keeps trace data on private networks inside your cloud service provider (CSP).
 
+## Availability by cloud and region
+
+Engine depends on a LangSmith Intelligence deployment in your cloud and region. That coverage is expanding, so availability is narrower than the architectures described below:
+
+| Cloud | Region | Status |
+| --- | --- | --- |
+| AWS | US | Available |
+| AWS | EU | Coming soon |
+| GCP | US | Coming soon |
+| Azure | — | Planned |
+
+Contact your account team to confirm coverage for your region and for current timing. The GCP and Azure sections below describe the intended architecture for those clouds, not deployments you can enable today.
+
 ## How inference works
 
 Engine's inference is delivered through a LangChain-managed service, LangSmith Intelligence. The service is fully isolated from LangSmith and does not trace, store, or persist any customer data.
@@ -40,7 +53,7 @@ If the connection to LangSmith Intelligence is unavailable, Engine fails closed:
 
 {/* TODO(author): Link or list the specific models served on each platform so customers can validate against approved-model policies. */}
 
-### AWS
+### AWS (available in US)
 
 <Frame caption="AWS: private link to LangSmith Intelligence, models served by Bedrock">
   <img
@@ -49,7 +62,7 @@ If the connection to LangSmith Intelligence is unavailable, Engine fails closed:
   />
 </Frame>
 
-### GCP
+### GCP (coming soon)
 
 <Frame caption="GCP: Private Service Connect to LangSmith Intelligence, models served by Vertex">
   <img
@@ -58,7 +71,7 @@ If the connection to LangSmith Intelligence is unavailable, Engine fails closed:
   />
 </Frame>
 
-### Azure
+### Azure (planned)
 
 <Frame caption="Azure: private link to LangSmith Intelligence, models served by Foundry">
   <img

--- a/src/langsmith/engine-self-hosted.mdx
+++ b/src/langsmith/engine-self-hosted.mdx
@@ -1,7 +1,7 @@
 ---
 title: LangSmith Engine on self-hosted
 sidebarTitle: Self-hosted
-description: How LangSmith Engine runs in a self-hosted deployment, reaches managed inference in AWS, and handles your data.
+description: How LangSmith Engine runs in a self-hosted deployment, what it depends on outside your environment, and how it handles your data.
 ---
 
 <Info>
@@ -10,7 +10,7 @@ Self-hosted Engine requires LangSmith Helm chart `0.16.0` or later and a license
 
 LangSmith Engine is an agent within LangSmith that monitors your production traces, clusters them into issues, diagnoses each issue against your source code, proposes a fix as a PR, and identifies ground truth evals to add to your datasets. For a product overview, see [Engine](/langsmith/engine-overview).
 
-This page explains how Engine runs in a self-hosted deployment, how it reaches managed inference, and what that means for your data. To install it, see [Enable Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine).
+This page explains how Engine runs in a self-hosted deployment, what it depends on outside your environment, and what that means for your data. To install it, see [Enable Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine).
 
 Engine works with three kinds of data:
 
@@ -18,7 +18,7 @@ Engine works with three kinds of data:
 - **Traces:** runtime data from your agents, which can include user messages, tool outputs, and PII.
 - **Model:** the LLM calls Engine makes to run diagnosis, generate fixes, and write evaluators.
 
-In a self-hosted deployment, Engine's orchestration runs inside your VPC as part of LangSmith: reading traces, reading code, and running its detect, fix, and verify loop. The models it calls are the exception. Rather than run them locally, Engine sends the content required for each model call to LangSmith Intelligence (LSI), a LangChain-managed zero data retention (ZDR) inference service hosted in AWS.
+In a self-hosted deployment, Engine's orchestration runs inside your VPC as part of LangSmith: reading traces, reading code, and running its detect, fix, and verify loop. It cannot run entirely there, however. Engine depends on LangSmith Intelligence (LSI), a LangChain-managed zero data retention (ZDR) service hosted in AWS, and sends LSI the content it needs to do its work.
 
 ## Availability by cloud and region
 
@@ -33,18 +33,18 @@ Engine depends on LSI coverage. That coverage is expanding, so availability vari
 
 Contact your account team to confirm coverage for your region and for current timing. The GCP and Azure sections below describe future availability, not deployments you can enable today.
 
-## How inference works
+## How it works
 
-Engine's inference is delivered through LSI.
+LSI is the LangChain-managed service that powers Engine.
 
 The flow:
 
 - Your self-hosted Engine sends an HTTPS request to `https://beacon.aws.langchain.com/intelligence`.
 - Engine authenticates with a short-lived license JWT obtained during LangSmith license verification. You do not provide separate model-provider credentials.
 - LSI validates the JWT and routes the request to AWS Bedrock through private AWS networking in LangChain's environment.
-- LSI returns the model response to your self-hosted Engine.
+- LSI returns the response to your self-hosted Engine.
 
-Each inference request carries the trace content, code, and intermediate outputs the model needs to reason. LSI and AWS Bedrock process that content for inference. LSI does not persist prompt or completion bodies.
+Each request carries the trace content, code, and intermediate outputs Engine needs to do its work. LSI and AWS Bedrock process that content to serve the request. LSI does not persist prompt or completion bodies.
 
 Your cluster must allow outbound HTTPS to `beacon.aws.langchain.com`. This documentation does not assume that the connection from your environment to LSI uses AWS PrivateLink. If your security policy requires private connectivity, contact your account team to confirm availability and setup before enabling Engine.
 
@@ -61,7 +61,7 @@ For model-provider retention and training commitments, see [Engine security](/la
 
 ### AWS (available in US)
 
-Self-hosted Engine sends model requests through the LSI gateway. LSI routes them to AWS Bedrock in LangChain's AWS environment.
+Self-hosted Engine sends its requests through the LSI gateway. LSI routes them to AWS Bedrock in LangChain's AWS environment.
 
 ### GCP (coming soon)
 
@@ -82,7 +82,7 @@ Managed inference makes that possible. Because Engine always runs the model Lang
 In a self-hosted deployment, Engine separates data handling between your environment and LangChain's AWS environment:
 
 - **Your environment:** Engine orchestration and LangSmith-stored traces remain in your self-hosted deployment.
-- **LangChain's AWS environment:** Content required for model inference is processed by LSI and AWS Bedrock. LSI retains the billing metadata listed above, but it does not persist prompt or completion bodies.
+- **LangChain's AWS environment:** Content Engine sends is processed by LSI and AWS Bedrock. LSI retains the billing metadata listed above, but it does not persist prompt or completion bodies.
 
 Engine's deployment-independent data handling, including zero data retention with every model provider and no use of customer data to train or fine-tune models, is described in [Engine security](/langsmith/engine-security).
 

--- a/src/langsmith/engine-self-hosted.mdx
+++ b/src/langsmith/engine-self-hosted.mdx
@@ -4,15 +4,13 @@ sidebarTitle: Self-hosted
 description: How LangSmith Engine runs in a self-hosted deployment, how it reaches managed inference over a private link, and what that means for your data.
 ---
 
-<Note>
-  Engine for self-hosted is coming soon!
-</Note>
+<Info>
+Self-hosted Engine requires LangSmith Helm chart `0.16.0` or later and a license that includes the Engine entitlement. It is not available on earlier chart versions. [Contact your account team](https://www.langchain.com/contact-sales) to have the entitlement added to your order.
+</Info>
 
 LangSmith Engine is an agent within LangSmith that monitors your production traces, clusters them into issues, diagnoses each issue against your source code, proposes a fix as a PR, and identifies ground truth evals to add to your datasets. For a product overview, see [Engine](/langsmith/engine-overview).
 
-This page explains how Engine runs in a self-hosted deployment, how it reaches managed inference, and what that means for your data.
-
-{/* TODO(author): Add a version-added <Note> stating the minimum LangSmith / Helm chart version that supports self-hosted Engine managed inference. Required by the docs style guide for new features. */}
+This page explains how Engine runs in a self-hosted deployment, how it reaches managed inference, and what that means for your data. To install it, see [Enable Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine).
 
 Engine works with three kinds of data:
 
@@ -38,7 +36,7 @@ Each inference request carries the trace content, code, and intermediate outputs
 
 {/* TODO(author): State data residency: which region(s) the models run in, whether the customer selects the region, and whether any cross-region inference can occur. */}
 
-{/* TODO(author): Document the failure mode: what happens to the detect-fix-verify loop if the private link to LangSmith Intelligence is unavailable (degrade, queue, or fail closed). */}
+If the connection to LangSmith Intelligence is unavailable, Engine fails closed: there is no in-cluster model and no secondary provider to fall back to, so the affected run ends with an error rather than degrading to lower-quality output. The rest of your LangSmith deployment is unaffected, and Engine tries again on its next scheduled scan.
 
 {/* TODO(author): Link or list the specific models served on each platform so customers can validate against approved-model policies. */}
 
@@ -86,6 +84,7 @@ Engine's deployment-independent data handling, including zero data retention wit
 
 ## See also
 
+- [Enable Engine on self-hosted](/langsmith/deploy-self-hosted-full-platform#enable-engine)
 - [Engine](/langsmith/engine-overview)
 - [Configure Engine](/langsmith/engine)
 - [Engine security](/langsmith/engine-security)

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -34,6 +34,10 @@ This page covers how to set up Engine, work through the fix and evaluation loop,
 
 Setting up Engine is a two-step process: an [Organization Admin](/langsmith/rbac#organization-admin) first enables Engine for the [workspace](/langsmith/administration-overview#workspaces), then any user can configure Engine for each tracing project.
 
+<Note>
+On a self-hosted deployment, an operator must enable Engine in the LangSmith Helm chart before either step is available. See [Enable Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine) and [Engine on self-hosted](/langsmith/engine-self-hosted).
+</Note>
+
 ### Enable Engine for your organization
 
 <Note>You must be an [**Organization Admin**](/langsmith/rbac#organization-admin) to enable Engine. To find your admins, open **Settings**, select **Members** under **Access and Security**, and look for members with the **Organization Admin** role.</Note>

--- a/src/langsmith/self-host-egress.mdx
+++ b/src/langsmith/self-host-egress.mdx
@@ -18,7 +18,7 @@ Self-hosted LangSmith stores platform data in your environment. Unless you are r
 </Warning>
 
 <Note>
-If you enable [Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine), content required for model inference leaves your environment through a second egress destination. See [Model inference for Engine](#model-inference-for-engine).
+If you enable [Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine), it requires a second egress destination, and Engine content leaves your environment through it. See [LangSmith Intelligence for Engine](#langsmith-intelligence-for-engine).
 </Note>
 
 ## Billing telemetry
@@ -466,11 +466,11 @@ Add this to the `commonEnv` section of your Helm configuration to permanently di
 Disabling usage telemetry does **not** affect billing or operational telemetry. License verification and subscription/usage reporting will continue to function normally.
 </Warning>
 
-## Model inference for Engine
+## LangSmith Intelligence for Engine
 
-This section applies only if you enable [Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine). Every other LangSmith feature runs its models either in your cluster or against model providers you configure yourself and needs no egress beyond what this page already describes.
+This section applies only if you enable [Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine). LangSmith Intelligence is the LangChain-managed service that powers Engine. No other LangSmith feature depends on it, and none requires egress beyond what this page already describes.
 
-Engine does not run models in your cluster. For AWS US deployments, it sends model requests to LangSmith Intelligence, a LangChain-managed zero data retention (ZDR) inference service in AWS, which routes them to AWS Bedrock. Allow outbound HTTPS to `beacon.aws.langchain.com`.
+Engine cannot run entirely inside your cluster. For AWS US deployments, it sends requests to LangSmith Intelligence, a LangChain-managed zero data retention (ZDR) service in AWS, which routes them to AWS Bedrock. Allow outbound HTTPS to `beacon.aws.langchain.com`.
 
 <Note>
 Engine is currently available for self-hosted deployments in **AWS US**. AWS EU and GCP US are coming soon, and Azure is planned. See [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region).
@@ -482,11 +482,11 @@ Add the gateway as a specific allowlist entry rather than opening general outbou
 
 ### What it does
 
-- **Model inference**: Runs the LLM calls Engine makes to cluster issues, diagnose root cause, generate fixes, and write evaluators.
+- **Powers Engine**: Engine depends on LangSmith Intelligence and cannot run without it.
 
 ### What we collect
 
-Each request may carry the trace content, source code, and intermediate output required for the model call. LangSmith Intelligence and AWS Bedrock process that content for inference. LangSmith Intelligence does not persist prompt or completion bodies.
+Each request may carry the trace content, source code, and intermediate output Engine needs to do its work. LangSmith Intelligence and AWS Bedrock process that content to serve the request. LangSmith Intelligence does not persist prompt or completion bodies.
 
 LangSmith Intelligence retains the following metadata for usage attribution and billing:
 
@@ -496,9 +496,9 @@ LangSmith Intelligence retains the following metadata for usage attribution and 
 For the complete data flow and model-provider commitments, see [Engine on self-hosted](/langsmith/engine-self-hosted).
 
 <Info>
-Offline (air-gapped) deployments cannot run Engine, because it has no in-cluster model to fall back on. Every other LangSmith feature continues to work offline.
+Offline (air-gapped) deployments cannot run Engine, because it cannot reach LangSmith Intelligence. Every other LangSmith feature continues to work offline.
 </Info>
 
 ## Our commitment
 
-The following commitments apply to the billing, operational, and usage telemetry described on this page. LangChain will not store sensitive information in that telemetry or share it with a third party. Log messages are filtered to only include error severity levels, and we do not capture log messages that could contain sensitive application data. Engine model inference is a separate data flow described in [Engine on self-hosted](/langsmith/engine-self-hosted). If you have any concerns about the data being sent, disable optional telemetry or contact your account team.
+The following commitments apply to the billing, operational, and usage telemetry described on this page. LangChain will not store sensitive information in that telemetry or share it with a third party. Log messages are filtered to only include error severity levels, and we do not capture log messages that could contain sensitive application data. Engine's use of LangSmith Intelligence is a separate data flow described in [Engine on self-hosted](/langsmith/engine-self-hosted). If you have any concerns about the data being sent, disable optional telemetry or contact your account team.

--- a/src/langsmith/self-host-egress.mdx
+++ b/src/langsmith/self-host-egress.mdx
@@ -9,9 +9,9 @@ This page only applies to customers who are not running in offline (air-gapped) 
 
 Self-hosted LangSmith stores platform data in your environment. Unless you are running in offline mode, LangSmith requires egress to `https://beacon.langchain.com` for the following:
 
-- **Billing telemetry** — License verification and subscription/usage reporting (required)
-- **Operational telemetry** — Logs, metrics, and traces for support diagnostics (optional, can be disabled)
-- **Usage telemetry** — Anonymized usage snapshots for product insights (optional, can be disabled)
+- **Billing telemetry**: License verification and subscription/usage reporting (required)
+- **Operational telemetry**: Logs, metrics, and traces for support diagnostics (optional, can be disabled)
+- **Usage telemetry**: Anonymized usage snapshots for product insights (optional, can be disabled)
 
 <Warning>
 **Egress to `https://beacon.langchain.com` is required.** Refer to the [allowlisting IP section](/langsmith/cloud#allowlisting-ip-addresses) for static IP addresses, if needed.

--- a/src/langsmith/self-host-egress.mdx
+++ b/src/langsmith/self-host-egress.mdx
@@ -7,7 +7,7 @@ sidebarTitle: Configure egress
 This page only applies to customers who are not running in offline (air-gapped) mode and assumes you are using a self-hosted LangSmith instance serving version 0.9.0 or later.
 </Info>
 
-Self-hosted LangSmith instances store all information locally and never send sensitive information outside of your network. However, unless you are running in offline mode, LangSmith requires egress to `https://beacon.langchain.com` for the following:
+Self-hosted LangSmith stores platform data in your environment. Unless you are running in offline mode, LangSmith requires egress to `https://beacon.langchain.com` for the following:
 
 - **Billing telemetry** — License verification and subscription/usage reporting (required)
 - **Operational telemetry** — Logs, metrics, and traces for support diagnostics (optional, can be disabled)
@@ -18,7 +18,7 @@ Self-hosted LangSmith instances store all information locally and never send sen
 </Warning>
 
 <Note>
-If you enable [Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine), it requires a second egress destination for model inference. See [Model inference for Engine](#model-inference-for-engine).
+If you enable [Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine), content required for model inference leaves your environment through a second egress destination. See [Model inference for Engine](#model-inference-for-engine).
 </Note>
 
 ## Billing telemetry
@@ -468,16 +468,16 @@ Disabling usage telemetry does **not** affect billing or operational telemetry. 
 
 ## Model inference for Engine
 
-This section applies only if you enable [Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine). Every other LangSmith feature runs its models either in your cluster or against model providers you configure yourself, and needs no egress beyond what this page already describes.
+This section applies only if you enable [Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine). Every other LangSmith feature runs its models either in your cluster or against model providers you configure yourself and needs no egress beyond what this page already describes.
 
-Engine does not run models in your cluster. It routes model calls to LangSmith Intelligence, a LangChain-managed zero data retention inference service, which runs models inside your cloud provider. This requires outbound HTTPS to the LangSmith Intelligence gateway — for AWS US deployments, `beacon.aws.langchain.com`.
+Engine does not run models in your cluster. For AWS US deployments, it sends model requests to LangSmith Intelligence, a LangChain-managed zero data retention (ZDR) inference service in AWS, which routes them to AWS Bedrock. Allow outbound HTTPS to `beacon.aws.langchain.com`.
 
 <Note>
 Engine is currently available for self-hosted deployments in **AWS US**. AWS EU and GCP US are coming soon, and Azure is planned. See [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region).
 </Note>
 
 <Warning>
-Add the gateway as a specific allowlist entry rather than opening general outbound access. Requests authenticate with your existing LangSmith license key; no additional model provider credentials are needed.
+Add the gateway as a specific allowlist entry rather than opening general outbound access. Requests authenticate with a short-lived license JWT obtained during LangSmith license verification. No additional model-provider credentials are needed.
 </Warning>
 
 ### What it does
@@ -486,9 +486,14 @@ Add the gateway as a specific allowlist entry rather than opening general outbou
 
 ### What we collect
 
-Each request carries the trace content, source code, and intermediate output the model needs in order to reason. That content is processed by a model running inside your cloud provider and is not stored. LangSmith Intelligence records only request metadata for billing, plus the telemetry needed to keep the service reliable.
+Each request may carry the trace content, source code, and intermediate output required for the model call. LangSmith Intelligence and AWS Bedrock process that content for inference. LangSmith Intelligence does not persist prompt or completion bodies.
 
-For how this is isolated, which platform serves the models on each cloud, and what it means for your data, see [Engine on self-hosted](/langsmith/engine-self-hosted).
+LangSmith Intelligence retains the following metadata for usage attribution and billing:
+
+- Account, workspace, and project identifiers used to attribute usage.
+- Model and token-usage metadata used for billing.
+
+For the complete data flow and model-provider commitments, see [Engine on self-hosted](/langsmith/engine-self-hosted).
 
 <Info>
 Offline (air-gapped) deployments cannot run Engine, because it has no in-cluster model to fall back on. Every other LangSmith feature continues to work offline.
@@ -496,4 +501,4 @@ Offline (air-gapped) deployments cannot run Engine, because it has no in-cluster
 
 ## Our commitment
 
-LangChain will not store any sensitive information in billing or operational telemetry. Any data collected will not be shared with a third party. Log messages are filtered to only include error severity levels, and we do not capture log messages that could contain sensitive application data. If you have any concerns about the data being sent, disable telemetry and/or reach out to your account team.
+The following commitments apply to the billing, operational, and usage telemetry described on this page. LangChain will not store sensitive information in that telemetry or share it with a third party. Log messages are filtered to only include error severity levels, and we do not capture log messages that could contain sensitive application data. Engine model inference is a separate data flow described in [Engine on self-hosted](/langsmith/engine-self-hosted). If you have any concerns about the data being sent, disable optional telemetry or contact your account team.

--- a/src/langsmith/self-host-egress.mdx
+++ b/src/langsmith/self-host-egress.mdx
@@ -17,6 +17,10 @@ Self-hosted LangSmith instances store all information locally and never send sen
 **Egress to `https://beacon.langchain.com` is required.** Refer to the [allowlisting IP section](/langsmith/cloud#allowlisting-ip-addresses) for static IP addresses, if needed.
 </Warning>
 
+<Note>
+If you enable [Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine), it requires a second egress destination for model inference. See [Model inference for Engine](#model-inference-for-engine).
+</Note>
+
 ## Billing telemetry
 
 Billing telemetry is **required** for self-hosted LangSmith instances that are not running in offline mode. This includes license verification and subscription/usage reporting.
@@ -461,6 +465,30 @@ Add this to the `commonEnv` section of your Helm configuration to permanently di
 <Warning>
 Disabling usage telemetry does **not** affect billing or operational telemetry. License verification and subscription/usage reporting will continue to function normally.
 </Warning>
+
+## Model inference for Engine
+
+This section applies only if you enable [Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine). Every other LangSmith feature runs its models either in your cluster or against model providers you configure yourself, and needs no egress beyond what this page already describes.
+
+Engine does not run models in your cluster. It routes model calls to LangSmith Intelligence, a LangChain-managed zero data retention inference service, which runs models inside your cloud provider. This requires outbound HTTPS to the LangSmith Intelligence gateway for your cloud — on AWS, `beacon.aws.langchain.com`. For other clouds, get the hostname from your account team.
+
+<Warning>
+Add the gateway as a specific allowlist entry rather than opening general outbound access. Requests authenticate with your existing LangSmith license key; no additional model provider credentials are needed.
+</Warning>
+
+### What it does
+
+- **Model inference**: Runs the LLM calls Engine makes to cluster issues, diagnose root cause, generate fixes, and write evaluators.
+
+### What we collect
+
+Each request carries the trace content, source code, and intermediate output the model needs in order to reason. That content is processed by a model running inside your cloud provider and is not stored. LangSmith Intelligence records only request metadata for billing, plus the telemetry needed to keep the service reliable.
+
+For how this is isolated, which platform serves the models on each cloud, and what it means for your data, see [Engine on self-hosted](/langsmith/engine-self-hosted).
+
+<Info>
+Offline (air-gapped) deployments cannot run Engine, because it has no in-cluster model to fall back on. Every other LangSmith feature continues to work offline.
+</Info>
 
 ## Our commitment
 

--- a/src/langsmith/self-host-egress.mdx
+++ b/src/langsmith/self-host-egress.mdx
@@ -470,7 +470,11 @@ Disabling usage telemetry does **not** affect billing or operational telemetry. 
 
 This section applies only if you enable [Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine). Every other LangSmith feature runs its models either in your cluster or against model providers you configure yourself, and needs no egress beyond what this page already describes.
 
-Engine does not run models in your cluster. It routes model calls to LangSmith Intelligence, a LangChain-managed zero data retention inference service, which runs models inside your cloud provider. This requires outbound HTTPS to the LangSmith Intelligence gateway for your cloud — on AWS, `beacon.aws.langchain.com`. For other clouds, get the hostname from your account team.
+Engine does not run models in your cluster. It routes model calls to LangSmith Intelligence, a LangChain-managed zero data retention inference service, which runs models inside your cloud provider. This requires outbound HTTPS to the LangSmith Intelligence gateway — for AWS US deployments, `beacon.aws.langchain.com`.
+
+<Note>
+Engine is currently available for self-hosted deployments in **AWS US**. AWS EU and GCP US are coming soon, and Azure is planned. See [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region).
+</Note>
 
 <Warning>
 Add the gateway as a specific allowlist entry rather than opening general outbound access. Requests authenticate with your existing LangSmith license key; no additional model provider credentials are needed.

--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -133,7 +133,7 @@ The chart does not set `images.juicefsMountImage` by default. When it is unset, 
 
 ## Additional images for Engine
 
-[Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine) runs on `langsmith-insights-engine`, which the mirroring script includes by default, and requires Sandboxes — so mirror with `--include-sandboxes` and configure the sandbox runtime image as described above.
+[Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine) runs on `langsmith-insights-engine`, which the mirroring script includes by default, and requires Sandboxes, so mirror with `--include-sandboxes` and configure the sandbox runtime image as described above.
 
 Then point the Engine and Insights image at your mirror:
 
@@ -149,7 +149,7 @@ images:
 The repository name must still end in `langsmith-insights-engine`; the chart validates it to catch installs left pointing at the retired `langsmith-clio` image, which serves only Insights.
 </Note>
 
-Engine also reaches the LangSmith Intelligence gateway for model inference, which is a network dependency rather than an image — mirroring does not remove it. See [Model inference for Engine](/langsmith/self-host-egress#model-inference-for-engine).
+Engine also reaches the LangSmith Intelligence gateway for model inference, which is a network dependency rather than an image, so mirroring does not remove it. See [Model inference for Engine](/langsmith/self-host-egress#model-inference-for-engine).
 
 ## Additional images for Fleet and Insights
 

--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -149,7 +149,7 @@ images:
 The repository name must still end in `langsmith-insights-engine`; the chart validates it to catch installs left pointing at the retired `langsmith-clio` image, which serves only Insights.
 </Note>
 
-Engine also reaches the LangSmith Intelligence gateway for model inference, which is a network dependency rather than an image, so mirroring does not remove it. See [Model inference for Engine](/langsmith/self-host-egress#model-inference-for-engine).
+Engine also depends on LangSmith Intelligence, which is a network dependency rather than an image, so mirroring does not remove it. See [LangSmith Intelligence for Engine](/langsmith/self-host-egress#langsmith-intelligence-for-engine).
 
 ## Additional images for Fleet and Insights
 

--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -131,6 +131,26 @@ images:
 
 The chart does not set `images.juicefsMountImage` by default. When it is unset, the JuiceFS CSI driver uses the `JUICEFS_CE_MOUNT_IMAGE` fallback baked into the CSI driver image. For the chart's current `docker.io/juicedata/juicefs-csi-driver:v0.31.4` default, that fallback is `juicedata/mount:ce-v1.3.1`. In private-registry or air-gapped environments, set both `images.juicefsMountImage.repository` and `images.juicefsMountImage.tag` so mount pods pull from your mirrored registry instead of the public default.
 
+## Additional images for Engine
+
+[Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine) runs on `langsmith-insights-engine`, which the mirroring script includes by default, and requires Sandboxes — so mirror with `--include-sandboxes` and configure the sandbox runtime image as described above.
+
+Then point the Engine and Insights image at your mirror:
+
+```yaml
+images:
+  engineInsightsAgentImage:
+    repository: "(your-registry)/langchain/langsmith-insights-engine"
+    pullPolicy: IfNotPresent
+    tag: "0.16.0"
+```
+
+<Note>
+The repository name must still end in `langsmith-insights-engine`; the chart validates it to catch installs left pointing at the retired `langsmith-clio` image, which serves only Insights.
+</Note>
+
+Engine also reaches the LangSmith Intelligence gateway for model inference, which is a network dependency rather than an image — mirroring does not remove it. See [Model inference for Engine](/langsmith/self-host-egress#model-inference-for-engine).
+
 ## Additional images for Fleet and Insights
 
 If you are using Fleet or Insights, the LangGraph operator dynamically creates Redis and PostgreSQL (pgvector) pods for each deployment. These pods use images defined in operator templates that require separate configuration.
@@ -251,7 +271,7 @@ A successful verification confirms:
 - The certificate chains to the Sigstore root and is logged in the [Rekor](https://docs.sigstore.dev/rekor/overview/) transparency log.
 - The signing certificate was issued to the stable-branch release workflow via GitHub Actions OIDC.
 
-The same command works against any of the released images by substituting the repository (`langsmith-frontend`, `langsmith-go-backend`, `agent-builder-deep-agent`, `langsmith-clio`, `langsmith-polly`, `agent-builder-tool-server`, `agent-builder-trigger-server`, `hosted-langserve-backend`, `langsmith-playground`, `langsmith-ace-backend`, plus their `*-fips` variants).
+The same command works against any of the released images by substituting the repository (`langsmith-frontend`, `langsmith-go-backend`, `agent-builder-deep-agent`, `langsmith-insights-engine`, `langsmith-polly`, `agent-builder-tool-server`, `agent-builder-trigger-server`, `hosted-langserve-backend`, `langsmith-playground`, `langsmith-ace-backend`, plus their `*-fips` variants).
 
 ### Pinning to a specific release
 

--- a/src/langsmith/self-host-using-an-existing-secret.mdx
+++ b/src/langsmith/self-host-using-an-existing-secret.mdx
@@ -54,6 +54,11 @@ stringData:
   insights_encryption_key: foo
   # Chat (formerly Polly)
   polly_encryption_key: foo
+  # Required only when enabling Engine.
+  engine_encryption_key: foo
+  # Optional; include only while rotating engine_encryption_key. Accepted for
+  # decryption only, so runs encrypted just before the swap still complete.
+  engine_encryption_key_previous: foo
   # Optional. Ed25519/OKP JWKS (JSON) that signs OAuth Authorization Server /
   # Remote MCP tokens. Required only to enable the LangSmith Remote MCP server
   # (see /langsmith/langsmith-remote-mcp); omit it otherwise.


### PR DESCRIPTION
## Overview
Adds the self-hosted enablement path for LangSmith Engine, which ships in
Helm chart 0.16.0 and is licensed separately, in the same way as Sandboxes.

- deploy-self-hosted-full-platform: new "Enable Engine" section covering
  components, prerequisites (Sandboxes, license entitlement, egress to the
  LangSmith Intelligence gateway, an externally reachable hostname, the
  Fernet key), Helm values, verification, the in-product steps that remain,
  and how to disable. Also adds Engine to the page title and intro.
- engine-self-hosted: replaces the "coming soon" note with the version and
  entitlement requirement, links to the enablement steps, and documents the
  fail-closed behavior when the inference gateway is unreachable.
- self-host-egress: documents the second required egress destination for
  Engine's model inference, and that offline installs cannot run Engine.
- self-host-using-an-existing-secret: adds engine_encryption_key and the
  rotation key.
- mirroring-images: adds the Engine image section and corrects the retired
  langsmith-clio reference in the signature-verification list.
- Insights now runs on the combined langsmith-insights-engine image, which
  the chart uses by default, so warn installs that still pin langsmith-clio
  to drop the pin before upgrading.

## Type of change

**Type:** New feature

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
