### PR TITLE
chore: document legacy deployment types

### DIFF
--- a/src/langsmith/cloud-platform-features.mdx
+++ b/src/langsmith/cloud-platform-features.mdx
@@ -25,7 +25,7 @@ The maximum payload size for all requests sent to Cloud deployments is 25 MB. A
 
 The control plane offers two deployment types: Serverless and Dedicated. Each is available in three sizes: Small, Medium, and Large.
 
-Organizations still on previous pricing continue to create Development and Production deployments until October 1, 2026. Those types do not include scale to zero. To select them with the CLI, pass `--deployment-type dev` or `--deployment-type prod`. For pricing and the transition timeline, see [Manage billing](/langsmith/billing#langsmith-deployment-billing). For the full list of `--deployment-type` values, see [`langgraph deploy`](/langsmith/cli#deploy).
+Organizations still on previous pricing use Development and Production deployments. For resource allocations, behavior, and transition details, see [Legacy deployment types](#legacy-deployment-types).
 
 | **Deployment type** | **Scaling** | **Database** | **Best for** |
 |---|---|---|---|
@@ -72,6 +72,23 @@ Runtime compute and memory are the total vCPU and memory provisioned across a de
 </Note>
 
 For the price of each size, see the [pricing page](https://www.langchain.com/pricing), which includes a deployment cost calculator. For how Serverless and Dedicated deployments are billed, see [Manage billing](/langsmith/billing#langsmith-deployment-billing).
+
+### Legacy deployment types
+
+Organizations still on previous pricing continue to create Development and Production deployments until October 1, 2026. Neither type includes scale to zero.
+
+| Deployment type | Compute per replica | Scaling | Database | Best for |
+|---|---|---|---|---|
+| Development | 1 CPU, 1 GB RAM | Up to 1 replica | 10 GB disk, no backups | Development and testing |
+| Production | 2 CPU, 2 GB RAM | Up to 10 replicas | Autoscaling disk, automatic backups, and high availability across multiple zones | Production workloads, including customer-facing applications in the critical path |
+
+To create these deployment types with the CLI, pass `--deployment-type dev` or `--deployment-type prod`. For all supported values, see [`langgraph deploy`](/langsmith/cli#deploy). For pricing and the transition timeline, see [Manage billing](/langsmith/billing#langsmith-deployment-billing).
+
+<Warning>
+Development deployments run on preemptible compute infrastructure. The API server, queue server, and database may be terminated without notice. This can cause intermittent Redis or Postgres connection timeouts or errors, and failed or retrying background runs. Agent Server automatically attempts to recover from these interruptions and retries failed background runs. Production deployments run on durable compute infrastructure.
+</Warning>
+
+Development database disk size and Production resources can be increased on a case-by-case basis, depending on the use case and capacity constraints. For most Development deployments, configure [TTLs](/langsmith/configure-ttl) to manage disk usage. Contact support via [support.langchain.com](https://support.langchain.com) to request an increase.
 
 ## Database provisioning
 

--- a/src/langsmith/cloud-platform-features.mdx
+++ b/src/langsmith/cloud-platform-features.mdx
@@ -75,7 +75,7 @@ For the price of each size, see the [pricing page](https://www.langchain.com/pri
 
 ### Legacy deployment types
 
-Organizations still on previous pricing continue to create Development and Production deployments until October 1, 2026. Neither type includes scale to zero.
+Organizations still on previous pricing continue to create Development and Production deployments. Neither type includes scale to zero.
 
 | Deployment type | Compute per replica | Scaling | Database | Best for |
 |---|---|---|---|---|


### PR DESCRIPTION
## Description
Documents legacy Development and Production deployment resources and behavior for customers who remain on previous pricing. The section restores sizing, scaling, database, preemptible infrastructure, CLI, and transition guidance from the pre-Serverless/Dedicated docs.

## Test Plan
- [x] `make lint_prose FILES="src/langsmith/cloud-platform-features.mdx"`
- [x] `make broken-links`

Made by [Open SWE](https://openswe.vercel.app/agents/8d4e070e-6ac1-baeb-e89d-46bc6fd91ef0)