### PR TITLE
docs: clarify Engine page structure

### DIFF
--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -6,17 +6,7 @@ description: Automatically detect and resolve recurring issues in your tracing p
 
 LangSmith Engine helps you ship more reliable agents without manually searching through traces. It is the LangSmith Agent for agent engineering: working from your production traces, it surfaces recurring issues, diagnoses their root cause, and drives the fix across every stage of the development lifecycle. For a product overview, see [Engine](/langsmith/engine-overview).
 
-## How Engine samples and prioritizes traces
-
-Engine analyzes both trace content and run feedback when selecting and ranking traces for each scan. It treats feedback—including online evaluator scores, annotation queue scores, and user feedback submitted via the SDK—as a high-priority signal, not supplementary data.
-
-To apply this signal, Engine:
-
-- Reads the feedback keys present in your project and performs a dedicated pull of low-scoring traces for each key, so the sample includes traces with poor evaluator scores rather than leaving them to recency.
-- Prioritizes traces with non-empty feedback scores ahead of other traces when screening the sample.
-- Preserves feedback scores on every trace in the analysis context, even when trace payloads are compacted to fit within context limits.
-
-Any source that writes feedback to a run contributes to this prioritization automatically. Engine requires no setup beyond evaluators or annotation queues.
+## How Engine works
 
 Each issue moves through a closed loop in which Engine:
 
@@ -41,6 +31,18 @@ flowchart LR
 ```
 
 This page covers how to set up Engine, work through the fix and evaluation loop, control costs, and route notifications.
+
+## How Engine samples and prioritizes traces
+
+Engine analyzes both trace content and run feedback when selecting and ranking traces for each scan. It treats feedback—including online evaluator scores, annotation queue scores, and user feedback submitted via the SDK—as a high-priority signal, not supplementary data.
+
+To apply this signal, Engine:
+
+- Reads the feedback keys present in your project and performs a dedicated pull of low-scoring traces for each key, so the sample includes traces with poor evaluator scores rather than leaving them to recency.
+- Prioritizes traces with non-empty feedback scores ahead of other traces when screening the sample.
+- Preserves feedback scores on every trace in the analysis context, even when trace payloads are compacted to fit within context limits.
+
+Any source that writes feedback to a run contributes to this prioritization automatically. Engine requires no setup beyond evaluators or annotation queues.
 
 ## Set up Engine
 


### PR DESCRIPTION
## Summary

- Separate the Engine issue-resolution lifecycle from trace sampling and prioritization.
- Add a **How Engine works** section immediately after the page introduction.

## Why

The lifecycle describes Engine's end-to-end workflow, while the sampling section describes only how Engine selects and ranks traces. Keeping them separate makes the page structure match those distinct concepts.

## Validation

- `make lint_prose FILES="src/langsmith/engine.mdx"`
- `git diff --check`

## Review focus

- Confirm that the new heading and ordering correctly distinguish Engine's lifecycle from trace-sampling behavior.

AI agent assisted with this change.