### PR TITLE
docs: list published Apertis LangChain integration

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -220,7 +220,7 @@ python:
     stream: true
     tool_calling: true
     structured_output: true
-    multimodal: false
+    multimodal: true
   - name: ChatEmpirioLabs
     pypi: langchain-empiriolabs
     docs_url: https://docs.empiriolabs.ai

--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -215,7 +215,12 @@ python:
     structured_output: true
     multimodal: false
   - name: Apertis
-    docs_url: https://docs.apertis.ai
+    pypi: langchain-apertis
+    docs_url: https://docs.apertis.ai/api/sdks/langchain/
+    stream: true
+    tool_calling: true
+    structured_output: true
+    multimodal: false
   - name: ChatEmpirioLabs
     pypi: langchain-empiriolabs
     docs_url: https://docs.empiriolabs.ai
@@ -1383,4 +1388,3 @@ javascript:
   - name: Leap0Sandbox
     npm: "@leap0/langchain-leap0"
     docs_url: https://leap0.dev/docs
-


### PR DESCRIPTION
Adds the published `langchain-apertis` package and verified provider capabilities to Apertis' existing external-integration listing.

Verification:
- Published from `apertis-ai/langchain-apertis` main at `c9ed041`.
- PyPI: `apertis==0.3.0` and `langchain-apertis==0.2.0` install together in a fresh Python 3.13 container.
- The provider forwards OpenAI-compatible image, input-audio, and video content, so the directory metadata now accurately marks multimodal support.