### PR TITLE
docs: add SerpApi Search Tools integration

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -719,6 +719,9 @@ python:
   - name: PolarisSearchTool
     pypi: langchain-polaris
     docs_url: https://github.com/Veroq-ai/polaris-sdks/tree/main/python/langchain_polaris
+  - name: SerpApi Search Tools
+    pypi: serpapi-search-tools
+    docs_url: https://serpapi.github.io/serpapi-search-tools-python/docs/sdk-examples/langchain.html
   middleware:
   - name: CopilotKit
     pypi: copilotkit

--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -2129,6 +2129,14 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
+        title="SerpApi"
+        href="https://serpapi.github.io/serpapi-search-tools-python/docs/sdk-examples/langchain.html"
+        icon="link"
+    >
+        Structured search tools for web, news, maps, images, shopping, video, and travel.
+    </Card>
+
+    <Card
         title="SERPdive"
         href="https://serpdive.com/docs"
         icon="link"

--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -41,6 +41,7 @@ The following table shows tools that execute online searches in some shape or fo
 | [Xpoz](https://www.xpoz.ai/docs) | Free tier available | Posts, user profiles, comments, engagement metrics (Twitter/X, Instagram, Reddit, TikTok) |
 | [You.com Search](https://you.com/docs/integrations/langchain) | $100 in credits on sign up | URL, Title, Page Content |
 | [Querit](https://querit.com/docs) | 1000 free searches/month on sign up | URL, Snippet, Title, Page_Age, Site_Name, Site_Icon |
+| [SerpApi Search Tools](https://serpapi.github.io/serpapi-search-tools-python/docs/sdk-examples/langchain.html) | 250 free searches/month | URL, Title, Snippet, Answer Box, Knowledge Graph, AI Overview |
 
 ## Code interpreter
 


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

Adds SerpApi’s `serpapi-search-tools` package to the Python integrations catalog.

This change:

- Registers the package as an external Python tool integration.
- Adds a SerpApi provider card.
- Adds SerpApi Search Tools to the search integrations table.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: N/A
- Feature PR: N/A

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly (N/A, no code examples were added)
- [x] I have used **root relative** paths for internal links (N/A, no internal links were added)
- [x] I have updated navigation in `src/docs.json` if needed (N/A, no page was added)


## Additional notes
N/A