### PR TITLE
Add langgraph-store-upstash to external stores listing

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -1144,6 +1144,9 @@ python:
   - name: TypeDBStore
     pypi: langgraph-store-typedb
     docs_url: https://typedb.com/docs
+  - name: UpstashStore
+    pypi: langgraph-store-upstash
+    docs_url: https://github.com/Tghez/langgraph-store-upstash
   chat_message_histories:
   - name: M3ChatMessageHistory
     pypi: m3-memory


### PR DESCRIPTION
## Summary

Adds `langgraph-store-upstash` to the `python.stores` section of `scripts/data/integration_external_docs.yaml`, following the [current integration submission process](https://docs.langchain.com/oss/python/contributing/publish-langchain#make-your-integration-discoverable) for packages under 50,000 monthly downloads.

[`langgraph-store-upstash`](https://github.com/Tghez/langgraph-store-upstash) ([PyPI](https://pypi.org/project/langgraph-store-upstash/)) is a LangGraph `BaseStore` implementation backed by Upstash Redis's REST client -- for serverless/edge runtimes that can't hold a TCP connection open. Same pattern as the existing `TypeDBStore` / `langgraph-store-typedb` entry already in this section.

## Test plan

- [x] Validated the YAML parses correctly
- [x] Ran `refresh_integration_downloads.validate_external_docs_urls()` locally against the change -- no errors
- [x] `docs_url` points to the package's GitHub repo (no dedicated partner docs site exists yet), matching this file's documented link-priority convention

## Related

Related to #5333, which adds a full LangGraph store integrations guide page -- this PR is the separate lightweight listing per the updated submission process referenced above.