### PR TITLE
docs: Describe Engine scan cadence as dynamic instead of fixed-interval

### DIFF
--- a/src/langsmith/engine-overview.mdx
+++ b/src/langsmith/engine-overview.mdx
@@ -27,7 +27,7 @@ For each issue, Engine surfaces the contributing traces, proposes a fix, generat
 
 ## How Engine runs
 
-Engine scans each connected tracing project every 6 hours, clustering and prioritizing issues by severity. It uses LangChain-managed inference and charges in LangChain Compute Units (LCUs). Each detected issue is tagged with an [issue category](/langsmith/engine-issue-categories) such as **Silent tool error** or **Hallucination**. For setup, costs, and the full issue workflow, see [Find and fix your agent's issues](/langsmith/engine). For how Engine handles your data, its GitHub and model subprocessor controls, and its compliance posture, see [Engine security](/langsmith/engine-security). For how Engine runs in a self-hosted deployment, see [Engine on self-hosted](/langsmith/engine-self-hosted).
+Engine scans each connected tracing project on a dynamic schedule tuned to balance cost and performance, clustering and prioritizing issues by severity. It uses LangChain-managed inference and charges in LangChain Compute Units (LCUs). Each detected issue is tagged with an [issue category](/langsmith/engine-issue-categories) such as **Silent tool error** or **Hallucination**. For setup, costs, and the full issue workflow, see [Find and fix your agent's issues](/langsmith/engine). For how Engine handles your data, its GitHub and model subprocessor controls, and its compliance posture, see [Engine security](/langsmith/engine-security). For how Engine runs in a self-hosted deployment, see [Engine on self-hosted](/langsmith/engine-self-hosted).
 
 ## Get started
 

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -83,9 +83,9 @@ Engine runs in two phases:
 | Phase | Trigger | Typical LCU usage |
 |---|---|---|
 | **Initialization** | First time you enable Engine on a project | 30-40 LCUs |
-| **Recurring scans** | Every 6 hours automatically | 10-15 LCUs |
+| **Recurring scans** | Automatically, on a dynamic schedule | 10-15 LCUs |
 
-On initialization, Engine audits past traces, clusters and prioritizes issues by severity, and proposes fixes to your prompts or code (if a repository is connected). Recurring scans run on the 6-hour schedule whether or not new issues are found, and surface new issues not previously detected.
+On initialization, Engine audits past traces, clusters and prioritizes issues by severity, and proposes fixes to your prompts or code (if a repository is connected). Recurring scans run on a dynamic schedule tuned to balance cost and performance, whether or not new issues are found, and surface new issues not previously detected.
 
 ### Set spend limits and monitor usage
 
@@ -156,7 +156,7 @@ To add a condition, choose its kind from the field selector, fill in the values,
 **Scope limitation:** The scope filter only accepts run name and metadata conditions. You cannot scope Engine's scan by feedback key, evaluator name, or score threshold. To focus Engine on traces with a specific evaluator's low scores, use the [**Preferences** and **Agent overview** settings](#configure-engine) to tell Engine what to prioritize. Engine already factors in all feedback signals automatically. See [How Engine samples and prioritizes traces](#how-engine-samples-and-prioritizes-traces).
 </Note>
 
-Scope determines which traces Engine analyzes to detect issues and build the agent overview document. Scope set during initial setup applies to Engine's first scan. Scope changed later in the [**Engine Settings**](#configure-engine) panel does not re-run Engine immediately; it applies on the next scan, which runs every 6 hours.
+Scope determines which traces Engine analyzes to detect issues and build the agent overview document. Scope set during initial setup applies to Engine's first scan. Scope changed later in the [**Engine Settings**](#configure-engine) panel does not re-run Engine immediately; it applies on the next scan.
 
 ## Browse and filter issues
 
@@ -293,7 +293,7 @@ Within a tracing project, click the **Engine Settings** <Icon icon="settings"/> 
 - **Notifications**: Click **Add destination** to add a Slack channel or webhook destination that receives a notification when Engine detects a new issue. Set a minimum priority level per destination to control which issues trigger a notification. See [Get notified about new issues](#get-notified-about-new-issues).
 - **Code repository**: Connect or update a GitHub repository so the agent can reference source code when diagnosing issues. Optionally set a **Subfolder** and a **Branch** (defaults to the repository default). For setup, see [Connect Engine to GitHub](/langsmith/engine-github).
 - **Context repository**: Connect a Context Hub repository so Engine can propose fixes to instructions, docs, and linked skills.
-- **Pause**: Engine scans your traces every 6 hours by default. Click **Pause** to stop scanning without deleting the existing issues, or **Resume** to resume scanning.
+- **Pause**: Engine scans your traces on a dynamic schedule tuned to balance cost and performance. Click **Pause** to stop scanning without deleting the existing issues, or **Resume** to resume scanning.
 - **Delete all issues**: This action cannot be undone. All issues and settings will be permanently removed.
 
 ## See also


### PR DESCRIPTION
## Summary
Removes the hardcoded "every 6 hours" scan-cadence claim from the LangSmith Engine docs and describes recurring scans as running on a dynamic schedule tuned to balance cost and performance instead.

- `src/langsmith/engine.mdx`: updated the LCU cost table's "Recurring scans" trigger and the accompanying prose.
- `src/langsmith/engine-overview.mdx`: updated the "How Engine runs" section.

## Why this approach?
The scan interval is an internal implementation detail that can change over time to optimize cost and performance. Documenting a fixed 6-hour interval creates a stale, overly specific commitment; describing the cadence as dynamic keeps the docs accurate without needing a follow-up edit whenever the interval changes.

## Test Plan
- [x] `make lint_prose FILES="src/langsmith/engine.mdx src/langsmith/engine-overview.mdx"` — 0 errors, 0 warnings, 0 suggestions
- [x] Verified no other `.mdx` file in the repo references Engine's scan interval as a fixed hour count

## Release Note
Updated the Engine docs to describe scan cadence as dynamic (tuned for cost/performance) rather than a fixed 6-hour interval.