### PR TITLE
docs(langsmith): add Tuned evaluators guide

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -2049,6 +2049,7 @@
                     "pages": [
                       "langsmith/online-evaluations-llm-as-judge",
                       "langsmith/online-evaluations-multi-turn",
+                      "langsmith/tuned-evaluators",
                       "langsmith/online-evaluations-code",
                       "langsmith/online-evaluations-composite"
                     ]

--- a/src/langsmith/evaluation-types.mdx
+++ b/src/langsmith/evaluation-types.mdx
@@ -60,7 +60,7 @@ Learn [how run pairwise evaluations](/langsmith/evaluate-pairwise).
 
 Online evaluation assesses production application outputs in near real-time. Without reference outputs, these evaluations focus on detecting issues, monitoring quality trends, and identifying edge cases that inform future offline testing.
 
-Online evaluators typically run server-side. LangSmith provides built-in [LLM-as-judge evaluators](/langsmith/llm-as-judge) for configuration, and supports custom code evaluators that run within LangSmith.
+Online evaluators typically run server-side. LangSmith supports custom [LLM-as-judge evaluators](/langsmith/llm-as-judge) and code evaluators. [LangChain Tuned evaluators](/langsmith/tuned-evaluators) provide specialized judges managed by LangChain.
 
 ![Online](/langsmith/images/online.png)
 

--- a/src/langsmith/evaluation-types.mdx
+++ b/src/langsmith/evaluation-types.mdx
@@ -60,7 +60,7 @@ Learn [how run pairwise evaluations](/langsmith/evaluate-pairwise).
 
 Online evaluation assesses production application outputs in near real-time. Without reference outputs, these evaluations focus on detecting issues, monitoring quality trends, and identifying edge cases that inform future offline testing.
 
-Online evaluators typically run server-side. LangSmith supports custom [LLM-as-judge evaluators](/langsmith/llm-as-judge) and code evaluators. [LangChain Tuned evaluators](/langsmith/tuned-evaluators) provide specialized judges managed by LangChain.
+Online evaluators typically run server-side. LangSmith supports custom [LLM-as-judge evaluators](/langsmith/llm-as-judge) and code evaluators. [LangChain Tuned Evaluators](/langsmith/tuned-evaluators) provide specialized judges managed by LangChain.
 
 ![Online](/langsmith/images/online.png)
 

