### PR TITLE
Add langchain-agentgate tool integration

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -775,6 +775,9 @@ python:
   - name: SerpApi Search Tools
     pypi: serpapi-search-tools
     docs_url: https://serpapi.github.io/serpapi-search-tools-python/docs/sdk-examples/langchain.html
+  - name: ApprovalRequiredTool
+    pypi: langchain-agentgate
+    docs_url: https://github.com/shakirriyaz/agentgate/tree/main/integrations/langchain-agentgate
   middleware:
   - name: CopilotKit
     pypi: copilotkit

--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -777,7 +777,7 @@ python:
     docs_url: https://serpapi.github.io/serpapi-search-tools-python/docs/sdk-examples/langchain.html
   - name: ApprovalRequiredTool
     pypi: langchain-agentgate
-    docs_url: https://github.com/shakirriyaz/agentgate/tree/main/integrations/langchain-agentgate
+    docs_url: https://useagentgate.com/docs
   middleware:
   - name: CopilotKit
     pypi: copilotkit

--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -99,6 +99,14 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
+        title="AgentGate"
+        href="https://useagentgate.com/docs"
+        icon="link"
+    >
+        Gate LangChain tools behind human approval in Slack or Microsoft Teams.
+    </Card>
+
+    <Card
         title="AgentLair"
         href="https://agentlair.dev/docs"
         icon="link"

--- a/src/snippets/oss/python-tools-downloads.mdx
+++ b/src/snippets/oss/python-tools-downloads.mdx
@@ -211,4 +211,5 @@
 | [`Browserless`](https://browserless.io) | <span data-sort-value="-1">N/A</span> |
 | [`HuangtingFlux`](https://huangtingflux.com/integrations/langchain) | <span data-sort-value="-1">N/A</span> |
 
+| [`ApprovalRequiredTool`](https://useagentgate.com/docs) | <span data-sort-value="0"><a href="https://pypi.org/project/langchain-agentgate/" target="_blank"><img src="https://static.pepy.tech/badge/langchain-agentgate/month" alt="Downloads per month" noZoom class="rounded not-prose" /></a></span> |
 </div>


### PR DESCRIPTION
Adds `ApprovalRequiredTool` to the external Python tools list.

`langchain-agentgate` wraps any `BaseTool` behind a human approval step in Slack or Microsoft Teams before it runs — useful for agent actions that are risky or hard to undo (sending email, deleting data, deploying, moving money).

- PyPI: https://pypi.org/project/langchain-agentgate/
- Source / docs: https://github.com/shakirriyaz/agentgate/tree/main/integrations/langchain-agentgate

Package is live and installable (`pip install langchain-agentgate`). Single-line addition to `scripts/data/integration_external_docs.yaml`, no other changes.