### PR TITLE
docs: remove stale Render hostnames

### DIFF
--- a/src/langsmith/langsmith-mcp-server.mdx
+++ b/src/langsmith/langsmith-mcp-server.mdx
@@ -37,34 +37,6 @@ The LangSmith MCP Server is a [Model Context Protocol](https://modelcontextproto
 - To connect and use this server in Fleet, see [Remote MCP servers](/langsmith/fleet/remote-mcp-servers).
 </Tip>
 
-## Quickstart (hosted)
-
-A hosted version of the LangSmith MCP Server is available over HTTP, so you can connect without running the server yourself.
-
-- **URL:** `https://langsmith-mcp-server.onrender.com/mcp`
-- **Authentication:** Send your [LangSmith API key](/langsmith/create-account-api-key) in the `LANGSMITH-API-KEY` header.
-
-<Note>
-The hosted instance is for [LangSmith Cloud](/langsmith/deploy-to-cloud). For a [self-hosted LangSmith](/langsmith/self-hosted) instance, run the server yourself and point it at your endpoint (see [Docker deployment](#docker-deployment-http-streamable)).
-</Note>
-
-**Example (Cursor `mcp.json`):**
-
-```json
-{
-  "mcpServers": {
-    "LangSmith MCP (Hosted)": {
-      "url": "https://langsmith-mcp-server.onrender.com/mcp",
-      "headers": {
-        "LANGSMITH-API-KEY": "lsv2_pt_your_api_key_here"
-      }
-    }
-  }
-}
-```
-
-Optional headers: `LANGSMITH-WORKSPACE-ID`, `LANGSMITH-ENDPOINT` (same as in [Environment variables](#environment-variables)).
-
 ## Available tools
 
 ### Conversation and threads

--- a/src/langsmith/langsmith-mcp-server.mdx
+++ b/src/langsmith/langsmith-mcp-server.mdx
@@ -37,6 +37,27 @@ The LangSmith MCP Server is a [Model Context Protocol](https://modelcontextproto
 - To connect and use this server in Fleet, see [Remote MCP servers](/langsmith/fleet/remote-mcp-servers).
 </Tip>
 
+## Quickstart (hosted)
+
+A hosted version of the LangSmith MCP Server is available through the [LangSmith Remote MCP](/langsmith/langsmith-remote-mcp), so you can connect without running the server yourself.
+
+- **URL:** `https://api.smith.langchain.com/mcp`
+- **Authentication:** Interactive MCP clients use OAuth 2.1. See [LangSmith Remote MCP authentication](/langsmith/langsmith-remote-mcp#authentication) for programmatic API key access.
+
+**Example (Cursor `mcp.json`):**
+
+```json
+{
+  "mcpServers": {
+    "langsmith": {
+      "url": "https://api.smith.langchain.com/mcp"
+    }
+  }
+}
+```
+
+The MCP client opens a browser window to complete the OAuth flow when you first connect.
+
 ## Available tools
 
 ### Conversation and threads

--- a/src/langsmith/prompt-commit.mdx
+++ b/src/langsmith/prompt-commit.mdx
@@ -30,7 +30,7 @@ Before we begin, ensure you have the following set up:
    * Go to **GitHub > Settings > Developer settings > Personal access tokens > Tokens (classic)**.
    * Click **Generate new token (classic)**.
    * Name it (e.g., "LangSmith Prompt Sync"), set an expiration, and select the required scopes.
-   * Click **Generate token** and **copy it immediately** — it won't be shown again.
+   * Click **Generate token** and **copy it immediately** because it is not shown again.
    * Store the token securely and provide it as an environment variable to your server.
 
 ## Understanding LangSmith "Prompt commits" and webhooks
@@ -342,7 +342,7 @@ The server's core functionality will include an endpoint for webhook reception, 
   * **Webhook Endpoint (`/webhook/commit`):** This is the URL path your LangSmith webhook will target.
   * **Error Handling:** Basic error handling for GitHub API interactions is included.
 
-  **Deploy this server to your chosen platform (e.g., Render) and note down its public URL (e.g., `https://prompt-commit-webhook.onrender.com`).**
+  **Deploy this server to your chosen platform (e.g., Render) and note down its public URL (e.g., `https://<your-render-service>.onrender.com`).**
 </Accordion>
 
 ## Configuring the webhook in LangSmith
@@ -361,7 +361,7 @@ Once your FastAPI server is deployed and you have its public URL, you can config
 
    ![LangSmith Webhook configuration modal](/langsmith/images/prompt-commit-webhook.png)
 
-   * **Webhook URL:** Enter the full public URL of your deployed FastAPI server's endpoint. For our example server, this would be `https://prompt-commit-webhook.onrender.com/webhook/commit`.
+   * **Webhook URL:** Enter the full public URL of your deployed FastAPI server's endpoint. For our example server, this would be `https://<your-render-service>.onrender.com/webhook/commit`.
    * **Headers (Optional):**
      * You can add custom headers that LangSmith will send with each webhook request.
 
@@ -379,7 +379,7 @@ Now, with everything set up, here's what happens:
 
 2. **Webhook Trigger:** LangSmith detects this new prompt commit and triggers the configured webhook.
 
-3. **HTTP Request:** LangSmith sends an HTTP POST request to the public URL of your FastAPI server (e.g., `https://prompt-commit-webhook.onrender.com/webhook/commit`). The body of this request contains the JSON prompt manifest for the entire workspace.
+3. **HTTP Request:** LangSmith sends an HTTP POST request to the public URL of your FastAPI server (e.g., `https://<your-render-service>.onrender.com/webhook/commit`). The body of this request contains the JSON prompt manifest for the entire workspace.
 
 4. **Server Receives Payload:** Your FastAPI server's endpoint receives the request.
 


### PR DESCRIPTION
## Summary

- Keep the hosted LangSmith MCP quickstart, but point it to the official `https://api.smith.langchain.com/mcp` endpoint and OAuth flow instead of the stale Render hostname
- Replace the concrete prompt webhook Render hostname with a non-claimable service-name placeholder
- Ensure neither reported Render hostname remains in the documentation source

## Validation

- `vale src/langsmith/langsmith-mcp-server.mdx src/langsmith/prompt-commit.mdx`
- `git diff --check`
- Confirmed both reported hostnames are absent from `src/`
