### PR TITLE
docs: fix stale StateGraph reference links in langgraph error pages

### DIFF
--- a/src/oss/langgraph/errors/GRAPH_RECURSION_LIMIT.mdx
+++ b/src/oss/langgraph/errors/GRAPH_RECURSION_LIMIT.mdx
@@ -2,7 +2,7 @@
 title: GRAPH_RECURSION_LIMIT
 ---
 
-Your LangGraph [`StateGraph`](https://langchain-ai.github.io/langgraph/reference/graphs/#langgraph.graph.state.StateGraph) reached the maximum number of steps before hitting a stop condition.
+Your LangGraph @[`StateGraph`] reached the maximum number of steps before hitting a stop condition.
 This is often due to an infinite loop caused by code like the example below:
 
 :::python

--- a/src/oss/langgraph/errors/INVALID_CONCURRENT_GRAPH_UPDATE.mdx
+++ b/src/oss/langgraph/errors/INVALID_CONCURRENT_GRAPH_UPDATE.mdx
@@ -2,7 +2,7 @@
 title: INVALID_CONCURRENT_GRAPH_UPDATE
 ---
 
-A LangGraph [`StateGraph`](https://langchain-ai.github.io/langgraph/reference/graphs/#langgraph.graph.state.StateGraph) received concurrent updates to its state from multiple nodes to a state property that doesn't
+A LangGraph @[`StateGraph`] received concurrent updates to its state from multiple nodes to a state property that doesn't
 support it.
 
 One way this can occur is if you are using a [fanout](/oss/langgraph/use-graph-api#map-reduce-and-the-send-api)

--- a/src/oss/langgraph/errors/INVALID_GRAPH_NODE_RETURN_VALUE.mdx
+++ b/src/oss/langgraph/errors/INVALID_GRAPH_NODE_RETURN_VALUE.mdx
@@ -3,7 +3,7 @@ title: INVALID_GRAPH_NODE_RETURN_VALUE
 ---
 
 :::python
-A LangGraph [`StateGraph`](https://langchain-ai.github.io/langgraph/reference/graphs/#langgraph.graph.state.StateGraph)
+A LangGraph @[`StateGraph`]
 received a non-dict return type from a node. Here's an example:
 
 ```python
@@ -36,7 +36,7 @@ Nodes in your graph must return a dict containing one or more keys defined in yo
 :::
 
 :::js
-A LangGraph [`StateGraph`](https://langchain-ai.github.io/langgraph/reference/graphs/#langgraph.graph.state.StateGraph)
+A LangGraph @[`StateGraph`]
 received a non-object return type from a node. Here's an example:
 
 ```typescript


### PR DESCRIPTION
Four links across three error reference pages (GRAPH_RECURSION_LIMIT.mdx,
INVALID_CONCURRENT_GRAPH_UPDATE.mdx, INVALID_GRAPH_NODE_RETURN_VALUE.mdx)
pointed to the old langchain-ai.github.io/langgraph/reference/graphs/ API
reference site. Replaced them with the repo's @[] auto-link syntax, which
resolves to the current reference.langchain.com URLs.

Notably, INVALID_GRAPH_NODE_RETURN_VALUE.mdx has separate :::python and
:::js blocks that both linked to the same python-only reference URL. Using
@[] instead of a hardcoded link lets the preprocessor's scope tracking pick
the correct language-specific reference automatically:
- :::python block -> reference.langchain.com/python/langgraph/graph/state/StateGraph
- :::js block     -> reference.langchain.com/javascript/langchain-langgraph/index/StateGraph

Verified by running the repo's own handle_auto_links.replace_autolinks()
against the edited files.