### PR TITLE
Add store integrations page, list langgraph-store-upstash

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -508,6 +508,7 @@
                           "oss/python/integrations/sandboxes/index",
                           "oss/python/integrations/backends/index",
                           "oss/python/integrations/checkpointers/index",
+                          "oss/python/integrations/long-term-memory/index",
                           "oss/python/integrations/retrievers/index",
                           "oss/python/integrations/splitters/index",
                           "oss/python/integrations/embeddings/index",

--- a/src/oss/langgraph/stores.mdx
+++ b/src/oss/langgraph/stores.mdx
@@ -20,7 +20,7 @@ When using the [Agent Server](/langsmith/agent-server), you do not need to imple
 </Info>
 
 <Note>
-@[InMemoryStore] is suitable for development and testing. For production, use a persistent store like `PostgresStore`, `MongoDBStore`, or `RedisStore`. All implementations extend @[BaseStore], which is the type annotation to use in node function signatures.
+@[InMemoryStore] is suitable for development and testing. For production, use a persistent store like `PostgresStore`, `MongoDBStore`, `RedisStore`, or `UpstashStore`. All implementations extend @[BaseStore], which is the type annotation to use in node function signatures. See [store integrations](/oss/integrations/long-term-memory/index) for the full list of available providers.
 </Note>
 
 ## Basic usage

--- a/src/oss/langgraph/stores.mdx
+++ b/src/oss/langgraph/stores.mdx
@@ -20,8 +20,14 @@ When using the [Agent Server](/langsmith/agent-server), you do not need to imple
 </Info>
 
 <Note>
-@[InMemoryStore] is suitable for development and testing. For production, use a persistent store like `PostgresStore`, `MongoDBStore`, `RedisStore`, or `UpstashStore`. All implementations extend @[BaseStore], which is the type annotation to use in node function signatures. See [store integrations](/oss/integrations/long-term-memory/index) for the full list of available providers.
+@[InMemoryStore] is suitable for development and testing. For production, use a persistent store like `PostgresStore`, `MongoDBStore`, `RedisStore`, or `UpstashStore`. All implementations extend @[BaseStore], which is the type annotation to use in node function signatures.
 </Note>
+
+:::python
+<Note>
+See [store integrations](/oss/integrations/long-term-memory/index) for the full list of available providers.
+</Note>
+:::
 
 ## Basic usage
 

--- a/src/oss/python/integrations/long-term-memory/index.mdx
+++ b/src/oss/python/integrations/long-term-memory/index.mdx
@@ -1,0 +1,17 @@
+---
+title: "Store integrations"
+sidebarTitle: Stores
+description: "Integrate with store backends for LangGraph long-term memory."
+---
+
+Stores enable [long-term memory](/oss/langgraph/stores) in LangGraph, allowing agents to persist and retrieve information across threads.
+
+To implement your own store for a custom storage backend, see [Build a custom store](/oss/langgraph/stores#build-a-custom-store).
+
+| Backend | Package | Source |
+|---------|---------|--------|
+| [In-memory](https://reference.langchain.com/python/langgraph.store/memory/InMemoryStore) | [`langgraph-checkpoint`](https://pypi.org/project/langgraph-checkpoint/) | [langchain-ai/langgraph](https://github.com/langchain-ai/langgraph/tree/main/libs/checkpoint) |
+| [PostgreSQL](https://reference.langchain.com/python/langgraph.store.postgres/PostgresStore) | [`langgraph-checkpoint-postgres`](https://pypi.org/project/langgraph-checkpoint-postgres/) | [langchain-ai/langgraph](https://github.com/langchain-ai/langgraph/tree/main/libs/checkpoint-postgres) |
+| Redis | [`langgraph-checkpoint-redis`](https://pypi.org/project/langgraph-checkpoint-redis/) | [redis-developer/langgraph-redis](https://github.com/redis-developer/langgraph-redis) |
+| MongoDB | [`langgraph-store-mongodb`](https://pypi.org/project/langgraph-store-mongodb/) | [langchain-ai/langchain-mongodb](https://github.com/langchain-ai/langchain-mongodb/tree/main/libs/langgraph-store-mongodb) |
+| Upstash Redis | [`langgraph-store-upstash`](https://pypi.org/project/langgraph-store-upstash/) | [Tghez/langgraph-store-upstash](https://github.com/Tghez/langgraph-store-upstash) |


### PR DESCRIPTION
## Summary

- `/oss/python/integrations/stores` documents `langchain_core`'s `ByteStore` interface (`mget`/`mset`/`mdelete`), not LangGraph's `BaseStore` (`get`/`put`/`search`/`list_namespaces`). There wasn't a catalog page for LangGraph store backends at all -- only an inline mention of `PostgresStore`/`MongoDBStore`/`RedisStore` in `oss/langgraph/stores.mdx`'s note, unlike checkpointers, which has a dedicated table at `oss/python/integrations/checkpointers/index.mdx`.
- Adds an analogous page at `oss/python/integrations/long-term-memory/index.mdx` (named to avoid colliding with the existing `integrations/stores/` path), mirroring the checkpointers page's `Backend | Package | Source` table format and wired into `src/docs.json`'s nav right next to it.
- Lists the existing backends (in-memory, Postgres, Redis, MongoDB) plus a new entry for [`langgraph-store-upstash`](https://github.com/Tghez/langgraph-store-upstash) ([PyPI](https://pypi.org/project/langgraph-store-upstash/)), a `BaseStore` implementation backed by Upstash Redis's REST client, for serverless/edge runtimes that can't hold a TCP connection open.
- Updates the note at the top of `stores.mdx` to mention `UpstashStore` alongside the others and link to the new integrations page.

## Notes for maintainers

- I named the new directory `long-term-memory` rather than `stores` since that path is already taken by the (differently-scoped) ByteStore page. Happy to rename if you have a preferred slug.
- Package/source links were verified against each project's actual PyPI listing rather than assumed from the checkpointer package names -- e.g. MongoDB's store ships as a separate `langgraph-store-mongodb` package (not bundled into `langgraph-checkpoint-mongodb`), while Redis's store is bundled into `langgraph-checkpoint-redis`.

## Test plan

- [x] Validated `src/docs.json` is well-formed JSON after the nav edit
- [x] Verified every new external link (PyPI packages, reference.langchain.com API pages) resolves with a 200
- [ ] Maintainer review of the new page's placement/naming in the nav