### PR TITLE
docs: refresh Scavio tool row and provider card

### DIFF
--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -2213,7 +2213,7 @@ Browse the complete collection of integrations available for Python. LangChain P
         href="https://scavio.dev/docs/langchain"
         icon="link"
     >
-        Real-time search API for AI agents across web, shopping, YouTube, Reddit, and TikTok.
+        Real-time search API for AI agents across the web, commerce, video, social, jobs, real estate, travel, app stores, ad libraries, and public filings, plus clean text extraction from any URL.
     </Card>
 
     <Card

--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -34,7 +34,7 @@ The following table shows tools that execute online searches in some shape or fo
 | [Perplexity Search](/oss/integrations/tools/perplexity_search) | Paid (with monthly free tier) | URL, Title, Snippet, Date, Last Updated |
 | [Search1API Search](https://www.search1api.com/docs/integrations/langchain#search) | 100 free credits on sign up, no credit card | URL, Title, Snippet, Content, Images |
 | [SearchApi](https://www.searchapi.io/docs/google) | 100 free searches/month | URL, Snippet, Title, Answer Box, Knowledge Graph |
-| [Scavio](https://scavio.dev/docs/langchain) | 50 free credits to start | URL, Title, Snippet, Knowledge Graph, Products, Videos, Transcripts, Social posts and profiles |
+| [Scavio](https://scavio.dev/docs/langchain) | 50 free credits to start | URL, Title, Snippet, Knowledge Graph, Products, Videos, Transcripts, Social posts and profiles, Job postings and salaries, Real-estate listings, Travel and hotel inventory, App-store listings, Ad-library creatives, Software reviews, Local business data, Regulatory filings, Extracted page content |
 | [SERPdive](https://serpdive.com/docs) | 1000 free credits/month | URL, Title, Date, Page Content, Answer |
 | [TalorData SERP](https://www.talordata.com/docs) | Paid | Title, URL, snippet, position, knowledge graph, answer box, AI overview |
 | [Tavily Search](/oss/integrations/tools/tavily_search) | 1000 free searches/month | URL, Content, Title, Images, Answer |


### PR DESCRIPTION
Refreshes the two Scavio surfaces in these docs to match the current package.

**What changed**

- `src/oss/python/integrations/tools/index.mdx` — the "what the tools return" column was written when Scavio covered web, shopping and social. The package now also returns job postings and salaries, real-estate listings, travel and hotel inventory, app-store listings and reviews, ad-library creatives, software reviews, local business data, regulatory filings, and extracted page content from any URL. Column updated; the row stays platform-agnostic so it does not go stale again.

- `src/oss/python/integrations/providers/all_providers.mdx` — the Scavio card still read "across web, shopping, YouTube, Reddit, and TikTok", which predates several launches. Rewritten category-first for the same reason.

**Why both files**

A previous PR (#5300) refreshed the tools table but not the provider card, so the two have disagreed since. This brings them back in sync.

**Package status**

`langchain-scavio` 4.0.1 on PyPI — 187 `BaseTool` classes across 31 platforms plus a top-level extract tool. Docs: https://scavio.dev/docs/langchain

No hosted integration pages are proposed here — per the policy on this repo, both surfaces link out.
