### PR TITLE
Name every llms.txt section index correctly so all are served

### DIFF
--- a/.github/workflows/check-llms-urls.yml
+++ b/.github/workflows/check-llms-urls.yml
@@ -1,0 +1,47 @@
+---
+name: Check llms.txt URLs resolve
+
+# The build derives API reference URLs by reproducing Mintlify's slug rules for
+# OpenAPI operations. That is not a published contract, so a change on their
+# side would turn hundreds of index entries into 404s with nothing in this repo
+# failing. Nothing in PR CI can catch it either, because it only shows up
+# against the deployed site. This job watches for it.
+
+on:
+  schedule:
+    # Weekly, Monday 07:13 UTC. Off the hour to avoid the scheduler rush.
+    - cron: "13 7 * * 1"
+  workflow_dispatch:
+    inputs:
+      check_all:
+        description: "Check every URL instead of a sample"
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  check-urls:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - uses: "./.github/actions/uv_setup"
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: uv sync --group test
+
+      - name: Build documentation
+        run: make build
+
+      - name: Check that indexed URLs resolve
+        run: |
+          uv run python scripts/check_llms_urls.py \
+            ${{ inputs.check_all && '--all' || '' }}

--- a/pipeline/core/builder.py
+++ b/pipeline/core/builder.py
@@ -1317,29 +1317,57 @@ class DocumentationBuilder:
                 return ""
         return "/".join(shared)
 
-    def _chunk_section(
-        self, prefix: str, lines: list[str]
-    ) -> list[tuple[str, list[str]]]:
-        """Split a section's lines into files that each stay under budget.
+    @staticmethod
+    def _weigh(entries: list[tuple[str, str]]) -> int:
+        """Return the byte size a set of index entries would occupy."""
+        return sum(len(line) + 1 for _, line in entries)
 
-        Returns (build-relative path, lines) pairs. Entries arrive sorted by
-        URL, so sequential chunking keeps pages from the same subtree together.
-        Every file sits exactly one directory level below the root index:
-        AFDocs's coverage walker descends one level into linked .txt files, and
-        anything deeper is dropped from the coverage denominator.
+    def _chunk_section(
+        self, prefix: str, entries: list[tuple[str, str]]
+    ) -> list[tuple[str, list[tuple[str, str]]]]:
+        """Split a section into index files that each stay under budget.
+
+        Returns (directory prefix, entries) pairs. Every index is written as
+        ``<prefix>/llms.txt``, because Mintlify serves that exact filename at
+        any path but 404s on anything else: numbered variants like
+        ``llms-2.txt`` are not served, which silently hid 802 pages from the
+        coverage walker.
+
+        An oversized section sheds its largest child directories into their own
+        indexes until the remainder fits, rather than giving every child a file.
+        That keeps the number of fetches an agent makes proportional to how
+        much content there actually is.
         """
-        chunks: list[list[str]] = [[]]
-        size = 0
-        for line in lines:
-            if chunks[-1] and size + len(line) + 1 > self._LLMS_SECTION_BUDGET:
-                chunks.append([])
-                size = 0
-            chunks[-1].append(line)
-            size += len(line) + 1
-        return [
-            (f"{prefix}/llms.txt" if i == 0 else f"{prefix}/llms-{i + 1}.txt", chunk)
-            for i, chunk in enumerate(chunks)
-        ]
+        if self._weigh(entries) <= self._LLMS_SECTION_BUDGET:
+            return [(prefix, entries)]
+
+        depth = len(prefix.split("/")) if prefix else 0
+        children: dict[str, list[tuple[str, str]]] = {}
+        remainder: list[tuple[str, str]] = []
+        for slug, line in entries:
+            parts = slug.split("/")
+            if len(parts) > depth + 1:
+                children.setdefault("/".join(parts[: depth + 1]), []).append(
+                    (slug, line)
+                )
+            else:
+                remainder.append((slug, line))
+
+        if not children:
+            # A flat directory cannot be subdivided further. Keep it whole:
+            # oversized beats invisible, and the validator will flag it.
+            return [(prefix, entries)]
+
+        out: list[tuple[str, list[tuple[str, str]]]] = []
+        # Shed the heaviest children first so the fewest files are created.
+        for key in sorted(children, key=lambda k: -self._weigh(children[k])):
+            if self._weigh(remainder) + self._weigh(children[key]) <= (
+                self._LLMS_SECTION_BUDGET
+            ):
+                remainder += children[key]
+            else:
+                out += self._chunk_section(key, children[key])
+        return [(prefix, remainder), *out] if remainder else out
 
     def _write_section_index(
         self, path: str, title: str, label: str, lines: list[str]
@@ -1594,8 +1622,10 @@ class DocumentationBuilder:
             except (OSError, json.JSONDecodeError):
                 logger.warning("Could not read docs.json for llms.txt metadata")
 
-        # section label -> list of (slug, "- [Title](url): description") pairs
+        # section label -> list of (slug, "- [Title](url)") pairs
         sections: dict[str, list[tuple[str, str]]] = {}
+        # plain entry -> the same entry with its description, for the root file
+        described_lines: dict[str, str] = {}
         page_count = 0
 
         for mdx in sorted(self.build_dir.rglob("*.mdx")):
@@ -1621,9 +1651,12 @@ class DocumentationBuilder:
                     label = section_label
                     break
 
+            # Descriptions roughly double an entry. They stay in the root file,
+            # where there is room, and are dropped from section indexes so more
+            # pages fit per file and fewer files are needed.
             line = f"- [{name}]({url})"
             if summary:
-                line += f": {summary[:300]}"
+                described_lines[line] = f"{line}: {summary[:300]}"
             sections.setdefault(label, []).append((slug, line))
             page_count += 1
 
@@ -1654,11 +1687,18 @@ class DocumentationBuilder:
             # a fetch for a handful of pages. A section with no shared
             # directory has nowhere to live but the root.
             if not prefix or size <= self._LLMS_INLINE_MAX:
-                inline.append((label, lines))
+                inline.append(
+                    (label, [described_lines.get(line, line) for line in lines])
+                )
             else:
-                for path, chunk in self._chunk_section(prefix, lines):
-                    self._write_section_index(path, title, label, chunk)
-                    linked.append((label, path, len(chunk)))
+                for section_prefix, chunk in self._chunk_section(prefix, entries):
+                    if not chunk:
+                        continue
+                    path = f"{section_prefix}/llms.txt"
+                    self._write_section_index(
+                        path, title, label, [line for _, line in chunk]
+                    )
+                    linked.append((section_prefix, path, len(chunk)))
 
         out = [f"# {title}", ""]
         if description:
@@ -1671,16 +1711,9 @@ class DocumentationBuilder:
                 "## Section indexes",
                 "",
             ]
-            seen_labels: dict[str, int] = {}
-            for label, path, count in linked:
-                seen_labels[label] = seen_labels.get(label, 0) + 1
-                suffix = (
-                    f" (part {seen_labels[label]})"
-                    if sum(1 for entry in linked if entry[0] == label) > 1
-                    else ""
-                )
+            for section_prefix, path, count in sorted(linked):
                 out.append(
-                    f"- [{label}{suffix}]({self._SITE_URL}/{path}): {count} pages"
+                    f"- [/{section_prefix}]({self._SITE_URL}/{path}): {count} pages"
                 )
             out.append("")
         for label, lines in inline:

--- a/pipeline/core/builder.py
+++ b/pipeline/core/builder.py
@@ -1240,9 +1240,9 @@ class DocumentationBuilder:
 
         entries: list[tuple[str, str, str]] = []
         for label, source, directory in groups:
-            spec_path = self.build_dir / source
-            if not spec_path.exists():
-                logger.warning("OpenAPI spec not found: %s", source)
+            spec_path = self._resolve_within(self.build_dir / source, self.build_dir)
+            if spec_path is None or not spec_path.exists():
+                logger.warning("OpenAPI spec not found or outside build: %s", source)
                 continue
             try:
                 spec = json.loads(spec_path.read_text(encoding="utf-8"))
@@ -1278,6 +1278,26 @@ class DocumentationBuilder:
                     seen.add(unique)
                     entries.append((label, f"{base}/{unique}", str(summary)))
         return entries
+
+    @staticmethod
+    def _resolve_within(candidate: Path, root: Path) -> Path | None:
+        """Resolve *candidate* and return it only if it stays inside *root*.
+
+        Paths that reach this point come from MDX text and docs.json, both of
+        which are editable in a pull request. ``Path.__truediv__`` does not
+        collapse ``..``, so joining an unvalidated path and reading it would
+        let a crafted import escape the build tree. CI commits ``build/`` to a
+        pushed preview branch, so anything read would be published.
+
+        Returns:
+            The resolved path, or None if it escapes *root* or cannot resolve.
+        """
+        try:
+            resolved = candidate.resolve()
+            resolved.relative_to(root.resolve())
+        except (ValueError, OSError):
+            return None
+        return resolved
 
     @staticmethod
     def _common_directory(slugs: list[str]) -> str:
@@ -1325,7 +1345,10 @@ class DocumentationBuilder:
         self, path: str, title: str, label: str, lines: list[str]
     ) -> None:
         """Write one section-level llms.txt."""
-        destination = self.build_dir / path
+        destination = self._resolve_within(self.build_dir / path, self.build_dir)
+        if destination is None:
+            logger.warning("Refusing to write section index outside build: %s", path)
+            return
         destination.parent.mkdir(parents=True, exist_ok=True)
         body = "\n".join(
             [
@@ -1371,8 +1394,10 @@ class DocumentationBuilder:
         urls = md_link.findall(root)
         for url in txt_link.findall(root):
             relative = url.removeprefix(f"{self._SITE_URL}/")
-            section_path = self.build_dir / relative
-            if not section_path.exists():
+            section_path = self._resolve_within(
+                self.build_dir / relative, self.build_dir
+            )
+            if section_path is None or not section_path.exists():
                 problems.append(f"{relative} is linked from llms.txt but missing")
                 continue
             section = section_path.read_text(encoding="utf-8")
@@ -1445,10 +1470,22 @@ class DocumentationBuilder:
         if depth > 6:
             return text.strip()
 
-        imports = {
-            name: self.build_dir / target.lstrip("/")
-            for name, target in self._SNIPPET_IMPORT.findall(text)
-        }
+        snippets_root = self.build_dir / "snippets"
+        imports: dict[str, Path] = {}
+        for name, target in self._SNIPPET_IMPORT.findall(text):
+            snippet = self._resolve_within(
+                self.build_dir / target.lstrip("/"), snippets_root
+            )
+            if snippet is None:
+                logger.warning(
+                    "Ignoring snippet import outside %s in %s: %s",
+                    snippets_root,
+                    path,
+                    target,
+                )
+                continue
+            imports[name] = snippet
+
         text = self._SNIPPET_IMPORT.sub("", text)
         for name, snippet in imports.items():
             body = self._page_body(snippet, depth + 1) if snippet.exists() else ""

--- a/pipeline/core/builder.py
+++ b/pipeline/core/builder.py
@@ -1127,6 +1127,14 @@ class DocumentationBuilder:
 
     _SITE_URL = "https://docs.langchain.com"
 
+    # A section smaller than this stays in the root file rather than becoming a
+    # separate fetch. Root stays far below the 50,000-character pass threshold.
+    _LLMS_INLINE_MAX = 8_000
+
+    # Per-section-file ceiling. Headroom under the 50,000-character threshold
+    # so a section does not cross it as pages are added between splits.
+    _LLMS_SECTION_BUDGET = 40_000
+
     @staticmethod
     def _slugify(value: str) -> str:
         """Lowercase, hyphenate, and strip a string for use in a URL path.
