### PR TITLE
fix(mda): redirect deleted and nested MDA paths

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -2583,6 +2583,46 @@
       "destination": "/langsmith/python/managed-deep-agents-overview"
     },
     {
+      "source": "/langsmith/managed-deep-agents-channels/index",
+      "destination": "/langsmith/python/managed-deep-agents-channels"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-channels/slack",
+      "destination": "/langsmith/python/managed-deep-agents-channels-slack"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-channels/github",
+      "destination": "/langsmith/python/managed-deep-agents-channels"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-connectors/index",
+      "destination": "/langsmith/python/managed-deep-agents-channels"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-connectors/mcp",
+      "destination": "/langsmith/python/managed-deep-agents-channels"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-connectors/langsmith",
+      "destination": "/langsmith/python/managed-deep-agents-channels"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-connectors/github",
+      "destination": "/langsmith/python/managed-deep-agents-channels"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-examples",
+      "destination": "/langsmith/python/managed-deep-agents-overview"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-how-it-works",
+      "destination": "/langsmith/python/managed-deep-agents-overview"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-mcp",
+      "destination": "/langsmith/python/managed-deep-agents-channels"
+    },
+    {
       "source": "/langsmith/managed-deep-agents-:path*",
       "destination": "/langsmith/python/managed-deep-agents-:path*"
     },


### PR DESCRIPTION
## Overview
Add explicit redirects for old Managed Deep Agents URLs that the wildcard cannot fix (subdirectory paths and pages that were deleted).

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue:
- Feature PR: Follow-up to #5329 and #5391
- Linear issue:
- Slack thread:

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
These go before `/langsmith/managed-deep-agents-:path*` so they win over the catch-all. Covers old `/channels/*`, `/connectors/*`, plus deleted `examples`, `how-it-works`, and `mcp` pages.