### PR TITLE
docs: add managed deep agents overview redirect

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -2581,6 +2581,10 @@
       "destination": "/langsmith/python/managed-deep-agents-overview"
     },
     {
+      "source": "/langsmith/managed-deep-agents-overview",
+      "destination": "/langsmith/python/managed-deep-agents-overview"
+    },
+    {
       "source": "/langsmith/managed-deep-agents",
       "destination": "/langsmith/python/managed-deep-agents-overview"
     },


### PR DESCRIPTION
Fixes DOC-1514

## Summary
- Add a redirect for the old Managed Deep Agents overview URL that currently returns 404.
- Point `/langsmith/managed-deep-agents-overview` to the Python Managed Deep Agents overview page.

## Review notes
- Please verify this is the intended destination for the old unversioned URL.

## AI involvement
- This PR was prepared with assistance from an AI coding agent.