### PR TITLE
feat: document context and diff line-number controls

### DIFF
--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -55,7 +55,7 @@ Deep Agents Code shows file-relative line numbers in transcript and approval dif
 show_diff_line_numbers = false
 ```
 
-Run `/line-numbers` in a session to toggle the preference and save it to `config.toml`. The change applies to new diffs; already rendered diffs do not change. Deep Agents Code omits line numbers when it cannot determine file-relative positions, such as an `edit_file` diff reconstructed from fragments after you resume a thread.
+Run `/line-numbers` in a session to toggle the preference and save it to `config.toml`. The change applies to new diffs; already rendered diffs do not change.
 
 ## Redact LangSmith trace secrets
 

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -46,6 +46,17 @@ Deep Agents Code warns once per thread when its cumulative estimated cost exceed
 session_cost_threshold_usd = 25
 ```
 
+## Diff line numbers
+
+Deep Agents Code shows file-relative line numbers in transcript and approval diffs by default. To hide them, set:
+
+```toml
+[ui]
+show_diff_line_numbers = false
+```
+
+Run `/line-numbers` in a session to toggle the preference and save it to `config.toml`. The change applies to new diffs; already rendered diffs do not change. Deep Agents Code omits line numbers when it cannot determine file-relative positions, such as an `edit_file` diff reconstructed from fragments after you resume a thread.
+
 ## Redact LangSmith trace secrets
 
 With LangSmith tracing enabled, Deep Agents Code sends agent-trace inputs and outputs without client-side secret redaction by default.

--- a/src/oss/deepagents/code/quickstart.mdx
+++ b/src/oss/deepagents/code/quickstart.mdx
@@ -150,7 +150,7 @@ The agent uses its built-in tools, skills, and memory to help you with tasks.
 
 ### Inspect context-window usage
 
-Run `/context` to open a color-coded report of the current model's context-window usage. The report shows the model's context limit, used tokens, remaining capacity, and a breakdown between the conversation and system prompt plus tools when those values are available. Press `Esc` to close the report.
+Run `/context` to open a color-coded report of the current model's context-window usage. The report shows the model's context limit, used tokens, remaining capacity, and a breakdown between the conversation and system prompt plus tools when those values are available.
 
 Provider-reported totals remain distinct from local conversation estimates. When a provider total is unavailable, the report labels the conversation count as an estimate and marks the total usage as unavailable. Use `/tokens` when you want a text summary in the conversation transcript instead.
 

--- a/src/oss/deepagents/code/quickstart.mdx
+++ b/src/oss/deepagents/code/quickstart.mdx
@@ -64,6 +64,7 @@ The agent uses its built-in tools, skills, and memory to help you with tasks.
         - `/skill:<name> [args]`: Directly invoke a skill by name. The skill's `SKILL.md` instructions are injected into the prompt along with any arguments you provide.
         - `/skill-creator [task]`: Guide for creating effective agent skills.
         - `/offload` (alias `/compact`) - Free up context window space by offloading messages to storage with a summary placeholder. The agent can retrieve the full history from the offloaded file if needed.
+        - `/context`: Open a color-coded context-window usage report with model capacity, usage categories, and remaining space.
         - `/tokens`: Display current context window token usage breakdown.
         - `/clear`: Clear conversation history and start a new thread.
         - `/force-clear`: Stop active work, clear the chat, and start a new thread.
@@ -75,6 +76,7 @@ The agent uses its built-in tools, skills, and memory to help you with tasks.
         - `/reload`: Re-read `.env` files, refresh configuration, and re-discover skills without restarting. This also reloads plugin skills and MCP configuration. Conversation state is preserved. See [`DEEPAGENTS_CODE_` prefix](/oss/deepagents/code/configuration#deepagents_code_-prefix) for override behavior.
         - `/theme`: Open the interactive theme selector to switch color themes. Built-in themes are available plus any [user-defined themes](/oss/deepagents/code/configuration#themes).
         - `/scrollbar`: Show or hide the chat scrollbar.
+        - `/line-numbers`: Show or hide file-relative line numbers in new diffs. See [Diff line numbers](/oss/deepagents/code/config-file#diff-line-numbers).
         - `/update`: Check for and install Deep Agents Code updates inline. Detects your install method (uv, Homebrew, pip) and runs the appropriate upgrade command.
         - `/auto-update`: Toggle automatic updates on or off.
         - `/install`: Install an optional integration.
@@ -145,6 +147,12 @@ The agent uses its built-in tools, skills, and memory to help you with tasks.
         </Note>
     </Accordion>
 </AccordionGroup>
+
+### Inspect context-window usage
+
+Run `/context` to open a color-coded report of the current model's context-window usage. The report shows the model's context limit, used tokens, remaining capacity, and a breakdown between the conversation and system prompt plus tools when those values are available. Press `Esc` to close the report.
+
+Provider-reported totals remain distinct from local conversation estimates. When a provider total is unavailable, the report labels the conversation count as an estimate and marks the total usage as unavailable. Use `/tokens` when you want a text summary in the conversation transcript instead.
 
 ### External editor
 


### PR DESCRIPTION
## Description
Documents the `/context` usage report and `/line-numbers` command and configuration so Deep Agents Code users can discover and configure both UI features.
## Release Note
none

## Test Plan
- [x] Run scoped Vale prose lint, build docs, and check broken links

Made by [Open SWE](https://openswe.vercel.app/agents/560e085c-723f-583d-d34e-e6e97df8a05d)