### PR TITLE
docs: update Terraform provider guide for v0.0.6

### DIFF
--- a/src/langsmith/manage-with-terraform.mdx
+++ b/src/langsmith/manage-with-terraform.mdx
@@ -2,10 +2,14 @@
 title: Manage LangSmith with Terraform
 sidebarTitle: Terraform provider
 icon: "brand-terraform"
-description: Use the official LangSmith Terraform provider to manage workspaces, roles, members, evaluators, run rules, and alert rules as code.
+description: Use the official LangSmith Terraform provider to manage workspaces, access controls, resource tags, evaluators, run rules, and alert rules as code.
 ---
 
-The official [LangSmith Terraform provider](https://registry.terraform.io/providers/langchain-ai/langsmith/latest) lets you manage LangSmith organization and workspace resources as code—workspaces, custom roles, organization and workspace members, evaluators, run rules, and alert rules. It's the infrastructure-as-code counterpart to [managing your organization using the API](/langsmith/manage-organization-by-api).
+The official [LangSmith Terraform provider](https://registry.terraform.io/providers/langchain-ai/langsmith/latest) lets you manage LangSmith organization and workspace resources as code: workspaces, custom roles, organization and workspace members, resource tags, access policies, evaluators, run rules, and alert rules. It is the infrastructure-as-code counterpart to [managing your organization using the API](/langsmith/manage-organization-by-api).
+
+<Note>
+Managing resource tags and access policies requires LangSmith Terraform provider v0.0.6 or later.
+</Note>
 
 <Check>
 Before diving in, it might be helpful to read:
@@ -23,7 +27,7 @@ terraform {
   required_providers {
     langsmith = {
       source  = "langchain-ai/langsmith"
-      version = "~> 0.0.2"
+      version = "~> 0.0.6"
     }
   }
 }
@@ -51,7 +55,7 @@ The provider resolves credentials the same way as the LangSmith SDK and CLI. Pre
 Create an API key or [service key](/langsmith/administration-overview#service-keys) in your LangSmith settings. See [Authentication methods](/langsmith/authentication-methods) for the available key types.
 
 <Warning>
-Organization-scoped operations—creating workspaces and inviting organization members—require an **organization-scoped service key with Organization Admin permissions**. Set `workspace_id` (or `LANGSMITH_WORKSPACE_ID`) to target workspace-scoped resources such as workspace memberships, evaluators, and run rules.
+Organization-scoped operations—creating workspaces, inviting organization members, and managing access policies—require an **organization-scoped service key with Organization Admin permissions**. Set `workspace_id` (or `LANGSMITH_WORKSPACE_ID`) to target workspace-scoped resources such as workspace memberships, resource tags, evaluators, and run rules.
 </Warning>
 
 ## Examples
@@ -97,6 +101,55 @@ resource "langsmith_workspace_role" "issues_agent" {
   display_name = "Issues Agent"
   description  = data.langsmith_workspace_role.admin.description
   permissions  = data.langsmith_workspace_role.admin.permissions
+}
+```
+
+### Manage resource tags and access policies
+
+Use [resource tags](/langsmith/set-up-resource-tags) to organize workspace resources and apply [attribute-based access control (ABAC)](/langsmith/abac). The `langsmith_tag` convenience resource owns one tag key and one value. Use the independent `langsmith_tag_key` and `langsmith_tag_value` resources when keys or values are shared across configurations.
+
+The following configuration creates an `Environment=production` tag, applies it to a tracing project, and limits a workspace role to production projects:
+
+```hcl
+resource "langsmith_tag" "production" {
+  key               = "Environment"
+  value             = "production"
+  key_description   = "Deployment environment"
+  value_description = "Production workloads"
+}
+
+resource "langsmith_tagging" "production_project" {
+  tag_value_id  = langsmith_tag.production.tag_value_id
+  resource_type = "project"
+  resource_id   = "00000000-0000-0000-0000-000000000000" # tracing project ID
+}
+
+resource "langsmith_workspace_role" "production_reader" {
+  display_name = "Production Reader"
+  description  = "Can read production projects"
+  permissions  = ["projects:read"]
+}
+
+resource "langsmith_access_policy" "production_readers" {
+  name        = "Production readers"
+  description = "Read access to production projects"
+  effect      = "allow"
+
+  condition_groups = [{
+    permission    = "projects:read"
+    resource_type = "project"
+    conditions = [{
+      attribute_name  = "resource_tag_key"
+      attribute_key   = "Environment"
+      operator        = "equals"
+      attribute_value = "production"
+    }]
+  }]
+}
+
+resource "langsmith_access_policy_attachment" "production_reader" {
+  role_id          = langsmith_workspace_role.production_reader.id
+  access_policy_id = langsmith_access_policy.production_readers.id
 }
 ```
 

--- a/src/langsmith/manage-with-terraform.mdx
+++ b/src/langsmith/manage-with-terraform.mdx
@@ -55,7 +55,7 @@ The provider resolves credentials the same way as the LangSmith SDK and CLI. Pre
 Create an API key or [service key](/langsmith/administration-overview#service-keys) in your LangSmith settings. See [Authentication methods](/langsmith/authentication-methods) for the available key types.
 
 <Warning>
-Organization-scoped operations—creating workspaces, inviting organization members, and managing access policies—require an **organization-scoped service key with Organization Admin permissions**. Set `workspace_id` (or `LANGSMITH_WORKSPACE_ID`) to target workspace-scoped resources such as workspace memberships, resource tags, evaluators, and run rules.
+Organization-scoped operations, like creating workspaces, inviting organization members, and managing access policies, require an **organization-scoped service key with Organization Admin permissions**. Set `workspace_id` (or `LANGSMITH_WORKSPACE_ID`) to target workspace-scoped resources such as workspace memberships, resource tags, evaluators, and run rules.
 </Warning>
 
 ## Examples


### PR DESCRIPTION
## Overview

Updates the LangSmith Terraform provider guide for the published v0.0.6 release. The guide now pins the example provider constraint to v0.0.6 and documents the new resource-tag and access-policy resources with a validated end-to-end example.

This keeps the product documentation aligned with the provider capabilities now available to users and links readers to the existing resource-tag and ABAC guides.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Provider release: https://github.com/langchain-ai/terraform-provider-langsmith/releases/tag/v0.0.6
- Release-runbook PR: https://github.com/langchain-ai/terraform-provider-langsmith/pull/42

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed (the existing page is already present, so no navigation change was required)

## Validation

- `mise exec -- .venv/bin/docs dev` (Node 22.23.1); verified `/langsmith/manage-with-terraform` returns HTTP 200
- `make lint_prose FILES="src/langsmith/manage-with-terraform.mdx"`
- `mise exec -- make broken-links`
- `terraform fmt -check` using Terraform 1.11.2
- `terraform init -backend=false` and `terraform validate` against `langchain-ai/langsmith` v0.0.6
- `git diff --check`

## Additional notes

This change was authored and validated with assistance from an OpenAI Codex coding agent under human direction and review.