### PR TITLE
docs: link annotation queue output rendering

### DIFF
--- a/src/langsmith/annotation-queues.mdx
+++ b/src/langsmith/annotation-queues.mdx
@@ -9,6 +9,8 @@ _Annotation queues_ give human reviewers a focused workflow for attaching feedba
 You can also manage annotation queues and feedback configs programmatically with the SDK. Refer to [Manage feedback & annotation queues programmatically](/langsmith/annotation-queues-sdk).
 </Info>
 
+To customize how run outputs appear during review, [configure custom output rendering for annotation queues](/langsmith/custom-output-rendering#for-annotation-queues).
+
 LangSmith supports two queue styles:
 
 - [**Single-run annotation queues**](#single-run-annotation-queues) present one queue item at a time, either a run or a thread, and let reviewers submit any rubric feedback you configure. For **run** items, single-run queues also support [assertions](/langsmith/assertions) to capture acceptance criteria for offline evaluation.


### PR DESCRIPTION
## Description
Add a direct link from the annotation queues guide to the queue-specific custom output rendering instructions so readers can find the configuration steps in context.

## Test Plan
- [x] Run `make lint_prose FILES="src/langsmith/annotation-queues.mdx"`
- [x] Run `make broken-links`

Made by [Open SWE](https://openswe.vercel.app/agents/af84cddc-8a8a-10a6-4588-d7c8d74c6133)