### PR TITLE
docs: list DeepKeep middleware integration

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -603,6 +603,10 @@ python:
     docs_url: https://github.com/cisco-ai-defense/ai-defense-langchain-middleware
     available: Runtime security inspection
     source: "[`cisco-ai-defense/ai-defense-langchain-middleware`](https://github.com/cisco-ai-defense/ai-defense-langchain-middleware)"
+  - name: DeepKeepMiddleware
+    pypi: langchain-deepkeep
+    docs_url: https://pypi.org/project/langchain-deepkeep/
+    available: DeepKeep AI Firewall pre-moderation and post-moderation for LangChain agents.
   - name: Tessera
     pypi: tessera-mesh
     docs_url: https://github.com/kenithphilip/Tessera


### PR DESCRIPTION
## Summary
- List DeepKeepMiddleware in the Python middleware integrations download table.
- Link the listing to the published langchain-deepkeep PyPI package.
- Follow the default discoverability path for integrations without hosted-guide eligibility.

## Testing
- python -m pytest tests/unit_tests/test_refresh_integration_downloads.py`n- Published and verified langchain-deepkeep==0.2.0 on PyPI