### PR TITLE
docs: clarify PolarDB PG provider capabilities

### DIFF
--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -2013,7 +2013,7 @@ Browse the complete collection of integrations available for Python. LangChain P
         href="https://github.com/polardb/langchain-polardb-pg"
         icon="link"
     >
-        PolarDB for PostgreSQL embeddings and vector store for LangChain.
+        PolarDB for PostgreSQL provides in-database embeddings, a LangChain vector store, and SQL-based registration and invocation of external AI models.
     </Card>
 
     <Card


### PR DESCRIPTION
## Overview

Updates the PolarDB PG card added in #5488 so it describes the package's in-database embeddings, LangChain vector store, and SQL-based registration and invocation of external AI models.

The wording distinguishes database-executed embedding and SQL operations from external model hosting. The model APIs are implemented by [`PolarDBPGModelManager`](https://github.com/polardb/langchain-polardb-pg/blob/main/src/langchain_polardb_pg/model_manager.py) through the `polar_ai` SQL functions.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: N/A
- Feature PR: #5488

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev` (not run; this is a one-sentence card description update)
- [ ] All code examples have been tested and work correctly (not applicable; no code examples changed)
- [ ] I have used **root relative** paths for internal links (not applicable; no internal links added)
- [ ] I have updated navigation in `src/docs.json` if needed (not applicable; no navigation changes)

## Additional notes

- `make lint_prose FILES=src/oss/python/integrations/providers/all_providers.mdx`: 0 errors, 0 warnings, and 0 suggestions
- `git diff --check`: passed
- No package code or registry metadata changed