### PR TITLE
fix: scope middleware guidance by language [closes DOC-1504]

### DIFF
--- a/src/oss/langchain/middleware/overview.mdx
+++ b/src/oss/langchain/middleware/overview.mdx
@@ -75,7 +75,7 @@ Reach for this pattern when the surrounding topology is more than a standard "lo
 `HumanInTheLoopMiddleware` matches against each tool's `.name`.
 
 :::python
-In Python, `@tool`-decorated functions take their name from the function, so the key below is `"send_email"`.
+`@tool`-decorated functions take their name from the function, so the key below is `"send_email"`.
 
 ```python
 from langchain.agents import AgentState, create_agent
@@ -101,7 +101,7 @@ graph = (
 :::
 
 :::js
-In TypeScript, the key matches the `name` you pass to `tool({...}, { name })`.
+The key matches the `name` you pass to `tool({...}, { name })`.
 
 ```typescript
 import { AgentState, createAgent, humanInTheLoopMiddleware } from "langchain";

--- a/src/oss/langchain/middleware/overview.mdx
+++ b/src/oss/langchain/middleware/overview.mdx
@@ -72,9 +72,11 @@ Middleware is not a separate runtime: hooks run inside the compiled [LangGraph](
 
 Reach for this pattern when the surrounding topology is more than a standard "loop until done": classifying input before routing to one of several agents, fanning out work in parallel, or stitching agent calls together with deterministic steps.
 
-`HumanInTheLoopMiddleware` matches against each tool's `.name`. In Python, `@tool`-decorated functions take their name from the function (so the key below is `"send_email"`); in TypeScript, the key matches the `name` you pass to `tool({...}, { name })`.
+`HumanInTheLoopMiddleware` matches against each tool's `.name`.
 
 :::python
+In Python, `@tool`-decorated functions take their name from the function, so the key below is `"send_email"`.
+
 ```python
 from langchain.agents import AgentState, create_agent
 from langchain.agents.middleware import HumanInTheLoopMiddleware
@@ -99,6 +101,8 @@ graph = (
 :::
 
 :::js
+In TypeScript, the key matches the `name` you pass to `tool({...}, { name })`.
+
 ```typescript
 import { AgentState, createAgent, humanInTheLoopMiddleware } from "langchain";
 import { StateGraph, START } from "@langchain/langgraph";


### PR DESCRIPTION
## Description
Scope tool-naming guidance to the matching language variant so TypeScript details no longer render in the Python middleware docs.

## Test Plan
- [x] Run focused Vale prose lint on the middleware overview
- [ ] Verify each language dropdown shows only its matching guidance in preview

Made by [Open SWE](https://openswe.vercel.app/agents/513d9af1-1321-d07d-b00d-dc78083b3bf8)