### PR TITLE
docs: fix stale pre-migration reference links in use-graph-api.mdx

### DIFF
--- a/src/oss/langgraph/use-graph-api.mdx
+++ b/src/oss/langgraph/use-graph-api.mdx
@@ -753,7 +753,7 @@ Output of graph invocation: {"a":"set by node3"}
 :::python
 ### Use pydantic models for graph state
 
-A [StateGraph](https://langchain-ai.github.io/langgraph/reference/graphs.md#langgraph.graph.StateGraph) accepts a @[`state_schema`] argument on initialization that specifies the "shape" of the state that the nodes in the graph can access and update.
+A @[StateGraph] accepts a @[`state_schema`] argument on initialization that specifies the "shape" of the state that the nodes in the graph can access and update.
 
 In our examples, we typically use a python-native `TypedDict` or [`dataclass`](https://docs.python.org/3/library/dataclasses.html) for `state_schema`, but @[`state_schema`] can be any [type](https://docs.python.org/3/library/stdtypes.html#type-objects).
 
@@ -2243,7 +2243,7 @@ graph.invoke({"value_1": "c"})
 
 ## Create branches
 
-Parallel execution of nodes is essential to speed up overall graph operation. LangGraph offers native support for parallel execution of nodes, which can significantly enhance the performance of graph-based workflows. This parallelization is achieved through fan-out and fan-in mechanisms, utilizing both standard edges and [conditional_edges](https://langchain-ai.github.io/langgraph/reference/graphs.md#langgraph.graph.MessageGraph.add_conditional_edges). Below are some examples showing how to add create branching dataflows that work for you.
+Parallel execution of nodes is essential to speed up overall graph operation. LangGraph offers native support for parallel execution of nodes, which can significantly enhance the performance of graph-based workflows. This parallelization is achieved through fan-out and fan-in mechanisms, utilizing both standard edges and @[conditional_edges][add_conditional_edges]. Below are some examples showing how to add create branching dataflows that work for you.
 
 ### Run graph nodes in parallel
 


### PR DESCRIPTION
Two links pointed to the old langchain-ai.github.io/langgraph/reference/graphs.md API reference site. Replaced them with the repo's own @[] auto-link syntax (already used for state_schema in the same paragraph), which resolves to the current reference.langchain.com URLs. The second link also incorrectly attributed add_conditional_edges to MessageGraph, a class that no longer exists in the repo's link map (it belongs to StateGraph). Verified by running the repo's own handle_auto_links preprocessor against the new text to confirm it resolves to the correct URLs — output: 

A [StateGraph](https://reference.langchain.com/python/langgraph/graph/state/StateGraph) accepts...
...utilizing both standard edges and [conditional_edges](https://reference.langchain.com/python/langgraph/graph/state/StateGraph/add_conditional_edges)...