### PR TITLE
docs: fix broken @[] auto-links inside code comments in mask-inputs-outputs.mdx

### DIFF
--- a/src/langsmith/mask-inputs-outputs.mdx
+++ b/src/langsmith/mask-inputs-outputs.mdx
@@ -479,7 +479,7 @@ def recursive_anonymize(data, depth=10):
 
 openai_client = wrap_openai(openai.Client())
 
-# Initialize the LangSmith @[Client] with the anonymization functions
+# Initialize the LangSmith Client with the anonymization functions
 langsmith_client = Client(
     hide_inputs=recursive_anonymize, hide_outputs=recursive_anonymize
 )
@@ -589,7 +589,7 @@ def presidio_anonymize(data):
 
 openai_client = wrap_openai(openai.Client())
 
-# initialize the langsmith @[Client] with the anonymization functions
+# initialize the langsmith Client with the anonymization functions
 langsmith_client = Client(
   hide_inputs=presidio_anonymize, hide_outputs=presidio_anonymize
 )
@@ -731,7 +731,7 @@ def comprehend_anonymize(data):
 
 openai_client = wrap_openai(openai.Client())
 
-# initialize the langsmith @[Client] with the anonymization functions
+# initialize the langsmith Client with the anonymization functions
 langsmith_client = Client(
   hide_inputs=comprehend_anonymize, hide_outputs=comprehend_anonymize
 )


### PR DESCRIPTION
Three @[Client] auto-links appear inside Python code comments. The repo's
replace_autolinks() preprocessor intentionally skips content inside fenced
code blocks (in_code_block_fence check), so these were never being
transformed and rendered as literal, broken '@[Client]' text in the example
code on the live page. Removed the @[] wrapper since a markdown link
wouldn't render inside a code comment anyway -- the comment now just reads
plain text, matching the other code comments in this same file that never
used the auto-link syntax in the first place.