@@ -1253,6 +1261,68 @@ class DocumentationBuilder:
                     entries.append((label, f"{base}/{unique}", str(summary)))
         return entries
 
+    @staticmethod
+    def _common_directory(slugs: list[str]) -> str:
+        """Return the deepest directory shared by every slug, or "" if none."""
+        if not slugs:
+            return ""
+        parts = [slug.split("/")[:-1] for slug in slugs]
+        shared = parts[0]
+        for candidate in parts[1:]:
+            keep = 0
+            for a, b in zip(shared, candidate):
+                if a != b:
+                    break
+                keep += 1
+            shared = shared[:keep]
+            if not shared:
+                return ""
+        return "/".join(shared)
+
+    def _chunk_section(
+        self, prefix: str, lines: list[str]
+    ) -> list[tuple[str, list[str]]]:
+        """Split a section's lines into files that each stay under budget.
+
+        Returns (build-relative path, lines) pairs. Entries arrive sorted by
+        URL, so sequential chunking keeps pages from the same subtree together.
+        Every file sits exactly one directory level below the root index:
+        AFDocs's coverage walker descends one level into linked .txt files, and
+        anything deeper is dropped from the coverage denominator.
+        """
+        chunks: list[list[str]] = [[]]
+        size = 0
+        for line in lines:
+            if chunks[-1] and size + len(line) + 1 > self._LLMS_SECTION_BUDGET:
+                chunks.append([])
+                size = 0
+            chunks[-1].append(line)
+            size += len(line) + 1
+        return [
+            (f"{prefix}/llms.txt" if i == 0 else f"{prefix}/llms-{i + 1}.txt", chunk)
+            for i, chunk in enumerate(chunks)
+        ]
+
+    def _write_section_index(
+        self, path: str, title: str, label: str, lines: list[str]
+    ) -> None:
+        """Write one section-level llms.txt."""
+        destination = self.build_dir / path
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        body = "\n".join(
+            [
+                f"# {title}: {label}",
+                "",
+                f"> Markdown index of the {label} documentation.",
+                "",
+                f"## {label}",
+                "",
+                *lines,
+                "",
+            ]
+        )
+        destination.write_text(body, encoding="utf-8")
+
     def _generate_llms_txt(self) -> None:
         """Write a custom llms.txt listing every published page.
 
@@ -1271,8 +1341,8 @@ class DocumentationBuilder:
             except (OSError, json.JSONDecodeError):
                 logger.warning("Could not read docs.json for llms.txt metadata")
 
-        # section label -> list of "- [Title](url): description" lines
-        sections: dict[str, list[str]] = {}
+        # section label -> list of (slug, "- [Title](url): description") pairs
+        sections: dict[str, list[tuple[str, str]]] = {}
         page_count = 0
 
         for mdx in sorted(self.build_dir.rglob("*.mdx")):
@@ -1301,12 +1371,12 @@ class DocumentationBuilder:
             line = f"- [{name}]({url})"
             if summary:
                 line += f": {summary[:300]}"
-            sections.setdefault(label, []).append(line)
+            sections.setdefault(label, []).append((slug, line))
             page_count += 1
 
-        for group_label, slug, name in self._openapi_entries():
+        for group_label, api_slug, name in self._openapi_entries():
             sections.setdefault(group_label, []).append(
-                f"- [{name}]({self._SITE_URL}/{slug}.md)"
+                (api_slug, f"- [{name}]({self._SITE_URL}/{api_slug}.md)")
             )
             page_count += 1
 
@@ -1316,20 +1386,60 @@ class DocumentationBuilder:
 
         ordered = ["Docs", *[label for _, label in self._LLMS_SECTIONS]]
         ordered += [label for label in sections if label not in ordered]
+        ordered = [label for label in ordered if sections.get(label)]
+
+        inline: list[tuple[str, list[str]]] = []
+        linked: list[tuple[str, str, int]] = []  # (label, section path, page count)
+
+        for label in ordered:
+            entries = sections[label]
+            lines = [line for _, line in entries]
+            size = sum(len(line) + 1 for line in lines)
+            prefix = self._common_directory([slug for slug, _ in entries])
+            # Small sections ride along in the root file. That keeps real .md
+            # links in the canonical index for link sampling, and saves agents
+            # a fetch for a handful of pages. A section with no shared
+            # directory has nowhere to live but the root.
+            if not prefix or size <= self._LLMS_INLINE_MAX:
+                inline.append((label, lines))
+            else:
+                for path, chunk in self._chunk_section(prefix, lines):
+                    self._write_section_index(path, title, label, chunk)
+                    linked.append((label, path, len(chunk)))
 
         out = [f"# {title}", ""]
         if description:
             out += [f"> {description}", ""]
-        for label in ordered:
-            lines = sections.get(label)
-            if not lines:
-                continue
+        if linked:
+            out += [
+                "Each section index below lists the markdown version of every "
+                "page in that section.",
+                "",
+                "## Section indexes",
+                "",
+            ]
+            seen_labels: dict[str, int] = {}
+            for label, path, count in linked:
+                seen_labels[label] = seen_labels.get(label, 0) + 1
+                suffix = (
+                    f" (part {seen_labels[label]})"
+                    if sum(1 for entry in linked if entry[0] == label) > 1
+                    else ""
+                )
+                out.append(
+                    f"- [{label}{suffix}]({self._SITE_URL}/{path}): {count} pages"
+                )
+            out.append("")
+        for label, lines in inline:
             out += [f"## {label}", "", *lines, ""]
 
         content = "\n".join(out)
         (self.build_dir / "llms.txt").write_text(content, encoding="utf-8")
         logger.info(
-            "✅ llms.txt written: %d pages, %d characters", page_count, len(content)
+            "✅ llms.txt written: %d pages, %d characters in root, %d section indexes",
+            page_count,
+            len(content),
+            len(linked),
         )
 
     def _copy_shared_files(self) -> None:

--- a/pipeline/core/builder.py
+++ b/pipeline/core/builder.py
@@ -130,6 +130,9 @@ class DocumentationBuilder:
         logger.debug("Generating llms.txt...")
         self._generate_llms_txt()
 
+        logger.debug("Generating llms-full.txt...")
+        self._generate_llms_full_txt()
+
         logger.debug("New structure build complete")
 
     def _convert_yaml_to_json(self, yaml_file_path: Path, output_path: Path) -> None:
@@ -1135,6 +1138,17 @@ class DocumentationBuilder:
     # so a section does not cross it as pages are added between splits.
     _LLMS_SECTION_BUDGET = 40_000
 
+    # Page-path prefixes lifted out of the root llms-full.txt into their own
+    # corpus file, with the label used to point at them from the root.
+    _LLMS_FULL_SPLITS: ClassVar[list[tuple[str, str]]] = [
+        ("oss/python", "Open source (Python)"),
+        ("oss/javascript", "Open source (TypeScript)"),
+    ]
+
+    _SNIPPET_IMPORT = re.compile(
+        r"^import\s+(\w+)\s+from\s+'(/snippets/[^']+)';[ \t]*\n?", re.MULTILINE
+    )
+
     @staticmethod
     def _slugify(value: str) -> str:
         """Lowercase, hyphenate, and strip a string for use in a URL path.
