### PR TITLE
docs(sandboxes): document Context Hub mounts

### DIFF
--- a/src/langsmith/sandbox-sdk.mdx
+++ b/src/langsmith/sandbox-sdk.mdx
@@ -331,24 +331,25 @@ Pass the mount through `mount_config`. The API key that creates the sandbox must
 <CodeGroup>
 
 ```python Python
-from langsmith.sandbox import SandboxClient, context_hub_mount, mount_config
+from langsmith.sandbox import AsyncSandboxClient, context_hub_mount, mount_config
 
-client = SandboxClient()
 
-with client.sandbox(
-    name="context-hub-mount-sandbox",
-    mount_config=mount_config(
-        mounts=[
-            context_hub_mount(
-                id="memories",
-                mount_path="/memories",
-                repo="-/my-agent",
-            )
-        ],
-    ),
-) as sb:
-    result = sb.run("ls /memories")
-    print(result.stdout)
+async def main():
+    async with AsyncSandboxClient() as client:
+        async with await client.sandbox(
+            name="context-hub-mount-sandbox",
+            mount_config=mount_config(
+                mounts=[
+                    context_hub_mount(
+                        id="memories",
+                        mount_path="/memories",
+                        repo="-/my-agent",
+                    )
+                ],
+            ),
+        ) as sb:
+            result = await sb.run("ls /memories")
+            print(result.stdout)
 ```
 
 ```ts TypeScript

--- a/src/langsmith/sandbox-sdk.mdx
+++ b/src/langsmith/sandbox-sdk.mdx
@@ -326,6 +326,10 @@ try {
 
 Mount a [Context Hub](/langsmith/use-the-context-hub) repo to give sandbox code filesystem access to your agents and skills. The repo's latest commit tree is mirrored into the mount path and kept in sync for the sandbox's lifetime, so a new commit shows up in the running sandbox without a restart.
 
+<Warning>
+Context Hub mounts are **read-only**. The sync is one-way, from the repo into the sandbox: files an agent writes under the mount path are never pushed back to the repo, and the next sync overwrites them. Write sandbox output to a path outside the mount, and [push it with the SDK](/langsmith/manage-contexts-sdk) if it belongs in the repo.
+</Warning>
+
 Pass the mount through `mount_config`. The API key that creates the sandbox must have access to the repo, otherwise creation fails with a `403`.
 
 <CodeGroup>
@@ -388,12 +392,7 @@ try {
 
 `mount_path` must be an absolute, clean path, and cannot be the filesystem root or sit at or under a system directory such as `/etc` or `/usr`. Any other path works — unlike bucket and Git mounts, Context Hub mounts are not restricted to `/mnt/mounts`.
 
-Two options change the sync behavior:
-
-| Option | Effect |
-|--------|--------|
-| `initial_pull_only` / `initialPullOnly` | Sync once at startup instead of polling for repo updates. |
-| `read_only` / `readOnly` | Make the mount pull-only. |
+Pass `initial_pull_only` / `initialPullOnly` to sync once at startup instead of polling for repo updates.
 
 ## Sandbox lifetime and retention
 

--- a/src/langsmith/sandbox-sdk.mdx
+++ b/src/langsmith/sandbox-sdk.mdx
@@ -322,6 +322,78 @@ try {
 
 </CodeGroup>
 
+## Mount a Context Hub repo
+
+Mount a [Context Hub](/langsmith/use-the-context-hub) repo to give sandbox code filesystem access to your agents and skills. The repo's latest commit tree is mirrored into the mount path and kept in sync for the sandbox's lifetime, so a new commit shows up in the running sandbox without a restart.
+
+Pass the mount through `mount_config`. The API key that creates the sandbox must have access to the repo, otherwise creation fails with a `403`.
+
+<CodeGroup>
+
+```python Python
+from langsmith.sandbox import SandboxClient, context_hub_mount, mount_config
+
+client = SandboxClient()
+
+with client.sandbox(
+    name="context-hub-mount-sandbox",
+    mount_config=mount_config(
+        mounts=[
+            context_hub_mount(
+                id="memories",
+                mount_path="/memories",
+                repo="-/my-agent",
+            )
+        ],
+    ),
+) as sb:
+    result = sb.run("ls /memories")
+    print(result.stdout)
+```
+
+```ts TypeScript
+import {
+  SandboxClient,
+  contextHubMount,
+  mountConfig,
+} from "langsmith/sandbox";
+
+const client = new SandboxClient();
+
+const sandbox = await client.createSandbox({
+  name: "context-hub-mount-sandbox",
+  mountConfig: mountConfig({
+    mounts: [
+      contextHubMount({
+        id: "memories",
+        mountPath: "/memories",
+        repo: "-/my-agent",
+      }),
+    ],
+  }),
+});
+
+try {
+  const result = await sandbox.run("ls /memories");
+  console.log(result.stdout);
+} finally {
+  await sandbox.delete();
+}
+```
+
+</CodeGroup>
+
+`repo` is the repo handle, optionally qualified as `owner/repo`, where `-` is the current workspace.
+
+`mount_path` must be an absolute, clean path, and cannot be the filesystem root or sit at or under a system directory such as `/etc` or `/usr`. Any other path works — unlike bucket and Git mounts, Context Hub mounts are not restricted to `/mnt/mounts`.
+
+Two options change the sync behavior:
+
+| Option | Effect |
+|--------|--------|
+| `initial_pull_only` / `initialPullOnly` | Sync once at startup instead of polling for repo updates. |
+| `read_only` / `readOnly` | Make the mount pull-only. |
+
 ## Sandbox lifetime and retention
 
 Sandboxes are governed by a two-stage retention model anchored to **idle

--- a/src/langsmith/use-the-context-hub.mdx
+++ b/src/langsmith/use-the-context-hub.mdx
@@ -71,4 +71,4 @@ Agent runtimes that resolve context by environment tag (for example, `:productio
 - [Context engineering concepts](/langsmith/context-engineering-concepts): learn about skills, agents, versioning, and sharing.
 - [Manage contexts with the SDK](/langsmith/manage-contexts-sdk): push, pull, list, and delete contexts programmatically.
 - [Configure commit webhooks](/langsmith/context-hub-webhooks): send workspace Context Hub commits to an external HTTPS endpoint.
