### PR TITLE
docs(langsmith): mark GCP US available and AWS EU planned

### DIFF
--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -1191,13 +1191,20 @@ Engine also adds configuration to `platform-backend` and `ingest-queue`, which d
   </Step>
 
   <Step title="Allow egress to LangSmith Intelligence">
-    Allow outbound HTTPS from the cluster to the LangSmith Intelligence gateway, `beacon.aws.langchain.com`, which is the value of `engine.intelligenceBaseUrl` below.
+    Allow outbound HTTPS from the cluster to the LangSmith Intelligence gateway for your cloud. This is the host in `engine.intelligenceBaseUrl` below.
+
+    | Cloud | Gateway host |
+    | --- | --- |
+    | AWS | `beacon.aws.langchain.com` |
+    | GCP | `beacon.langchain.com` |
+
+    On GCP that is the same host LangSmith already uses for license verification and billing telemetry, so Engine adds a path rather than a new egress destination.
 
     <Note>
-    Engine is currently available for self-hosted deployments in **AWS US**. AWS EU and GCP US are coming soon, and Azure is planned. Check [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region) and confirm coverage with your account team before planning a rollout.
+    Engine is currently available for self-hosted deployments in **AWS US** and **GCP US**. AWS EU and Azure are planned. Check [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region) and confirm coverage with your account team before planning a rollout.
     </Note>
 
-    Add it as a specific allowlist entry rather than opening general egress. Requests use a short-lived license JWT obtained during LangSmith license verification. This is separate from the billing and operational telemetry egress described in [Configure egress](/langsmith/self-host-egress).
+    Add the gateway as a specific allowlist entry rather than opening general egress. Requests use a short-lived license JWT obtained during LangSmith license verification. Engine's traffic is separate from the billing and operational telemetry described in [Configure egress](/langsmith/self-host-egress), even where it shares a host.
 
     <Note>
     Offline (air-gapped) installs cannot run Engine. There is no in-cluster model for it to fall back on.
