### PR TITLE
fix: link v16 notes to Gateway access request

### DIFF
--- a/src/langsmith/self-hosted-changelog.mdx
+++ b/src/langsmith/self-hosted-changelog.mdx
@@ -44,7 +44,7 @@ If you want to book time for your upgrade, feel free to contact LangChain suppor
     - Proposes fixes, opens PRs if source code is connected, creates evaluators and ground truth examples to catch regressions, and monitors issues automatically for recurrence.
     - Usage is charged in [LangChain Compute Units (LCUs)](/langsmith/pricing-plans) with an optional monthly spend limit at the organization and project level. On self-hosted, Engine emits no LangSmith traces.
     - Sends trace content to LangSmith Intelligence, a LangChain-managed zero-data-retention service. Requires egress to `beacon.langchain.com` on GCP or `beacon.aws.langchain.com` on AWS. Air-gapped installs cannot run Engine.
-- **LangSmith LLM Gateway** is available in public beta. Express interest through the [Support Portal](https://support.langchain.com/) and the team will follow up promptly to get your team up and running.
+- **LangSmith LLM Gateway** is available in public beta. If you are interested in LLM Gateway for self-hosted deployments, submit the [LLM Gateway self-hosted access request](https://www.langchain.com/langsmith-llm-gateway-self-hosted-access-request).
     - **Spend and rate limits**: Rate-limit policies alongside spend caps, weekly cap periods, and scoping of both by custom header for any subject.
     - **Data protection**: Configurable guard timeout action (allow or block), granular PII rule selection, expanded secret-token detection, and redacted-placeholder explanations passed to the model.
     - **Provider coverage**: Full OpenAI API route pass-through, OpenAI embeddings with cost and trace tracking, and Anthropic Files and Managed Agents.


### PR DESCRIPTION
## Description
Updates the v0.16 self-hosted release notes to direct customers interested in LLM Gateway to the dedicated access-request form instead of the Support Portal.

## Test Plan
- [x] Ran the focused Vale prose lint.
- [x] Ran the broken-link check and verified the access-request page resolves.

Made by [Open SWE](https://openswe.vercel.app/agents/fa613e3b-aa7c-7d3f-bd93-c06d6e28fd09)