@@ -1322,6 +1336,132 @@ class DocumentationBuilder:
             ]
         )
         destination.write_text(body, encoding="utf-8")
+
+    def _site_metadata(self) -> tuple[str, str]:
+        """Return the site title and description from docs.json."""
+        docs_json = self.build_dir / "docs.json"
+        title, description = "Docs by LangChain", ""
+        if docs_json.exists():
+            try:
+                config = json.loads(docs_json.read_text(encoding="utf-8"))
+                title = config.get("name", title)
+                description = config.get("description", "")
+            except (OSError, json.JSONDecodeError):
+                logger.warning("Could not read docs.json for site metadata")
+        return title, description
+
+    def _page_body(self, path: Path, depth: int = 0) -> str:
+        """Return an MDX page's body with frontmatter stripped, snippets inlined.
+
+        Mintlify expands snippet imports when it renders, so a corpus built
+        from the raw build tree would silently drop content from the ~300
+        pages that import snippets. Component props are ignored: the snippet
+        body is the content, and the corpus is plain text.
+        """
+        try:
+            text = path.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            return ""
+        if text.startswith("---"):
+            end = text.find("\n---", 3)
+            if end != -1:
+                text = text[end + 4 :]
+        if depth > 6:
+            return text.strip()
+
+        imports = {
+            name: self.build_dir / target.lstrip("/")
+            for name, target in self._SNIPPET_IMPORT.findall(text)
+        }
+        text = self._SNIPPET_IMPORT.sub("", text)
+        for name, snippet in imports.items():
+            body = self._page_body(snippet, depth + 1) if snippet.exists() else ""
+            text = re.sub(rf"<{name}(?:\s[^/>]*)?\s*/>", lambda _, b=body: b, text)
+        return text.strip()
+
+    def _generate_llms_full_txt(self) -> None:
+        """Write llms-full.txt, splitting language variants into their own files.
+
+        The combined corpus is dominated by the Python and TypeScript renders
+        of the same documentation. Keeping both in one file makes it far larger
+        than long-context agents can ingest, so the TypeScript pages move to
+        their own corpus and the root points at it.
+        """
+        title, description = self._site_metadata()
+        buckets: dict[str, list[str]] = {"": []}
+        for prefix, _ in self._LLMS_FULL_SPLITS:
+            buckets[prefix] = []
+
+        for mdx in sorted(self.build_dir.rglob("*.mdx")):
+            relative = mdx.relative_to(self.build_dir)
+            if relative.parts and relative.parts[0] == "snippets":
+                continue
+            meta = self._read_frontmatter(mdx)
+            if meta.get("noindex") is True:
+                continue
+            slug = relative.with_suffix("").as_posix()
+            name = str(
+                meta.get("title")
+                or meta.get("sidebarTitle")
+                or slug.rsplit("/", 1)[-1].replace("-", " ").title()
+            )
+            key = next(
+                (p for p, _ in self._LLMS_FULL_SPLITS if slug.startswith(f"{p}/")), ""
+            )
+            body = self._page_body(mdx)
+            buckets[key].append(
+                f"# {name}\nSource: {self._SITE_URL}/{slug}\n\n{body}\n\n"
+            )
+
+        # Generated API reference pages have no MDX to read, so record their
+        # identity and let the index in llms.txt carry the detail.
+        for _, slug, name in self._openapi_entries():
+            buckets[""].append(f"# {name}\nSource: {self._SITE_URL}/{slug}\n\n")
+
+        if not any(buckets.values()):
+            logger.debug("No pages found, skipping llms-full.txt")
+            return
+
+        pointers = []
+        for prefix, label in self._LLMS_FULL_SPLITS:
+            if not buckets[prefix]:
+                continue
+            target = f"{prefix}/llms-full.txt"
+            destination = self.build_dir / target
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            destination.write_text(
+                f"# {title}: {label}\n\n"
+                f"> Full text of the {label} documentation.\n\n"
+                + "\n".join(buckets[prefix]),
+                encoding="utf-8",
+            )
+            pointers.append(f"- {label} documentation: {self._SITE_URL}/{target}")
+            logger.info(
+                "✅ %s written: %d pages, %d characters",
+                target,
+                len(buckets[prefix]),
+                destination.stat().st_size,
+            )
+
+        # A custom llms-full.txt has to open with the site title as an H1, or
+        # the first page heading in the corpus reads as the site title.
+        header = [f"# {title}", ""]
+        if description:
+            header += [f"> {description}", ""]
+        if pointers:
+            header += [
+                "Language-specific documentation is published as a separate corpus:",
+                "",
+                *pointers,
+                "",
+            ]
+        content = "\n".join(header) + "\n" + "\n".join(buckets[""])
+        (self.build_dir / "llms-full.txt").write_text(content, encoding="utf-8")
+        logger.info(
+            "✅ llms-full.txt written: %d pages, %d characters",
+            len(buckets[""]),
+            len(content),
+        )
 
     def _generate_llms_txt(self) -> None:
         """Write a custom llms.txt listing every published page.

--- a/pipeline/core/builder.py
+++ b/pipeline/core/builder.py
@@ -1138,6 +1138,10 @@ class DocumentationBuilder:
     # so a section does not cross it as pages are added between splits.
     _LLMS_SECTION_BUDGET = 40_000
 
+    # Size at which agent platforms start truncating an index. Every emitted
+    # file has to stay under it, not just the root.
+    _LLMS_MAX = 50_000
+
     # Page-path prefixes lifted out of the root llms-full.txt into their own
     # corpus file, with the label used to point at them from the root.
     _LLMS_FULL_SPLITS: ClassVar[list[tuple[str, str]]] = [
@@ -1336,6 +1340,78 @@ class DocumentationBuilder:
             ]
         )
         destination.write_text(body, encoding="utf-8")
+
+    def _validate_llms_indexes(self, expected_pages: int) -> None:
+        """Check the generated indexes against the invariants agents rely on.
+
+        These are properties of the emitted files, not of the code that emits
+        them, so they catch drift the unit tests cannot: a root that creeps
+        over the size threshold as pages are added, a section index that
+        accidentally nests, or a page that lands in two indexes or none.
+
+        Raises:
+            ValueError: If any invariant is violated.
+        """
+        root_path = self.build_dir / "llms.txt"
+        if not root_path.exists():
+            return
+
+        md_link = re.compile(r"\((https://\S+?\.md)\)")
+        txt_link = re.compile(r"\((https://\S+?llms[\w-]*\.txt)\)")
+
+        root = root_path.read_text(encoding="utf-8")
+        problems: list[str] = []
+
+        if len(root) > self._LLMS_MAX:
+            problems.append(
+                f"llms.txt is {len(root):,} characters, over the "
+                f"{self._LLMS_MAX:,} threshold agents truncate at"
+            )
+
+        urls = md_link.findall(root)
+        for url in txt_link.findall(root):
+            relative = url.removeprefix(f"{self._SITE_URL}/")
+            section_path = self.build_dir / relative
+            if not section_path.exists():
+                problems.append(f"{relative} is linked from llms.txt but missing")
+                continue
+            section = section_path.read_text(encoding="utf-8")
+            if len(section) > self._LLMS_MAX:
+                problems.append(
+                    f"{relative} is {len(section):,} characters, over the "
+                    f"{self._LLMS_MAX:,} threshold"
+                )
+            nested = txt_link.findall(section)
+            if nested:
+                problems.append(
+                    f"{relative} links to {len(nested)} further .txt files; "
+                    "coverage walkers descend only one level, so those pages "
+                    "would drop out of the index"
+                )
+            urls += md_link.findall(section)
+
+        duplicates = {url for url in urls if urls.count(url) > 1}
+        if duplicates:
+            sample = ", ".join(sorted(duplicates)[:3])
+            problems.append(f"{len(duplicates)} pages listed more than once: {sample}")
+
+        if len(set(urls)) != expected_pages:
+            problems.append(
+                f"indexes list {len(set(urls)):,} unique pages "
+                f"but {expected_pages:,} were built"
+            )
+
+        if problems:
+            detail = "\n  - ".join(problems)
+            msg = f"Generated llms.txt indexes are invalid:\n  - {detail}"
+            raise ValueError(msg)
+
+        logger.info(
+            "✅ llms.txt indexes valid: %d pages, root %d/%d characters",
+            expected_pages,
+            len(root),
+            self._LLMS_MAX,
+        )
 
     def _site_metadata(self) -> tuple[str, str]:
         """Return the site title and description from docs.json."""
@@ -1581,6 +1657,7 @@ class DocumentationBuilder:
             len(content),
             len(linked),
         )
+        self._validate_llms_indexes(page_count)
 
     def _copy_shared_files(self) -> None:
         """Copy files that should be shared between versions."""

--- a/scripts/check_llms_urls.py
+++ b/scripts/check_llms_urls.py
@@ -105,6 +105,33 @@ def main() -> int:
     derived, pages = collect_urls(args.build_dir, args.base_url)
     print(f"index lists {len(derived):,} derived API URLs, {len(pages):,} page URLs")
 
+    # Check the section indexes themselves first. Mintlify serves the exact
+    # filename llms.txt at any path but 404s on anything else, so a rename or
+    # a routing change makes whole sections invisible to coverage walkers
+    # while every local check still passes.
+    root = (args.build_dir / "llms.txt").read_text(encoding="utf-8")
+    section_urls = sorted(set(TXT_LINK.findall(root)))
+    print(f"checking {len(section_urls)} section indexes are served\n")
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        section_results = list(pool.map(status_of, section_urls))
+    unserved = [
+        (url, status)
+        for url, status in zip(section_urls, section_results, strict=True)
+        if status != 200
+    ]
+    if unserved:
+        print(
+            f"❌ {len(unserved)} of {len(section_urls)} section indexes are not served:\n"
+        )
+        for url, status in unserved[:20]:
+            print(f"  {status or 'no response'}  {url}")
+        print(
+            "\nEvery section index must be named exactly llms.txt. Mintlify "
+            "404s other .txt filenames, which hides those pages from coverage."
+        )
+        return 1
+    print(f"✅ all {len(section_urls)} section indexes are served\n")
+
     # Sampling picks which URLs to spot-check; nothing here is security-relevant.
     rng = random.Random(args.seed)  # noqa: S311
     if args.all:

--- a/scripts/check_llms_urls.py
+++ b/scripts/check_llms_urls.py
@@ -1,0 +1,150 @@
+"""Verify that URLs listed in the generated llms.txt indexes still resolve.
+
+The build derives API reference URLs from the OpenAPI specs by reproducing
+Mintlify's slug rules. Those rules are not a published contract, so a change on
+their side would silently turn hundreds of index entries into 404s without
+anything in this repo failing. Page URLs come from real files and are far
+safer, but they can still rot when a page is renamed mid-build.
+
+Run against a build tree (``make build`` first):
+
+    uv run python scripts/check_llms_urls.py
+    uv run python scripts/check_llms_urls.py --all --base-url https://docs.langchain.com
+"""
+
+from __future__ import annotations
+
+import argparse
+import random
+import re
+import sys
+import time
+import urllib.error
+import urllib.request
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+MD_LINK = re.compile(r"\((https://\S+?\.md)\)")
+TXT_LINK = re.compile(r"\((https://\S+?llms[\w-]*\.txt)\)")
+# Derived from an OpenAPI spec rather than from a file on disk.
+DERIVED = re.compile(r"/(smith-api|agent-server-api)/")
+
+DEFAULT_BASE_URL = "https://docs.langchain.com"
+REQUEST_TIMEOUT = 30
+MAX_WORKERS = 4
+RETRY_ATTEMPTS = 3
+RETRY_BACKOFF = 1.0
+
+
+def collect_urls(build_dir: Path, base_url: str) -> tuple[list[str], list[str]]:
+    """Return (derived API URLs, page URLs) listed across the llms.txt indexes."""
+    root_path = build_dir / "llms.txt"
+    if not root_path.exists():
+        msg = f"{root_path} not found. Run `make build` first."
+        raise SystemExit(msg)
+
+    root = root_path.read_text(encoding="utf-8")
+    urls = set(MD_LINK.findall(root))
+    for link in TXT_LINK.findall(root):
+        section = build_dir / link.removeprefix(f"{base_url}/")
+        if section.exists():
+            urls |= set(MD_LINK.findall(section.read_text(encoding="utf-8")))
+
+    same_origin = sorted(u for u in urls if u.startswith(f"{base_url}/"))
+    return (
+        [u for u in same_origin if DERIVED.search(u)],
+        [u for u in same_origin if not DERIVED.search(u)],
+    )
+
+
+def status_of(url: str) -> int:
+    """Return the HTTP status for *url*, or 0 if it stayed unreachable.
+
+    A connection that drops is retried, and HEAD is retried as GET: some CDNs
+    answer HEAD unreliably under concurrency. Without this the job reports
+    healthy pages as broken, and a check that cries wolf gets ignored.
+    """
+    for attempt in range(RETRY_ATTEMPTS):
+        for method in ("HEAD", "GET"):
+            request = urllib.request.Request(url, method=method)  # noqa: S310
+            try:
+                with urllib.request.urlopen(  # noqa: S310
+                    request, timeout=REQUEST_TIMEOUT
+                ) as response:
+                    return int(response.status)
+            except urllib.error.HTTPError as exc:
+                # A real HTTP status is an answer, not a failure to reach.
+                return int(exc.code)
+            except (urllib.error.URLError, TimeoutError, ConnectionError):
+                continue
+        time.sleep(RETRY_BACKOFF * (attempt + 1))
+    return 0
+
+
+def main() -> int:
+    """Sample index URLs and report any that do not resolve."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--build-dir", type=Path, default=Path("build"))
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL)
+    parser.add_argument(
+        "--sample-derived",
+        type=int,
+        default=120,
+        help="How many derived API URLs to check (these carry the real risk).",
+    )
+    parser.add_argument(
+        "--sample-pages",
+        type=int,
+        default=40,
+        help="How many ordinary page URLs to check.",
+    )
+    parser.add_argument("--all", action="store_true", help="Check every URL.")
+    parser.add_argument("--seed", type=int, default=0)
+    args = parser.parse_args()
+
+    derived, pages = collect_urls(args.build_dir, args.base_url)
+    print(f"index lists {len(derived):,} derived API URLs, {len(pages):,} page URLs")
+
+    # Sampling picks which URLs to spot-check; nothing here is security-relevant.
+    rng = random.Random(args.seed)  # noqa: S311
+    if args.all:
+        checking = derived + pages
+    else:
+        checking = rng.sample(derived, min(args.sample_derived, len(derived)))
+        checking += rng.sample(pages, min(args.sample_pages, len(pages)))
+
+    print(f"checking {len(checking):,} URLs against {args.base_url}\n")
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        results = list(pool.map(status_of, checking))
+
+    # A redirect still lands an agent on real content; only treat it as a note.
+    reachable = (200, 301, 302, 307, 308)
+    broken = [
+        (url, status)
+        for url, status in zip(checking, results, strict=True)
+        if status not in reachable
+    ]
+    redirects = sum(1 for status in results if status in reachable[1:])
+
+    if redirects:
+        print(f"note: {redirects} URLs redirect (still reachable)")
+    if broken:
+        print(f"\n❌ {len(broken)} of {len(checking)} URLs do not resolve:\n")
+        for url, status in sorted(broken)[:40]:
+            label = status or "no response"
+            print(f"  {label}  {url}")
+        if DERIVED.search(broken[0][0]):
+            print(
+                "\nDerived API URLs are failing. Mintlify's slug rules for "
+                "OpenAPI operations have most likely changed; compare against "
+                "the live sitemap and update _tag_slug/_slugify in "
+                "pipeline/core/builder.py."
+            )
+        return 1
+
+    print(f"\n✅ all {len(checking):,} sampled URLs resolve")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/unit_tests/test_builder.py
+++ b/tests/unit_tests/test_builder.py
@@ -817,3 +817,50 @@ def test_llms_txt_splits_large_sections_into_section_indexes() -> None:
             body = (fs.build_dir / "langsmith" / name).read_text(encoding="utf-8")
             listed += re.findall(r"\((https://\S+?\.md)\)", body)
         assert len(listed) == len(set(listed)) == 400
