### PR TITLE
docs: warn against trailing slash in LANGSMITH_ENDPOINT

### DIFF
--- a/src/langsmith/cicd-pipeline-example.mdx
+++ b/src/langsmith/cicd-pipeline-example.mdx
@@ -340,7 +340,7 @@ For LangSmith API operations (traces, evaluations, datasets):
 For self-hosted LangSmith instances, use `http(s)://<langsmith-url>/api` where `<langsmith-url>` is your self-hosted instance URL.
 
 <Note>
-If you're setting the endpoint in the `LANGSMITH_ENDPOINT` environment variable, you need to add `/v1` at the end (e.g., `https://api.smith.langchain.com/v1` or `http(s)://<langsmith-url>/api/v1` if self-hosted).
+If you're setting the endpoint in the `LANGSMITH_ENDPOINT` environment variable, use the full API URL without a trailing slash (e.g., `https://api.smith.langchain.com` or `http(s)://<langsmith-url>/api` if self-hosted). A trailing slash can cause authentication errors with some endpoints.
 </Note>
 
 #### LangSmith Deployment API (Deployments)

--- a/src/langsmith/deploy-standalone-server.mdx
+++ b/src/langsmith/deploy-standalone-server.mdx
@@ -70,7 +70,7 @@ Do not run standalone servers in serverless environments. Scale-to-zero may caus
         </Tip>
   3. `LANGSMITH_API_KEY`: LangSmith API key.
   4. `LANGGRAPH_CLOUD_LICENSE_KEY`: LangSmith license key. This will be used to authenticate ONCE at server start up.
-  5. `LANGSMITH_ENDPOINT`: To send traces to a [self-hosted LangSmith](/langsmith/self-hosted) instance, set `LANGSMITH_ENDPOINT` to the hostname of the self-hosted LangSmith instance.
+  5. `LANGSMITH_ENDPOINT`: To send traces to a [self-hosted LangSmith](/langsmith/self-hosted) instance, set `LANGSMITH_ENDPOINT` to the hostname of the self-hosted LangSmith instance. Do not add a trailing slash to the URL, as this can cause authentication errors.
 4. Egress to `https://beacon.langchain.com` from your network. This is required for license verification and usage reporting if not running in air-gapped mode. See the [Egress documentation](/langsmith/self-host-egress) for more details.
 
 <a id="helm"></a>

--- a/src/langsmith/observability-quickstart.mdx
+++ b/src/langsmith/observability-quickstart.mdx
@@ -68,7 +68,7 @@ This example uses OpenAI as the LLM provider. You can adapt it for your own prov
 
     <SaasRegionUrls prefix="api.smith" />
 
-    For example, EU accounts: `export LANGSMITH_ENDPOINT="https://eu.api.smith.langchain.com"`.
+    For example, EU accounts: `export LANGSMITH_ENDPOINT="https://eu.api.smith.langchain.com"`. Do not add a trailing slash to the URL, as this can cause authentication errors.
     </Note>
 
     If you are using Anthropic, use the [Anthropic wrapper](/langsmith/trace-anthropic). If you are using Google Gemini, use the [Gemini wrapper](/langsmith/trace-with-google-gemini). For other providers, use the [`@traceable` decorator](/langsmith/annotate-code#use-%40traceable-%2F-traceable) to trace calls manually.

--- a/src/langsmith/trace-with-langchain.mdx
+++ b/src/langsmith/trace-with-langchain.mdx
@@ -51,7 +51,7 @@ If your account is in a region other than US (the default), also set `LANGSMITH_
 
 <SaasRegionUrls prefix="api.smith" />
 
-For example, EU accounts: `export LANGSMITH_ENDPOINT="https://eu.api.smith.langchain.com"`.
+For example, EU accounts: `export LANGSMITH_ENDPOINT="https://eu.api.smith.langchain.com"`. Do not add a trailing slash to the URL, as this can cause authentication errors.
 </Note>
 
 <Info>

--- a/src/langsmith/trace-with-langgraph.mdx
+++ b/src/langsmith/trace-with-langgraph.mdx
@@ -55,7 +55,7 @@ If your account is in a region other than US (the default), also set `LANGSMITH_
 
 <SaasRegionUrls prefix="api.smith" />
 
-For example, EU accounts: `export LANGSMITH_ENDPOINT="https://eu.api.smith.langchain.com"`.
+For example, EU accounts: `export LANGSMITH_ENDPOINT="https://eu.api.smith.langchain.com"`. Do not add a trailing slash to the URL, as this can cause authentication errors.
 </Note>
 
 <Info>
@@ -258,7 +258,7 @@ If your account is in a region other than US (the default), also set `LANGSMITH_
 
 <SaasRegionUrls prefix="api.smith" />
 
-For example, EU accounts: `export LANGSMITH_ENDPOINT="https://eu.api.smith.langchain.com"`.
+For example, EU accounts: `export LANGSMITH_ENDPOINT="https://eu.api.smith.langchain.com"`. Do not add a trailing slash to the URL, as this can cause authentication errors.
 </Note>
 
 <Info>


### PR DESCRIPTION
Fixes #478. Users following documentation examples that add a trailing slash to LANGSMITH_ENDPOINT URLs encounter authentication errors when using Docker deployments. Updated all LANGSMITH_ENDPOINT documentation to explicitly warn against adding trailing slashes, which can cause auth endpoint resolution failures.

## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
