### PR TITLE
docs(langsmith): document sandbox proxy rule env vars

### DIFF
--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -118,6 +118,7 @@ Add a `proxy_config` when creating a sandbox, or update an existing sandbox by p
 | `match_hosts` | Hosts to intercept (supports globs like `*.github.com`) |
 | `match_paths` | Paths to match (empty = all paths) |
 | `headers` | Headers to inject, each with a `name`, `type`, and `value` |
+| `env_vars` | Environment variables to set in the sandbox while the rule is enabled |
 | `no_proxy` | Hosts to bypass the proxy entirely (e.g. `localhost`) |
 
 ### Header types
@@ -129,6 +130,29 @@ Each header has a `type` that controls how its value is stored and displayed:
 | `workspace_secret` | References a workspace secret using `{KEY}` syntax. Resolved when the proxy configuration is applied. |
 | `plaintext` | Value is stored and returned as-is. Use for non-sensitive headers. |
 | `opaque` | Write-only. Value is encrypted at rest and never returned via the API. |
+
+### Set environment variables from a rule
+
+A rule's `env_vars` are plaintext environment variables set for every command in the sandbox while that rule is enabled. Use them for tools that refuse to run unless a credential variable is present, even though the proxy injects the real credential on the wire: give the variable a placeholder value so the command starts, and the proxy supplies the real credential.
+
+Values are plaintext and are returned by the API, so never put a secret in `env_vars`. Use a header with the `workspace_secret` or `opaque` type instead.
+
+Environment variables resolve in this order, from lowest precedence to highest:
+
+1. **Enabled proxy rules**: When two enabled rules declare the same name, the later rule in `rules` wins.
+2. **The sandbox's own `env_vars`**: Explicit per-sandbox values override values from rules.
+3. **Variables managed by an enabled AWS or GCP auth rule**: A rule that declares one of these names is rejected when the matching auth rule is enabled.
+
+```json
+{
+  "name": "github-api",
+  "match_hosts": ["api.github.com"],
+  "headers": [
+    {"name": "Authorization", "type": "opaque", "value": "Bearer <github-token>"}
+  ],
+  "env_vars": {"GH_TOKEN": "proxy-injected"}
+}
+```
 
 ## Authenticate AWS requests
 
@@ -460,6 +484,7 @@ def github_proxy_rules(github_token: str) -> list[dict[str, Any]]:
                     "value": f"Bearer {github_token}",
                 }
             ],
+            "env_vars": {"GH_TOKEN": "proxy-injected"},
         },
         {
             "name": "github",
@@ -490,15 +515,15 @@ def configure_github_proxy(sandbox_name: str, github_token: str) -> None:
 
 Call `configure_github_proxy` after creating or reattaching to a sandbox. GitHub App installation tokens expire, so refresh the proxy config whenever you reuse a sandbox for a new run.
 
-Inside the sandbox, set a non-secret placeholder token when a CLI requires a local credential before it sends a request:
+The `github-api` rule sets `GH_TOKEN` to a non-secret placeholder, which satisfies the `gh` CLI's local credential check. Commands then run without a per-command prefix:
 
 ```bash
-GH_TOKEN=dummy gh repo view langchain-ai/langchain
-GH_TOKEN=dummy gh pr list --repo langchain-ai/langchain
-GH_TOKEN=dummy gh repo clone langchain-ai/langchain
+gh repo view langchain-ai/langchain
+gh pr list --repo langchain-ai/langchain
+gh repo clone langchain-ai/langchain
 ```
 
-The placeholder only satisfies the `gh` CLI's local check. The proxy injects the real `Authorization` header into the outbound request.
+The placeholder never leaves the sandbox. The proxy injects the real `Authorization` header into the outbound request.
 
 ## Configure via SDK
 


### PR DESCRIPTION
The sandbox auth proxy page never mentioned a proxy rule's `env_vars`, and its GitHub example told readers to prefix every command with `GH_TOKEN=dummy` — which is exactly what the field removes.

- Adds `env_vars` to the rule field table and a section covering what it is for, the plaintext warning, and the precedence order (enabled rules < the sandbox's own `env_vars` < variables managed by an enabled AWS or GCP auth rule).
- Updates the GitHub example so the rule sets `GH_TOKEN`, and the `gh` commands run unprefixed.

## Test Plan

- [x] `make lint_prose FILES=src/langsmith/sandbox-auth-proxy.mdx` — 0 errors, 0 warnings, 0 suggestions