### PR TITLE
Add langchain-pdf-inspector document loader integration

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -974,3 +974,7 @@ packages:
   repo: thalam-ai/langchain-thalam
   js: "n/a"
   downloads: 66
+- name: langchain-pdf-inspector
+  name_title: pdf-inspector
+  repo: undacmic/langchain-pdf-inspector
+  js: "n/a"

--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -1181,6 +1181,9 @@ python:
   - name: AnakinLoader
     pypi: langchain-anakin
     docs_url: https://anakin.io/docs/documentation
+  - name: PdfInspectorLoader
+    pypi: langchain-pdf-inspector
+    docs_url: https://github.com/undacmic/langchain-pdf-inspector
   document_transformers:
   - name: HighSNRDocumentTransformer
     pypi: langchain-highsnr

--- a/src/oss/python/integrations/document_loaders/index.mdx
+++ b/src/oss/python/integrations/document_loaders/index.mdx
@@ -82,7 +82,7 @@ The below document loaders allow you to load PDF documents.
 | [CVFileLoader](https://cvfile.org) | Load .cv PDF/A-3u files with embedded Markdown, HTML, and JSON Resume payloads | Package |
 | [pdfmuse](https://github.com/casperkwok/pdfmuse) | Load PDF and DOCX files deterministically, with exact coordinates, tables and per-block section metadata for RAG | Package |
 | [oxidize-pdf](https://github.com/bzsanti/oxidize-pdf-integrations/tree/main/langchain) | Load PDF files using a Rust engine with element-disjoint RAG chunking | Package |
-
+| [pdf-inspector](https://github.com/undacmic/langchain-pdf-inspector) | Load PDF files using pdf-inspector | Package |
 ### Cloud providers
 
 The below document loaders allow you to load documents from your favorite cloud providers.

--- a/src/oss/python/integrations/document_loaders/index.mdx
+++ b/src/oss/python/integrations/document_loaders/index.mdx
@@ -83,6 +83,7 @@ The below document loaders allow you to load PDF documents.
 | [pdfmuse](https://github.com/casperkwok/pdfmuse) | Load PDF and DOCX files deterministically, with exact coordinates, tables and per-block section metadata for RAG | Package |
 | [oxidize-pdf](https://github.com/bzsanti/oxidize-pdf-integrations/tree/main/langchain) | Load PDF files using a Rust engine with element-disjoint RAG chunking | Package |
 | [pdf-inspector](https://github.com/undacmic/langchain-pdf-inspector) | Load PDF files using pdf-inspector | Package |
+
 ### Cloud providers
 
 The below document loaders allow you to load documents from your favorite cloud providers.


### PR DESCRIPTION
## Overview
Adds documentation for langchain-pdf-inspector, an independently published third-party document loader.

## Type of change

**Type:** Update existing documentation (metadata/listing only — no guide page, no code) 


## Overview

Adds `langchain-pdf-inspector` to the LangChain Python integration listings.

`langchain-pdf-inspector` (v0.1.1, PyPI) provides `PdfInspectorLoader` (a `BasePDFLoader`-style document loader) and `PdfInspectorParser` (a blob parser), loading PDFs as plain text, markdown, positional text, or region-cropped text via the Rust-backed `pdf-inspector` library, returning `langchain_core` Document objects. It is published at the repo root of `https://github.com/undacmic/langchain-pdf-inspector` and has no hosted partner docs.

This PR is listing-metadata only — it registers the package in the docs
registries and does not create any guide or provider pages (document loaders are
not a hosted-guide category, and the package is under the 50K-download
listing threshold).


## Related issues/PRs

- N/A (initial listing)

## Checklist

- [x] Added `packages.yml` entry (`name_title: pdf-inspector`, `repo:
      undacmic/langchain-pdf-inspector`, no `path` — package at repo root,
      `js: "n/a"`); `downloads`/`downloads_updated_at` intentionally omitted
- [x] Added `scripts/data/integration_external_docs.yaml` row under
      `python.document_loaders` (`PdfInspectorLoader` / `langchain-pdf-inspector`)
- [x] Added PDFs-table row in
      `src/oss/python/integrations/document_loaders/index.mdx`
- [x] Ran `scripts/refresh_integration_downloads.py --check-docs-urls`
- [x] Verified the live PyPI page for `langchain-pdf-inspector` v0.1.1

