### PR TITLE
fix: surface dynamic subagents under delegation

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -225,15 +225,7 @@
                           "oss/python/deepagents/permissions",
                           "oss/python/deepagents/multimodal",
                           "oss/python/deepagents/sandboxes",
-                          {
-                            "group": "Interpreters",
-                            "tag": "Beta",
-                            "root": "oss/python/deepagents/interpreters",
-                            "expanded": true,
-                            "pages": [
-                              "oss/python/deepagents/dynamic-subagents"
-                            ]
-                          },
+                          "oss/python/deepagents/interpreters",
                           "oss/python/deepagents/event-streaming",
                           "oss/python/deepagents/streaming"
                         ]
@@ -255,6 +247,7 @@
                         "expanded": true,
                         "pages": [
                           "oss/python/deepagents/subagents",
+                          "oss/python/deepagents/dynamic-subagents",
                           "oss/python/deepagents/async-subagents"
                         ]
                       },
@@ -731,15 +724,7 @@
                           "oss/javascript/deepagents/permissions",
                           "oss/javascript/deepagents/multimodal",
                           "oss/javascript/deepagents/sandboxes",
-                          {
-                            "group": "Interpreters",
-                            "tag": "Beta",
-                            "root": "oss/javascript/deepagents/interpreters",
-                            "expanded": true,
-                            "pages": [
-                              "oss/javascript/deepagents/dynamic-subagents"
-                            ]
-                          },
+                          "oss/javascript/deepagents/interpreters",
                           "oss/javascript/deepagents/event-streaming",
                           "oss/javascript/deepagents/streaming"
                         ]
@@ -761,6 +746,7 @@
                         "expanded": true,
                         "pages": [
                           "oss/javascript/deepagents/subagents",
+                          "oss/javascript/deepagents/dynamic-subagents",
                           "oss/javascript/deepagents/async-subagents"
                         ]
                       },


### PR DESCRIPTION
## Description
Moves the existing Dynamic subagents page into the Delegation navigation group, immediately after Subagents, for both Python and TypeScript. This makes the feature discoverable where readers look for subagent documentation while keeping Interpreters available as its own page.

## Test Plan
- [x] Validate `src/docs.json` with `python -m json.tool`
- [x] Run `make broken-links`

Made by [Open SWE](https://openswe.vercel.app/agents/d685dc24-5d4a-4dc0-4d52-d302929b7ee3)