### PR TITLE
docs(mda): simplify LLM Gateway setup

### DIFF
--- a/src/langsmith/managed-deep-agents-agent-definition.mdx
+++ b/src/langsmith/managed-deep-agents-agent-definition.mdx
@@ -202,33 +202,17 @@ Pass a LangChain chat model instance instead when you need to configure model pa
 
 ### Use LLM Gateway
 
-You can use [LLM Gateway](langsmith/llm-gateway) to control rate limits, fallbacks, and more.
+You can use [LLM Gateway](/langsmith/llm-gateway) to apply rate limits, fallbacks, and other policies to model calls.
 
-In order to use LLM Gateway, you should:
-- Use the ChatOpenAI model directly
-- Set a base url of `https://gateway.smith.langchain.com/v1`
-- Use your `LANGSMITH_API_KEY` for authentication. Set `LANGSMITH_GATEWAY_API_KEY` only if you need a different key for gateway calls.
+Prefix the gateway model ID with `langsmith:`:
 
 :::python
-```py
-import os
-
+```python
 from managed_deepagents import define_deep_agent
-from langchain_openai import ChatOpenAI
-
-api_key = os.environ.get(
-    "LANGSMITH_GATEWAY_API_KEY",
-    os.environ.get("LANGSMITH_API_KEY", "missing-langsmith-api-key"),
-)
-base_url = "https://gateway.smith.langchain.com/v1"
 
 agent = define_deep_agent(
     name="my-agent",
-    model=ChatOpenAI(
-        model="moonshotai/Kimi-K3",
-        api_key=api_key,
-        base_url=base_url,
-    ),
+    model="langsmith:moonshotai/kimi-k3",
 )
 ```
 :::
@@ -236,52 +220,21 @@ agent = define_deep_agent(
 :::js
 ```ts
 import { defineDeepAgent } from "managed-deepagents";
-import { ChatOpenAI } from "@langchain/openai";
-
-const apiKey =
-  process.env.LANGSMITH_GATEWAY_API_KEY ??
-  process.env.LANGSMITH_API_KEY ??
-  "missing-langsmith-api-key";
-const baseURL = "https://gateway.smith.langchain.com/v1";
 
 export const agent = defineDeepAgent({
   name: "my-agent",
-  model: new ChatOpenAI({
-    model: "moonshotai/Kimi-K3",
-    apiKey,
-    configuration: { baseURL },
-  }),
+  model: "langsmith:moonshotai/kimi-k3",
 });
 ```
 :::
 
 <Note>
-The model slug should be `provider/model-name` when using Gateway. When NOT using Gateway, it is normally `provider:model-name`
+Gateway model IDs use a slash between provider and model (`langsmith:provider/model-name`). Model strings that call a provider directly use a colon (`provider:model-name`).
 </Note>
 
-In order to scaffold your project to use Gateway from the start, you can pass a `--gateway` flag when initializing your agent:
+The gateway routes each request by model ID. `moonshotai/kimi-k3` is a LangChain-hosted model, so it requires no provider secret and draws on [Gateway Credits](/langsmith/llm-gateway-credits). A model ID that starts with a provider your workspace has configured, such as `anthropic/claude-opus-5`, uses that [provider secret](/langsmith/llm-gateway-admin-setup#1-add-provider-secrets) and bills to your own provider account.
 
-:::python
-```bash
-uvx --from managed-deepagents mda init my-agent --gateway
-```
-:::
-
-:::js
-<CodeGroup>
-    ```bash npm
-    npx managed-deepagents init my-agent --gateway
-    ```
-
-    ```bash pnpm
-    pnpm dlx managed-deepagents init my-agent --gateway
-    ```
-
-    ```bash bun
-    bunx managed-deepagents init my-agent --gateway
-    ```
-</CodeGroup>
-:::
+For more information, see [LLM Gateway](/langsmith/llm-gateway).
 
 ## Tools
 


### PR DESCRIPTION
Use the `langsmith:` provider for both Python and TypeScript Managed Deep Agents Gateway Credits examples.

The TypeScript example depends on [langchainjs #11369](https://github.com/langchain-ai/langchainjs/pull/11369) and should merge only after its patch release and the corresponding Managed Deep Agents dependency update.

Reference: https://docs.langchain.com/langsmith/llm-gateway-quickstart#using-langchain-and-deep-agents

Closes https://github.com/langchain-ai/managed-deepagents-sdk/issues/318