### PR TITLE
Point SafePrompt provider card at its LangChain integration page

### DIFF
--- a/src/oss/javascript/integrations/providers/all_providers.mdx
+++ b/src/oss/javascript/integrations/providers/all_providers.mdx
@@ -949,7 +949,7 @@ Connect LangGraph agents to front ends and observability platforms.
 
   <Card
     title="SafePrompt"
-    href="https://docs.safeprompt.dev"
+    href="https://docs.safeprompt.dev/langchain"
     icon="link"
   >
     Validate prompts for prompt injection before they reach your model.


### PR DESCRIPTION
Follow-up to #4649: the SafePrompt card linked to the docs home; this points it at the dedicated LangChain (JS) integration page (https://docs.safeprompt.dev/langchain) so click-throughs land on the SafePromptCallbackHandler docs directly.