### PR TITLE
fix: omit Dockerfile snapshot capacity examples

### DIFF
--- a/src/langsmith/sandbox-snapshots.mdx
+++ b/src/langsmith/sandbox-snapshots.mdx
@@ -98,7 +98,7 @@ List, inspect, update, and delete registries with `client.registries.list()`, `c
 
 When you have a local `Dockerfile` but don't want to publish the image to a registry first, build a snapshot directly from the `Dockerfile` and its build context. LangSmith spins up a temporary builder sandbox, uploads the context, runs the build inside it with [BuildKit](https://docs.docker.com/build/buildkit/), and captures the resulting image as a snapshot. The builder sandbox is torn down automatically once the build finishes.
 
-The call blocks until the snapshot is ready (default timeout is 60 seconds; raise it for large or slow builds). `fs_capacity_bytes` must be large enough to hold the build context, the intermediate layers, and the final image.
+The call blocks until the snapshot is ready (default timeout is 60 seconds; raise it for large or slow builds). Dockerfile builds require `fs_capacity_bytes` of at least 16 GiB because the temporary builder starts from the 16 GiB default snapshot. Set a higher capacity when the build context, intermediate layers, and final image need more space.
 
 <CodeGroup>
 
@@ -110,7 +110,7 @@ client = SandboxClient()
 snapshot = client.create_snapshot_from_dockerfile(
     "my-app",
     dockerfile="Dockerfile",
-    fs_capacity_bytes=2 * 1024**3,  # 2 GiB
+    fs_capacity_bytes=16 * 1024**3,  # 16 GiB
     context=".",  # build context directory (default: current directory)
 )
 
@@ -125,7 +125,7 @@ const client = new SandboxClient();
 const snapshot = await client.createSnapshotFromDockerfile(
   "my-app",
   "Dockerfile",
-  2_147_483_648, // 2 GiB
+  17_179_869_184, // 16 GiB
   { context: "." },
 );
 
@@ -148,7 +148,7 @@ Pass `build_args` / `buildArgs` to set Docker `ARG` values, and `target` to stop
 snapshot = client.create_snapshot_from_dockerfile(
     "my-app",
     dockerfile="Dockerfile",
-    fs_capacity_bytes=2 * 1024**3,
+    fs_capacity_bytes=16 * 1024**3,
     build_args={"PYTHON_VERSION": "3.12", "ENV": "prod"},
     target="runtime",
 )
@@ -158,7 +158,7 @@ snapshot = client.create_snapshot_from_dockerfile(
 const snapshot = await client.createSnapshotFromDockerfile(
   "my-app",
   "Dockerfile",
-  2_147_483_648,
+  17_179_869_184,
   {
     buildArgs: { PYTHON_VERSION: "3.12", ENV: "prod" },
     target: "runtime",
@@ -178,7 +178,7 @@ Pass a callback to `on_build_log` / `onBuildLog` to receive the build's stdout a
 snapshot = client.create_snapshot_from_dockerfile(
     "my-app",
     dockerfile="Dockerfile",
-    fs_capacity_bytes=2 * 1024**3,
+    fs_capacity_bytes=16 * 1024**3,
     on_build_log=lambda line: print(line, end=""),
 )
 ```
