### PR TITLE
docs: give Cursor and Copilot the full prose style guide

### DIFF
--- a/.cursor/rules/docs-style.mdc
+++ b/.cursor/rules/docs-style.mdc
@@ -1,0 +1,97 @@
+---
+description: LangChain docs prose style guide, applied when authoring or editing MDX pages
+globs: src/**/*.mdx
+alwaysApply: false
+---
+
+## Style guide
+
+Follow [Google Developer Documentation Style Guide](https://developers.google.com/style).
+
+**Do:**
+
+- Match existing conventions in the file you are editing — do not restructure, combine, or split pages unless explicitly asked
+- Reference existing pages for style patterns when creating new content
+- Be concise — cut filler words and wordy phrases ("to" not "in order to", "because" not "due to the fact that", "can" not "has the ability to")
+- Second-person imperative present tense ("Run the following code…")
+- Active voice ("The function returns a list" not "A list is returned by the function")
+- Sentence-case headings starting with active verb, not gerund ("Add a tool" not "Adding a tool")
+- American English spelling
+- Oxford commas in lists ("traces, datasets, and experiments")
+- Descriptive link text ("[View the tracing docs](/langsmith/tracing)" not "click [this link](/langsmith/tracing)")
+- Add cross-links where applicable
+- Use `@[ClassName]` link map for API references
+- Use `:::python`/`:::js` fencing on OSS docs
+- Language tags on all code blocks (use actual language, not `output`)
+- Sort imports in all code snippets (stdlib, third-party, local)
+- Use `.content_blocks` instead of `.content` when accessing message content in LangChain code snippets
+- Test code examples and links before publishing
+
+**Don't:**
+
+- Skip frontmatter
+- Use absolute URLs for internal links
+- Use markdown in description fields
+- Use `/python/` or `/javascript/` in links (resolved by build pipeline)
+- Use model aliases — use full identifiers (e.g., `claude-sonnet-4-6`)
+- Use FontAwesome icon names
+- Use nested double quotes in component attributes — use `default="['a', 'b']"` not `default='["a", "b"]'`
+- Use contractions ("do not" not "don't", "cannot" not "can't", "it is" not "it's")
+- Use first person ("we", "I", "our", "let's") — write in second person or use the product name as subject
+- Use future tense ("The function returns X" not "The function will return X")
+- Use weasel words or filler (avoid "simply", "easily", "just", "very", "basically", "obviously")
+- Use H5 or H6 headings
+- Start headings with articles ("Add a tool" not "The tool setup guide")
+- Use em dashes — prefer commas, colons, or separate sentences instead. Only use an em dash when no alternative reads naturally
+- Add spaces around em dashes — write `word—word` not `word — word` (`make lint_prose` enforces this)
+- Use excessive bold/italics in body text
+- Start bulleted list items with a lowercase letter — always capitalize the first word
+- Include "key features" lists
+- Use horizontal lines (`---`) to separate sections — use headings instead
+- Apply bold to UI element names unless existing docs already do so
+- Misspell product names — use "prebuilt" (not "pre-built"), "Deep Agents" (not "DeepAgents"), "PyPI" (not "PyPi"), "URL" (not "url")
+- Skip `make lint_prose` — always run it on changed files before committing and fix all violations
+
+### Structure conventions
+
+Match these patterns, drawn from established pages, when authoring new content:
+
+- **Open with definition, then benefit, then task** — start a section (and the page) with a one-sentence statement of what the feature is or does, follow with a sentence on what it enables for the reader, then give the procedure or detail. When a page has a sibling variant (for example, a paid or self-hosted version), link it in the opening lines.
+- **Introduce procedures with a colon lead-in** — precede steps with a phrase such as "To add a channel:", then a numbered list (or the `<Steps>` component) of imperative steps. State a step's result as a follow-on line when it matters ("The Add User modal displays."). Flag optional steps inline with "(Optional)". For long, multi-stage tasks, use `### Step N. <verb>` headings.
+- **Use bold-led definition lists for options** — for parameters, permissions, secrets, or enumerated types, write `- **Term**: Explanation.` and end each explanation with a period.
+- **Link on first mention, and point forward at section ends** — link a feature, class, or term on first mention only, not on repeats. Use the pointer phrasing "For more information, see [Page](/path)". Close substantial pages with a `## See also` list of related links.
+- **State requirements and constraints up front** — put permission, plan tier, or preview requirements before the steps they govern ("Adding MCP servers requires admin permissions."). Write hard constraints as plain facts ("Once an agent identity is set, it cannot be changed.").
+
+### Model references
+
+Always use the latest generally available (GA) models when referencing LLMs in docstrings and illustrative code snippets. Avoid preview or beta identifiers unless the model has no GA equivalent. Outdated model names signal stale code and confuse users.
+
+Before writing or updating model references, verify current model IDs against the provider's official docs. Do not rely on memorized or cached model names — they go stale quickly.
+
+### Release stage names
+
+LangSmith ships features through three release stages: alpha, beta, and generally available (GA). See [Release stages](/langsmith/release-stages) for what each stage means.
+
+These are common nouns, not proper nouns. Write them lowercase in prose, including parenthetical and inline status markers:
+
+- Lowercase mid-sentence and in markers: "available in beta", "is in beta", "(beta)", "the feature is in alpha".
+- Capitalize only where normal sentence case requires it: the first word of a sentence or heading ("Beta is optional.", "## Beta").
+- Keep the literal product UI label capitalized when quoting it as a tag: the `Beta` tag, frontmatter `tag: "Beta"`. The same applies to a stage name standing alone as a table cell's only label.
+- Spell out "generally available" on first use, then use "GA". GA is always uppercase.
+- Do not change code identifiers, package version identifiers (`1.0.0b1`), or literal CLI output that contains "Beta".
+
+### Product and feature name capitalization
+
+Capitalize a word when it refers to a **product or brand name**. Use lowercase when it refers to a **common noun** — a thing you build, an instance, or a type.
+
+**Capitalize** product and brand names:
+
+- LangChain, LangGraph, LangSmith, Deep Agents, Fleet, Engine
+
+**Lowercase** common nouns (things you create, instances, or types):
+
+- "Create a dashboard" (dashboard = a thing you build, not a product name)
+- "a deep agent created using Deep Agents" (the first "deep agent" is a common noun; "Deep Agents" is the product name)
+- "Run an experiment", "View your traces", "Manage your projects"
+
+When in doubt, ask: is this word the product's proper name, or is it describing a thing the user creates or works with? If the latter, use lowercase.

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,41 +1,35 @@
 # LangChain Documentation Guidelines
 
-Documentation for LangChain products hosted on Mintlify. These guidelines apply to manually authored content under `src/`—not Mintlify `build/` output.
+Documentation for LangChain products hosted on Mintlify. These guidelines apply to manually authored content under `src/`, not Mintlify `build/` output.
 
-For full guidelines, see `CLAUDE.md` in the repository root.
+`AGENTS.md` in the repository root is the authoritative guide. Read it before making any non-trivial change. This file carries only the rules that apply to every task.
+
+Prose style rules (voice, headings, terminology, page structure) live in `.cursor/rules/docs-style.mdc` and load automatically when you edit `src/**/*.mdx`.
 
 ## Critical rules
 
 1. **Always ask for clarification** rather than making assumptions
-2. **Never use markdown in frontmatter `description`** — breaks SEO
-3. **Never edit `build/`** — Mintlify build output (regenerate with `make build` or `make dev`)
-4. **Always update `src/docs.json`** when adding new pages
-5. **Use Tabler icons only** — not FontAwesome
-6. **Test code examples** before including them
+2. **Never fabricate** examples, JSON snippets, policy details, or use case descriptions — use only content from the user or existing source files
+3. **Never use markdown in frontmatter `description`** — breaks SEO
+4. **Never edit `build/`** — Mintlify build output (regenerate with `make build` or `make dev`)
+5. **Always update `src/docs.json`** when adding new pages
+6. **Use Tabler icons only** — not FontAwesome
+7. **Test code examples** before including them
+8. **Always run `make lint_prose`** on changed files before committing — CI blocks on it
 
 ## Repository structure
 
-```
+```txt
 docs/
 ├── src/                        # All manually authored content
-│   ├── docs.json               # Mintlify config + navigation (88KB)
+│   ├── docs.json               # Mintlify config + navigation
 │   ├── index.mdx               # Home page
 │   ├── style.css               # Custom CSS
-│   ├── langsmith/              # LangSmith product docs (~324 MDX files)
-│   ├── oss/                    # Open source docs (~1800 MDX files)
-│   │   ├── langchain/          #   LangChain framework
-│   │   ├── langgraph/          #   LangGraph framework
-│   │   ├── deepagents/         #   Deep Agents
-│   │   ├── python/             #   Python-specific (integrations, migrations, releases)
-│   │   ├── javascript/         #   TypeScript-specific (integrations, migrations, releases)
-│   │   ├── integrations/       #   Shared integration content
-│   │   ├── concepts/           #   Conceptual overviews
-│   │   ├── contributing/       #   Contribution guides
-│   │   └── reference/          #   Reference tab entry pages (link to reference.langchain.com)
+│   ├── langsmith/              # LangSmith product docs
+│   │   └── fleet/              #   LangSmith Fleet
+│   ├── oss/                    # Open source docs (LangChain, LangGraph, Deep Agents)
 │   ├── snippets/               # Reusable MDX snippets
 │   ├── images/                 # Documentation images
-│   │   ├── brand/              #   Logos, favicons
-│   │   └── providers/          #   Provider icons (dark/ and light/ variants)
 │   └── fonts/                  # Font files
 ├── pipeline/                   # Python build system & preprocessors
 ├── build/                      # Build output — do not edit
@@ -43,41 +37,7 @@ docs/
 └── tests/                      # Pipeline tests
 ```
 
-## Navigation map
-
-Navigation is defined in `src/docs.json`. The site has 4 products. When adding pages, find the correct product/tab/group below, then update the matching section in `docs.json`.
-
-### Home
-Single page (`src/index.mdx`). No tabs.
-
-### LangSmith (`src/langsmith/`)
-7 tabs, all files in `src/langsmith/`:
-
-| Tab | Groups |
-|-----|--------|
-| Get started | Account administration (Workspace setup, Users & access control, Billing & usage), Tools, Additional resources |
-| Observability | Tracing setup (Integrations, Manual instrumentation), Configuration & troubleshooting, Viewing & managing traces, Automations, Feedback & evaluation, Monitoring & alerting |
-| Evaluation | Datasets, Set up evaluations (Run, Types, Frameworks, Techniques, Tutorials), Analyze experiment results, Annotation & human feedback |
-| Prompt engineering | Create and update prompts, Tutorials |
-| Agent deployment | Configure app, Deployment guides, App development, Studio, Auth & access control, Server customization |
-| Platform setup | Overview, Hybrid, Self-hosted (by cloud provider, Setup guides, Enable features, Configuration, External services, Auth) |
-| Reference | LangSmith Deployment APIs, Releases |
-
-### Fleet (`src/langsmith/fleet/`)
-Flat groups (no tabs): Get started, Tools and integrations, Advanced, Additional resources
-
-### Open source (`src/oss/`)
-2 language dropdowns (Python, TypeScript), each with 7 identical tabs:
-
-| Tab | Directory |
-|-----|-----------|
-| Deep Agents | `src/oss/deepagents/` |
-| LangChain | `src/oss/langchain/` |
-| LangGraph | `src/oss/langgraph/` |
-| Integrations | `src/oss/python/integrations/` or `src/oss/javascript/integrations/` |
-| Learn | `src/oss/` (various) |
-| Reference | `src/oss/reference/` — short entry pages linking to reference.langchain.com |
-| Contribute | `src/oss/contributing/` |
+For the navigation map (every product, tab, and group), see `AGENTS.md`. Navigation is defined in `src/docs.json`, and new pages must be added to the correct product, tab, and group.
 
 ## Quick reference
 
@@ -86,9 +46,9 @@ Flat groups (no tabs): Get started, Tools and integrations, Advanced, Additional
 | Navigation config | `src/docs.json` |
 | Reusable snippets | `src/snippets/` |
 | Provider icons | `src/images/providers/` |
-| Icon library | Tabler — https://tabler.io/icons |
-| Mintlify components | https://mintlify.com/docs/components |
-| Auto-link syntax | `@[ClassName]` — defined in `pipeline/preprocessors/link_map.py` |
+| Icon library | Tabler, <https://tabler.io/icons> |
+| Mintlify components | <https://mintlify.com/docs/components> |
+| Auto-link syntax | `@[ClassName]`, defined in `pipeline/preprocessors/link_map.py` |
 
 ## Frontmatter
 
@@ -103,19 +63,6 @@ description: SEO summary — no markdown allowed (no links, backticks, formattin
 
 ## Syntax
 
-- Language-specific content: `:::python` or `:::js` fences (generates separate Python/JS pages)
+- Language-specific content: `:::python` or `:::js` fences (generates separate Python and TypeScript pages)
 - Code highlighting: `# [!code highlight]`, `# [!code ++]`, `# [!code --]`
-- API reference links: `@[ClassName]` for first mention of SDK classes/methods
-
-## Style
-
-Follow [Google Developer Documentation Style Guide](https://developers.google.com/style).
-
-- Be concise — second-person imperative present tense
-- Sentence-case headings with active verb, not gerund ("Add a tool" not "Adding a tool")
-- American English spelling
-- No markdown in description fields
-- No absolute URLs for internal links
-- No `/python/` or `/javascript/` in links (resolved by build pipeline)
-- No FontAwesome icon names
-- No H5 or H6 headings
+- API reference links: `@[ClassName]` for the first mention of SDK classes or methods

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,39 +1,35 @@
 # LangChain Documentation Guidelines
 
-Documentation for LangChain products hosted on Mintlify. These guidelines apply to manually authored content under `src/`—not Mintlify `build/` output.
+Documentation for LangChain products hosted on Mintlify. These guidelines apply to manually authored content under `src/`, not Mintlify `build/` output.
+
+`AGENTS.md` in the repository root is the authoritative guide. Read it before making any non-trivial change. This file carries only the rules that apply to every task.
+
+Prose style rules (voice, headings, terminology, page structure) live in `.github/instructions/docs-style.instructions.md` and load automatically when you edit `src/**/*.mdx`.
 
 ## Critical rules
 
 1. **Always ask for clarification** rather than making assumptions
-1. **Never use markdown in frontmatter `description`** — breaks SEO
-1. **Never edit `build/`** — Mintlify build output (regenerate with `make build` or `make dev`)
-1. **Always update `src/docs.json`** when adding new pages
-1. **Use Tabler icons only** — not FontAwesome
-1. **Test code examples** before including them
+2. **Never fabricate** examples, JSON snippets, policy details, or use case descriptions — use only content from the user or existing source files
+3. **Never use markdown in frontmatter `description`** — breaks SEO
+4. **Never edit `build/`** — Mintlify build output (regenerate with `make build` or `make dev`)
+5. **Always update `src/docs.json`** when adding new pages
+6. **Use Tabler icons only** — not FontAwesome
+7. **Test code examples** before including them
+8. **Always run `make lint_prose`** on changed files before committing — CI blocks on it
 
 ## Repository structure
 
-```
+```txt
 docs/
 ├── src/                        # All manually authored content
-│   ├── docs.json               # Mintlify config + navigation (88KB)
+│   ├── docs.json               # Mintlify config + navigation
 │   ├── index.mdx               # Home page
 │   ├── style.css               # Custom CSS
-│   ├── langsmith/              # LangSmith product docs (~324 MDX files)
-│   ├── oss/                    # Open source docs (~1800 MDX files)
-│   │   ├── langchain/          #   LangChain framework
-│   │   ├── langgraph/          #   LangGraph framework
-│   │   ├── deepagents/         #   Deep Agents
-│   │   ├── python/             #   Python-specific (integrations, migrations, releases)
-│   │   ├── javascript/         #   TypeScript-specific (integrations, migrations, releases)
-│   │   ├── integrations/       #   Shared integration content
-│   │   ├── concepts/           #   Conceptual overviews
-│   │   ├── contributing/       #   Contribution guides
-│   │   └── reference/          #   Reference tab entry pages (link to reference.langchain.com)
+│   ├── langsmith/              # LangSmith product docs
+│   │   └── fleet/              #   LangSmith Fleet
+│   ├── oss/                    # Open source docs (LangChain, LangGraph, Deep Agents)
 │   ├── snippets/               # Reusable MDX snippets
 │   ├── images/                 # Documentation images
-│   │   ├── brand/              #   Logos, favicons
-│   │   └── providers/          #   Provider icons (dark/ and light/ variants)
 │   └── fonts/                  # Font files
 ├── pipeline/                   # Python build system & preprocessors
 ├── build/                      # Build output — do not edit
@@ -41,41 +37,7 @@ docs/
 └── tests/                      # Pipeline tests
 ```
 
-## Navigation map
-
-Navigation is defined in `src/docs.json`. The site has 4 products. When adding pages, find the correct product/tab/group below, then update the matching section in `docs.json`.
-
-### Home
-Single page (`src/index.mdx`). No tabs.
-
-### LangSmith (`src/langsmith/`)
-7 tabs, all files in `src/langsmith/`:
-
-| Tab | Groups |
-|-----|--------|
-| Get started | Account administration (Workspace setup, Users & access control, Billing & usage), Tools, Additional resources |
-| Observability | Tracing setup (Integrations, Manual instrumentation), Configuration & troubleshooting, Viewing & managing traces, Automations, Feedback & evaluation, Monitoring & alerting |
-| Evaluation | Datasets, Set up evaluations (Run, Types, Frameworks, Techniques, Tutorials), Analyze experiment results, Annotation & human feedback |
-| Prompt engineering | Create and update prompts, Tutorials |
-| Agent deployment | Configure app, Deployment guides, App development, Studio, Auth & access control, Server customization |
-| Platform setup | Overview, Hybrid, Self-hosted (by cloud provider, Setup guides, Enable features, Configuration, External services, Auth) |
-| Reference | LangSmith Deployment APIs, Releases |
-
-### Fleet (`src/langsmith/fleet/`)
-Flat groups (no tabs): Get started, Tools and integrations, Advanced, Additional resources
-
-### Open source (`src/oss/`)
-2 language dropdowns (Python, TypeScript), each with 7 identical tabs:
-
-| Tab | Directory |
-|-----|-----------|
-| Deep Agents | `src/oss/deepagents/` |
-| LangChain | `src/oss/langchain/` |
-| LangGraph | `src/oss/langgraph/` |
-| Integrations | `src/oss/python/integrations/` or `src/oss/javascript/integrations/` |
-| Learn | `src/oss/` (various) |
-| Reference | `src/oss/reference/` — short entry pages linking to reference.langchain.com |
-| Contribute | `src/oss/contributing/` |
+For the navigation map (every product, tab, and group), see `AGENTS.md`. Navigation is defined in `src/docs.json`, and new pages must be added to the correct product, tab, and group.
 
 ## Quick reference
 
@@ -84,9 +46,9 @@ Flat groups (no tabs): Get started, Tools and integrations, Advanced, Additional
 | Navigation config | `src/docs.json` |
 | Reusable snippets | `src/snippets/` |
 | Provider icons | `src/images/providers/` |
-| Icon library | Tabler — https://tabler.io/icons |
-| Mintlify components | https://mintlify.com/docs/components |
-| Auto-link syntax | `@[ClassName]` — defined in `pipeline/preprocessors/link_map.py` |
+| Icon library | Tabler, <https://tabler.io/icons> |
+| Mintlify components | <https://mintlify.com/docs/components> |
+| Auto-link syntax | `@[ClassName]`, defined in `pipeline/preprocessors/link_map.py` |
 
 ## Frontmatter
 
@@ -101,19 +63,6 @@ description: SEO summary — no markdown allowed (no links, backticks, formattin
 
 ## Syntax
 
-- Language-specific content: `:::python` or `:::js` fences (generates separate Python/JS pages)
+- Language-specific content: `:::python` or `:::js` fences (generates separate Python and TypeScript pages)
 - Code highlighting: `# [!code highlight]`, `# [!code ++]`, `# [!code --]`
-- API reference links: `@[ClassName]` for first mention of SDK classes/methods
-
-## Style
-
-Follow [Google Developer Documentation Style Guide](https://developers.google.com/style).
-
-- Be concise — second-person imperative present tense
-- Sentence-case headings with active verb, not gerund ("Add a tool" not "Adding a tool")
-- American English spelling
-- No markdown in description fields
-- No absolute URLs for internal links
-- No `/python/` or `/javascript/` in links (resolved by build pipeline)
-- No FontAwesome icon names
-- No H5 or H6 headings
+- API reference links: `@[ClassName]` for the first mention of SDK classes or methods

--- a/.github/instructions/docs-style.instructions.md
+++ b/.github/instructions/docs-style.instructions.md
@@ -1,0 +1,95 @@
+---
+applyTo: "src/**/*.mdx"
+---
+
+## Style guide
+
+Follow [Google Developer Documentation Style Guide](https://developers.google.com/style).
+
+**Do:**
+
+- Match existing conventions in the file you are editing — do not restructure, combine, or split pages unless explicitly asked
+- Reference existing pages for style patterns when creating new content
+- Be concise — cut filler words and wordy phrases ("to" not "in order to", "because" not "due to the fact that", "can" not "has the ability to")
+- Second-person imperative present tense ("Run the following code…")
+- Active voice ("The function returns a list" not "A list is returned by the function")
+- Sentence-case headings starting with active verb, not gerund ("Add a tool" not "Adding a tool")
+- American English spelling
+- Oxford commas in lists ("traces, datasets, and experiments")
+- Descriptive link text ("[View the tracing docs](/langsmith/tracing)" not "click [this link](/langsmith/tracing)")
+- Add cross-links where applicable
+- Use `@[ClassName]` link map for API references
+- Use `:::python`/`:::js` fencing on OSS docs
+- Language tags on all code blocks (use actual language, not `output`)
+- Sort imports in all code snippets (stdlib, third-party, local)
+- Use `.content_blocks` instead of `.content` when accessing message content in LangChain code snippets
+- Test code examples and links before publishing
+
+**Don't:**
+
+- Skip frontmatter
+- Use absolute URLs for internal links
+- Use markdown in description fields
+- Use `/python/` or `/javascript/` in links (resolved by build pipeline)
+- Use model aliases — use full identifiers (e.g., `claude-sonnet-4-6`)
+- Use FontAwesome icon names
+- Use nested double quotes in component attributes — use `default="['a', 'b']"` not `default='["a", "b"]'`
+- Use contractions ("do not" not "don't", "cannot" not "can't", "it is" not "it's")
+- Use first person ("we", "I", "our", "let's") — write in second person or use the product name as subject
+- Use future tense ("The function returns X" not "The function will return X")
+- Use weasel words or filler (avoid "simply", "easily", "just", "very", "basically", "obviously")
+- Use H5 or H6 headings
+- Start headings with articles ("Add a tool" not "The tool setup guide")
+- Use em dashes — prefer commas, colons, or separate sentences instead. Only use an em dash when no alternative reads naturally
+- Add spaces around em dashes — write `word—word` not `word — word` (`make lint_prose` enforces this)
+- Use excessive bold/italics in body text
+- Start bulleted list items with a lowercase letter — always capitalize the first word
+- Include "key features" lists
+- Use horizontal lines (`---`) to separate sections — use headings instead
+- Apply bold to UI element names unless existing docs already do so
+- Misspell product names — use "prebuilt" (not "pre-built"), "Deep Agents" (not "DeepAgents"), "PyPI" (not "PyPi"), "URL" (not "url")
+- Skip `make lint_prose` — always run it on changed files before committing and fix all violations
+
+### Structure conventions
+
+Match these patterns, drawn from established pages, when authoring new content:
+
+- **Open with definition, then benefit, then task** — start a section (and the page) with a one-sentence statement of what the feature is or does, follow with a sentence on what it enables for the reader, then give the procedure or detail. When a page has a sibling variant (for example, a paid or self-hosted version), link it in the opening lines.
+- **Introduce procedures with a colon lead-in** — precede steps with a phrase such as "To add a channel:", then a numbered list (or the `<Steps>` component) of imperative steps. State a step's result as a follow-on line when it matters ("The Add User modal displays."). Flag optional steps inline with "(Optional)". For long, multi-stage tasks, use `### Step N. <verb>` headings.
+- **Use bold-led definition lists for options** — for parameters, permissions, secrets, or enumerated types, write `- **Term**: Explanation.` and end each explanation with a period.
+- **Link on first mention, and point forward at section ends** — link a feature, class, or term on first mention only, not on repeats. Use the pointer phrasing "For more information, see [Page](/path)". Close substantial pages with a `## See also` list of related links.
+- **State requirements and constraints up front** — put permission, plan tier, or preview requirements before the steps they govern ("Adding MCP servers requires admin permissions."). Write hard constraints as plain facts ("Once an agent identity is set, it cannot be changed.").
+
+### Model references
+
+Always use the latest generally available (GA) models when referencing LLMs in docstrings and illustrative code snippets. Avoid preview or beta identifiers unless the model has no GA equivalent. Outdated model names signal stale code and confuse users.
+
+Before writing or updating model references, verify current model IDs against the provider's official docs. Do not rely on memorized or cached model names — they go stale quickly.
+
+### Release stage names
+
+LangSmith ships features through three release stages: alpha, beta, and generally available (GA). See [Release stages](/langsmith/release-stages) for what each stage means.
+
+These are common nouns, not proper nouns. Write them lowercase in prose, including parenthetical and inline status markers:
+
+- Lowercase mid-sentence and in markers: "available in beta", "is in beta", "(beta)", "the feature is in alpha".
+- Capitalize only where normal sentence case requires it: the first word of a sentence or heading ("Beta is optional.", "## Beta").
+- Keep the literal product UI label capitalized when quoting it as a tag: the `Beta` tag, frontmatter `tag: "Beta"`. The same applies to a stage name standing alone as a table cell's only label.
+- Spell out "generally available" on first use, then use "GA". GA is always uppercase.
+- Do not change code identifiers, package version identifiers (`1.0.0b1`), or literal CLI output that contains "Beta".
+
+### Product and feature name capitalization
+
+Capitalize a word when it refers to a **product or brand name**. Use lowercase when it refers to a **common noun** — a thing you build, an instance, or a type.
+
+**Capitalize** product and brand names:
+
+- LangChain, LangGraph, LangSmith, Deep Agents, Fleet, Engine
+
+**Lowercase** common nouns (things you create, instances, or types):
+
+- "Create a dashboard" (dashboard = a thing you build, not a product name)
+- "a deep agent created using Deep Agents" (the first "deep agent" is a common noun; "Deep Agents" is the product name)
+- "Run an experiment", "View your traces", "Manage your projects"
+
+When in doubt, ask: is this word the product's proper name, or is it describing a thing the user creates or works with? If the latter, use lowercase.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,9 @@
 > **Keep in sync:** `AGENTS.md` and `CLAUDE.md` contain identical guidelines. If you update one, update the other.
+>
+> Four files derive from this one, for agents that do not read `CLAUDE.md` or `AGENTS.md`. When you change a section listed below, update its copies in the same PR:
+>
+> - **Style guide** (through Product and feature name capitalization) is mirrored verbatim in `.cursor/rules/docs-style.mdc` and `.github/instructions/docs-style.instructions.md`. Both are path-scoped to `src/**/*.mdx`, so they load only when a page is edited.
+> - **Critical rules, Repository structure, Quick reference, Frontmatter, and Syntax** are summarized in `.cursorrules` and `.github/copilot-instructions.md`.
 
 # LangChain Documentation Guidelines
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,4 +1,9 @@
 > **Keep in sync:** `AGENTS.md` and `CLAUDE.md` contain identical guidelines. If you update one, update the other.
+>
+> Four files derive from this one, for agents that do not read `CLAUDE.md` or `AGENTS.md`. When you change a section listed below, update its copies in the same PR:
+>
+> - **Style guide** (through Product and feature name capitalization) is mirrored verbatim in `.cursor/rules/docs-style.mdc` and `.github/instructions/docs-style.instructions.md`. Both are path-scoped to `src/**/*.mdx`, so they load only when a page is edited.
+> - **Critical rules, Repository structure, Quick reference, Frontmatter, and Syntax** are summarized in `.cursorrules` and `.github/copilot-instructions.md`.
 
 # LangChain Documentation Guidelines
 


### PR DESCRIPTION
## Why

`.cursorrules` and `.github/copilot-instructions.md` were hand-maintained subsets of `CLAUDE.md`. Comparing headings, the subsets dropped 26 of them, including the whole style guide and the structure conventions:

```console
$ diff <(grep -E "^#{2,3} " CLAUDE.md) <(grep -E "^#{2,3} " .cursorrules) | grep '^<'
< ## Style guide
< ### Structure conventions
< ### Model references
< ### Release stage names
< ### Product and feature name capitalization
< ## Components
< ## Mermaid diagram styling
...
```

So a contributor on Cursor or Copilot got the repository layout and none of the rules about how the prose should read.

They are also stale. Both last changed **2026-05-13**; `CLAUDE.md` last changed **2026-07-22**. The product and feature name capitalization rule added in #5036 never reached either file.

## What changed

Rather than copying all 398 lines into every file, the style guide is mirrored into two path-scoped rule files, which is each tool's native way to attach rules to file patterns:

| File | Scoping | Loads when |
|------|---------|-----------|
| `.cursor/rules/docs-style.mdc` | `globs: src/**/*.mdx` | Editing a page under `src/` |
| `.github/instructions/docs-style.instructions.md` | `applyTo: "src/**/*.mdx"` | Editing a page under `src/` |

Both bodies are byte-identical to lines 219 to 309 of `CLAUDE.md`, verified with `diff`. The scoping matches 2,275 MDX files under `src/`.

`.cursorrules` and `copilot-instructions.md` are trimmed to what applies to every task: critical rules, repository structure, quick reference, frontmatter, syntax, and a pointer to `AGENTS.md`. Both are 68 lines and differ only in the line naming their own style rule file.

The sync banner at the top of `CLAUDE.md` and `AGENTS.md` now names all four derived files and says which sections feed each, so the next style guide edit updates them in the same PR.

## Removed on purpose

The trimmed files no longer carry a navigation map. The one they had was wrong: it listed the LangSmith "Configure app" tab and Fleet's "Tools and integrations" group, neither of which exists now. `AGENTS.md` has the current map, and the trimmed files point at it. Restating it in four places is what produced the staleness in the first place.

## Review notes

Two things worth a second opinion:

1. **The cut line.** Only the style guide is path-scoped. Frontmatter, components, and Mermaid styling rules still live only in `CLAUDE.md` and `AGENTS.md`, though they are just as relevant when editing an MDX file. Extending the scoped files to cover them is a reasonable follow-up; it was left out to keep this reviewable.
2. **Sync is still manual.** The banner tells a human what to update. It does not enforce anything. A CI drift check would, and is the obvious next step if this pattern holds.

No page content is touched, so there is nothing to preview.

Drafted with Claude Code.
