### PR TITLE
docs: fix stale Command reference link in use-graph-api.mdx

### DIFF
--- a/src/oss/langgraph/use-graph-api.mdx
+++ b/src/oss/langgraph/use-graph-api.mdx
@@ -3290,7 +3290,7 @@ See the [streaming guide](/oss/langgraph/streaming) for examples of streaming wi
 
 ## Combine control flow and state updates with `Command`
 
-It can be useful to combine control flow (edges) and state updates (nodes). For example, you might want to BOTH perform state updates AND decide which node to go to next in the SAME node. LangGraph provides a way to do so by returning a [Command](https://langchain-ai.github.io/langgraph/reference/types/#langgraph.types.Command) object from node functions:
+It can be useful to combine control flow (edges) and state updates (nodes). For example, you might want to BOTH perform state updates AND decide which node to go to next in the SAME node. LangGraph provides a way to do so by returning a @[Command] object from node functions:
 
 :::python
 ```python


### PR DESCRIPTION
The Command link in the "Combine control flow and state updates with Command" section still pointed to the old langchain-ai.github.io/langgraph/reference/types/ API reference site, while Command is already linked correctly via the repo's @[] auto-link syntax elsewhere in the same file. Replaced it with @[Command] for consistency; verified via the repo's own handle_auto_links.replace_autolinks() that it resolves to https://reference.langchain.com/python/langgraph/types/Command.