### PR TITLE
docs(engine): add GitHub setup guide

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -2353,6 +2353,7 @@
             "pages": [
               "langsmith/engine-overview",
               "langsmith/engine",
+              "langsmith/engine-github",
               "langsmith/engine-issue-categories",
               "langsmith/engine-webhooks",
               "langsmith/engine-security",

--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -1326,7 +1326,7 @@ Enabling Engine in Helm makes the feature available; it does not start any scans
 1. An [Organization Admin](/langsmith/rbac#organization-admin) turns Engine on for the organization under **Settings > Engine enablement**.
 2. Any user sets Engine up for a tracing project from the project's **Engine** tab.
 
-Connecting a GitHub repository is optional and improves Engine's diagnosis and fixes. Without one, Engine still detects and diagnoses issues and proposes prompt fixes, but it cannot read your source code or open pull requests. Repository connection depends on a GitHub App registered against `host-backend`, which the chart does not yet expose as Helm values. Contact technical support through the [Support Portal](https://support.langchain.com) to set it up.
+Connecting a GitHub repository is optional and improves Engine's diagnosis and fixes. Without one, Engine still detects and diagnoses issues and proposes prompt fixes, but it cannot read your source code or open pull requests. To create the GitHub App and configure `host-backend`, see [Connect Engine to GitHub](/langsmith/engine-github#self-hosted).
 
 ### Disable Engine
 

--- a/src/langsmith/engine-github.mdx
+++ b/src/langsmith/engine-github.mdx
@@ -1,0 +1,154 @@
+---
+title: Connect LangSmith Engine to GitHub
+sidebarTitle: GitHub setup
+description: Connect LangSmith Engine to GitHub in LangSmith Cloud, or create and configure your own GitHub App for a self-hosted deployment.
+---
+
+LangSmith Engine reads your source code to diagnose issues and opens pull requests with proposed fixes. It connects to GitHub through a GitHub App. This page covers connecting repositories in LangSmith Cloud and configuring your own GitHub App for a self-hosted deployment.
+
+## LangSmith Cloud
+
+In LangSmith Cloud, Engine connects through a LangChain-managed GitHub App. You do not create or configure an app yourself.
+
+To connect your repositories:
+
+1. In the [LangSmith console](https://smith.langchain.com), open a tracing project and go to the **Engine** tab.
+2. Under **Connect your agent's code repository**, click **Connect GitHub** and authorize the LangChain-managed GitHub App.
+3. Install the app on the repositories Engine should access. Installing the app on a GitHub organization may require approval from a GitHub organization owner. If you are not an owner, GitHub sends the owner an installation request to approve before the app becomes available.
+4. Select the connected repository in the **GitHub Repository** field on the **Engine** tab.
+
+For the access and retention model of the managed app, see [Engine security](/langsmith/engine-security#github-integration).
+
+## Self-hosted
+
+In a self-hosted deployment, you create and manage your own GitHub App and pass its credentials to the LangSmith Helm chart.
+
+### Create a GitHub App
+
+<Steps>
+  <Step title="Create the app">
+    Go to [GitHub Settings > Developer settings > GitHub Apps](https://github.com/settings/apps) and click **New GitHub App**.
+
+    - **GitHub App name**: Any unique name, for example `acme-langsmith-engine`.
+    - **Homepage URL**: Your LangSmith deployment URL, for example `https://langsmith.example.com`.
+    - **Where can this GitHub App be installed?**: For most self-hosted deployments, select **Only on this account**. Select **Any account** only if you intend to distribute the app.
+  </Step>
+
+  <Step title="Set the callback URL">
+    Add the following **Callback URL**, replacing `<langsmith-host>` with your LangSmith hostname:
+
+    ```
+    https://<langsmith-host>/api-host/v1/integrations/forge/github/callback
+    ```
+  </Step>
+
+  <Step title="Set the webhook URL and secret">
+    Generate a random webhook secret of at least 32 bytes with your secret manager or another cryptographically secure generator. Use the same value in GitHub and your LangSmith secret store.
+
+    Under **Webhook**, select **Active** and set the **Webhook URL**, replacing `<langsmith-host>` with your LangSmith hostname:
+
+    ```
+    https://<langsmith-host>/api-host/v1/integrations/forge/github/webhook
+    ```
+
+    Paste the generated value into **Webhook secret**.
+  </Step>
+
+  <Step title="Set repository permissions">
+    Under **Permissions > Repository permissions**, grant the following:
+
+    - **Contents**: Read and write.
+    - **Pull requests**: Read and write.
+    - **Metadata**: Read-only (automatically selected).
+
+    Under **Subscribe to events**, select no events. Engine does not require any event subscriptions.
+  </Step>
+
+  <Step title="Create the app and gather its values">
+    Click **Create GitHub App**. GitHub supplies the following values on the app settings page:
+
+    | Value | Where to find it | Environment variable |
+    |-------|------------------|----------------------|
+    | **App ID** | Numeric, at the top of the page | `FORGE_GITHUB_APP_ID` |
+    | **Public link** | For example, `https://github.com/apps/acme-langsmith-engine` | `FORGE_GITHUB_APP_PUBLIC_LINK` |
+    | **Client ID** | Under **About** | `FORGE_GITHUB_CLIENT_ID` |
+    | **Client secret** | Under **Client secrets**, click **Generate a new client secret** (shown once) | `FORGE_GITHUB_CLIENT_SECRET` |
+    | **Private key** | Under **Private keys**, click **Generate a private key** (downloads a `.pem` file) | `FORGE_GITHUB_APP_PEM` |
+  </Step>
+
+  <Step title="Generate a state JWT secret">
+    LangSmith signs short-lived OAuth state tokens with an HMAC key. Generate a random secret of at least 32 bytes with your secret manager or another cryptographically secure generator. GitHub does not provide this value.
+
+    This is `FORGE_GITHUB_STATE_JWT_SECRET`. Generate it separately, and do not reuse the webhook secret or any other credential.
+  </Step>
+
+  <Step title="Create a Kubernetes Secret">
+    With your existing secret-management workflow, create a Kubernetes Secret named `langsmith-forge-github` with these keys:
+
+    | Key | Value |
+    |-----|-------|
+    | `forge_github_client_secret` | GitHub client secret |
+    | `forge_github_state_jwt_secret` | Separately generated state JWT secret |
+    | `forge_github_app_pem` | Contents of the GitHub App private-key PEM |
+    | `forge_github_webhook_secret` | Webhook secret also configured in GitHub |
+
+    Do not put these values in Helm values or command-line arguments. For production deployments, use your existing secrets workflow, such as [Sealed Secrets](https://github.com/bitnami-labs/sealed-secrets) or [External Secrets Operator](https://external-secrets.io/). See [Use an existing secret](/langsmith/self-host-using-an-existing-secret) for more.
+  </Step>
+
+  <Step title="Add the configuration to your langsmith_config.yaml">
+    Add the following to `hostBackend.deployment.extraEnv` in your [`langsmith_config.yaml`](/langsmith/kubernetes#configure-your-helm-charts). Reference the sensitive values with `secretKeyRef`; never set them through `commonEnv` or as inline values:
+
+    ```yaml
+    hostBackend:
+      deployment:
+        extraEnv:
+          - name: FORGE_GITHUB_APP_ID
+            value: "<app-id>"
+          - name: FORGE_GITHUB_APP_PUBLIC_LINK
+            value: "https://github.com/apps/<app-slug>"
+          - name: FORGE_GITHUB_CLIENT_ID
+            value: "<client-id>"
+          - name: FORGE_GITHUB_CLIENT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: langsmith-forge-github
+                key: forge_github_client_secret
+          - name: FORGE_GITHUB_STATE_JWT_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: langsmith-forge-github
+                key: forge_github_state_jwt_secret
+          - name: FORGE_GITHUB_APP_PEM
+            valueFrom:
+              secretKeyRef:
+                name: langsmith-forge-github
+                key: forge_github_app_pem
+          - name: FORGE_GITHUB_WEBHOOK_SECRET
+            valueFrom:
+              secretKeyRef:
+                name: langsmith-forge-github
+                key: forge_github_webhook_secret
+    ```
+
+    Then apply the updated chart:
+
+    ```bash
+    helm upgrade -i langsmith langchain/langsmith --values langsmith_config.yaml --version <version> -n <namespace> --wait --debug
+    ```
+  </Step>
+
+  <Step title="Install the app on repositories">
+    Once pods are healthy, install the GitHub App on the repositories Engine should access:
+
+    1. Open the app's public link (`FORGE_GITHUB_APP_PUBLIC_LINK`) and click **Install**, or open **Settings > Applications > GitHub Apps** in your GitHub organization.
+    2. Select the repositories Engine should access. If the installation does not grant access to all repositories, explicitly select each private repository Engine needs.
+    3. In LangSmith, open a tracing project, go to the **Engine** tab, and select the repository in the **GitHub Repository** field.
+  </Step>
+</Steps>
+
+## See also
+
+- [Find and fix your agent's issues](/langsmith/engine): Engine setup, costs, and the issue workflow.
+- [Engine on self-hosted](/langsmith/engine-self-hosted): Self-hosted architecture and data handling.
+- [Engine security](/langsmith/engine-security): How Engine handles your data and GitHub access.
+- [Enable Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine): Enable Engine in the LangSmith Helm chart.

--- a/src/langsmith/engine-self-hosted.mdx
+++ b/src/langsmith/engine-self-hosted.mdx
@@ -10,7 +10,7 @@ Self-hosted Engine requires LangSmith Helm chart `0.16.0` or later and a license
 
 LangSmith Engine is an agent within LangSmith that monitors your production traces, clusters them into issues, diagnoses each issue against your source code, proposes a fix as a PR, and identifies ground truth evals to add to your datasets. For a product overview, see [Engine](/langsmith/engine-overview).
 
-This page explains how Engine runs in a self-hosted deployment, what it depends on outside your environment, and what that means for your data. To install it, see [Enable Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine).
+This page explains how Engine runs in a self-hosted deployment, what it depends on outside your environment, and what that means for your data. To install it, see [Enable Engine](/langsmith/deploy-self-hosted-full-platform#enable-engine). To connect it to your source code, create and configure your own GitHub App as described in [Connect Engine to GitHub](/langsmith/engine-github).
 
 Engine works with three kinds of data:
 
@@ -114,6 +114,7 @@ Engine's deployment-independent data handling, including zero data retention wit
 ## See also
 
 - [Enable Engine on self-hosted](/langsmith/deploy-self-hosted-full-platform#enable-engine)
+- [Connect Engine to GitHub](/langsmith/engine-github)
 - [Engine](/langsmith/engine-overview)
 - [Configure Engine](/langsmith/engine)
 - [Engine security](/langsmith/engine-security)

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -92,7 +92,7 @@ To monitor usage, you can view your organization's monthly LCU spend on the **En
     In the [LangSmith console](https://smith.langchain.com), navigate to **Tracing** in the UI sidebar, select a project, then click the **Engine** tab in the project navigation.
   </Step>
   <Step title="Connect a code repository (optional)">
-    Although optional, connecting a code repository is recommended. Engine reads your source code to locate the code path behind a failing trace, ground its proposed fixes in the actual implementation, and open pull requests directly from issues. Under **Connect your agent's code repository**, select a repository in the **GitHub Repository** field. Only repositories the GitHub app can access are shown. Click **Manage app access →** to update permissions. To give Engine additional project context, select a repository in the **Context Hub repository** field. You can update either repository at any time from the [**Engine Settings**](#configure-engine) panel.
+    Although optional, connecting a code repository is recommended. Engine reads your source code to locate the code path behind a failing trace, ground its proposed fixes in the actual implementation, and open pull requests directly from issues. Under **Connect your agent's code repository**, select a repository in the **GitHub Repository** field. Only repositories the GitHub app can access are shown. Click **Manage app access →** to update permissions. For GitHub App setup and organization approval, see [Connect Engine to GitHub](/langsmith/engine-github). To give Engine additional project context, select a repository in the **Context Hub repository** field. You can update either repository at any time from the [**Engine Settings**](#configure-engine) panel.
   </Step>
   <Step title="Select preference categories (optional)">
     Under **What matters most to you?**, select categories to prioritize for your review (for example, **Tool Call Failures** or **Latency**). Click **+ Add something specific** to describe a custom concern. You can update **Preferences** at any time from the [**Engine Settings**](#configure-engine) panel.
@@ -272,7 +272,7 @@ Within a tracing project, click the **Engine Settings** <Icon icon="settings"/> 
 - **Engine spend**: View the month-to-date Engine LCU spend for this project. Click **Set limit** to cap monthly spend. New runs pause when the monthly limit is reached.
 - **Focus on specific traces**: Narrow Engine's attention to a subset of runs by run name or metadata. Edits save automatically and take effect on the next scan. See [Focus on specific traces](#focus-on-specific-traces).
 - **Notifications**: Click **Add destination** to add a Slack channel or webhook destination that receives a notification when Engine detects a new issue. Set a minimum priority level per destination to control which issues trigger a notification. See [Get notified about new issues](#get-notified-about-new-issues).
-- **Code repository**: Connect or update a GitHub repository so the agent can reference source code when diagnosing issues. Optionally set a **Subfolder** and a **Branch** (defaults to the repository default).
+- **Code repository**: Connect or update a GitHub repository so the agent can reference source code when diagnosing issues. Optionally set a **Subfolder** and a **Branch** (defaults to the repository default). For setup, see [Connect Engine to GitHub](/langsmith/engine-github).
 - **Context repository**: Connect a Context Hub repository so Engine can propose fixes to instructions, docs, and linked skills.
 - **Pause**: Engine scans your traces every 6 hours by default. Click **Pause** to stop scanning without deleting the existing issues, or **Resume** to resume scanning.
 - **Delete all issues**: This action cannot be undone. All issues and settings will be permanently removed.
@@ -280,6 +280,7 @@ Within a tracing project, click the **Engine Settings** <Icon icon="settings"/> 
 ## See also
 
 - [Engine](/langsmith/engine-overview): Product overview and where Engine fits in the development lifecycle.
+- [Connect Engine to GitHub](/langsmith/engine-github): Connect repositories in LangSmith Cloud, or create and configure your own GitHub App for a self-hosted deployment.
 - [Engine issue categories](/langsmith/engine-issue-categories): Reference for the failure categories Engine assigns to detected issues.
 - [Engine webhook events](/langsmith/engine-webhooks): Event payload reference, signing-secret verification, and delivery semantics.
 - [Engine on self-hosted](/langsmith/engine-self-hosted): Self-hosted architecture and data handling.


### PR DESCRIPTION
## What

Add one guide for connecting Engine to GitHub in LangSmith Cloud and self-hosted deployments. Link it from the Engine and self-hosted setup documentation.

## Why

Cloud uses the LangChain-managed GitHub App, while self-hosted operators must create and configure their own app. The existing docs did not explain the self-hosted setup and incorrectly directed users to support.

## How

- Document the callback, webhook, repository permissions, and installation flow.
- Separate GitHub-provided values from the state and webhook secrets operators generate.
- Keep sensitive values in a Kubernetes Secret referenced from `hostBackend.deployment.extraEnv`.
- Pair with the in-product setup link in [langchain-ai/langchainplus#33090](https://github.com/langchain-ai/langchainplus/pull/33090).

## Testing

- [x] `python3 -m json.tool src/docs.json`
- [x] `make lint_prose VALE_BIN=/opt/homebrew/bin/vale FILES="src/langsmith/engine-github.mdx src/langsmith/engine.mdx src/langsmith/engine-self-hosted.mdx src/langsmith/deploy-self-hosted-full-platform.mdx"`
