### PR TITLE
fix(mda): stop serving unversioned MDA pages outside nav

### DIFF
--- a/pipeline/core/builder.py
+++ b/pipeline/core/builder.py
@@ -512,15 +512,23 @@ class DocumentationBuilder:
     def _build_unversioned_file(self, file_path: Path, relative_path: Path) -> None:
         """Build an unversioned file (langsmith).
 
+        Managed Deep Agents pages only emit language-prefixed routes
+        (``langsmith/python/...`` and ``langsmith/javascript/...``). The
+        unversioned ``/langsmith/managed-deep-agents*`` URLs redirect to the
+        Python routes via ``docs.json`` so Mintlify does not serve orphaned
+        pages outside the Managed Deep Agents nav.
+
         Args:
             file_path: Path to the source file.
             relative_path: Relative path from src_dir.
         """
+        if self.is_managed_deep_agents_file(file_path):
+            self._build_managed_deep_agents_variants(file_path)
+            return
+
         output_path = self.build_dir / relative_path
         if self._build_single_file_to_path(file_path, output_path, "python"):
             logger.debug("Built: %s", relative_path)
-        if self.is_managed_deep_agents_file(file_path):
-            self._build_managed_deep_agents_variants(file_path)
 
     def _build_shared_file(self, file_path: Path, relative_path: Path) -> None:
         """Build a shared file (images, docs.json, JS/CSS files).
@@ -898,6 +906,9 @@ class DocumentationBuilder:
             file_path
             for file_path in self._safe_source_files(src_path)
             if not self.is_shared_file(file_path)
+            # Managed Deep Agents emit language-prefixed routes only
+            # (see `_build_managed_deep_agents_versions`).
+            and not self.is_managed_deep_agents_file(file_path)
         ]
 
         if not all_files:

--- a/src/docs.json
+++ b/src/docs.json
@@ -2540,19 +2540,27 @@
     },
     {
       "source": "/langsmith/managed-deep-agents-invoke",
-      "destination": "/langsmith/managed-deep-agents-overview"
+      "destination": "/langsmith/python/managed-deep-agents-overview"
     },
     {
       "source": "/langsmith/managed-deep-agents-sdk",
-      "destination": "/langsmith/managed-deep-agents-overview"
+      "destination": "/langsmith/python/managed-deep-agents-overview"
     },
     {
       "source": "/langsmith/managed-deep-agents-api",
-      "destination": "/langsmith/managed-deep-agents-overview"
+      "destination": "/langsmith/python/managed-deep-agents-overview"
     },
     {
       "source": "/langsmith/managed-deep-agents-api-overview",
-      "destination": "/langsmith/managed-deep-agents-overview"
+      "destination": "/langsmith/python/managed-deep-agents-overview"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents",
+      "destination": "/langsmith/python/managed-deep-agents-overview"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-:path*",
+      "destination": "/langsmith/python/managed-deep-agents-:path*"
     },
     {
       "source": "/langsmith/polly",
@@ -2956,23 +2964,23 @@
     },
     {
       "source": "/oss/python/deepagents/deploy",
-      "destination": "/langsmith/managed-deep-agents-overview"
+      "destination": "/langsmith/python/managed-deep-agents-overview"
     },
     {
       "source": "/oss/javascript/deepagents/deploy",
-      "destination": "/langsmith/managed-deep-agents-overview"
+      "destination": "/langsmith/javascript/managed-deep-agents-overview"
     },
     {
       "source": "/oss/python/deepagents/deploy/overview",
-      "destination": "/langsmith/managed-deep-agents-overview"
+      "destination": "/langsmith/python/managed-deep-agents-overview"
     },
     {
       "source": "/oss/javascript/deepagents/deploy/overview",
-      "destination": "/langsmith/managed-deep-agents-overview"
+      "destination": "/langsmith/javascript/managed-deep-agents-overview"
     },
     {
       "source": "/langsmith/deploy-managed-deep-agent",
-      "destination": "/langsmith/managed-deep-agents-overview"
+      "destination": "/langsmith/python/managed-deep-agents-overview"
     },
     {
       "source": "/oss/langchain/retrieval",

--- a/src/langsmith/deployment-quickstart-da.mdx
+++ b/src/langsmith/deployment-quickstart-da.mdx
@@ -2,5 +2,5 @@
 title: Deploy Managed Deep Agents
 sidebarTitle: Managed Deep Agents
 tag: "BETA"
-url: "/langsmith/managed-deep-agents-quickstart"
+url: "/langsmith/python/managed-deep-agents-quickstart"
 ---

--- a/tests/unit_tests/test_builder.py
+++ b/tests/unit_tests/test_builder.py
@@ -617,9 +617,14 @@ def test_build_all_creates_managed_deep_agents_language_routes() -> None:
         builder = DocumentationBuilder(fs.src_dir, fs.build_dir)
         builder.build_all()
 
-        default_page = (
+        # Unversioned routes are redirects only; do not emit orphaned pages.
+        assert not (
             fs.build_dir / "langsmith" / "managed-deep-agents-overview.mdx"
-        ).read_text()
+        ).exists()
+        assert not (
+            fs.build_dir / "langsmith" / "managed-deep-agents-quickstart.mdx"
+        ).exists()
+
         python_page = (
             fs.build_dir / "langsmith" / "python" / "managed-deep-agents-overview.mdx"
         ).read_text()
@@ -630,7 +635,6 @@ def test_build_all_creates_managed_deep_agents_language_routes() -> None:
             / "managed-deep-agents-overview.mdx"
         ).read_text()
 
-        assert "/langsmith/python/managed-deep-agents-quickstart" in default_page
         assert "/langsmith/python/managed-deep-agents-quickstart" in python_page
         assert "/langsmith/javascript/managed-deep-agents-quickstart" in js_page
         assert "/oss/python/deepagents/overview" in python_page


### PR DESCRIPTION
## Overview
Unversioned Managed Deep Agents URLs were still built after the python/javascript route split, so Mintlify treated them as orphans and showed the wrong sidebar (Datasets & Experiments). Stop emitting those pages and redirect them to the language-prefixed routes.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue:
- Feature PR:
- Linear issue: https://linear.app/langchain/issue/DOC-1512/fix-mda-quickstart-page-placement-incorrectly-shown-under-dataset-and
- Slack thread:

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
- Ran `uv run pytest tests/unit_tests/test_builder.py`
- After deploy, `/langsmith/managed-deep-agents-quickstart` should redirect to `/langsmith/python/managed-deep-agents-quickstart` with the Managed Deep Agents nav