-- [Mount a Context Hub repo in a sandbox](/langsmith/sandbox-sdk#mount-a-context-hub-repo): give sandbox code filesystem access to a repo, kept in sync as it changes.
+- [Mount a Context Hub repo in a sandbox](/langsmith/sandbox-sdk#mount-a-context-hub-repo): give sandbox code read-only filesystem access to a repo, kept in sync as it changes.

--- a/src/langsmith/use-the-context-hub.mdx
+++ b/src/langsmith/use-the-context-hub.mdx
@@ -71,3 +71,4 @@ Agent runtimes that resolve context by environment tag (for example, `:productio
 - [Context engineering concepts](/langsmith/context-engineering-concepts): learn about skills, agents, versioning, and sharing.
 - [Manage contexts with the SDK](/langsmith/manage-contexts-sdk): push, pull, list, and delete contexts programmatically.
 - [Configure commit webhooks](/langsmith/context-hub-webhooks): send workspace Context Hub commits to an external HTTPS endpoint.
+- [Mount a Context Hub repo in a sandbox](/langsmith/sandbox-sdk#mount-a-context-hub-repo): give sandbox code filesystem access to a repo, kept in sync as it changes.


### PR DESCRIPTION
Context Hub repos can be mounted into sandboxes, but that was documented nowhere — the sandbox SDK page covers files, service URLs, tunnels, and retention, and never mentions mounts.

Adds a **Mount a Context Hub repo** section to `sandbox-sdk.mdx` with Python and TypeScript examples, the mount-path rules, and the two sync options (`initial_pull_only`, `read_only`). Links to it from the Context Hub page's next steps.

⚠️ The `context_hub_mount` / `contextHubMount` helpers used in the examples come from langchain-ai/langsmith-sdk#3351 — merge this after the langsmith release that ships them.