+
+
+def test_llms_full_txt_splits_languages_and_inlines_snippets() -> None:
+    """Test that llms-full.txt splits language corpora and expands snippets.
+
+    Mintlify expands snippet imports when it renders, so a corpus built from
+    the raw build tree would silently drop content from every page that
+    imports one. The root file must also open with the site title as an H1.
+    """
+    files: list[File] = [
+        {"path": "docs.json", "content": json.dumps({"name": "Test Docs"})},
+        {
+            "path": "snippets/shared-block.mdx",
+            "content": "UNIQUE_SNIPPET_CONTENT\n",
+        },
+        {
+            "path": "oss/guide.mdx",
+            "content": (
+                "---\ntitle: Guide\n---\n\n"
+                "import SharedBlock from '/snippets/shared-block.mdx';\n\n"
+                "Intro.\n\n<SharedBlock />\n"
+            ),
+        },
+        {"path": "langsmith/core.mdx", "content": "---\ntitle: Core\n---\n\nCore.\n"},
+    ]
+    with file_system(files) as fs:
+        builder = DocumentationBuilder(fs.src_dir, fs.build_dir)
+        builder.build_all()
+
+        root = (fs.build_dir / "llms-full.txt").read_text(encoding="utf-8")
+        py = (fs.build_dir / "oss/python/llms-full.txt").read_text(encoding="utf-8")
+        js = (fs.build_dir / "oss/javascript/llms-full.txt").read_text(encoding="utf-8")
+
+    # Root opens with the site title and points at the language corpora.
+    assert root.startswith("# Test Docs")
+    assert "oss/python/llms-full.txt" in root
+    assert "oss/javascript/llms-full.txt" in root
+
+    # Language pages live in their own corpus, not the root.
+    assert "Source: https://docs.langchain.com/oss/python/guide" in py
+    assert "Source: https://docs.langchain.com/oss/python/guide" not in root
+    assert "Source: https://docs.langchain.com/langsmith/core" in root
+
+    # Snippets are inlined, and the import line itself is gone.
+    assert "UNIQUE_SNIPPET_CONTENT" in py
+    assert "UNIQUE_SNIPPET_CONTENT" in js
+    assert "import SharedBlock" not in py

