### PR TITLE
[Docs Alignment] aligning short term memo docs with PyPi docs of langgraph-checkpoint-postgres

### DIFF
--- a/src/oss/langchain/short-term-memory.mdx
+++ b/src/oss/langchain/short-term-memory.mdx
@@ -59,6 +59,17 @@ In production, use a checkpointer backed by a database:
 ```shell
 pip install langgraph-checkpoint-postgres
 ```
+<Note>
+Please be advised that by default, langgraph-checkpoint-postgres installs psycopg (Psycopg 3) without any extras. You can choose a specific installation that best suits your needs from the Psycopg installation docs, for example psycopg[binary], which is recommended for most users.
+
+```shell
+# pip
+pip install psycopg[binary]
+
+# uv
+uv add psycopg[binary]
+```
+</Note>
 
 ```python
 from langchain.agents import create_agent

--- a/src/oss/langchain/short-term-memory.mdx
+++ b/src/oss/langchain/short-term-memory.mdx
@@ -56,19 +56,18 @@ In production, use a checkpointer backed by a database:
 
 
 :::python
-```shell
-pip install langgraph-checkpoint-postgres
+<CodeGroup>
+```bash pip
+pip install -U langgraph-checkpoint-postgres "psycopg[binary]"
 ```
+
+```bash uv
+uv add langgraph-checkpoint-postgres "psycopg[binary]"
+```
+</CodeGroup>
+
 <Note>
-Please be advised that by default, langgraph-checkpoint-postgres installs psycopg (Psycopg 3) without any extras. You can choose a specific installation that best suits your needs from the Psycopg installation docs, for example psycopg[binary], which is recommended for most users.
-
-```shell
-# pip
-pip install psycopg[binary]
-
-# uv
-uv add psycopg[binary]
-```
+By default, `langgraph-checkpoint-postgres` installs `psycopg` (Psycopg 3) without extras. The install above adds `psycopg[binary]`, which is recommended for most users. For other options, see the [Psycopg installation docs](https://www.psycopg.org/psycopg3/docs/basic/install.html).
 </Note>
 
 ```python


### PR DESCRIPTION
## Overview
Installing langgraph-checkpoint-postgres implies pure Python installation of psycopg but it's only mentioned in the official PyPi docs of langgraph-checkpoint-postgres, rather than short term memo docs.

What's worse, according to the docs of psycopg, using pure python installation of psycopg requires libpq and i assume most of the developers don't have it and they will fail at the first time (https://www.psycopg.org/psycopg3/docs/basic/install.html#pure-python-installation).

Handy installation CLIs are also provided but i am not sure how watchers are thinking about uv CLIs. Would like to add uv CLI to the installation guide of every package lol.

## Type of change

**Type:** Update existing documentation / Fix typo/bug/link/formatting

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
This is the screenshot of PyPi docs of the langgraph-checkpoint-postgres
<img width="806" height="517" alt="image" src="https://github.com/user-attachments/assets/2c776950-8e68-4693-9105-d2647f7b6364" />

This is from the official docs of psycopg
<img width="825" height="597" alt="image" src="https://github.com/user-attachments/assets/26a0e7c9-4114-42c8-bf60-040ef874e0fb" />
