### PR TITLE
fix: pin mirrored image examples

### DIFF
--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -29,10 +29,10 @@ bash mirror_langsmith_images.sh <your-registry> [<platform>]
 
 Where `<your-registry>` is the URL of your Docker registry (e.g. `myregistry.com`) and `<platform>` is the platform you are using (e.g. `linux/amd64`, `linux/arm64`, etc.). If you do not specify a platform, it will default to `linux/amd64`.
 
-For example, if your registry is `myregistry.com`, your platform is `linux/arm64`, and your LangSmith app version is `0.10.66`, run:
+For example, if your registry is `myregistry.com`, your platform is `linux/arm64`, and your LangSmith app version is `0.16.36`, run:
 
 ```bash
-bash mirror_langsmith_images.sh --registry myregistry --platform linux/arm64 --version 0.10.66
+bash mirror_langsmith_images.sh --registry myregistry --platform linux/arm64 --version 0.16.36
 ```
 
 Note that this script will assume that you have Docker installed and that you are authenticated to your registry. It will also push the images to the specified registry with the same repository/tag as the original images.
@@ -45,9 +45,9 @@ Here is an example of how to mirror the images using Docker:
 
 ```bash
 # Pull the images from the public registry
-docker pull langchain/langsmith-backend:0.10.66
-docker tag langchain/langsmith-backend:0.10.66 <your-registry>/langsmith-backend:0.10.66
-docker push <your-registry>/langsmith-backend:0.10.66
+docker pull langchain/langsmith-backend:0.16.36
+docker tag langchain/langsmith-backend:0.16.36 <your-registry>/langsmith-backend:0.16.36
+docker push <your-registry>/langsmith-backend:0.16.36
 ```
 
 You will need to repeat this for each image that you want to mirror.

--- a/src/langsmith/self-host-mirroring-images.mdx
+++ b/src/langsmith/self-host-mirroring-images.mdx
@@ -29,7 +29,7 @@ bash mirror_langsmith_images.sh <your-registry> [<platform>]
 
 Where `<your-registry>` is the URL of your Docker registry (e.g. `myregistry.com`) and `<platform>` is the platform you are using (e.g. `linux/amd64`, `linux/arm64`, etc.). If you do not specify a platform, it will default to `linux/amd64`.
 
-For example, if your registry is `myregistry.com`, your platform is `linux/arm64`, and you want to use the latest version of the images, you would run:
+For example, if your registry is `myregistry.com`, your platform is `linux/arm64`, and your LangSmith app version is `0.10.66`, run:
 
 ```bash
 bash mirror_langsmith_images.sh --registry myregistry --platform linux/arm64 --version 0.10.66
@@ -37,15 +37,17 @@ bash mirror_langsmith_images.sh --registry myregistry --platform linux/arm64 --v
 
 Note that this script will assume that you have Docker installed and that you are authenticated to your registry. It will also push the images to the specified registry with the same repository/tag as the original images.
 
+For LangSmith images, use the `appVersion` from your Helm chart release as the image tag. Do not use `latest`: it is mutable, and pulling images while a release is being published can result in mismatched service versions.
+
 Alternatively, you can pull, mirror, and push the images manually. The images that you will need to mirror are found in the `values.yaml` file of the LangSmith Helm Chart. These can be found here: [LangSmith Helm Chart values.yaml](https://github.com/langchain-ai/helm/blob/main/charts/langsmith/values.yaml#L14)
 
 Here is an example of how to mirror the images using Docker:
 
 ```bash
 # Pull the images from the public registry
-docker pull langchain/langsmith-backend:latest
-docker tag langchain/langsmith-backend:latest <your-registry>/langsmith-backend:latest
-docker push <your-registry>/langsmith-backend:latest
+docker pull langchain/langsmith-backend:0.10.66
+docker tag langchain/langsmith-backend:0.10.66 <your-registry>/langsmith-backend:0.10.66
+docker push <your-registry>/langsmith-backend:0.10.66
 ```
 
 You will need to repeat this for each image that you want to mirror.


### PR DESCRIPTION
## Description
The mirroring guide told users to use mutable `latest` tags, which can lead to mixed service versions during releases. It now directs users to the Helm chart `appVersion` and uses a concrete version in Docker examples.

## Test Plan
- [x] Run Vale on the changed page
- [x] Verify the example image tag exists on Docker Hub

Made by [Open SWE](https://openswe.vercel.app/agents/72c6367c-4a4b-9450-bc47-ab5f5754a7c2)