### PR TITLE
docs(langsmith): document previews for tag deployments

### DIFF
--- a/src/langsmith/deploy-to-cloud.mdx
+++ b/src/langsmith/deploy-to-cloud.mdx
@@ -36,7 +36,7 @@ Choose the deployment method that fits your workflow—the LangSmith UI connects
         1. Select **Import from GitHub** and follow the GitHub OAuth workflow to install and authorize LangChain's `hosted-langserve` GitHub app to access the selected repositories. After installation is complete, return to the **Create New Deployment** panel and select the GitHub repository to deploy from the dropdown menu.
             <Note> The GitHub user installing LangChain's `hosted-langserve` GitHub app must be an [owner](https://docs.github.com/en/organizations/managing-peoples-access-to-your-organization-with-roles/roles-in-an-organization#organization-owners) of the organization or account. This authorization only needs to be completed once per LangSmith workspace—subsequent deployments can be created by any user with deployment permissions.</Note>
         1. Specify a name for the deployment.
-        1. Specify the desired **Git Branch**. A deployment is linked to a branch. When a new revision is created, code for the linked branch will be deployed. The branch can be updated later in the [Deployment Settings](#deployment-settings).
+        1. Specify the desired **Git Branch** or tag. A deployment is linked to that Git source. When a new revision is created, code for the linked source is deployed. You can update the source later in the [Deployment Settings](#deployment-settings).
         1. Specify the full path to the [LangGraph API config file](/langsmith/cli#configuration-file) including the file name. For example, if the file `langgraph.json` is in the root of the repository, specify `langgraph.json`.
         1. Use the checkbox to **Automatically update deployment on push to branch**. If checked, the deployment will automatically be updated when changes are pushed to the specified **Git Branch**. You can enable or disable this setting on the [Deployment Settings](#deployment-settings) in [the UI](https://smith.langchain.com).
         For **Deployment Type**:
@@ -249,6 +249,14 @@ Starting from the **Deployments** view:
 1. Check/uncheck checkbox to **Automatically update deployment on push to branch**.
     1. Branch creation/deletion and tag creation/deletion events will not trigger an update. Only pushes to an existing branch will trigger an update.
     1. Pushes in quick succession to a branch will queue subsequent updates. Once a build completes, the most recent commit will begin building and the other queued builds will be skipped.
+
+### Configure preview builds
+
+Preview builds create short-lived deployments for pull requests. In **Deployment Settings**, enable preview builds and choose whether to create them for every pull request or only pull requests with a selected label.
+
+For a deployment that uses a branch as its Git source, previews match pull requests targeting that branch. For a deployment pinned to a Git tag, set a **Preview base branch**. The main deployment remains pinned to the tag, while pull requests targeting the preview base branch create previews.
+
+Configure the idle TTL and maximum concurrent previews to limit how long previews run and how many can be active at once.
 
 ## Add or remove GitHub repositories
 


### PR DESCRIPTION
## Summary
- Document branches and tags as deployment Git sources.
- Explain how a tag-pinned deployment uses Preview base branch to create pull request previews without moving the main deployment.
- Related implementation: https://github.com/langchain-ai/langchainplus/pull/33347

## Test Plan
- [x] Review the updated Cloud deployment settings flow.
- [ ] Validate the documented setting in the UI after the implementation deploys.