### PR TITLE
fix(mda): use async custom middleware example

### DIFF
--- a/src/langsmith/managed-deep-agents-middleware.mdx
+++ b/src/langsmith/managed-deep-agents-middleware.mdx
@@ -89,7 +89,9 @@ Middleware is the right place for cross-cutting behavior such as PII handling, r
 For a more advanced option, you can also define [custom middleware](/oss/langchain/middleware/custom).
 
 :::python
-Managed Deep Agents run agents asynchronously with `ainvoke` and `astream`, so custom middleware must implement the corresponding async hooks. Synchronous middleware remains supported when you run Deep Agents with `invoke` or `stream`.
+<Note>
+Managed Deep Agents use `ainvoke` and `astream`, so custom middleware must use async hooks. Synchronous hooks remain supported with Deep Agents `invoke` and `stream`.
+</Note>
 
 ```python middleware/audit.py
 from collections.abc import Awaitable, Callable

--- a/src/langsmith/managed-deep-agents-middleware.mdx
+++ b/src/langsmith/managed-deep-agents-middleware.mdx
@@ -89,8 +89,10 @@ Middleware is the right place for cross-cutting behavior such as PII handling, r
 For a more advanced option, you can also define [custom middleware](/oss/langchain/middleware/custom).
 
 :::python
+Managed Deep Agents run agents asynchronously with `ainvoke` and `astream`, so custom middleware must implement the corresponding async hooks. Synchronous middleware remains supported when you run Deep Agents with `invoke` or `stream`.
+
 ```python middleware/audit.py
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 
 from langchain.agents.middleware import wrap_tool_call
 from langchain.messages import ToolMessage
@@ -99,12 +101,12 @@ from langgraph.types import Command
 
 
 @wrap_tool_call
-def log_tool_calls(
+async def log_tool_calls(
     request: ToolCallRequest,
-    handler: Callable[[ToolCallRequest], ToolMessage | Command],
+    handler: Callable[[ToolCallRequest], Awaitable[ToolMessage | Command]],
 ) -> ToolMessage | Command:
     print(f"Calling tool: {request.tool_call['name']}")
-    result = handler(request)
+    result = await handler(request)
     print(f"Finished tool: {request.tool_call['name']}")
     return result
 ```


### PR DESCRIPTION
## Overview

Updates the Managed Deep Agents custom tool-call middleware example to use an async middleware function and await the handler. Clarifies that Managed Deep Agents use `ainvoke` and `astream`, while synchronous middleware remains valid for Deep Agents `invoke` and `stream` usage.

The previous decorator-based example used a synchronous function, which implements only `wrap_tool_call`. Managed Deep Agents execute asynchronously and call `awrap_tool_call`, so the example failed with `NotImplementedError` on the first tool call.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs

- GitHub issue: N/A
- Feature PR: N/A
- Linear issue: N/A
- Slack thread: N/A

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

Validation performed:

- Executed the async middleware example through `awrap_tool_call`
- `make lint_prose FILES="src/langsmith/managed-deep-agents-middleware.mdx"`
- `.venv/bin/docs build`
- `git diff --check`

This PR was prepared with assistance from an AI coding agent.