--- a/tests/unit_tests/test_builder.py
+++ b/tests/unit_tests/test_builder.py
@@ -1008,3 +1008,41 @@ def test_resolve_within_blocks_escapes_and_allows_children() -> None:
 
     assert inside is not None
     assert escape is None
+
+
+def test_section_indexes_are_always_named_llms_txt() -> None:
+    """Test that oversized sections split by directory, never by filename.
+
+    Mintlify serves the exact filename llms.txt at any path but 404s on
+    anything else, so numbered variants like llms-2.txt are silently
+    unreachable and every page in them drops out of coverage.
+    """
+    # Enough pages across real subdirectories to force a split.
+    files: list[File] = [
+        {
+            "path": f"langsmith/{area}/page-{i:03d}.mdx",
+            "content": f"---\ntitle: {area} {i}\n---\n\nBody.\n",
+        }
+        for area in ("alpha", "beta", "gamma")
+        for i in range(250)
+    ]
+    with file_system(files) as fs:
+        builder = DocumentationBuilder(fs.src_dir, fs.build_dir)
+        builder.build_all()
+
+        indexes = sorted(
+            p.relative_to(fs.build_dir).as_posix()
+            for p in fs.build_dir.rglob("llms*.txt")
+            if p.name != "llms-full.txt"
+        )
+        root = (fs.build_dir / "llms.txt").read_text(encoding="utf-8")
+
+    assert len(indexes) > 1, "expected the section to split"
+    # Every index, at every depth, is named exactly llms.txt.
+    for path in indexes:
+        assert path.endswith("llms.txt"), path
+        assert "llms-" not in path, f"numbered index would 404: {path}"
+    # And each split index is reachable in one hop from the root.
+    for path in indexes:
+        if path != "llms.txt":
+            assert f"({builder._SITE_URL}/{path})" in root

