### PR TITLE
docs: editorial pass on the data store IAM authentication page

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -1713,8 +1713,8 @@
                     "group": "Server customization",
                     "pages": [
                       "langsmith/caching",
-                      "langsmith/encryption",
                       "langsmith/configure-iam-auth",
+                      "langsmith/encryption",
                       "langsmith/graph-rebuild",
                       {
                         "group": "Replace built-in backends",

--- a/src/langsmith/configure-iam-auth.mdx
+++ b/src/langsmith/configure-iam-auth.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Data store IAM authentication
 description: Configure Agent Server to use cloud workload identities for PostgreSQL and Redis authentication.
 ---
 
-Agent Server can use a cloud workload identity to generate short-lived PostgreSQL and Redis credentials at runtime. This removes static database and cache passwords from the deployment configuration while preserving the existing connection and pooling behavior.
+Agent Server can use a cloud workload identity to generate short-lived PostgreSQL and Redis credentials at runtime. This removes static database and cache passwords from your deployment configuration. Connection and pooling behavior stay the same.
 
 <Note>
 Data store IAM authentication requires `langgraph-api>=0.12.0`.
@@ -24,7 +24,7 @@ The GCP PostgreSQL provider supports Cloud SQL. It does not support AlloyDB, whi
 
 The provider setting controls authentication only. Configure network access, TLS, database users, cache users, and provider permissions before starting Agent Server.
 
-## Configure Agent Server
+## Enable IAM authentication
 
 To enable IAM authentication:
 
@@ -34,10 +34,10 @@ To enable IAM authentication:
 4. Set a connection URI that contains the principal name but no static password.
 5. Set the corresponding provider selector to `aws`, `azure`, or `gcp`:
 
-```shell
-AGENT_POSTGRES_IAM_AUTH_PROVIDER=<provider>
-AGENT_REDIS_IAM_AUTH_PROVIDER=<provider>
-```
+    ```shell
+    AGENT_POSTGRES_IAM_AUTH_PROVIDER=<provider>
+    AGENT_REDIS_IAM_AUTH_PROVIDER=<provider>
+    ```
 
 You can enable IAM authentication for PostgreSQL, Redis, or both. When a selector is unset, Agent Server continues to use the password from that data store's connection URI.
 
@@ -48,7 +48,12 @@ Use these connection URI variables for your deployment type:
 | Standalone Agent Server | `DATABASE_URI` | `REDIS_URI` |
 | Self-hosted deployment with a control plane | `POSTGRES_URI_CUSTOM` | `REDIS_URI_CUSTOM` |
 
-Use `sslmode=require` or a stricter verification mode for PostgreSQL and `rediss://` for Redis. Percent-encode URI-reserved characters in usernames, such as `@` as `%40`. If Redis TLS uses a private certificate authority, set `REDIS_TLS_CA_CERT` to the base64-encoded PEM CA bundle. If the Redis service uses cluster mode, also set `REDIS_CLUSTER=true`.
+The connection URIs must meet the following requirements:
+
+- **Transport security**: Use `sslmode=require` or a stricter verification mode for PostgreSQL, and `rediss://` for Redis.
+- **Character encoding**: Percent-encode URI-reserved characters in usernames, such as `@` as `%40`.
+- **Private certificate authority**: If Redis TLS uses a private certificate authority, set `REDIS_TLS_CA_CERT` to the base64-encoded PEM CA bundle.
+- **Cluster mode**: If the Redis service uses cluster mode, also set `REDIS_CLUSTER=true`.
 
 ## Configure AWS
 
@@ -70,7 +75,7 @@ DATABASE_URI="postgresql://<rds-user>@<rds-endpoint>:5432/<database>?sslmode=req
 REDIS_URI="rediss://<elasticache-iam-user>@<elasticache-endpoint>:6379"
 ```
 
-The Redis username must match the IAM-enabled ElastiCache user. Agent Server supports provisioned ElastiCache cache clusters and replication groups. ElastiCache IAM authentication requires Valkey 7.2 or later or Redis OSS 7.0 or later, with in-transit encryption enabled.
+The Redis username must match the IAM-enabled ElastiCache user. Agent Server supports provisioned ElastiCache cache clusters and replication groups. ElastiCache IAM authentication requires in-transit encryption and either Valkey 7.2 or later or Redis OSS 7.0 or later.
 
 ## Configure Azure
 
@@ -115,7 +120,7 @@ REDIS_CLUSTER=true
 
 For a service account, the Cloud SQL database username is its email address without the `.gserviceaccount.com` suffix.
 
-## Configure the standalone Agent Server Helm chart
+## Configure the standalone Helm chart
 
 For a [standalone Agent Server deployment](/langsmith/deploy-standalone-server) on Kubernetes, set the provider selectors on every Agent Server workload. If the separate queue deployment is enabled, configure the API and queue deployments with the same identity and environment variables.
 
@@ -155,4 +160,5 @@ Configure `apiServer.serviceAccount` and `queue.serviceAccount` with the cloud p
 
 - [Self-host standalone servers](/langsmith/deploy-standalone-server)
 - [Self-hosted Agent Server environment variables](/langsmith/env-var-self-hosted)
+- [Self-hosted platform features](/langsmith/self-hosted-platform-features)
 - [Configure Agent Server for scale](/langsmith/agent-server-scale)


### PR DESCRIPTION
Stacked on #5429. This targets `open-swe/langgraph-api-iam-auth-docs` rather than `main`, so the edits land on the IAM authentication page before that PR merges.

## Why

An editorial pass over `configure-iam-auth.mdx` after the initial draft, plus one navigation fix. No behavior or configuration guidance changes: every environment variable, version requirement, and provider constraint is the same.

## What changed

**Navigation.** `Server customization` listed `configure-iam-auth` after `encryption`, out of alphabetical order with the rest of the group. Now: caching, configure-iam-auth, encryption, graph-rebuild.

**Requirements as a definition list.** The connection URI constraints were a five-clause paragraph mixing transport security, character encoding, private CAs, and cluster mode. They are now four bold-led bullets, matching the structure convention for enumerated requirements. This is the change most worth a look, since it is the only one that alters how the section is read rather than worded.

**Headings shortened.** "Configure Agent Server" became "Enable IAM authentication", which says what the section does and no longer collides with the sibling "Configure AWS/Azure/GCP" headings. "Configure the standalone Agent Server Helm chart" lost the redundant product name.

**Code block indented into its step.** The provider selector block sat outside the numbered list, so it rendered as though the procedure had ended at step 5.

**Two sentences rewritten.** The opening sentence was split in two, and the ElastiCache requirements reordered so the encryption prerequisite is not stranded after the version list.

**One link added** to the See also list.

## Checks

- `make lint_prose FILES="src/langsmith/configure-iam-auth.mdx"` passes with 0 errors, 0 warnings, 0 suggestions.
- `src/docs.json` parses, and the group order is verified above.

## Review notes

The definition-list conversion is the judgment call. If you would rather keep the requirements as prose, that hunk reverts cleanly on its own without affecting anything else.

Drafted with Claude Code.
