### PR TITLE
docs: document Deep Agents Code updates

### DIFF
--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -39,7 +39,7 @@ Explicit `-a`/`--agent` always overrides both, and `-r`/`--resume` bypasses both
 
 ## Session cost warning
 
-Deep Agents Code warns once per thread when its cumulative estimated cost exceeds $50 and suggests using `/offload` or `/clear`. Configure the threshold in USD, or set it to `0` or a negative value to disable the warning:
+Deep Agents Code warns once per thread when its cumulative estimated cost exceeds $50 and suggests using `/offload` or `/clear`. You can configure the threshold in USD, or set it to `0` or a negative value to disable the warning:
 
 ```toml
 [warnings]

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -37,6 +37,15 @@ recent = "frontend-dev"  # last /agents switch (written automatically)
 
 Explicit `-a`/`--agent` always overrides both, and `-r`/`--resume` bypasses both so the thread's original agent is restored. See [Command reference](/oss/deepagents/code/cli-reference#command-line-options) for related flags.
 
+## Session cost warning
+
+Deep Agents Code warns once per thread when its cumulative estimated cost exceeds $50 and suggests using `/offload` or `/clear`. Configure the threshold in USD, or set it to `0` or a negative value to disable the warning:
+
+```toml
+[warnings]
+session_cost_threshold_usd = 25
+```
+
 ## Redact LangSmith trace secrets
 
 With LangSmith tracing enabled, Deep Agents Code sends agent-trace inputs and outputs without client-side secret redaction by default.

--- a/src/oss/deepagents/code/plugins.mdx
+++ b/src/oss/deepagents/code/plugins.mdx
@@ -29,15 +29,11 @@ Removing a marketplace uninstalls its plugins and removes managed cache data. De
 
 ## Automatically update plugins
 
-Installed, enabled plugins can opt in to background updates after the first prompt. Add the following extension to the plugin manifest:
+Installed, enabled plugins can opt in to background updates after the first prompt. Set `autoUpdate` in the plugin manifest:
 
 ```json
 {
-  "extensions": {
-    "com.langchain.deepagents.code": {
-      "autoUpdate": true
-    }
-  }
+  "autoUpdate": true
 }
 ```
 

--- a/src/oss/deepagents/code/plugins.mdx
+++ b/src/oss/deepagents/code/plugins.mdx
@@ -29,9 +29,7 @@ Removing a marketplace uninstalls its plugins and removes managed cache data. De
 
 ## Automatically update plugins
 
-Deep Agents Code automatically updates installed, enabled, versioned plugins from remote marketplaces after the first prompt when their manifest sets `extensions.com.langchain.deepagents.code.autoUpdate` to `true`. This includes Claude-style manifests at `.claude-plugin/plugin.json`.
-
-Plugin authors can opt in with the following extension:
+Installed, enabled plugins can opt in to background updates after the first prompt. Add the following extension to the plugin manifest:
 
 ```json
 {

--- a/src/oss/deepagents/code/plugins.mdx
+++ b/src/oss/deepagents/code/plugins.mdx
@@ -29,7 +29,9 @@ Removing a marketplace uninstalls its plugins and removes managed cache data. De
 
 ## Automatically update plugins
 
-Installed, enabled plugins can opt in to background updates after the first prompt. Add the following extension to the plugin manifest:
+Deep Agents Code automatically updates installed, enabled, versioned plugins from remote marketplaces after the first prompt when their manifest sets `extensions.com.langchain.deepagents.code.autoUpdate` to `true`. This includes Claude-style manifests at `.claude-plugin/plugin.json`.
+
+Plugin authors can opt in with the following extension:
 
 ```json
 {

--- a/src/oss/deepagents/code/plugins.mdx
+++ b/src/oss/deepagents/code/plugins.mdx
@@ -27,6 +27,22 @@ The plugin manager also lets you enable, disable, and uninstall installed plugin
 
 Removing a marketplace uninstalls its plugins and removes managed cache data. Deep Agents Code preserves the original source when the marketplace came from a local directory or file. Run `/reload` or start a new session to apply the removal to an active session.
 
+## Automatically update plugins
+
+Installed, enabled plugins can opt in to background updates after the first prompt. Add the following extension to the plugin manifest:
+
+```json
+{
+  "extensions": {
+    "com.langchain.deepagents.code": {
+      "autoUpdate": true
+    }
+  }
+}
+```
+
+The running session continues to use its current plugin version until you run `/reload`. To disable automatic plugin updates globally, set `[plugins].auto_update = false` in `config.toml` or `DEEPAGENTS_CODE_PLUGIN_AUTO_UPDATE=false` in the environment.
+
 ## Manage plugins from the command line
 
 Use `dcode plugin` for scripts and terminal-based administration. Plugin IDs use the format `plugin-name@marketplace-name`.

--- a/src/oss/deepagents/code/plugins.mdx
+++ b/src/oss/deepagents/code/plugins.mdx
@@ -29,7 +29,7 @@ Removing a marketplace uninstalls its plugins and removes managed cache data. De
 
 ## Automatically update plugins
 
-Installed, enabled plugins can opt in to background updates after the first prompt. Add the following extension to the plugin manifest:
+Deep Agents Code can update installed plugins in the background after the first prompt. Updates apply only to enabled plugins that opt in through their own manifest. Plugin authors opt in per plugin by adding this block to that plugin's `plugin.json`:
 
 ```json
 {

--- a/src/oss/deepagents/code/plugins.mdx
+++ b/src/oss/deepagents/code/plugins.mdx
@@ -29,11 +29,15 @@ Removing a marketplace uninstalls its plugins and removes managed cache data. De
 
 ## Automatically update plugins
 
-Installed, enabled plugins can opt in to background updates after the first prompt. Set `autoUpdate` in the plugin manifest:
+Installed, enabled plugins can opt in to background updates after the first prompt. Add the following extension to the plugin manifest:
 
 ```json
 {
-  "autoUpdate": true
+  "extensions": {
+    "com.langchain.deepagents.code": {
+      "autoUpdate": true
+    }
+  }
 }
 ```
 


### PR DESCRIPTION
## Description
Document automatic plugin updates and configurable session cost warnings in Deep Agents Code.

## Release Note
none

## Test Plan
- [x] Run scoped Vale prose lint

Made by [Open SWE](https://openswe.vercel.app/agents/019ff2e0-31f5-75db-b8d8-dca23c3def6b)