### PR TITLE
chore: add Python gateway environment setup

### DIFF
--- a/src/langsmith/llm-gateway-quickstart.mdx
+++ b/src/langsmith/llm-gateway-quickstart.mdx
@@ -39,10 +39,21 @@ To preserve a provider's native API without format translation, use a [direct pr
 
 [LangChain](/oss/langchain/overview) chat models and [Deep Agents](/oss/deepagents/overview) (including [Deep Agents Code](/oss/deepagents/code/overview)) support the gateway through two convenience environment variables:
 
-```bash
+<CodeGroup>
+
+```bash Bash
 export LANGSMITH_GATEWAY="true"
 export LANGSMITH_GATEWAY_API_KEY="$LANGSMITH_API_KEY"
 ```
+
+```python Python
+import os
+
+os.environ["LANGSMITH_GATEWAY"] = "true"
+os.environ["LANGSMITH_GATEWAY_API_KEY"] = os.environ["LANGSMITH_API_KEY"]
+```
+
+</CodeGroup>
 
 This routes all supported chat models through the gateway at `https://gateway.smith.langchain.com`. To use a different gateway (for example, the EU instance), set its URL instead of `true`:
 


### PR DESCRIPTION
## Description
Add a Python option alongside Bash for configuring LangChain and Deep Agents to use the LangSmith LLM Gateway.

## Test Plan
- [x] Compile the Python setup snippet
- [x] Verify the changed page with Vale prose lint

Made by [Open SWE](https://openswe.vercel.app/agents/500db86d-9ade-4bbf-088b-637bf4ec2928)