### PR TITLE
docs(llm gateway): add Pi configuration note for OpenAI, Anthropic

### DIFF
--- a/src/langsmith/llm-gateway-coding-agents.mdx
+++ b/src/langsmith/llm-gateway-coding-agents.mdx
@@ -1,6 +1,6 @@
 ---
 title: Set up coding agents
-description: Configure Claude Code, Codex, Gemini CLI, and Deep Agents Code to route LLM calls through the LLM Gateway.
+description: Configure Claude Code, Codex, Gemini CLI, Pi, and Deep Agents Code to route LLM calls through the LLM Gateway.
 ---
 
 <Note>
@@ -9,7 +9,7 @@ description: Configure Claude Code, Codex, Gemini CLI, and Deep Agents Code to r
 
 Configure coding agents to use the standard LLM Gateway endpoint for centralized cost controls, observability, and audit trails. The gateway authenticates each caller, routes by model ID, enforces policies, and traces each call.
 
-Claude Code can use the standard Anthropic Messages format, while Codex and Deep Agents Code can use the standard OpenAI-compatible formats. Gemini CLI uses Google's native API and requires [direct model access](/langsmith/llm-gateway-direct-model-access).
+Claude Code and Pi can use the standard Anthropic Messages format, while Codex, Pi, and Deep Agents Code can use the standard OpenAI-compatible formats. Gemini CLI uses Google's native API and requires [direct model access](/langsmith/llm-gateway-direct-model-access).
 
 ## Prerequisites
 
@@ -76,6 +76,34 @@ Gemini CLI sends Google's native Generate Content requests, which the standard e
 ```bash
 gemini
 ```
+
+## Pi coding agent
+
+Pi supports overriding the base URLs for its built-in providers. Set the API key environment variables to your LangSmith API key:
+
+```bash
+export OPENAI_API_KEY="$LANGSMITH_API_KEY"
+export ANTHROPIC_API_KEY="$LANGSMITH_API_KEY"
+```
+
+Add the following provider overrides to `~/.pi/agent/models.json`:
+
+```json
+{
+  "providers": {
+    "openai": {
+      "baseUrl": "https://gateway.smith.langchain.com/openai/v1"
+    },
+    "anthropic": {
+      "baseUrl": "https://gateway.smith.langchain.com/anthropic"
+    }
+  }
+}
+```
+
+Pi does not currently read provider base URLs from environment variables, so you must set them in `models.json`. Pi reads the API keys from the environment variables, so you do not need to store sensitive keys in the file.
+
+Then run `pi` and select an OpenAI or Anthropic model with `/model`.
 
 ## Deep Agents Code
 


### PR DESCRIPTION
## Overview
Add configuration notes for LLM Gateway using the Pi agent. Some manual configuration of Pi is necessary since it does not (seem to) use the `$PROVIDER_BASE_URL` envvars when building requests.

Note: there are some provider's I've tried that don't seem to work (Fireworks) and some Pi community distributions that break ([example](https://omp.sh/)) that break when using Gateway that I haven't successfully debugged yet.



## Type of change

**Type:** Update existing documentation

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue: n/a
- Feature PR: n/a

<!-- For LangChain employees, if applicable: -->
- Linear issue: n/a
- Slack thread: https://langchain.slack.com/archives/C0AU0LZKFT8/p1786386692407579

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
