### PR TITLE
docs(langsmith):  Update engine cloud x region docs

### DIFF
--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -1158,7 +1158,7 @@ Engine requires Sandboxes and shares a runtime with Insights:
 - **[Sandboxes](#enable-sandboxes):** Every Engine run executes in one. Enable Sandboxes first. The chart refuses to render when `engine.enabled` is set without them.
 - **[Insights](#enable-fleet-insights-and-chat):** Engine and Insights are served by the same image and share one deployment. Insights is not an Engine prerequisite. On an install that already runs Insights, enabling Engine adds configuration rather than new pods.
 
-Unlike the other features on this page, Engine cannot run entirely inside your cluster. It depends on LangSmith Intelligence, a LangChain-managed zero data retention service in AWS, and authenticates with a short-lived license JWT obtained during LangSmith license verification. See [Engine on self-hosted](/langsmith/engine-self-hosted) for the data flow and retained billing metadata.
+Unlike the other features on this page, Engine cannot run entirely inside your cluster. It depends on LangSmith Intelligence, a LangChain-managed zero data retention service, and authenticates with a short-lived license JWT obtained during LangSmith license verification. See [Engine on self-hosted](/langsmith/engine-self-hosted) for the data flow and retained billing metadata.
 
 ### Components
 
@@ -1191,7 +1191,7 @@ Engine also adds configuration to `platform-backend` and `ingest-queue`, which d
   </Step>
 
   <Step title="Allow egress to LangSmith Intelligence">
-    Allow outbound HTTPS from the cluster to the LangSmith Intelligence gateway. For AWS US deployments that host is `beacon.aws.langchain.com`, which is the value of `engine.intelligenceBaseUrl` below.
+    Allow outbound HTTPS from the cluster to the LangSmith Intelligence gateway, `beacon.aws.langchain.com`, which is the value of `engine.intelligenceBaseUrl` below.
 
     <Note>
     Engine is currently available for self-hosted deployments in **AWS US**. AWS EU and GCP US are coming soon, and Azure is planned. Check [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region) and confirm coverage with your account team before planning a rollout.

--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -1191,13 +1191,20 @@ Engine also adds configuration to `platform-backend` and `ingest-queue`, which d
   </Step>
 
   <Step title="Allow egress to LangSmith Intelligence">
-    Allow outbound HTTPS from the cluster to the LangSmith Intelligence gateway, `beacon.aws.langchain.com`, which is the value of `engine.intelligenceBaseUrl` below.
+    Allow outbound HTTPS from the cluster to the LangSmith Intelligence gateway for your cloud. This is the host in `engine.intelligenceBaseUrl` below.
+
+    | Cloud | Gateway host |
+    | --- | --- |
+    | AWS | `beacon.aws.langchain.com` |
+    | GCP | `beacon.langchain.com` |
+
+    On GCP that is the same host LangSmith already uses for license verification and billing telemetry, so Engine adds a path rather than a new egress destination.
 
     <Note>
-    Engine is currently available for self-hosted deployments in **AWS US**. AWS EU and GCP US are coming soon, and Azure is planned. Check [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region) and confirm coverage with your account team before planning a rollout.
+    Engine is currently available for self-hosted deployments in **AWS US** and **GCP US**. AWS EU and Azure are planned. Check [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region) and confirm coverage with your account team before planning a rollout.
     </Note>
 
-    Add it as a specific allowlist entry rather than opening general egress. Requests use a short-lived license JWT obtained during LangSmith license verification. This is separate from the billing and operational telemetry egress described in [Configure egress](/langsmith/self-host-egress).
+    Add the gateway as a specific allowlist entry rather than opening general egress. Requests use a short-lived license JWT obtained during LangSmith license verification. Engine's traffic is separate from the billing and operational telemetry described in [Configure egress](/langsmith/self-host-egress), even where it shares a host.
 
     <Note>
     Offline (air-gapped) installs cannot run Engine. There is no in-cluster model for it to fall back on.
@@ -1239,6 +1246,7 @@ Add the following to your [`langsmith_config.yaml`](/langsmith/kubernetes#config
 
     engine:
       enabled: true
+      # AWS; on GCP use https://beacon.langchain.com/intelligence
       intelligenceBaseUrl: "https://beacon.aws.langchain.com/intelligence"
 
     sandboxes:
@@ -1258,6 +1266,7 @@ Add the following to your [`langsmith_config.yaml`](/langsmith/kubernetes#config
 
     engine:
       enabled: true
+      # AWS; on GCP use https://beacon.langchain.com/intelligence
       intelligenceBaseUrl: "https://beacon.aws.langchain.com/intelligence"
       encryptionKey: "<engine-encryption-key>"
 

--- a/src/langsmith/engine-self-hosted.mdx
+++ b/src/langsmith/engine-self-hosted.mdx
@@ -27,11 +27,11 @@ Engine depends on LSI coverage. That coverage is expanding, so availability vari
 | Cloud | Region | Status |
 | --- | --- | --- |
 | AWS | US | Available |
-| AWS | EU | Coming soon |
-| GCP | US | Coming soon |
+| GCP | US | Available |
+| AWS | EU | Planned |
 | Azure | n/a | Planned |
 
-Contact your account team to confirm coverage for your region and for current timing. The GCP and Azure sections below describe future availability, not deployments you can enable today.
+Contact your account team to confirm coverage for your region and for current timing. The Azure section below describes future availability, not a deployment you can enable today.
 
 ## How it works
 
@@ -39,14 +39,14 @@ LSI is the LangChain-managed service that powers Engine.
 
 The flow:
 
-- Your self-hosted Engine sends an HTTPS request to `https://beacon.aws.langchain.com/intelligence`.
+- Your self-hosted Engine sends an HTTPS request to the LSI gateway for its cloud, listed in the per-cloud sections below.
 - Engine authenticates with a short-lived license JWT obtained during LangSmith license verification. You do not provide separate model-provider credentials.
 - LSI validates the JWT and routes the request to the model provider over private networking inside LangChain's environment.
 - LSI returns the response to your self-hosted Engine.
 
 Each request carries the trace content, code, and intermediate outputs Engine needs to do its work. LSI and the model provider process that content to serve the request. LSI does not persist prompt or completion bodies.
 
-Your cluster must allow outbound HTTPS to `beacon.aws.langchain.com`. This documentation does not assume that the connection from your environment to LSI uses AWS PrivateLink. If your security policy requires private connectivity, contact your account team to confirm availability and setup before enabling Engine.
+Your cluster must allow outbound HTTPS to that gateway. This documentation does not assume that the connection from your environment to LSI uses AWS PrivateLink. If your security policy requires private connectivity, contact your account team to confirm availability and setup before enabling Engine.
 
 If the connection to LSI is unavailable, Engine fails closed. There is no in-cluster model and no secondary provider to fall back on, so the affected run ends with an error rather than degrading to lower-quality output. The rest of your LangSmith deployment is unaffected, and Engine tries again on its next scheduled scan.
 
@@ -61,7 +61,7 @@ For model-provider retention and training commitments, see [Engine security](/la
 
 ### AWS (available in US)
 
-Self-hosted Engine sends its requests through the LSI gateway. LSI routes them to AWS Bedrock in LangChain's AWS environment.
+The gateway host is `beacon.aws.langchain.com`. LSI routes requests to AWS Bedrock in LangChain's AWS environment.
 
 <Frame caption="AWS: LangSmith and Engine run in your VPC; LSI and Bedrock run in LangChain's AWS environment.">
   <img
@@ -70,11 +70,15 @@ Self-hosted Engine sends its requests through the LSI gateway. LSI routes them t
   />
 </Frame>
 
-### GCP (coming soon)
+### GCP (available in US)
 
-Self-hosted Engine support on GCP is coming soon. Contact your account team for current timing. The diagram below shows the intended architecture.
+The gateway host is `beacon.langchain.com`. LSI routes requests to Vertex in LangChain's GCP environment.
 
-<Frame caption="GCP (intended): LangSmith and Engine run in your project; LSI and Vertex run in LangChain's GCP environment.">
+<Note>
+That is the same host self-hosted LangSmith already uses for license verification and billing telemetry, so a GCP deployment adds a path rather than a new egress destination. See [Configure egress](/langsmith/self-host-egress).
+</Note>
+
+<Frame caption="GCP: LangSmith and Engine run in your project; LSI and Vertex run in LangChain's GCP environment.">
   <img
     src="/langsmith/images/engine-self-hosted-gcp.png"
     alt="Architecture diagram showing a self-hosted LangSmith deployment in your GCP project connecting to LangSmith Intelligence in LangChain's cloud, which sends model inference requests to Vertex"

--- a/src/langsmith/engine-self-hosted.mdx
+++ b/src/langsmith/engine-self-hosted.mdx
@@ -18,7 +18,7 @@ Engine works with three kinds of data:
 - **Traces:** runtime data from your agents, which can include user messages, tool outputs, and PII.
 - **Model:** the LLM calls Engine makes to run diagnosis, generate fixes, and write evaluators.
 
-In a self-hosted deployment, Engine's orchestration runs inside your VPC as part of LangSmith: reading traces, reading code, and running its detect, fix, and verify loop. It cannot run entirely there, however. Engine depends on LangSmith Intelligence (LSI), a LangChain-managed zero data retention (ZDR) service hosted in AWS, and sends LSI the content it needs to do its work.
+In a self-hosted deployment, Engine's orchestration runs inside your VPC as part of LangSmith: reading traces, reading code, and running its detect, fix, and verify loop. It cannot run entirely there, however. Engine depends on LangSmith Intelligence (LSI), a LangChain-managed zero data retention (ZDR) service, and sends LSI the content it needs to do its work.
 
 ## Availability by cloud and region
 
@@ -41,10 +41,10 @@ The flow:
 
 - Your self-hosted Engine sends an HTTPS request to `https://beacon.aws.langchain.com/intelligence`.
 - Engine authenticates with a short-lived license JWT obtained during LangSmith license verification. You do not provide separate model-provider credentials.
-- LSI validates the JWT and routes the request to AWS Bedrock through private AWS networking in LangChain's environment.
+- LSI validates the JWT and routes the request to the model provider over private networking inside LangChain's environment.
 - LSI returns the response to your self-hosted Engine.
 
-Each request carries the trace content, code, and intermediate outputs Engine needs to do its work. LSI and AWS Bedrock process that content to serve the request. LSI does not persist prompt or completion bodies.
+Each request carries the trace content, code, and intermediate outputs Engine needs to do its work. LSI and the model provider process that content to serve the request. LSI does not persist prompt or completion bodies.
 
 Your cluster must allow outbound HTTPS to `beacon.aws.langchain.com`. This documentation does not assume that the connection from your environment to LSI uses AWS PrivateLink. If your security policy requires private connectivity, contact your account team to confirm availability and setup before enabling Engine.
 
@@ -100,10 +100,10 @@ Managed inference makes that possible. Because Engine always runs the model Lang
 
 ## What this means for your data
 
-In a self-hosted deployment, Engine separates data handling between your environment and LangChain's AWS environment:
+In a self-hosted deployment, Engine separates data handling between your environment and LangChain's:
 
 - **Your environment:** Engine orchestration and LangSmith-stored traces remain in your self-hosted deployment.
-- **LangChain's AWS environment:** Content Engine sends is processed by LSI and AWS Bedrock. LSI retains the billing metadata listed above, but it does not persist prompt or completion bodies.
+- **LangChain's environment:** Content Engine sends is processed by LSI and the model provider. LSI retains the billing metadata listed above, but it does not persist prompt or completion bodies.
 
 Engine's deployment-independent data handling, including zero data retention with every model provider and no use of customer data to train or fine-tune models, is described in [Engine security](/langsmith/engine-security).
 

--- a/src/langsmith/self-host-egress.mdx
+++ b/src/langsmith/self-host-egress.mdx
@@ -470,7 +470,7 @@ Disabling usage telemetry does **not** affect billing or operational telemetry. 
 
 This section applies only if you enable [Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine). LangSmith Intelligence is the LangChain-managed service that powers Engine. No other LangSmith feature depends on it, and none requires egress beyond what this page already describes.
 
-Engine cannot run entirely inside your cluster. For AWS US deployments, it sends requests to LangSmith Intelligence, a LangChain-managed zero data retention (ZDR) service in AWS, which routes them to AWS Bedrock. Allow outbound HTTPS to `beacon.aws.langchain.com`.
+Engine cannot run entirely inside your cluster. It sends requests to LangSmith Intelligence, a LangChain-managed zero data retention (ZDR) service that routes them to a model provider inside LangChain's environment. Allow outbound HTTPS to `beacon.aws.langchain.com`.
 
 <Note>
 Engine is currently available for self-hosted deployments in **AWS US**. AWS EU and GCP US are coming soon, and Azure is planned. See [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region).
@@ -486,7 +486,7 @@ Add the gateway as a specific allowlist entry rather than opening general outbou
 
 ### What we collect
 
-Each request may carry the trace content, source code, and intermediate output Engine needs to do its work. LangSmith Intelligence and AWS Bedrock process that content to serve the request. LangSmith Intelligence does not persist prompt or completion bodies.
+Each request may carry the trace content, source code, and intermediate output Engine needs to do its work. LangSmith Intelligence and the model provider process that content to serve the request. LangSmith Intelligence does not persist prompt or completion bodies.
 
 LangSmith Intelligence retains the following metadata for usage attribution and billing:
 

--- a/src/langsmith/self-host-egress.mdx
+++ b/src/langsmith/self-host-egress.mdx
@@ -470,10 +470,10 @@ Disabling usage telemetry does **not** affect billing or operational telemetry. 
 
 This section applies only if you enable [Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine). LangSmith Intelligence is the LangChain-managed service that powers Engine. No other LangSmith feature depends on it, and none requires egress beyond what this page already describes.
 
-Engine cannot run entirely inside your cluster. It sends requests to LangSmith Intelligence, a LangChain-managed zero data retention (ZDR) service that routes them to a model provider inside LangChain's environment. Allow outbound HTTPS to `beacon.aws.langchain.com`.
+Engine cannot run entirely inside your cluster. It sends requests to LangSmith Intelligence, a LangChain-managed zero data retention (ZDR) service that routes them to a model provider inside LangChain's environment. Allow outbound HTTPS to the gateway for your cloud: `beacon.aws.langchain.com` on AWS, or `beacon.langchain.com` on GCP. On GCP that is the same host this page already requires, so Engine adds a path rather than a new destination.
 
 <Note>
-Engine is currently available for self-hosted deployments in **AWS US**. AWS EU and GCP US are coming soon, and Azure is planned. See [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region).
+Engine is currently available for self-hosted deployments in **AWS US** and **GCP US**. AWS EU and Azure are planned. See [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region).
 </Note>
 
 <Warning>


### PR DESCRIPTION
## Overview

Update engine cloud x region docs

## Type of change

**Type:** Update existing documentation

## Related PRs

- #5307 (original docs), #5317 (diagrams, merged), #5318 (Azure region — open, touches a different line, no conflict)

Written by Claude (via Claude Code) on @baskaryan's behalf.