### PR TITLE
docs: explain OpenWiki coding agent discovery [closes DOC-1464]

### DIFF
--- a/src/oss/openwiki/overview.mdx
+++ b/src/oss/openwiki/overview.mdx
@@ -23,6 +23,10 @@ openwiki --init
 
 See the [Quickstart](/oss/openwiki/quickstart) to choose a model provider, generate docs, and keep them up to date.
 
+<Note>
+    OpenWiki does not provide a formal connector for Claude or Codex. In code mode, it adds pointers to the generated wiki in the repository-root `AGENTS.md` and `CLAUDE.md` files, so compatible coding agents can discover and consult the wiki.
+</Note>
+
 ## Modes
 
 OpenWiki has two modes:


### PR DESCRIPTION
## Description
Clarifies that OpenWiki has no formal Claude or Codex connector and explains how repository-root agent files point compatible coding agents to the generated wiki.

## Test Plan
- [x] Run scoped Vale prose lint on the OpenWiki overview

Made by [Open SWE](https://openswe.vercel.app/agents/77afddad-9825-6427-631c-ed48226a016c)