### PR TITLE
Name every llms.txt section index correctly so all are served

### DIFF
--- a/pipeline/core/builder.py
+++ b/pipeline/core/builder.py
@@ -1317,29 +1317,57 @@ class DocumentationBuilder:
                 return ""
         return "/".join(shared)
 
-    def _chunk_section(
-        self, prefix: str, lines: list[str]
-    ) -> list[tuple[str, list[str]]]:
-        """Split a section's lines into files that each stay under budget.
+    @staticmethod
+    def _weigh(entries: list[tuple[str, str]]) -> int:
+        """Return the byte size a set of index entries would occupy."""
+        return sum(len(line) + 1 for _, line in entries)
 
-        Returns (build-relative path, lines) pairs. Entries arrive sorted by
-        URL, so sequential chunking keeps pages from the same subtree together.
-        Every file sits exactly one directory level below the root index:
-        AFDocs's coverage walker descends one level into linked .txt files, and
-        anything deeper is dropped from the coverage denominator.
+    def _chunk_section(
+        self, prefix: str, entries: list[tuple[str, str]]
+    ) -> list[tuple[str, list[tuple[str, str]]]]:
+        """Split a section into index files that each stay under budget.
+
+        Returns (directory prefix, entries) pairs. Every index is written as
+        ``<prefix>/llms.txt``, because Mintlify serves that exact filename at
+        any path but 404s on anything else: numbered variants like
+        ``llms-2.txt`` are not served, which silently hid 802 pages from the
+        coverage walker.
+
+        An oversized section sheds its largest child directories into their own
+        indexes until the remainder fits, rather than giving every child a file.
+        That keeps the number of fetches an agent makes proportional to how
+        much content there actually is.
         """
-        chunks: list[list[str]] = [[]]
-        size = 0
-        for line in lines:
-            if chunks[-1] and size + len(line) + 1 > self._LLMS_SECTION_BUDGET:
-                chunks.append([])
-                size = 0
-            chunks[-1].append(line)
-            size += len(line) + 1
-        return [
-            (f"{prefix}/llms.txt" if i == 0 else f"{prefix}/llms-{i + 1}.txt", chunk)
-            for i, chunk in enumerate(chunks)
-        ]
+        if self._weigh(entries) <= self._LLMS_SECTION_BUDGET:
+            return [(prefix, entries)]
+
+        depth = len(prefix.split("/")) if prefix else 0
+        children: dict[str, list[tuple[str, str]]] = {}
+        remainder: list[tuple[str, str]] = []
+        for slug, line in entries:
+            parts = slug.split("/")
+            if len(parts) > depth + 1:
+                children.setdefault("/".join(parts[: depth + 1]), []).append(
+                    (slug, line)
+                )
+            else:
+                remainder.append((slug, line))
+
+        if not children:
+            # A flat directory cannot be subdivided further. Keep it whole:
+            # oversized beats invisible, and the validator will flag it.
+            return [(prefix, entries)]
+
+        out: list[tuple[str, list[tuple[str, str]]]] = []
+        # Shed the heaviest children first so the fewest files are created.
+        for key in sorted(children, key=lambda k: -self._weigh(children[k])):
+            if self._weigh(remainder) + self._weigh(children[key]) <= (
+                self._LLMS_SECTION_BUDGET
+            ):
+                remainder += children[key]
+            else:
+                out += self._chunk_section(key, children[key])
+        return [(prefix, remainder), *out] if remainder else out
 
     def _write_section_index(
         self, path: str, title: str, label: str, lines: list[str]
@@ -1594,8 +1622,10 @@ class DocumentationBuilder:
             except (OSError, json.JSONDecodeError):
                 logger.warning("Could not read docs.json for llms.txt metadata")
 
-        # section label -> list of (slug, "- [Title](url): description") pairs
+        # section label -> list of (slug, "- [Title](url)") pairs
         sections: dict[str, list[tuple[str, str]]] = {}
+        # plain entry -> the same entry with its description, for the root file
+        described_lines: dict[str, str] = {}
         page_count = 0
 
         for mdx in sorted(self.build_dir.rglob("*.mdx")):
@@ -1621,9 +1651,12 @@ class DocumentationBuilder:
                     label = section_label
                     break
 
+            # Descriptions roughly double an entry. They stay in the root file,
+            # where there is room, and are dropped from section indexes so more
+            # pages fit per file and fewer files are needed.
             line = f"- [{name}]({url})"
             if summary:
-                line += f": {summary[:300]}"
+                described_lines[line] = f"{line}: {summary[:300]}"
             sections.setdefault(label, []).append((slug, line))
             page_count += 1
 
@@ -1654,11 +1687,18 @@ class DocumentationBuilder:
             # a fetch for a handful of pages. A section with no shared
             # directory has nowhere to live but the root.
             if not prefix or size <= self._LLMS_INLINE_MAX:
-                inline.append((label, lines))
+                inline.append(
+                    (label, [described_lines.get(line, line) for line in lines])
+                )
             else:
-                for path, chunk in self._chunk_section(prefix, lines):
-                    self._write_section_index(path, title, label, chunk)
-                    linked.append((label, path, len(chunk)))
+                for section_prefix, chunk in self._chunk_section(prefix, entries):
+                    if not chunk:
+                        continue
+                    path = f"{section_prefix}/llms.txt"
+                    self._write_section_index(
+                        path, title, label, [line for _, line in chunk]
+                    )
+                    linked.append((section_prefix, path, len(chunk)))
 
         out = [f"# {title}", ""]
         if description:
@@ -1671,16 +1711,9 @@ class DocumentationBuilder:
                 "## Section indexes",
                 "",
             ]
-            seen_labels: dict[str, int] = {}
-            for label, path, count in linked:
-                seen_labels[label] = seen_labels.get(label, 0) + 1
-                suffix = (
-                    f" (part {seen_labels[label]})"
-                    if sum(1 for entry in linked if entry[0] == label) > 1
-                    else ""
-                )
+            for section_prefix, path, count in sorted(linked):
                 out.append(
-                    f"- [{label}{suffix}]({self._SITE_URL}/{path}): {count} pages"
+                    f"- [/{section_prefix}]({self._SITE_URL}/{path}): {count} pages"
                 )
             out.append("")
         for label, lines in inline:

--- a/scripts/check_llms_urls.py
+++ b/scripts/check_llms_urls.py
@@ -105,6 +105,33 @@ def main() -> int:
     derived, pages = collect_urls(args.build_dir, args.base_url)
     print(f"index lists {len(derived):,} derived API URLs, {len(pages):,} page URLs")
 
+    # Check the section indexes themselves first. Mintlify serves the exact
+    # filename llms.txt at any path but 404s on anything else, so a rename or
+    # a routing change makes whole sections invisible to coverage walkers
+    # while every local check still passes.
+    root = (args.build_dir / "llms.txt").read_text(encoding="utf-8")
+    section_urls = sorted(set(TXT_LINK.findall(root)))
+    print(f"checking {len(section_urls)} section indexes are served\n")
+    with ThreadPoolExecutor(max_workers=MAX_WORKERS) as pool:
+        section_results = list(pool.map(status_of, section_urls))
+    unserved = [
+        (url, status)
+        for url, status in zip(section_urls, section_results, strict=True)
+        if status != 200
+    ]
+    if unserved:
+        print(
+            f"❌ {len(unserved)} of {len(section_urls)} section indexes are not served:\n"
+        )
+        for url, status in unserved[:20]:
+            print(f"  {status or 'no response'}  {url}")
+        print(
+            "\nEvery section index must be named exactly llms.txt. Mintlify "
+            "404s other .txt filenames, which hides those pages from coverage."
+        )
+        return 1
+    print(f"✅ all {len(section_urls)} section indexes are served\n")
+
     # Sampling picks which URLs to spot-check; nothing here is security-relevant.
     rng = random.Random(args.seed)  # noqa: S311
     if args.all:

--- a/tests/unit_tests/test_builder.py
+++ b/tests/unit_tests/test_builder.py
@@ -1008,3 +1008,41 @@ def test_resolve_within_blocks_escapes_and_allows_children() -> None:
 
     assert inside is not None
     assert escape is None
+
+
+def test_section_indexes_are_always_named_llms_txt() -> None:
+    """Test that oversized sections split by directory, never by filename.
+
+    Mintlify serves the exact filename llms.txt at any path but 404s on
+    anything else, so numbered variants like llms-2.txt are silently
+    unreachable and every page in them drops out of coverage.
+    """
+    # Enough pages across real subdirectories to force a split.
+    files: list[File] = [
+        {
+            "path": f"langsmith/{area}/page-{i:03d}.mdx",
+            "content": f"---\ntitle: {area} {i}\n---\n\nBody.\n",
+        }
+        for area in ("alpha", "beta", "gamma")
+        for i in range(250)
+    ]
+    with file_system(files) as fs:
+        builder = DocumentationBuilder(fs.src_dir, fs.build_dir)
+        builder.build_all()
+
+        indexes = sorted(
+            p.relative_to(fs.build_dir).as_posix()
+            for p in fs.build_dir.rglob("llms*.txt")
+            if p.name != "llms-full.txt"
+        )
+        root = (fs.build_dir / "llms.txt").read_text(encoding="utf-8")
+
+    assert len(indexes) > 1, "expected the section to split"
+    # Every index, at every depth, is named exactly llms.txt.
+    for path in indexes:
+        assert path.endswith("llms.txt"), path
+        assert "llms-" not in path, f"numbered index would 404: {path}"
+    # And each split index is reachable in one hop from the root.
+    for path in indexes:
+        if path != "llms.txt":
+            assert f"({builder._SITE_URL}/{path})" in root


### PR DESCRIPTION
## Why

Coverage fell from ~100% to **57%** after #5514. This is my regression, and the cause is a Mintlify behavior I assumed rather than tested.

**Mintlify serves the exact filename `llms.txt` at any path, and 404s on anything else.** The numbered variants my split produced were never reachable:

| URL | status |
|---|---|
| `/oss/python/llms.txt` | 200 |
| `/oss/python/llms-2.txt` | **404** |
| `/oss/python/llms-3.txt` | **404** |
| `/langsmith/smith-api/llms.txt` | 200 |
| `/langsmith/smith-api/llms-2.txt` | **404** |

Only 4 of 9 section indexes were reachable. That left 1,229 visible links — 1,112 across the four served files plus 117 inline in the root — which is exactly what the audit reported: 883 sitemap pages plus 346 links not in the sitemap. The other **802 pages did not exist as far as any agent was concerned**.

Confirmed the rule is filename-based, not path-based: `.well-known/security.txt` is in the build and 404s, while `/oss/python/llms.txt` byte-matches the file my build produced, so Mintlify is serving my static file by name.

## What changed

Sections now split **by directory** rather than by filename. Every index is written as `<prefix>/llms.txt`.

An oversized section sheds its heaviest child directories into their own indexes until the remainder fits, instead of giving every child its own file — a naive recursive split produced 109 files, most of them a single page. Descriptions are also dropped from section indexes, which roughly halves each entry; the root keeps them, since it has room.

| | before | after |
|---|---|---|
| root | 16,449 chars | 21,656 chars |
| section indexes | 9 (5 unreachable) | 56 (all reachable) |
| largest section | 40,101 | 42,263 |
| pages indexed | 2,038 (1,229 visible) | 2,038 |

All 56 are named `llms.txt`, none exceed 50,000 characters, and each is one hop from the root so the coverage walker still reaches everything.

## The real gap

Every guard I added in #5514 checked **local files**, and nothing checked they were **served**. The build-time validator passed happily while a third of the index was unreachable in production.

`scripts/check_llms_urls.py` now verifies each section index returns 200 before it samples page URLs. Run against production today it correctly reports 52 of 56 unserved, because the new paths are not deployed yet — that is the check working. A unit test asserts no index is ever named `llms-N.txt`.

## Still open: LLMS Full Size (a Mintlify routing issue, not a repo one)

The custom `llms-full.txt` **is** being picked up — Mintlify just serves it on the wrong route. Probing all four endpoints:

| Route | Bytes | Whose |
|---|---:|---|
| `/llms.txt` | 16,449 | ours |
| `/.well-known/llms.txt` | 99,940 | Mintlify's, **truncated** |
| `/llms-full.txt` | 15,101,956 | Mintlify's |
| `/.well-known/llms-full.txt` | 6,246,717 | ours |

The override is applied to exactly one route per file, and they are crossed. Verified by content rather than size: `/.well-known/llms-full.txt` opens with `# Docs by LangChain`, while `/.well-known/llms.txt` still ends with `_Note: this index was truncated to stay under 100,000 characters; 569 pages and 3 OpenAPI specs omitted._`. Neither `.well-known` file exists in our build (it contains only `security.txt`), so both are served by Mintlify's own routing.

Two consequences:

1. **`LLMS Full Size` will keep failing** while the check reads `/llms-full.txt`, because that route serves Mintlify's 15.1 MB file regardless of the custom one. Nothing in this repo changes that.
2. **`/.well-known/llms.txt` serves a truncated index** that omits 569 pages, so any agent following the `.well-known` convention gets the pre-fix file even though the root is correct.

This looks like a Mintlify bug and needs a support ticket, not a code change here. Their documentation does not describe how custom files interact with the `.well-known` mirrors. Separately, **no target size for `llms-full.txt` is documented** by AFDocs or Mintlify, so even with the routing fixed I cannot say whether 6.2 MB clears the bar.

## Other checks

- **Markdown Content Parity** (warning): unchanged diagnosis, not a content defect. The only substantive gap is OpenAPI pages, where the markdown is *richer* than the HTML. Set both parity thresholds to 0 for informational mode.
- **LLMS TXT Directive Html** (1 of 15 pages), **Page Size Html** (1 page at 59K markdown from 1,195K HTML, 98% boilerplate), **Redirect Behavior** (1 cross-host redirect): all single-page warnings in Mintlify-controlled chrome or intentional `reference.langchain.com` redirects. No repo change proposed.
- **Content Structure** and **Authentication**: skipped, not failures. Both score 100.

## Validation

- 215 tests pass (1 new)
- `make lint` clean, `make broken-links` clean
- 56 section indexes, 0 named `llms-N.txt`, 0 over 50,000 chars
- 2,038 pages indexed, verified no duplicates and none lost

## AI disclosure

Authored with Claude Code (Claude Opus 5). The serving rule was established by probing production rather than inferred, after the previous PR shipped on an untested assumption about exactly this.