--- a/src/langsmith/evaluators.mdx
+++ b/src/langsmith/evaluators.mdx
@@ -41,7 +41,7 @@ You can create an evaluator in the [LangSmith UI](https://smith.langchain.com) o
 1. Click **+ Evaluator** to open the new evaluator panel.
 1. The panel lets you:
    - **Create from scratch**: Build a new [LLM-as-a-Judge](/langsmith/llm-as-judge) or [Code](/langsmith/online-evaluations-code) evaluator.
-   - **Add a LangChain Tuned evaluator**: Attach a [specialized judge managed by LangChain](/langsmith/tuned-evaluators) to a compatible tracing project without configuring a prompt, model, or API key.
+   - **Add a LangChain Tuned Evaluator**: Attach a [specialized judge managed by LangChain](/langsmith/tuned-evaluators) to a compatible tracing project without configuring a prompt, model, or API key.
    - **Create from a template**: Start from a ready-made evaluator (also known as a prebuilt evaluator) for common evaluation patterns. A **Recommended** section surfaces popular templates first, followed by templates organized by the following categories:
 
      | Category | Description |

--- a/src/langsmith/evaluators.mdx
+++ b/src/langsmith/evaluators.mdx
@@ -41,6 +41,7 @@ You can create an evaluator in the [LangSmith UI](https://smith.langchain.com) o
 1. Click **+ Evaluator** to open the new evaluator panel.
 1. The panel lets you:
    - **Create from scratch**: Build a new [LLM-as-a-Judge](/langsmith/llm-as-judge) or [Code](/langsmith/online-evaluations-code) evaluator.
+   - **Add a LangChain Tuned evaluator**: Attach a [specialized judge managed by LangChain](/langsmith/tuned-evaluators) to a compatible tracing project without configuring a prompt, model, or API key.
    - **Create from a template**: Start from a ready-made evaluator (also known as a prebuilt evaluator) for common evaluation patterns. A **Recommended** section surfaces popular templates first, followed by templates organized by the following categories:
 
      | Category | Description |

--- a/src/langsmith/online-evaluations-multi-turn.mdx
+++ b/src/langsmith/online-evaluations-multi-turn.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Multi-turn evaluators
 
 Multi-turn online evaluators allow you to evaluate entire conversations between a human and an agent—not just individual exchanges. They measure end-to-end interaction quality across all turns in a thread.
 
-<Tip>To use a pre-tuned thread-level judge without configuring a model, API key, or prompt, see [LangChain Tuned evaluators](/langsmith/tuned-evaluators).</Tip>
+<Tip>To use a LangChain-managed, thread-level judge without configuring a model, API key, or prompt, see [LangChain Tuned Evaluators](/langsmith/tuned-evaluators).</Tip>
 
 You can use multi-turn evaluations to measure:
 1. Semantic Intent: What the user was trying to do.

--- a/src/langsmith/online-evaluations-multi-turn.mdx
+++ b/src/langsmith/online-evaluations-multi-turn.mdx
@@ -5,6 +5,8 @@ sidebarTitle: Multi-turn evaluators
 
 Multi-turn online evaluators allow you to evaluate entire conversations between a human and an agent—not just individual exchanges. They measure end-to-end interaction quality across all turns in a thread.
 
+<Tip>To use a pre-tuned thread-level judge without configuring a model, API key, or prompt, see [LangChain Tuned evaluators](/langsmith/tuned-evaluators).</Tip>
+
 You can use multi-turn evaluations to measure:
 1. Semantic Intent: What the user was trying to do.
 2. Semantic Outcome: What actually happened, did the task succeed.

--- a/src/langsmith/tuned-evaluators.mdx
+++ b/src/langsmith/tuned-evaluators.mdx
@@ -81,7 +81,7 @@ Disabling the feature pauses attached Tuned evaluators. LangSmith preserves thei
 
 ## Review usage charges
 
-Availability and pricing vary by Tuned evaluator. Each successful evaluation incurs a managed evaluation charge in addition to ordinary trace usage. Skipped and failed evaluations are not billed. For general usage and pricing information, see [LangSmith pricing](/langsmith/pricing).
+Availability and pricing vary by Tuned evaluator. Each successful evaluation incurs a managed evaluation charge in addition to ordinary trace usage. Skipped and failed evaluations are not billed. For general usage and pricing information, see [LangSmith pricing](/langsmith/pricing-plans).
 
 ## Troubleshoot Tuned evaluators
 

--- a/src/langsmith/tuned-evaluators.mdx
+++ b/src/langsmith/tuned-evaluators.mdx
@@ -1,89 +1,99 @@
 ---
-title: Set up LangChain Tuned evaluators
-sidebarTitle: Tuned evaluators
-tag: Beta
-description: Use specialized LangChain-managed judges to attach quality feedback to production traces.
+title: Set up LangChain Tuned Evaluators
+sidebarTitle: Tuned Evaluators
+tag: Coming soon
+description: Use specialized LangChain-managed judges to attach quality feedback to traces.
 ---
 
 <Note>
-LangChain Tuned evaluators are in **[beta](/langsmith/release-stages)**. Their interface and behavior may change before general availability.
+**Coming soon:** Perceived Error (Tuned), the first LangChain Tuned Evaluator, is not yet available.
 </Note>
 
-LangChain Tuned evaluators attach feedback to your traces. Each evaluator uses a specialized judge trained for a specific evaluation task. LangChain writes, tests, versions, and maintains the prompt and judge model so that you can focus on using the feedback to find and fix problems in your agent.
+LangChain Tuned Evaluators attach feedback to your traces. Each evaluator uses a specialized judge trained for a specific evaluation task. LangChain writes, tests, versions, and maintains the prompt and judge model so that you can focus on using the feedback to find and fix problems in your agent.
 
-## How Tuned evaluators work
+Perceived Error (Tuned) detects conversations with evidence that an agent made a mistake, misunderstood a request, or took the interaction in the wrong direction. It returns `true` when the user appears to perceive an error and `false` otherwise. Evidence can include a user correction, repeated request, rejected action, contradictory response, acknowledged mistake, persistent misunderstanding, or unresolved outcome.
 
-1. Add a Tuned evaluator to a tracing project.
-1. LangSmith identifies traces or threads that meet the evaluator's requirements.
-1. A specialized LangChain-managed judge evaluates each eligible trace or thread.
-1. LangSmith attaches the result and its explanation to the trace or thread as feedback.
-1. You use that feedback to investigate failures, find recurring problems, and build datasets and evaluations for testing improvements.
-
-## Perceived Error
-
-**Perceived Error (Tuned)** detects conversations with evidence that an agent made a mistake, misunderstood a request, or took the interaction in the wrong direction. It returns `true` when the user appears to perceive an error and `false` otherwise.
-
-The evidence can be explicit, such as a user correction, repeated request, or rejected action. Perceived Error can also recognize evidence in contradictory responses, acknowledged mistakes, persistent misunderstandings, and unresolved outcomes. This makes it useful when users do not leave ratings or other direct feedback.
-
-## Use the feedback to improve your agent
-
-Perceived Error feedback can help you:
+Use Perceived Error feedback to:
 
 - Find failures that did not produce a system error or explicit user rating.
 - Filter for conversations that need investigation and review the evaluator's explanation with the original interaction.
 - Compare flagged threads to identify recurring failure modes.
 - Add useful threads to evaluation datasets or send ambiguous cases for human review.
-- Test agent changes against examples drawn from production failures.
+- Test agent changes against examples drawn from traced failures.
+
+## Understand how LangChain Tuned Evaluators work
+
+<Steps>
+  <Step title="Add an evaluator">
+    Add a LangChain Tuned Evaluator to a compatible tracing project.
+  </Step>
+  <Step title="Identify an eligible thread">
+    LangSmith identifies a thread that meets the evaluator's requirements and the project's filters and sampling configuration.
+  </Step>
+  <Step title="Evaluate the thread">
+    The specialized LangChain-managed judge evaluates the eligible thread.
+  </Step>
+  <Step title="Attach feedback">
+    LangSmith attaches the result and its explanation to the thread as feedback.
+  </Step>
+</Steps>
 
 ## Before you begin
 
 Before you add Perceived Error (Tuned):
 
-- An [organization admin](/langsmith/rbac#organization-admin) must enable LangChain Tuned evaluators for the organization.
+- An [organization admin](/langsmith/rbac#organization-admin) must enable LangChain Tuned Evaluators for the organization.
 - The source must be a tracing project that uses [threads](/langsmith/threads). The Perceived Error (Tuned) evaluator cannot run on individual runs.
 - Thread traces must contain supported [message lists](/langsmith/online-evaluations-multi-turn#prerequisites). At least one non-empty user message must be followed by a non-empty assistant message.
 - Each thread must contain at least two traces before the evaluator can run.
 
-## Enable Tuned evaluators
+## Enable LangChain Tuned Evaluators
 
-Enabling Tuned evaluators lets members attach them to tracing projects throughout the organization. Evaluation data is processed using LangChain-managed API keys.
+Enabling LangChain Tuned Evaluators lets members attach them to tracing projects throughout the organization. Evaluation data is processed using LangChain-managed API keys.
 
-To enable Tuned evaluators as an organization admin:
+To enable LangChain Tuned Evaluators as an organization admin:
 
-1. In LangSmith, open **Settings**.
+1. In the [LangSmith UI](https://smith.langchain.com), open **Settings**.
 1. Select **Tuned evaluators**.
 1. Turn on **Enable LangChain Tuned evaluators** and accept the terms.
 
-An organization admin can also accept and enable Tuned evaluators when first saving one from the evaluator gallery.
+An organization admin can also accept and enable LangChain Tuned Evaluators when first saving one from the evaluator gallery.
 
-## Add a Tuned evaluator to a project
+## Add a LangChain Tuned Evaluator to a project
 
 To add Perceived Error (Tuned) to a tracing project:
 
 1. Open a tracing project and select the **Evaluators** tab.
 1. Select **+ Evaluator**.
 1. Under **LangChain Tuned**, select **Perceived Error (Tuned)**.
-1. Optionally configure filters and the sampling rate. The evaluator name, prompt, model, variable mapping, and thread-level source are managed by LangChain and cannot be changed. You can change the feedback key.
-1. Select **Save**.
+1. (Optional) Configure filters and the sampling rate.
+
+   <Note>
+   Only the feedback key can be changed. The evaluator name, prompt, model, variable mapping, and thread-level source are not editable.
+   </Note>
+
+1. Click **Save**.
 
 Before creating the evaluator, LangSmith checks the recent threads in the project for the supported message list with a complete user-to-assistant exchange.
 
 LangSmith blocks creation when the project is empty or none of the recent threads has a compatible message structure.
 
-## Disable Tuned evaluators
+## Disable LangChain Tuned Evaluators
 
-To disable Tuned evaluators for the organization:
+To disable LangChain Tuned Evaluators for the organization:
 
 1. Open **Settings** and select **Tuned evaluators**.
 1. Turn off **Enable LangChain Tuned evaluators**.
 
-Disabling the feature pauses attached Tuned evaluators. LangSmith preserves their configuration, and they resume when an organization admin enables the feature again.
+Disabling the feature pauses attached LangChain Tuned Evaluators. LangSmith preserves their configuration, and they resume when an organization admin enables the feature again.
 
 ## Review usage charges
 
-Availability and pricing vary by Tuned evaluator. Each successful evaluation incurs a managed evaluation charge in addition to ordinary trace usage. Skipped and failed evaluations are not billed. For general usage and pricing information, see [LangSmith pricing](/langsmith/pricing-plans).
+Availability and pricing vary by LangChain Tuned Evaluator. LangSmith charges LCUs only for an evaluation run that attaches feedback. The evaluator does not create a separate trace. Skipped and failed evaluation attempts that do not attach feedback are not billed as evaluation runs.
 
-## Troubleshoot Tuned evaluators
+Like other online evaluators, LangChain Tuned Evaluators upgrade evaluated traces to extended retention. This can increase trace storage charges. For current rates, see [LangSmith pricing](/langsmith/pricing-plans). For details about retention upgrades and trace charges, see [data retention auto-upgrades](/langsmith/usage-and-billing#data-retention-auto-upgrades).
+
+## Troubleshoot LangChain Tuned Evaluators
 
 ### The project is empty
 
@@ -97,7 +107,7 @@ Check the inputs and outputs of the project's most recent threads. Their top-lev
 
 Check the following conditions:
 
-- The organization still has Tuned evaluators enabled.
+- The organization still has LangChain Tuned Evaluators enabled.
 - The thread contains at least two traces.
 - The project's thread idle time has elapsed.
 - The thread matches the evaluator's filters and sampling configuration.

--- a/src/langsmith/tuned-evaluators.mdx
+++ b/src/langsmith/tuned-evaluators.mdx
@@ -1,0 +1,115 @@
+---
+title: Set up LangChain Tuned evaluators
+sidebarTitle: Tuned evaluators
+description: Use specialized LangChain-managed judges to attach quality feedback to production traces.
+---
+
+LangChain Tuned evaluators attach feedback to your traces. Each evaluator uses a specialized judge trained for a specific evaluation task. LangChain writes, tests, versions, and maintains the prompt and judge model so that you can focus on using the feedback to find and fix problems in your agent.
+
+## How Tuned evaluators work
+
+1. Add a Tuned evaluator to a tracing project.
+1. LangSmith identifies traces or threads that meet the evaluator's requirements.
+1. A specialized LangChain-managed judge evaluates each eligible trace or thread.
+1. LangSmith attaches the result and its explanation to the trace or thread as feedback.
+1. You use that feedback to investigate failures, find recurring problems, and build datasets and evaluations for testing improvements.
+
+## Perceived Error
+
+**Perceived Error (Tuned)** detects conversations with evidence that an agent made a mistake, misunderstood a request, or took the interaction in the wrong direction. It returns `true` when the user appears to perceive an error and `false` otherwise.
+
+The evidence can be explicit, such as a user correction, repeated request, or rejected action. Perceived Error can also recognize evidence in contradictory responses, acknowledged mistakes, persistent misunderstandings, and unresolved outcomes. This makes it useful when users do not leave ratings or other direct feedback.
+
+## Use the feedback to improve your agent
+
+Perceived Error feedback can help you:
+
+- Find failures that did not produce a system error or explicit user rating.
+- Filter for conversations that need investigation and review the evaluator's explanation with the original interaction.
+- Compare flagged threads to identify recurring failure modes.
+- Add useful threads to evaluation datasets or send ambiguous cases for human review.
+- Test agent changes against examples drawn from production failures.
+
+## Before you begin
+
+Before you add Perceived Error (Tuned):
+
+- An [organization admin](/langsmith/rbac#organization-admin) must enable LangChain Tuned evaluators for the organization.
+- The source must be a tracing project that uses [threads](/langsmith/threads). Tuned evaluators cannot run on individual runs.
+- Thread traces must contain supported [message lists](/langsmith/online-evaluations-multi-turn#prerequisites). At least one non-empty user message must be followed by a non-empty assistant message.
+- Each thread must contain at least two traces before the evaluator can run.
+
+## Enable Tuned evaluators
+
+Enabling Tuned evaluators lets members attach them to tracing projects throughout the organization. Evaluation data is processed using LangChain-managed API keys.
+
+To enable Tuned evaluators as an organization admin:
+
+1. In LangSmith, open **Settings**.
+1. Select **Tuned evaluators**.
+1. Turn on **Enable LangChain Tuned evaluators** and accept the terms.
+
+An organization admin can also accept and enable Tuned evaluators when first saving one from the evaluator gallery.
+
+<Note>
+All model providers used for LangChain-managed inference operate under zero data retention and are contractually prohibited from training or fine-tuning on your data. Use of Tuned evaluators is subject to the [LangChain Terms of Service](https://www.langchain.com/terms-of-service).
+</Note>
+
+## Add a Tuned evaluator to a project
+
+To add Perceived Error (Tuned) to a tracing project:
+
+1. Open a tracing project and select the **Evaluators** tab.
+1. Select **+ Evaluator**.
+1. Under **LangChain Tuned**, select **Perceived Error (Tuned)**.
+1. Optionally configure filters and the sampling rate. The evaluator name, prompt, model, variable mapping, and thread-level source are managed by LangChain and cannot be changed. You can change the feedback key.
+1. Select **Save**.
+
+Before creating the evaluator, LangSmith checks the recent threads in the project for the supported message list with a complete user-to-assistant exchange.
+
+LangSmith blocks creation when the project is empty or none of the recent threads has a compatible message structure.
+
+## Disable Tuned evaluators
+
+To disable Tuned evaluators for the organization:
+
+1. Open **Settings** and select **Tuned evaluators**.
+1. Turn off **Enable LangChain Tuned evaluators**.
+
+Disabling the feature pauses attached Tuned evaluators. LangSmith preserves their configuration, and they resume when an organization admin enables the feature again.
+
+## Review usage charges
+
+Availability and pricing vary by Tuned evaluator. Each successfully evaluated thread incurs a managed evaluation charge in addition to ordinary trace usage. Skipped and failed evaluations are not billed. For general usage and billing information, see [LangSmith usage and billing](/langsmith/usage-and-billing).
+
+## Troubleshoot Tuned evaluators
+
+### The project is empty
+
+Add a thread to the tracing project, then try to save the evaluator again. The thread must contain supported message lists and at least one complete user-to-assistant exchange.
+
+### The project does not contain a valid message list
+
+Check the inputs and outputs of the project's most recent threads. Their top-level `messages` fields must contain message lists in a [supported format](/langsmith/online-evaluations-multi-turn#prerequisites), and at least one user message must be followed by an assistant message.
+
+### The evaluator does not produce feedback
+
+Check the following conditions:
+
+- The organization still has Tuned evaluators enabled.
+- The thread contains at least two traces.
+- The project's thread idle time has elapsed.
+- The thread matches the evaluator's filters and sampling configuration.
+- The thread contains a complete user-to-assistant exchange in a supported message format.
+
+To inspect evaluator activity, open the tracing project's **Evaluators** tab and select **Logs** for the evaluator.
+
+### Enabling the feature does not take effect immediately
+
+Organization settings can take a few seconds to propagate. If LangSmith reports that the managed-evaluator setting is still taking effect, wait a few seconds and try again.
+
+## See also
+
+- [Manage evaluators](/langsmith/evaluators)
+- [Set up multi-turn online evaluators](/langsmith/online-evaluations-multi-turn)
+- [Trace with threads](/langsmith/threads)

--- a/src/langsmith/tuned-evaluators.mdx
+++ b/src/langsmith/tuned-evaluators.mdx
@@ -56,10 +56,6 @@ To enable Tuned evaluators as an organization admin:
 
 An organization admin can also accept and enable Tuned evaluators when first saving one from the evaluator gallery.
 
-<Note>
-All model providers used for LangChain-managed inference operate under zero data retention and are contractually prohibited from training or fine-tuning on your data. Use of Tuned evaluators is subject to the [LangChain Terms of Service](https://www.langchain.com/terms-of-service).
-</Note>
-
 ## Add a Tuned evaluator to a project
 
 To add Perceived Error (Tuned) to a tracing project:

--- a/src/langsmith/tuned-evaluators.mdx
+++ b/src/langsmith/tuned-evaluators.mdx
@@ -1,8 +1,13 @@
 ---
 title: Set up LangChain Tuned evaluators
 sidebarTitle: Tuned evaluators
+tag: Beta
 description: Use specialized LangChain-managed judges to attach quality feedback to production traces.
 ---
+
+<Note>
+LangChain Tuned evaluators are in **[beta](/langsmith/release-stages)**. Their interface and behavior may change before general availability.
+</Note>
 
 LangChain Tuned evaluators attach feedback to your traces. Each evaluator uses a specialized judge trained for a specific evaluation task. LangChain writes, tests, versions, and maintains the prompt and judge model so that you can focus on using the feedback to find and fix problems in your agent.
 

--- a/src/langsmith/tuned-evaluators.mdx
+++ b/src/langsmith/tuned-evaluators.mdx
@@ -35,7 +35,7 @@ Perceived Error feedback can help you:
 Before you add Perceived Error (Tuned):
 
 - An [organization admin](/langsmith/rbac#organization-admin) must enable LangChain Tuned evaluators for the organization.
-- The source must be a tracing project that uses [threads](/langsmith/threads). Tuned evaluators cannot run on individual runs.
+- The source must be a tracing project that uses [threads](/langsmith/threads). The Perceived Error (Tuned) evaluator cannot run on individual runs.
 - Thread traces must contain supported [message lists](/langsmith/online-evaluations-multi-turn#prerequisites). At least one non-empty user message must be followed by a non-empty assistant message.
 - Each thread must contain at least two traces before the evaluator can run.
 
@@ -80,7 +80,7 @@ Disabling the feature pauses attached Tuned evaluators. LangSmith preserves thei
 
 ## Review usage charges
 
-Availability and pricing vary by Tuned evaluator. Each successfully evaluated thread incurs a managed evaluation charge in addition to ordinary trace usage. Skipped and failed evaluations are not billed. For general usage and billing information, see [LangSmith usage and billing](/langsmith/usage-and-billing).
+Availability and pricing vary by Tuned evaluator. Each successful evaluation incurs a managed evaluation charge in addition to ordinary trace usage. Skipped and failed evaluations are not billed. For general usage and billing information, see [LangSmith usage and billing](/langsmith/usage-and-billing).
 
 ## Troubleshoot Tuned evaluators
 

--- a/src/langsmith/tuned-evaluators.mdx
+++ b/src/langsmith/tuned-evaluators.mdx
@@ -1,12 +1,12 @@
 ---
 title: Set up LangChain Tuned Evaluators
 sidebarTitle: Tuned Evaluators
-tag: Coming soon
+tag: Beta
 description: Use specialized LangChain-managed judges to attach quality feedback to traces.
 ---
 
 <Note>
-**Coming soon:** Perceived Error (Tuned), the first LangChain Tuned Evaluator, is not yet available.
+LangChain Tuned Evaluators are in **[beta](/langsmith/release-stages)**. Their interface and behavior may change before general availability.
 </Note>
 
 LangChain Tuned Evaluators attach feedback to your traces. Each evaluator uses a specialized judge trained for a specific evaluation task. LangChain writes, tests, versions, and maintains the prompt and judge model so that you can focus on using the feedback to find and fix problems in your agent.
@@ -67,11 +67,6 @@ To add Perceived Error (Tuned) to a tracing project:
 1. Select **+ Evaluator**.
 1. Under **LangChain Tuned**, select **Perceived Error (Tuned)**.
 1. (Optional) Configure filters and the sampling rate.
-
-   <Note>
-   Only the feedback key can be changed. The evaluator name, prompt, model, variable mapping, and thread-level source are not editable.
-   </Note>
-
 1. Click **Save**.
 
 Before creating the evaluator, LangSmith checks the recent threads in the project for the supported message list with a complete user-to-assistant exchange.
@@ -89,7 +84,7 @@ Disabling the feature pauses attached LangChain Tuned Evaluators. LangSmith pres
 
 ## Review usage charges
 
-Availability and pricing vary by LangChain Tuned Evaluator. LangSmith charges LCUs only for an evaluation run that attaches feedback. The evaluator does not create a separate trace. Skipped and failed evaluation attempts that do not attach feedback are not billed as evaluation runs.
+Availability and pricing vary by LangChain Tuned Evaluator. LangSmith charges LCUs only for an evaluation run that attaches feedback. Skipped and failed evaluation attempts that do not attach feedback are not billed.
 
 Like other online evaluators, LangChain Tuned Evaluators upgrade evaluated traces to extended retention. This can increase trace storage charges. For current rates, see [LangSmith pricing](/langsmith/pricing-plans). For details about retention upgrades and trace charges, see [data retention auto-upgrades](/langsmith/usage-and-billing#data-retention-auto-upgrades).
 

--- a/src/langsmith/tuned-evaluators.mdx
+++ b/src/langsmith/tuned-evaluators.mdx
@@ -81,7 +81,7 @@ Disabling the feature pauses attached Tuned evaluators. LangSmith preserves thei
 
 ## Review usage charges
 
-Availability and pricing vary by Tuned evaluator. Each successful evaluation incurs a managed evaluation charge in addition to ordinary trace usage. Skipped and failed evaluations are not billed. For general usage and billing information, see [LangSmith usage and billing](/langsmith/usage-and-billing).
+Availability and pricing vary by Tuned evaluator. Each successful evaluation incurs a managed evaluation charge in addition to ordinary trace usage. Skipped and failed evaluations are not billed. For general usage and pricing information, see [LangSmith pricing](/langsmith/pricing).
 
 ## Troubleshoot Tuned evaluators
 


### PR DESCRIPTION
## What

Add a guide for LangChain Tuned evaluators, starting with Perceived Error. Link the guide from evaluator management, evaluation types, and multi-turn online evaluator documentation, and add it to the Online evaluators navigation.

## Why

Tuned evaluators use specialized LangChain-managed judges to attach feedback to traces without requiring customers to maintain prompts, models, credentials, or inference infrastructure. The existing docs cover custom online evaluators but do not explain Tuned evaluator enablement, project requirements, validation, or operational behavior.

## How

- Explain how Tuned evaluators work and how teams can use Perceived Error feedback.
- Document organization-level enablement, data handling, and how to disable the feature.
- Document tracing-project and thread requirements, save-time message-list validation, filters, sampling, charges, and troubleshooting.
- Cross-link the guide from related evaluator and multi-turn documentation.

Related implementation:

- [langchain-ai/langchainplus#32896](https://github.com/langchain-ai/langchainplus/pull/32896)
- [langchain-ai/langchainplus#32906](https://github.com/langchain-ai/langchainplus/pull/32906)
- [langchain-ai/langchainplus#32949](https://github.com/langchain-ai/langchainplus/pull/32949)
- [langchain-ai/langchainplus#33015](https://github.com/langchain-ai/langchainplus/pull/33015)
- [langchain-ai/langchainplus#33259](https://github.com/langchain-ai/langchainplus/pull/33259)
- [langchain-ai/langchainplus#33331](https://github.com/langchain-ai/langchainplus/pull/33331)

## Review notes

Please review the project eligibility, managed-inference data handling, and usage-charge language against launch behavior.

## Testing

- [x] `make lint_prose FILES="src/langsmith/tuned-evaluators.mdx src/langsmith/evaluators.mdx src/langsmith/online-evaluations-multi-turn.mdx src/langsmith/evaluation-types.mdx"`
- [x] `make broken-links`
- [x] `python3 -m json.tool src/docs.json`
- [x] Verify changed files contain no trailing whitespace.