@@ -187,7 +187,7 @@ snapshot = client.create_snapshot_from_dockerfile(
 const snapshot = await client.createSnapshotFromDockerfile(
   "my-app",
   "Dockerfile",
-  2_147_483_648,
+  17_179_869_184,
   { onBuildLog: (line) => process.stdout.write(line) },
 );
 ```
@@ -204,7 +204,7 @@ const snapshot = await client.createSnapshotFromDockerfile(
 snapshot = client.create_snapshot_from_dockerfile(
     "my-app",
     dockerfile="Dockerfile",
-    fs_capacity_bytes=2 * 1024**3,
+    fs_capacity_bytes=16 * 1024**3,
     vcpus=2,
     mem_bytes=4 * 1024**3,  # 4 GiB
     timeout=600,
@@ -215,7 +215,7 @@ snapshot = client.create_snapshot_from_dockerfile(
 const snapshot = await client.createSnapshotFromDockerfile(
   "my-app",
   "Dockerfile",
-  2_147_483_648,
+  17_179_869_184,
   {
     vCpus: 2,
     memBytes: 4_294_967_296, // 4 GiB

--- a/src/langsmith/sandbox-snapshots.mdx
+++ b/src/langsmith/sandbox-snapshots.mdx
@@ -98,7 +98,7 @@ List, inspect, update, and delete registries with `client.registries.list()`, `c
 
 When you have a local `Dockerfile` but don't want to publish the image to a registry first, build a snapshot directly from the `Dockerfile` and its build context. LangSmith spins up a temporary builder sandbox, uploads the context, runs the build inside it with [BuildKit](https://docs.docker.com/build/buildkit/), and captures the resulting image as a snapshot. The builder sandbox is torn down automatically once the build finishes.
 
-The call blocks until the snapshot is ready (default timeout is 60 seconds; raise it for large or slow builds). Dockerfile builds require `fs_capacity_bytes` of at least 16 GiB because the temporary builder starts from the 16 GiB default snapshot. Set a higher capacity when the build context, intermediate layers, and final image need more space.
+The call blocks until the snapshot is ready (default timeout is 60 seconds; raise it for large or slow builds). The temporary builder and resulting snapshot use the server's default filesystem capacity unless you pass `fs_capacity_bytes` / `fsCapacityBytes`. Set a higher capacity when the build context, intermediate layers, and final image need more space.
 
 <CodeGroup>
 
@@ -110,7 +110,6 @@ client = SandboxClient()
 snapshot = client.create_snapshot_from_dockerfile(
     "my-app",
     dockerfile="Dockerfile",
-    fs_capacity_bytes=16 * 1024**3,  # 16 GiB
     context=".",  # build context directory (default: current directory)
 )
 
@@ -125,7 +124,6 @@ const client = new SandboxClient();
 const snapshot = await client.createSnapshotFromDockerfile(
   "my-app",
   "Dockerfile",
-  17_179_869_184, // 16 GiB
   { context: "." },
 );
 
@@ -148,7 +146,6 @@ Pass `build_args` / `buildArgs` to set Docker `ARG` values, and `target` to stop
 snapshot = client.create_snapshot_from_dockerfile(
     "my-app",
     dockerfile="Dockerfile",
-    fs_capacity_bytes=16 * 1024**3,
     build_args={"PYTHON_VERSION": "3.12", "ENV": "prod"},
     target="runtime",
 )
@@ -158,7 +155,6 @@ snapshot = client.create_snapshot_from_dockerfile(
 const snapshot = await client.createSnapshotFromDockerfile(
   "my-app",
   "Dockerfile",
-  17_179_869_184,
   {
     buildArgs: { PYTHON_VERSION: "3.12", ENV: "prod" },
     target: "runtime",
@@ -178,7 +174,6 @@ Pass a callback to `on_build_log` / `onBuildLog` to receive the build's stdout a
 snapshot = client.create_snapshot_from_dockerfile(
     "my-app",
     dockerfile="Dockerfile",
-    fs_capacity_bytes=16 * 1024**3,
     on_build_log=lambda line: print(line, end=""),
 )
 ```
@@ -187,7 +182,6 @@ snapshot = client.create_snapshot_from_dockerfile(
 const snapshot = await client.createSnapshotFromDockerfile(
   "my-app",
   "Dockerfile",
-  17_179_869_184,
   { onBuildLog: (line) => process.stdout.write(line) },
 );
 ```
@@ -204,7 +198,6 @@ const snapshot = await client.createSnapshotFromDockerfile(
 snapshot = client.create_snapshot_from_dockerfile(
     "my-app",
     dockerfile="Dockerfile",
-    fs_capacity_bytes=16 * 1024**3,
     vcpus=2,
     mem_bytes=4 * 1024**3,  # 4 GiB
     timeout=600,
@@ -215,7 +208,6 @@ snapshot = client.create_snapshot_from_dockerfile(
 const snapshot = await client.createSnapshotFromDockerfile(
   "my-app",
   "Dockerfile",
-  17_179_869_184,
   {
     vCpus: 2,
     memBytes: 4_294_967_296, // 4 GiB


### PR DESCRIPTION
## Description
Remove explicit capacities from the Dockerfile snapshot examples so builders use the server default, and explain how to request more space. Depends on https://github.com/langchain-ai/langsmith-sdk/pull/3383 making the SDK arguments optional.

## Test Plan
- [x] `make lint_prose FILES="src/langsmith/sandbox-snapshots.mdx"`

Made by [Open SWE](https://openswe.vercel.app/agents/ec45e23c-e028-7ecb-9b7f-dd0dd32e21b8)