### PR TITLE
Fix typo in Rate Limits section

### DIFF
--- a/src/oss/langchain/models.mdx
+++ b/src/oss/langchain/models.mdx
@@ -1639,7 +1639,7 @@ Many chat model providers impose a limit on the number of invocations that can b
 To help manage rate limits, chat model integrations accept a `rate_limiter` parameter that can be provided during initialization to control the rate at which requests are made.
 
 <Accordion title="Initialize and use a rate limiter" icon="gauge">
-    LangChain in comes with (an optional) built-in @[`InMemoryRateLimiter`]. This limiter is thread safe and can be shared by multiple threads in the same process.
+    LangChain comes with (an optional) built-in @[`InMemoryRateLimiter`]. This limiter is thread safe and can be shared by multiple threads in the same process.
 
     ```python Define a rate limiter
     from langchain.rate_limiters import InMemoryRateLimiter


### PR DESCRIPTION
Additional "in" after LangChain

## Overview
Just removing the small typo

## Type of change

**Type:** Fix typo

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
