### PR TITLE
docs: align Messages view wording with the trajectory concept

### DIFF
--- a/src/langsmith/messages-view-integrations.mdx
+++ b/src/langsmith/messages-view-integrations.mdx
@@ -1,13 +1,13 @@
 ---
 title: Messages view integrations
-description: Frameworks and SDKs that render in the LangSmith Messages view, and the metadata each one sets.
+description: Frameworks and SDKs that render in the LangSmith Messages view and the metadata each one sets.
 ---
 
 <Note>
 The [Messages view](/langsmith/view-traces#messages-view) is in **[beta](/langsmith/release-stages)**.
 </Note>
 
-The [Messages view](/langsmith/view-traces#messages-view) renders an agent's trace as a chat-style conversation: user prompts, model responses, tool calls, and tool results, in order. The Messages view needs two pieces of run metadata to render the main conversation:
+The [Messages view](/langsmith/view-traces#messages-view) renders the [traces](/langsmith/observability-concepts#traces) of a [thread](/langsmith/observability-concepts#threads) as a [trajectory](/langsmith/observability-concepts#trajectories): user prompts, model responses, tool calls, and tool results, in order. The Messages view needs two pieces of run metadata to render a trajectory:
 
 - **Thread grouping**: `thread_id` on each run tells LangSmith that a set of runs belongs to the same conversation.
 - **Run classification**: `ls_agent_type: "root"` on the top-level run of a turn marks that run as part of the main conversation. Runs marked as subagent appear as a subagent action in the thread while runs marked as middleware or compaction are currently filtered out.

--- a/src/langsmith/view-traces.mdx
+++ b/src/langsmith/view-traces.mdx
@@ -13,7 +13,7 @@ The Threads tab and the Turns view are only available for runs instrumented with
 
 Three views are available at the top of the side panel:
 
-- [**Messages**](#messages-view) (**beta**): The conversation layer. Scan the full thread as inputs, outputs, reasoning, tool calls, and subagent activity. Use this to find where to look. Press `M` to switch to this view.
+- [**Messages**](#messages-view) (**beta**): The conversation layer. Scan the [trajectory](/langsmith/observability-concepts#trajectories) as inputs, outputs, reasoning, tool calls, and subagent activity. Use this to find where to look. Press `M` to switch to this view.
 - [**Turns**](#turns-view): The per-turn summary. View each turn in the thread as a card showing its inputs and outputs, with expand/collapse. Use this when you want a structural overview without the full conversation rendering. Press `T` to switch to this view.
 - [**Details**](#details-view): The debugging layer. Drill into a specific run to inspect inputs, outputs, timing, token counts, errors, and metadata. Use this to understand what happened at a specific point in execution. Press `D` to switch to this view.
 
@@ -25,15 +25,15 @@ Use the Messages view to orient yourself in the conversation and identify where 
 
 <Steps>
   <Step title="Start in the Messages view">
-    Open a thread and switch to the Messages view to see the full thread.
+    Open a thread and switch to the Messages view to see the trajectory.
   </Step>
   <Step title="Investigate">
-    Scan the thread to identify unexpected behavior, for example, a bad tool result, an unexpected subagent handoff, a latency spike.
+    Scan the trajectory to identify unexpected behavior, for example, a bad tool result, an unexpected subagent handoff, a latency spike.
   </Step>
   <Step title="Inspect the run">
     Click the relevant message or tool call to open the Details view at the exact run that produced it. Review its inputs, outputs, timing, errors, and metadata.
   </Step>
-  <Step title="Return to the thread">
+  <Step title="Return to the trajectory">
     Toggle back to the Messages view to continue scanning the conversation.
   </Step>
 </Steps>
@@ -42,11 +42,11 @@ Use the Messages view to orient yourself in the conversation and identify where 
 
 <Note>The Messages view is in **[beta](/langsmith/release-stages)**. The side panel defaults to the [Details view](#details-view).</Note>
 
-Use the Messages view to scan the full thread and identify unexpected behavior, such as a bad tool result, an unexpected subagent handoff, or a latency spike, before drilling into a specific run.
+Use the Messages view to scan the full [trajectory](/langsmith/observability-concepts#trajectories) and identify unexpected behavior, such as a bad tool result, an unexpected subagent handoff, or a latency spike, before drilling into a specific run.
 
 ### What the Messages view shows
 
-Each turn in the thread renders as a single block containing the model's response, the tool calls it triggered, and the results those tools returned. You can scan the full thread and read the agent's behavior without opening a child run.
+Each turn in the trajectory renders as a single block containing the model's response, the tool calls it triggered, and the results those tools returned. You can scan the full trajectory and read the agent's behavior without opening a child run.
 
 The metadata row for each block shows:
 


### PR DESCRIPTION
Updating Messages view docs with trajectory concept