@@ -1239,6 +1246,7 @@ Add the following to your [`langsmith_config.yaml`](/langsmith/kubernetes#config
 
     engine:
       enabled: true
+      # AWS; on GCP use https://beacon.langchain.com/intelligence
       intelligenceBaseUrl: "https://beacon.aws.langchain.com/intelligence"
 
     sandboxes:
@@ -1258,6 +1266,7 @@ Add the following to your [`langsmith_config.yaml`](/langsmith/kubernetes#config
 
     engine:
       enabled: true
+      # AWS; on GCP use https://beacon.langchain.com/intelligence
       intelligenceBaseUrl: "https://beacon.aws.langchain.com/intelligence"
       encryptionKey: "<engine-encryption-key>"
 

--- a/src/langsmith/engine-self-hosted.mdx
+++ b/src/langsmith/engine-self-hosted.mdx
@@ -27,11 +27,11 @@ Engine depends on LSI coverage. That coverage is expanding, so availability vari
 | Cloud | Region | Status |
 | --- | --- | --- |
 | AWS | US | Available |
-| AWS | EU | Coming soon |
-| GCP | US | Coming soon |
+| GCP | US | Available |
+| AWS | EU | Planned |
 | Azure | n/a | Planned |
 
-Contact your account team to confirm coverage for your region and for current timing. The GCP and Azure sections below describe future availability, not deployments you can enable today.
+Contact your account team to confirm coverage for your region and for current timing. The Azure section below describes future availability, not a deployment you can enable today.
 
 ## How it works
 
@@ -39,14 +39,14 @@ LSI is the LangChain-managed service that powers Engine.
 
 The flow:
 
-- Your self-hosted Engine sends an HTTPS request to `https://beacon.aws.langchain.com/intelligence`.
+- Your self-hosted Engine sends an HTTPS request to the LSI gateway for its cloud, listed in the per-cloud sections below.
 - Engine authenticates with a short-lived license JWT obtained during LangSmith license verification. You do not provide separate model-provider credentials.
 - LSI validates the JWT and routes the request to the model provider over private networking inside LangChain's environment.
 - LSI returns the response to your self-hosted Engine.
 
 Each request carries the trace content, code, and intermediate outputs Engine needs to do its work. LSI and the model provider process that content to serve the request. LSI does not persist prompt or completion bodies.
 
-Your cluster must allow outbound HTTPS to `beacon.aws.langchain.com`. This documentation does not assume that the connection from your environment to LSI uses AWS PrivateLink. If your security policy requires private connectivity, contact your account team to confirm availability and setup before enabling Engine.
+Your cluster must allow outbound HTTPS to that gateway. This documentation does not assume that the connection from your environment to LSI uses AWS PrivateLink. If your security policy requires private connectivity, contact your account team to confirm availability and setup before enabling Engine.
 
 If the connection to LSI is unavailable, Engine fails closed. There is no in-cluster model and no secondary provider to fall back on, so the affected run ends with an error rather than degrading to lower-quality output. The rest of your LangSmith deployment is unaffected, and Engine tries again on its next scheduled scan.
 
@@ -61,7 +61,7 @@ For model-provider retention and training commitments, see [Engine security](/la
 
 ### AWS (available in US)
 
-Self-hosted Engine sends its requests through the LSI gateway. LSI routes them to AWS Bedrock in LangChain's AWS environment.
+The gateway host is `beacon.aws.langchain.com`. LSI routes requests to AWS Bedrock in LangChain's AWS environment.
 
 <Frame caption="AWS: LangSmith and Engine run in your VPC; LSI and Bedrock run in LangChain's AWS environment.">
   <img
@@ -70,11 +70,15 @@ Self-hosted Engine sends its requests through the LSI gateway. LSI routes them t
   />
 </Frame>
 
-### GCP (coming soon)
+### GCP (available in US)
 
-Self-hosted Engine support on GCP is coming soon. Contact your account team for current timing. The diagram below shows the intended architecture.
+The gateway host is `beacon.langchain.com`. LSI routes requests to Vertex in LangChain's GCP environment.
 
-<Frame caption="GCP (intended): LangSmith and Engine run in your project; LSI and Vertex run in LangChain's GCP environment.">
+<Note>
+That is the same host self-hosted LangSmith already uses for license verification and billing telemetry, so a GCP deployment adds a path rather than a new egress destination. See [Configure egress](/langsmith/self-host-egress).
+</Note>
+
+<Frame caption="GCP: LangSmith and Engine run in your project; LSI and Vertex run in LangChain's GCP environment.">
   <img
     src="/langsmith/images/engine-self-hosted-gcp.png"
     alt="Architecture diagram showing a self-hosted LangSmith deployment in your GCP project connecting to LangSmith Intelligence in LangChain's cloud, which sends model inference requests to Vertex"

--- a/src/langsmith/self-host-egress.mdx
+++ b/src/langsmith/self-host-egress.mdx
@@ -470,10 +470,10 @@ Disabling usage telemetry does **not** affect billing or operational telemetry. 
 
 This section applies only if you enable [Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine). LangSmith Intelligence is the LangChain-managed service that powers Engine. No other LangSmith feature depends on it, and none requires egress beyond what this page already describes.
 
-Engine cannot run entirely inside your cluster. It sends requests to LangSmith Intelligence, a LangChain-managed zero data retention (ZDR) service that routes them to a model provider inside LangChain's environment. Allow outbound HTTPS to `beacon.aws.langchain.com`.
+Engine cannot run entirely inside your cluster. It sends requests to LangSmith Intelligence, a LangChain-managed zero data retention (ZDR) service that routes them to a model provider inside LangChain's environment. Allow outbound HTTPS to the gateway for your cloud: `beacon.aws.langchain.com` on AWS, or `beacon.langchain.com` on GCP. On GCP that is the same host this page already requires, so Engine adds a path rather than a new destination.
 
 <Note>
-Engine is currently available for self-hosted deployments in **AWS US**. AWS EU and GCP US are coming soon, and Azure is planned. See [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region).
+Engine is currently available for self-hosted deployments in **AWS US** and **GCP US**. AWS EU and Azure are planned. See [Availability by cloud and region](/langsmith/engine-self-hosted#availability-by-cloud-and-region).
 </Note>
 
 <Warning>


### PR DESCRIPTION
## Overview

Corrects the Engine self-hosted availability table — GCP US is available today, and AWS EU is planned rather than imminent — and follows the consequences through the pages that assumed AWS was the only option.

| Cloud | Region | Status |
| --- | --- | --- |
| AWS | US | Available |
| GCP | US | Available |
| AWS | EU | Planned |
| Azure | n/a | Planned |

## Why this touches more than the table

GCP US uses a different LSI gateway, `beacon.langchain.com`, and several pages hard-coded the AWS host as though it were the only one:

- **Request flow** and the **egress prerequisite** now point at "the gateway for your cloud", with a per-cloud table where operators need the value.
- **The GCP section** gains its host and names Vertex as the provider, and drops the "intended architecture" framing now that it is real.
- **Both Helm examples** note the GCP value alongside the AWS default, so nobody copies the wrong `engine.intelligenceBaseUrl`.
- **Availability notes** on the egress and enablement pages now read "AWS US and GCP US. AWS EU and Azure are planned."

## Worth knowing

On GCP the gateway is `beacon.langchain.com` — the same host self-hosted LangSmith already contacts for license verification and billing telemetry. So a GCP deployment adds a *path*, not a new egress destination. That is called out on all three pages, because an operator sizing firewall changes would otherwise plan for a second destination that does not exist.

I also reworded two sentences that no longer held: "Add **it** as a specific allowlist entry" was ambiguous with two hosts, and "this is separate from the billing and operational telemetry egress" now says "separate ... even where it shares a host."

## Stacked on #5324

Based on `bagatur/lsi-deemphasize-aws` because it edits the same lines. GitHub will retarget this to `main` when #5324 merges. **#5318** also edits this table (the Azure Region cell) and will need a trivial rebase whichever way these land — merging #5318 first is the simplest order.

## Type of change

**Type:** Update existing documentation

Written by Claude (via Claude Code) on @baskaryan's behalf.