--- a/tests/unit_tests/test_builder.py
+++ b/tests/unit_tests/test_builder.py
@@ -6,6 +6,7 @@ directory structure preservation, and error conditions.
 """
 
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -774,3 +775,45 @@ def test_openapi_entries_skip_hidden_and_number_duplicates() -> None:
         slugs = [slug for _, slug, _ in builder._openapi_entries()]
 
     assert slugs == ["langsmith/api/orgs/get-info", "langsmith/api/orgs/get-info-1"]
+
+
+def test_llms_txt_splits_large_sections_into_section_indexes() -> None:
+    """Test that a large section becomes linked section files, not root bulk.
+
+    AFDocs passes `llms-txt-size` only under 50,000 characters, and its
+    coverage walker descends exactly one level into linked .txt files, so
+    section indexes must sit one hop from the root and must not nest further.
+    """
+    files: list[File] = [
+        {
+            "path": f"langsmith/page-{i:03d}.mdx",
+            "content": (
+                f"---\ntitle: Page {i}\ndescription: {'x' * 250}\n---\n\nBody.\n"
+            ),
+        }
+        for i in range(400)
+    ]
+    with file_system(files) as fs:
+        builder = DocumentationBuilder(fs.src_dir, fs.build_dir)
+        builder.build_all()
+
+        root = (fs.build_dir / "llms.txt").read_text(encoding="utf-8")
+        sections = sorted(
+            p.name for p in (fs.build_dir / "langsmith").glob("llms*.txt")
+        )
+
+        # Root stays under the pass threshold and delegates to section files.
+        assert len(root) < 50_000
+        assert sections, "expected at least one section index"
+        for name in sections:
+            section = (fs.build_dir / "langsmith" / name).read_text(encoding="utf-8")
+            assert len(section) < 50_000
+            assert "llms.txt" not in section.replace("# ", ""), "must not nest deeper"
+            assert f"({builder._SITE_URL}/langsmith/{name})" in root
+
+        # Every page is listed exactly once across root plus sections.
+        listed = re.findall(r"\((https://\S+?\.md)\)", root)
+        for name in sections:
+            body = (fs.build_dir / "langsmith" / name).read_text(encoding="utf-8")
+            listed += re.findall(r"\((https://\S+?\.md)\)", body)
+        assert len(listed) == len(set(listed)) == 400

--- a/tests/unit_tests/test_builder.py
+++ b/tests/unit_tests/test_builder.py
@@ -949,3 +949,62 @@ def test_validate_llms_indexes_rejects_duplicate_and_missing_pages() -> None:
         _write_index(fs.build_dir, "oss/llms.txt", f"# Site\n\n- [A]({site}/a.md)\n")
         with pytest.raises(ValueError, match="but 5 were built"):
             builder._validate_llms_indexes(5)
+
+
+def test_page_body_rejects_snippet_imports_outside_the_build_tree() -> None:
+    """Test that a traversing snippet import cannot read files outside build/.
+
+    Snippet import paths come from MDX text, which is editable in a pull
+    request, and CI commits build/ to a pushed preview branch. Path joins do
+    not collapse "..", so an unvalidated import would publish any readable
+    file on the build host.
+    """
+    files: list[File] = [
+        # A real snippet, so build/snippets/ exists and ".." can actually
+        # traverse out of it. Without this the read fails for the wrong reason
+        # and the test passes even when the containment check is removed.
+        {"path": "snippets/real.mdx", "content": "Legitimate snippet.\n"},
+        {
+            "path": "langsmith/evil.mdx",
+            "content": (
+                "---\ntitle: Evil\n---\n\n"
+                "import Leak from '/snippets/../../secret.txt';\n\n"
+                "Body.\n\n<Leak />\n"
+            ),
+        },
+    ]
+    with file_system(files) as fs:
+        secret = fs.temp_dir / "secret.txt"
+        secret.write_text("TOP_SECRET_TOKEN_VALUE", encoding="utf-8")
+
+        builder = DocumentationBuilder(fs.src_dir, fs.build_dir)
+        builder.build_all()
+
+        page = fs.build_dir / "langsmith/evil.mdx"
+        body = builder._page_body(page)
+        corpus = (fs.build_dir / "llms-full.txt").read_text(encoding="utf-8")
+
+    # The traversing import is dropped, not followed.
+    assert "TOP_SECRET_TOKEN_VALUE" not in body
+    assert "TOP_SECRET_TOKEN_VALUE" not in corpus
+    # The page itself still renders, minus the rejected import.
+    assert "Body." in body
+
+
+def test_resolve_within_blocks_escapes_and_allows_children() -> None:
+    """Test the containment helper directly, including symlink-free traversal."""
+    with file_system([]) as fs:
+        fs.build_dir.mkdir(parents=True, exist_ok=True)
+        builder = DocumentationBuilder(fs.src_dir, fs.build_dir)
+        (fs.build_dir / "snippets").mkdir(parents=True, exist_ok=True)
+        (fs.build_dir / "snippets/ok.mdx").write_text("fine", encoding="utf-8")
+        (fs.temp_dir / "outside.txt").write_text("nope", encoding="utf-8")
+
+        root = fs.build_dir / "snippets"
+        inside = builder._resolve_within(fs.build_dir / "snippets/ok.mdx", root)
+        escape = builder._resolve_within(
+            fs.build_dir / "snippets/../../outside.txt", root
+        )
+
+    assert inside is not None
+    assert escape is None

--- a/tests/unit_tests/test_builder.py
+++ b/tests/unit_tests/test_builder.py
@@ -864,3 +864,88 @@ def test_llms_full_txt_splits_languages_and_inlines_snippets() -> None:
     assert "UNIQUE_SNIPPET_CONTENT" in py
     assert "UNIQUE_SNIPPET_CONTENT" in js
     assert "import SharedBlock" not in py
+
+
+def _write_index(build_dir: Path, name: str, body: str) -> None:
+    """Write an llms index file into a build directory for validator tests."""
+    path = build_dir / name
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body, encoding="utf-8")
+
+
+def test_validate_llms_indexes_accepts_a_well_formed_index() -> None:
+    """Test that the validator passes a root plus section index that is correct."""
+    with file_system([]) as fs:
+        fs.build_dir.mkdir(parents=True, exist_ok=True)
+        builder = DocumentationBuilder(fs.src_dir, fs.build_dir)
+        site = builder._SITE_URL
+        _write_index(
+            fs.build_dir,
+            "llms.txt",
+            f"# Site\n\n- [A]({site}/a.md)\n- [Section]({site}/oss/llms.txt)\n",
+        )
+        _write_index(fs.build_dir, "oss/llms.txt", f"# Site\n\n- [B]({site}/b.md)\n")
+
+        builder._validate_llms_indexes(2)  # does not raise
+
+
+def test_validate_llms_indexes_rejects_oversized_root() -> None:
+    """Test that a root over the truncation threshold fails the build."""
+    with file_system([]) as fs:
+        fs.build_dir.mkdir(parents=True, exist_ok=True)
+        builder = DocumentationBuilder(fs.src_dir, fs.build_dir)
+        padding = "x" * builder._LLMS_MAX
+        _write_index(
+            fs.build_dir,
+            "llms.txt",
+            f"# Site\n\n{padding}\n- [A]({builder._SITE_URL}/a.md)\n",
+        )
+
+        with pytest.raises(ValueError, match="over the 50,000 threshold"):
+            builder._validate_llms_indexes(1)
+
+
+def test_validate_llms_indexes_rejects_second_level_nesting() -> None:
+    """Test that a section index linking to further .txt files fails.
+
+    Coverage walkers descend one level, so pages behind a second hop drop out
+    of the index entirely.
+    """
+    with file_system([]) as fs:
+        fs.build_dir.mkdir(parents=True, exist_ok=True)
+        builder = DocumentationBuilder(fs.src_dir, fs.build_dir)
+        site = builder._SITE_URL
+        _write_index(
+            fs.build_dir, "llms.txt", f"# Site\n\n- [S]({site}/oss/llms.txt)\n"
+        )
+        _write_index(
+            fs.build_dir,
+            "oss/llms.txt",
+            f"# Site\n\n- [A]({site}/a.md)\n- [Deeper]({site}/oss/py/llms.txt)\n",
+        )
+
+        with pytest.raises(ValueError, match="descend only one level"):
+            builder._validate_llms_indexes(1)
+
+
+def test_validate_llms_indexes_rejects_duplicate_and_missing_pages() -> None:
+    """Test that a page listed twice, or a page count mismatch, fails."""
+    with file_system([]) as fs:
+        fs.build_dir.mkdir(parents=True, exist_ok=True)
+        builder = DocumentationBuilder(fs.src_dir, fs.build_dir)
+        site = builder._SITE_URL
+        _write_index(
+            fs.build_dir, "llms.txt", f"# Site\n\n- [S]({site}/oss/llms.txt)\n"
+        )
+        _write_index(
+            fs.build_dir,
+            "oss/llms.txt",
+            f"# Site\n\n- [A]({site}/a.md)\n- [A again]({site}/a.md)\n",
+        )
+
+        with pytest.raises(ValueError, match="listed more than once"):
+            builder._validate_llms_indexes(1)
+
+        _write_index(fs.build_dir, "oss/llms.txt", f"# Site\n\n- [A]({site}/a.md)\n")
+        with pytest.raises(ValueError, match="but 5 were built"):
+            builder._validate_llms_indexes(5)


### PR DESCRIPTION
## Why

Coverage fell from ~100% to **57%** after #5514. This is my regression, and the cause is a Mintlify behavior I assumed rather than tested.

**Mintlify serves the exact filename `llms.txt` at any path, and 404s on anything else.** The numbered variants my split produced were never reachable:

| URL | status |
|---|---|
| `/oss/python/llms.txt` | 200 |
| `/oss/python/llms-2.txt` | **404** |
| `/oss/python/llms-3.txt` | **404** |
| `/langsmith/smith-api/llms.txt` | 200 |
| `/langsmith/smith-api/llms-2.txt` | **404** |

Only 4 of 9 section indexes were reachable. That left 1,229 visible links — 1,112 across the four served files plus 117 inline in the root — which is exactly what the audit reported: 883 sitemap pages plus 346 links not in the sitemap. The other **802 pages did not exist as far as any agent was concerned**.

Confirmed the rule is filename-based, not path-based: `.well-known/security.txt` is in the build and 404s, while `/oss/python/llms.txt` byte-matches the file my build produced, so Mintlify is serving my static file by name.

## What changed

Sections now split **by directory** rather than by filename. Every index is written as `<prefix>/llms.txt`.

An oversized section sheds its heaviest child directories into their own indexes until the remainder fits, instead of giving every child its own file — a naive recursive split produced 109 files, most of them a single page. Descriptions are also dropped from section indexes, which roughly halves each entry; the root keeps them, since it has room.

| | before | after |
|---|---|---|
| root | 16,449 chars | 21,656 chars |
| section indexes | 9 (5 unreachable) | 56 (all reachable) |
| largest section | 40,101 | 42,263 |
| pages indexed | 2,038 (1,229 visible) | 2,038 |

All 56 are named `llms.txt`, none exceed 50,000 characters, and each is one hop from the root so the coverage walker still reaches everything.

## The real gap

Every guard I added in #5514 checked **local files**, and nothing checked they were **served**. The build-time validator passed happily while a third of the index was unreachable in production.

`scripts/check_llms_urls.py` now verifies each section index returns 200 before it samples page URLs. Run against production today it correctly reports 52 of 56 unserved, because the new paths are not deployed yet — that is the check working. A unit test asserts no index is ever named `llms-N.txt`.

## Still open: LLMS Full Size (a Mintlify routing issue, not a repo one)

The custom `llms-full.txt` **is** being picked up — Mintlify just serves it on the wrong route. Probing all four endpoints:

| Route | Bytes | Whose |
|---|---:|---|
| `/llms.txt` | 16,449 | ours |
| `/.well-known/llms.txt` | 99,940 | Mintlify's, **truncated** |
| `/llms-full.txt` | 15,101,956 | Mintlify's |
| `/.well-known/llms-full.txt` | 6,246,717 | ours |

The override is applied to exactly one route per file, and they are crossed. Verified by content rather than size: `/.well-known/llms-full.txt` opens with `# Docs by LangChain`, while `/.well-known/llms.txt` still ends with `_Note: this index was truncated to stay under 100,000 characters; 569 pages and 3 OpenAPI specs omitted._`. Neither `.well-known` file exists in our build (it contains only `security.txt`), so both are served by Mintlify's own routing.

Two consequences:

1. **`LLMS Full Size` will keep failing** while the check reads `/llms-full.txt`, because that route serves Mintlify's 15.1 MB file regardless of the custom one. Nothing in this repo changes that.
2. **`/.well-known/llms.txt` serves a truncated index** that omits 569 pages, so any agent following the `.well-known` convention gets the pre-fix file even though the root is correct.

This looks like a Mintlify bug and needs a support ticket, not a code change here. Their documentation does not describe how custom files interact with the `.well-known` mirrors. Separately, **no target size for `llms-full.txt` is documented** by AFDocs or Mintlify, so even with the routing fixed I cannot say whether 6.2 MB clears the bar.

## Other checks

- **Markdown Content Parity** (warning): unchanged diagnosis, not a content defect. The only substantive gap is OpenAPI pages, where the markdown is *richer* than the HTML. Set both parity thresholds to 0 for informational mode.
- **LLMS TXT Directive Html** (1 of 15 pages), **Page Size Html** (1 page at 59K markdown from 1,195K HTML, 98% boilerplate), **Redirect Behavior** (1 cross-host redirect): all single-page warnings in Mintlify-controlled chrome or intentional `reference.langchain.com` redirects. No repo change proposed.
- **Content Structure** and **Authentication**: skipped, not failures. Both score 100.

## Validation

- 215 tests pass (1 new)
- `make lint` clean, `make broken-links` clean
- 56 section indexes, 0 named `llms-N.txt`, 0 over 50,000 chars
- 2,038 pages indexed, verified no duplicates and none lost

## AI disclosure

Authored with Claude Code (Claude Opus 5). The serving rule was established by probing production rather than inferred, after the previous PR shipped on an untested assumption about exactly this.
