### PR TITLE
[Docs Alignment and uv everywhere] add uv as an option to install langchain-model-profiles and include a warning

### DIFF
--- a/src/oss/langchain/models.mdx
+++ b/src/oss/langchain/models.mdx
@@ -1338,10 +1338,18 @@ Model profile data allow applications to work around model capabilities dynamica
     1. (If needed) update the source data at [models.dev](https://models.dev/) through a pull request to its [repository on GitHub](https://github.com/sst/models.dev).
     2. (If needed) update additional fields and overrides in `langchain_<package>/data/profile_augmentations.toml` through a pull request to the LangChain [integration package](/oss/integrations/providers/overview)`.
     3. Use the [`langchain-model-profiles`](https://pypi.org/project/langchain-model-profiles/) CLI tool to pull the latest data from [models.dev](https://models.dev/), merge in the augmentations and update the profile data:
+    <CodeGroup>
+        ```bash pip
+        pip install -U langchain-model-profiles
+        ```
 
-    ```bash
-    pip install langchain-model-profiles
-    ```
+        ```bash uv
+        uv add langchain-model-profiles
+        ```
+    </CodeGroup>
+    <Note>
+        As of Aug 7th 2026, langchain-model-profiles is in development and the API is still subject to change. Please choose a version to install if necessary.
+    </Note>
 
     ```bash
     langchain-profiles refresh --provider <provider> --data-dir <data_dir>

--- a/src/oss/langchain/models.mdx
+++ b/src/oss/langchain/models.mdx
@@ -1347,9 +1347,6 @@ Model profile data allow applications to work around model capabilities dynamica
         uv add langchain-model-profiles
         ```
     </CodeGroup>
-    <Note>
-        As of Aug 7th 2026, langchain-model-profiles is in development and the API is still subject to change. Please choose a version to install if necessary.
-    </Note>
 
     ```bash
     langchain-profiles refresh --provider <provider> --data-dir <data_dir>


### PR DESCRIPTION
## Overview
docs alignment and uv everywhere for langchain-model-profiles

## Type of change

**Type:** Update existing documentation

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed


## Additional notes
warning is from this page: https://pypi.org/project/langchain-model-profiles/
<img width="645" height="273" alt="image" src="https://github.com/user-attachments/assets/62e8bc14-896a-4cdb-84d2-a7876d6f814b" />
