### PR TITLE
feat: document Agent Server IAM authentication

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -1714,6 +1714,7 @@
                     "pages": [
                       "langsmith/caching",
                       "langsmith/encryption",
+                      "langsmith/configure-iam-auth",
                       "langsmith/graph-rebuild",
                       {
                         "group": "Replace built-in backends",

--- a/src/docs.json
+++ b/src/docs.json
@@ -1713,8 +1713,8 @@
                     "group": "Server customization",
                     "pages": [
                       "langsmith/caching",
-                      "langsmith/encryption",
                       "langsmith/configure-iam-auth",
+                      "langsmith/encryption",
                       "langsmith/graph-rebuild",
                       {
                         "group": "Replace built-in backends",

--- a/src/langsmith/configure-iam-auth.mdx
+++ b/src/langsmith/configure-iam-auth.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Data store IAM authentication
 description: Configure Agent Server to use cloud workload identities for PostgreSQL and Redis authentication.
 ---
 
-Agent Server can use a cloud workload identity to generate short-lived PostgreSQL and Redis credentials at runtime. This removes static database and cache passwords from the deployment configuration while preserving the existing connection and pooling behavior.
+Agent Server can use a cloud workload identity to generate short-lived PostgreSQL and Redis credentials at runtime. This removes static database and cache passwords from your deployment configuration. Connection and pooling behavior stay the same.
 
 <Note>
 Data store IAM authentication requires `langgraph-api>=0.12.0`.
@@ -24,7 +24,7 @@ The GCP PostgreSQL provider supports Cloud SQL. It does not support AlloyDB, whi
 
 The provider setting controls authentication only. Configure network access, TLS, database users, cache users, and provider permissions before starting Agent Server.
 
-## Configure Agent Server
+## Enable IAM authentication
 
 To enable IAM authentication:
 
@@ -34,10 +34,10 @@ To enable IAM authentication:
 4. Set a connection URI that contains the principal name but no static password.
 5. Set the corresponding provider selector to `aws`, `azure`, or `gcp`:
 
-```shell
-AGENT_POSTGRES_IAM_AUTH_PROVIDER=<provider>
-AGENT_REDIS_IAM_AUTH_PROVIDER=<provider>
-```
+    ```shell
+    AGENT_POSTGRES_IAM_AUTH_PROVIDER=<provider>
+    AGENT_REDIS_IAM_AUTH_PROVIDER=<provider>
+    ```
 
 You can enable IAM authentication for PostgreSQL, Redis, or both. When a selector is unset, Agent Server continues to use the password from that data store's connection URI.
 
@@ -48,7 +48,12 @@ Use these connection URI variables for your deployment type:
 | Standalone Agent Server | `DATABASE_URI` | `REDIS_URI` |
 | Self-hosted deployment with a control plane | `POSTGRES_URI_CUSTOM` | `REDIS_URI_CUSTOM` |
 
-Use `sslmode=require` or a stricter verification mode for PostgreSQL and `rediss://` for Redis. Percent-encode URI-reserved characters in usernames, such as `@` as `%40`. If Redis TLS uses a private certificate authority, set `REDIS_TLS_CA_CERT` to the base64-encoded PEM CA bundle. If the Redis service uses cluster mode, also set `REDIS_CLUSTER=true`.
+The connection URIs must meet the following requirements:
+
+- **Transport security**: Use `sslmode=require` or a stricter verification mode for PostgreSQL, and `rediss://` for Redis.
+- **Character encoding**: Percent-encode URI-reserved characters in usernames, such as `@` as `%40`.
+- **Private certificate authority**: If Redis TLS uses a private certificate authority, set `REDIS_TLS_CA_CERT` to the base64-encoded PEM CA bundle.
+- **Cluster mode**: If the Redis service uses cluster mode, also set `REDIS_CLUSTER=true`.
 
 ## Configure AWS
 
@@ -70,7 +75,7 @@ DATABASE_URI="postgresql://<rds-user>@<rds-endpoint>:5432/<database>?sslmode=req
 REDIS_URI="rediss://<elasticache-iam-user>@<elasticache-endpoint>:6379"
 ```
 
-The Redis username must match the IAM-enabled ElastiCache user. Agent Server supports provisioned ElastiCache cache clusters and replication groups. ElastiCache IAM authentication requires Valkey 7.2 or later or Redis OSS 7.0 or later, with in-transit encryption enabled.
+The Redis username must match the IAM-enabled ElastiCache user. Agent Server supports provisioned ElastiCache cache clusters and replication groups. ElastiCache IAM authentication requires in-transit encryption and either Valkey 7.2 or later or Redis OSS 7.0 or later.
 
 ## Configure Azure
 
@@ -115,7 +120,7 @@ REDIS_CLUSTER=true
 
 For a service account, the Cloud SQL database username is its email address without the `.gserviceaccount.com` suffix.
 
-## Configure the standalone Agent Server Helm chart
+## Configure the standalone Helm chart
 
 For a [standalone Agent Server deployment](/langsmith/deploy-standalone-server) on Kubernetes, set the provider selectors on every Agent Server workload. If the separate queue deployment is enabled, configure the API and queue deployments with the same identity and environment variables.
 
@@ -155,4 +160,5 @@ Configure `apiServer.serviceAccount` and `queue.serviceAccount` with the cloud p
 
 - [Self-host standalone servers](/langsmith/deploy-standalone-server)
 - [Self-hosted Agent Server environment variables](/langsmith/env-var-self-hosted)
+- [Self-hosted platform features](/langsmith/self-hosted-platform-features)
 - [Configure Agent Server for scale](/langsmith/agent-server-scale)

--- a/src/langsmith/configure-iam-auth.mdx
+++ b/src/langsmith/configure-iam-auth.mdx
@@ -1,0 +1,152 @@
+---
+title: Configure IAM authentication for data stores
+sidebarTitle: Data store IAM authentication
+description: Configure Agent Server to use cloud workload identities for PostgreSQL and Redis authentication.
+---
+
+Agent Server can use a cloud workload identity to generate short-lived PostgreSQL and Redis credentials at runtime. This removes static database and cache passwords from the deployment configuration while preserving the existing connection and pooling behavior.
+
+<Note>
+Data store IAM authentication requires `langgraph-api>=0.12.0`.
+</Note>
+
+## Supported services
+
+| Provider value | PostgreSQL | Redis | Credential source |
+|----------------|------------|-------|-------------------|
+| `aws` | Amazon RDS or Aurora PostgreSQL | Amazon ElastiCache provisioned cache clusters or replication groups | AWS SDK default credential chain |
+| `azure` | Azure Database for PostgreSQL Flexible Server | Azure Managed Redis or Azure Cache for Redis | Microsoft Entra `DefaultAzureCredential` |
+| `gcp` | Cloud SQL for PostgreSQL | Memorystore for Redis Cluster | Google Application Default Credentials (ADC) |
+
+<Warning>
+The GCP PostgreSQL provider supports Cloud SQL. It does not support AlloyDB, which requires a different token scope.
+</Warning>
+
+The provider setting controls authentication only. Configure network access, TLS, database users, cache users, and provider permissions before starting Agent Server.
+
+## Configure Agent Server
+
+To enable IAM authentication:
+
+1. Enable IAM or identity-based authentication on the managed data store.
+2. Create the database or cache principal and grant it only the permissions Agent Server needs.
+3. Make workload identity credentials available to every Agent Server API and queue process.
+4. Set a connection URI that contains the principal name but no static password.
+5. Set the corresponding provider selector to `aws`, `azure`, or `gcp`:
+
+```shell
+AGENT_POSTGRES_IAM_AUTH_PROVIDER=<provider>
+AGENT_REDIS_IAM_AUTH_PROVIDER=<provider>
+```
+
+You can enable IAM authentication for PostgreSQL, Redis, or both. When a selector is unset, Agent Server continues to use the password from that data store's connection URI.
+
+Use these connection URI variables for your deployment type:
+
+| Deployment | PostgreSQL URI | Redis URI |
+|------------|----------------|-----------|
+| Standalone Agent Server | `DATABASE_URI` | `REDIS_URI` |
+| Self-hosted deployment with a control plane | `POSTGRES_URI_CUSTOM` | `REDIS_URI_CUSTOM` |
+
+Use `sslmode=require` or a stricter verification mode for PostgreSQL and `rediss://` for Redis. Percent-encode URI-reserved characters in usernames, such as `@` as `%40`. If Redis TLS uses a private certificate authority, set `REDIS_TLS_CA_CERT` to the base64-encoded PEM CA bundle. If the Redis service uses cluster mode, also set `REDIS_CLUSTER=true`.
+
+## Configure AWS
+
+Agent Server uses the AWS SDK default credential chain to create RDS authentication tokens and ElastiCache SigV4 authentication tokens.
+
+Before configuring Agent Server:
+
+- [Enable IAM database authentication](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/UsingWithRDS.IAMDBAuth.html) for RDS or Aurora PostgreSQL. Grant the database user the `rds_iam` role and grant the workload identity `rds-db:connect` for that user.
+- [Enable IAM authentication](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/auth-iam.html) for the ElastiCache user. Grant the workload identity `elasticache:Connect` for both the ElastiCache cache or replication group and the ElastiCache user.
+- Configure AWS credentials through EKS Pod Identity, IAM roles for service accounts (IRSA), an instance profile, or another AWS SDK credential source. Set `AWS_REGION` or `AWS_DEFAULT_REGION` to the data store's region.
+
+Set the database usernames in the connection URIs:
+
+```shell
+AWS_REGION=<region>
+AGENT_POSTGRES_IAM_AUTH_PROVIDER=aws
+AGENT_REDIS_IAM_AUTH_PROVIDER=aws
+DATABASE_URI="postgresql://<rds-user>@<rds-endpoint>:5432/<database>?sslmode=require"
+REDIS_URI="rediss://<elasticache-iam-user>@<elasticache-endpoint>:6379"
+```
+
+The Redis username must match the IAM-enabled ElastiCache user. Agent Server supports provisioned ElastiCache cache clusters and replication groups. ElastiCache IAM authentication requires Valkey 7.2 or later or Redis OSS 7.0 or later, with in-transit encryption enabled.
+
+## Configure Azure
+
+Agent Server uses `DefaultAzureCredential` to obtain Microsoft Entra tokens for PostgreSQL and Redis. The credential chain supports Azure Workload Identity, managed identities, and service principals.
+
+Before configuring Agent Server:
+
+- [Configure Microsoft Entra authentication](https://learn.microsoft.com/azure/postgresql/security/security-connect-with-managed-identity) for Azure Database for PostgreSQL Flexible Server. Create a database role for the managed identity or service principal. Use that role name as the PostgreSQL URI username.
+- [Configure Microsoft Entra authentication](https://learn.microsoft.com/azure/redis/entra-for-authentication) and a data access policy for Azure Managed Redis. Use the managed identity or service principal object ID as the Redis URI username.
+- Configure Azure Workload Identity, a managed identity, or another `DefaultAzureCredential` source for each Agent Server workload.
+
+Set the Microsoft Entra principal identifiers in the connection URIs:
+
+```shell
+AGENT_POSTGRES_IAM_AUTH_PROVIDER=azure
+AGENT_REDIS_IAM_AUTH_PROVIDER=azure
+DATABASE_URI="postgresql://<entra-principal-name>@<postgres-host>:5432/<database>?sslmode=require"
+REDIS_URI="rediss://<entra-object-id>@<redis-host>:<port>"
+```
+
+Set `REDIS_CLUSTER=true` when using Azure Managed Redis in cluster mode. Agent Server refreshes Microsoft Entra tokens and reauthenticates open Redis connections before token expiration.
+
+## Configure GCP
+
+Agent Server uses Google ADC to obtain Cloud SQL login tokens and Memorystore access tokens. ADC supports GKE Workload Identity Federation, attached service accounts, service account impersonation, and `GOOGLE_APPLICATION_CREDENTIALS`.
+
+Before configuring Agent Server:
+
+- [Configure Cloud SQL IAM database authentication](https://cloud.google.com/sql/docs/postgres/iam-logins), add the IAM principal as a database user, and grant it `roles/cloudsql.instanceUser`. Grant database privileges separately.
+- [Configure Memorystore IAM authentication](https://cloud.google.com/memorystore/docs/cluster/manage-iam-auth) and grant the workload identity `roles/redis.dbConnectionUser`.
+- Configure ADC for each Agent Server workload. Prefer Workload Identity Federation or an attached service account over a service account key.
+
+Set the Cloud SQL IAM database user in the PostgreSQL URI. Memorystore supports only the `default` Redis username:
+
+```shell
+AGENT_POSTGRES_IAM_AUTH_PROVIDER=gcp
+AGENT_REDIS_IAM_AUTH_PROVIDER=gcp
+DATABASE_URI="postgresql://<cloud-sql-iam-user>@<cloud-sql-host>:5432/<database>?sslmode=require"
+REDIS_URI="rediss://default@<memorystore-discovery-endpoint>:<port>"
+REDIS_CLUSTER=true
+```
+
+For a service account, the Cloud SQL database username is its email address without the `.gserviceaccount.com` suffix.
+
+## Configure the standalone Helm chart
+
+For a standalone Kubernetes deployment, set the provider selectors on every Agent Server workload. If the separate queue deployment is enabled, configure the API and queue deployments with the same identity and environment variables:
+
+```yaml
+postgres:
+  external:
+    enabled: true
+    connectionUrl: "postgresql://<database-user>@<postgres-host>:5432/<database>?sslmode=require"
+redis:
+  external:
+    enabled: true
+    connectionUrl: "rediss://<redis-user>@<redis-host>:<port>"
+
+apiServer:
+  deployment:
+    extraEnv: &data-store-iam-env
+      - name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
+        value: <provider>
+      - name: AGENT_REDIS_IAM_AUTH_PROVIDER
+        value: <provider>
+
+queue:
+  enabled: true
+  deployment:
+    extraEnv: *data-store-iam-env
+```
+
+Configure `apiServer.serviceAccount` and `queue.serviceAccount` with the cloud provider's workload identity mechanism. Both workloads must be able to obtain credentials and connect to the data stores.
+
+## See also
+
+- [Self-host standalone servers](/langsmith/deploy-standalone-server)
+- [Self-hosted Agent Server environment variables](/langsmith/env-var-self-hosted)
+- [Configure Agent Server for scale](/langsmith/agent-server-scale)

--- a/src/langsmith/configure-iam-auth.mdx
+++ b/src/langsmith/configure-iam-auth.mdx
@@ -115,9 +115,11 @@ REDIS_CLUSTER=true
 
 For a service account, the Cloud SQL database username is its email address without the `.gserviceaccount.com` suffix.
 
-## Configure the standalone Helm chart
+## Configure the standalone Agent Server Helm chart
 
-For a standalone Kubernetes deployment, set the provider selectors on every Agent Server workload. If the separate queue deployment is enabled, configure the API and queue deployments with the same identity and environment variables:
+For a [standalone Agent Server deployment](/langsmith/deploy-standalone-server) on Kubernetes, set the provider selectors on every Agent Server workload. If the separate queue deployment is enabled, configure the API and queue deployments with the same identity and environment variables.
+
+The following example uses AWS for both data stores. Set each provider value to `azure` or `gcp` when using another cloud provider:
 
 ```yaml
 postgres:
@@ -131,16 +133,20 @@ redis:
 
 apiServer:
   deployment:
-    extraEnv: &data-store-iam-env
+    extraEnv:
       - name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
-        value: <provider>
+        value: "aws"
       - name: AGENT_REDIS_IAM_AUTH_PROVIDER
-        value: <provider>
+        value: "aws"
 
 queue:
   enabled: true
   deployment:
-    extraEnv: *data-store-iam-env
+    extraEnv:
+      - name: AGENT_POSTGRES_IAM_AUTH_PROVIDER
+        value: "aws"
+      - name: AGENT_REDIS_IAM_AUTH_PROVIDER
+        value: "aws"
 ```
 
 Configure `apiServer.serviceAccount` and `queue.serviceAccount` with the cloud provider's workload identity mechanism. Both workloads must be able to obtain credentials and connect to the data stores.

--- a/src/langsmith/self-hosted-platform-features.mdx
+++ b/src/langsmith/self-hosted-platform-features.mdx
@@ -9,13 +9,13 @@ This page describes the platform features that apply only to [self-hosted](/lang
 
 ## Custom PostgreSQL
 
-A custom PostgreSQL instance can be used instead of the [one automatically created by the control plane](/langsmith/cloud-platform-features#database-provisioning). Specify the [`POSTGRES_URI_CUSTOM`](/langsmith/env-var-self-hosted) environment variable to use a custom PostgreSQL instance.
+A custom PostgreSQL instance can be used instead of the [one automatically created by the control plane](/langsmith/cloud-platform-features#database-provisioning). Specify the [`POSTGRES_URI_CUSTOM`](/langsmith/env-var-self-hosted) environment variable to use a custom PostgreSQL instance. To authenticate with a cloud workload identity instead of a static password, see [Configure IAM authentication for data stores](/langsmith/configure-iam-auth).
 
 Multiple deployments can share the same PostgreSQL instance. For example, for `Deployment A`, `POSTGRES_URI_CUSTOM` can be set to `postgres://<user>:<password>@/<database_name_1>?host=<hostname_1>` and for `Deployment B`, `POSTGRES_URI_CUSTOM` can be set to `postgres://<user>:<password>@/<database_name_2>?host=<hostname_1>`. `<database_name_1>` and `<database_name_2>` are different databases within the same instance, but `<hostname_1>` is shared. **The same database cannot be used for separate deployments**.
 
 ## Custom Redis
 
-A custom Redis instance can be used instead of the one automatically created by the control plane. Specify the [`REDIS_URI_CUSTOM`](/langsmith/env-var-self-hosted) environment variable to use a custom Redis instance.
+A custom Redis instance can be used instead of the one automatically created by the control plane. Specify the [`REDIS_URI_CUSTOM`](/langsmith/env-var-self-hosted) environment variable to use a custom Redis instance. To authenticate with a cloud workload identity instead of a static password, see [Configure IAM authentication for data stores](/langsmith/configure-iam-auth).
 
 Multiple deployments can share the same Redis instance. For example, for `Deployment A`, `REDIS_URI_CUSTOM` can be set to `redis://<hostname_1>:<port>/1` and for `Deployment B`, `REDIS_URI_CUSTOM` can be set to `redis://<hostname_1>:<port>/2`. `1` and `2` are different database numbers within the same instance, but `<hostname_1>` is shared. **The same database number cannot be used for separate deployments**.
 

--- a/src/snippets/langsmith/env-vars/self-hosted-only.mdx
+++ b/src/snippets/langsmith/env-vars/self-hosted-only.mdx
@@ -1,3 +1,15 @@
+## `AGENT_POSTGRES_IAM_AUTH_PROVIDER`
+
+Set `AGENT_POSTGRES_IAM_AUTH_PROVIDER` to `aws`, `azure`, or `gcp` to replace the password in the PostgreSQL connection URI with a short-lived cloud identity token. Requires `langgraph-api>=0.12.0`.
+
+For provider prerequisites and connection URI requirements, see [Configure IAM authentication for data stores](/langsmith/configure-iam-auth).
+
+## `AGENT_REDIS_IAM_AUTH_PROVIDER`
+
+Set `AGENT_REDIS_IAM_AUTH_PROVIDER` to `aws`, `azure`, or `gcp` to authenticate Redis connections with a short-lived cloud identity token. Requires `langgraph-api>=0.12.0`.
+
+For provider prerequisites and connection URI requirements, see [Configure IAM authentication for data stores](/langsmith/configure-iam-auth).
+
 ## `LANGSMITH_API_KEY`
 
 To send traces to a self-hosted LangSmith instance, set `LANGSMITH_API_KEY` to an API key created from the self-hosted instance.


### PR DESCRIPTION
## Description
Document how self-hosted Agent Server uses workload identity for PostgreSQL and Redis across AWS, Azure, and GCP, including provider prerequisites, secure URI formats, and standalone Helm configuration. Add environment variable references and navigation links.

## Test Plan
- [x] Scoped Vale prose lint and codespell
- [x] Docs build and broken-link check
- [x] Parsed the Helm values example as YAML

Made by [Open SWE](https://openswe.vercel.app/agents/1eccd108-982d-0ed7-f1ec-20c0f31c8aa2)