### PR TITLE
docs(google): document service_tier on ChatGoogleGenerativeAI

### DIFF
--- a/src/oss/python/integrations/chat/google_generative_ai.mdx
+++ b/src/oss/python/integrations/chat/google_generative_ai.mdx
@@ -933,6 +933,38 @@ Usage Metadata:
 {'input_tokens': 10, 'output_tokens': 24, 'total_tokens': 34, 'input_token_details': {'cache_read': 0}}
 ```
 
+## Choose a service tier
+
+A service tier sets the price and performance class a request is billed against. Use `flex` to pay less for latency-tolerant work, or `priority` to pay a premium for lower latency. Requests use the standard tier when the parameter is omitted.
+
+<Note>
+    `service_tier` requires `langchain-google-genai>=4.4.0`.
+</Note>
+
+Set the tier on the model, or pass it per request:
+
+```python
+from langchain_google_genai import ChatGoogleGenerativeAI
+
+model = ChatGoogleGenerativeAI(
+    model="gemini-3.6-flash",
+    service_tier="flex",  # [!code highlight]
+)
+
+# Per request, overriding the model-level value
+response = model.invoke("Summarize this transcript.", service_tier="priority")
+```
+
+Accepted values are `"standard"`, `"flex"`, and `"priority"`. The value is the same on both backends, and the integration sends it the way each backend expects: a request body field on the Gemini Developer API, a request header on Vertex AI.
+
+A tier has to be enabled for both the project and the model. An unavailable tier returns a `400` instead of falling back to the standard tier, so the request fails rather than billing at a price you did not ask for:
+
+```python
+ClientError: 400 INVALID_ARGUMENT. Flex API is not supported for model: gemini-2.5-flash.
+```
+
+For more information, see the Gemini Developer API guides for [Flex](https://ai.google.dev/gemini-api/docs/flex-inference) and [Priority](https://ai.google.dev/gemini-api/docs/priority-inference), and the Vertex AI guides for [Flex](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/flex-paygo) and [Priority](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/priority-paygo).
+
 ## Thinking support
 
 Certain Gemini models support configurable thinking depth. The parameter depends on the model version:


### PR DESCRIPTION
## Why

`ChatGoogleGenerativeAI` is gaining a `service_tier` parameter in langchain-ai/langchain-google#1937. This page has no section on tiers, and two things a reader needs are not obvious from the API reference alone:

- The same value works on both backends, but the integration has to send it differently: a body field on the Gemini Developer API, a request header on Vertex AI. Readers do not need to care, so the page states it once and moves on.
- A tier that is not enabled for both the project and the model returns a `400` rather than falling back to standard. That is the useful behavior to document, because the opposite would be a silent price change.

Placed after **Token usage tracking**, since both sections are about cost.

## Needs review

- **The version in the `<Note>` is a guess.** It says `langchain-google-genai>=4.4.0`, inferred from 4.3.3 being current and this being a feature. Please correct it to the release that actually ships #1937, or say which it is and I will update.
- This documents a parameter that is not released yet, which is why it is a draft. Happy to leave it open until #1937 lands and releases, or to close and reopen later, whichever suits your process.
- The example uses `gemini-3.6-flash` to match the rest of the page. The `400` example quotes `gemini-2.5-flash` because that is the model the error was observed on: flex is served on the 3.x models, not the 2.5 family.

## Testing

`make lint_prose` on the changed file: 0 errors, 0 warnings, 0 suggestions.

All four reference links verified to return `200`. The link previously used in the `service_tier` docstring returned `404`, and that is fixed in #1937.

The error message in the example is the verbatim response from Vertex AI, not a paraphrase.

Parts of this change were drafted with agent assistance; the measurements and links were verified manually.
