### PR TITLE
docs(mda): omit redundant current-directory paths

### DIFF
--- a/src/langsmith/managed-deep-agents-channels-slack.mdx
+++ b/src/langsmith/managed-deep-agents-channels-slack.mdx
@@ -75,7 +75,7 @@ After setting up the Slack channel, you need to create and deploy your Slack app
   First, [deploy your Managed Deep Agent](/langsmith/managed-deep-agents-deploy).
   
   ```
-  mda deploy .
+  mda deploy
   ```
   
   Wait for the deployment to finish. The agent is deployed even though Slack is
@@ -85,14 +85,14 @@ not active yet.
     Run a command to generate the Slack app manifest template.
     
     ```bash
-    mda channel add slack .
+    mda channel add slack
     ```
     MDA finds the existing deployment and writes two files:
     - A "template" manifest to `slack-app-manifest.json`
     - The full manifest to `.mda/slack/app-manifest.json`
     
     The template manifest is what you should edit directly to change scopes, etc. The full manifest is generated from this template manifest and includes information about the deployment.
-    If you make changes to the template manifest, you will need rerun `mda channel add slack .` to regenerate the full template. 
+    If you make changes to the template manifest, you will need rerun `mda channel add slack` to regenerate the full template.
     Do not directly edit the generated file at `.mda/slack/app-manifest.json`
     
   </Step>
@@ -123,7 +123,7 @@ not active yet.
   <Step title="Redeploy to activate Slack">
   
   ```
-  mda deploy .
+  mda deploy
   ```
   
   This deployment forwards the Slack credentials to the managed runtime and
@@ -131,12 +131,12 @@ enables authenticated event handling.
     
   </Step>
   <Step title="Updating Slack Bot Configurations">
-    The previous steps guide you through deploying the first iteration of your Managed Deepagent as a Slack bot. If you want to make any updates to the agent, you just simply rerun `mda deploy .` to update the deployed app.
+    The previous steps guide you through deploying the first iteration of your Managed Deepagent as a Slack bot. If you want to make any updates to the agent, you just simply rerun `mda deploy` to update the deployed app.
 
     If you want to make any configuration changes to the Slack application itself, the recommended steps are:
     
     1. Update the `slack-app-manifest.json` file locally
-    2. Run `mda channel add slack .` — this will regenerate the manifest with the latest changes. These changes are written to the `.mda/slack/app-manifest.json` file
+    2. Run `mda channel add slack` — this will regenerate the manifest with the latest changes. These changes are written to the `.mda/slack/app-manifest.json` file
     3. On https://api.slack.com/apps → locate your app → App Manifest 
     4. Replace the contents of the manifest with the new `.mda/slack/app-manifest.json` file → Click **Save Changes**
     5. Navigate to the **OAuth & Permissions** tab. Click on **Reinstall to Workspace**
@@ -145,7 +145,7 @@ enables authenticated event handling.
   </Step>
 </Steps>
 
-Treat `slack-app-manifest.json` as the source of truth. When you change its scopes, bot events, branding, or other settings, rerun `mda channel add slack .`, apply the regenerated `.mda/slack/app-manifest.json`, and reinstall the app if Slack requests it. The generated files under `.mda/` are build artifacts; do not commit them.
+Treat `slack-app-manifest.json` as the source of truth. When you change its scopes, bot events, branding, or other settings, rerun `mda channel add slack`, apply the regenerated `.mda/slack/app-manifest.json`, and reinstall the app if Slack requests it. The generated files under `.mda/` are build artifacts; do not commit them.
 
 ## Configure Slack behavior
 
@@ -312,7 +312,7 @@ A Slack event runs as an identity derived from the Slack workspace and user, suc
 
 ## Deploy changes
 
-Redeploy after changing the channel declaration, secrets, or identity configuration. Rerun `mda channel add slack .` when you change `slack-app-manifest.json`, the channel name, or the deployment so MDA can regenerate the final manifest with the current Events URL. Apply the generated manifest to the existing Slack app after the deployment completes.
+Redeploy after changing the channel declaration, secrets, or identity configuration. Rerun `mda channel add slack` when you change `slack-app-manifest.json`, the channel name, or the deployment so MDA can regenerate the final manifest with the current Events URL. Apply the generated manifest to the existing Slack app after the deployment completes.
 
 Avoid making lasting configuration changes only in the Slack dashboard. A later manifest update can replace settings that are not present in the checked-in template.
 
@@ -333,7 +333,7 @@ Design channel-triggered tools as idempotent when they perform external side eff
 - **`mda channel add slack` reports that it needs exactly one channel**: Keep exactly one `channels.slack(...)` declaration in the project when using the manifest workflow.
 - **MDA cannot read the template**: Confirm `slack-app-manifest.json` is a regular JSON file at the project root. Remove credentials and any `settings.event_subscriptions.request_url`, and keep Socket Mode disabled.
 - **The first deploy writes a bootstrap manifest and exits**: This is expected when the Slack credentials do not exist yet. Create and install the app, add both credentials, then rerun the same command.
-- **MDA does not write the final manifest**: Run `mda deploy .` without `--no-wait`, then rerun `mda channel add slack .`. The CLI needs the deployed Agent Server URL.
+- **MDA does not write the final manifest**: Run `mda deploy` without `--no-wait`, then rerun `mda channel add slack`. The CLI needs the deployed Agent Server URL.
 - **Slack cannot verify the request URL**: Confirm the deployment is healthy, the URL on the app's **Event Subscriptions** page matches `https://<agent-server>/channels/<name>/events`, and `SLACK_SIGNING_SECRET` belongs to that app. Redeploy after adding the Slack credentials, then apply the regenerated final manifest.
 - **Mentions do not start runs**: Subscribe to `app_mention`, add `app_mentions:read`, invite the bot to the conversation, and reinstall the app after changing scopes.
 - **Direct messages do not start runs**: Subscribe to `message.im` and add `im:history`.
@@ -345,7 +345,7 @@ Design channel-triggered tools as idempotent when they perform external side eff
 - **`mda channel add slack` reports that it needs exactly one channel**: Keep exactly one `channels.slack(...)` declaration in the project when using the manifest workflow.
 - **MDA cannot read the template**: Confirm `slack-app-manifest.json` is a regular JSON file at the project root. Remove credentials and any `settings.event_subscriptions.request_url`, and keep Socket Mode disabled.
 - **The first deploy writes a bootstrap manifest and exits**: This is expected when the Slack credentials do not exist yet. Create and install the app, add both credentials, then rerun the same command.
-- **MDA does not write the final manifest**: Run `mda deploy .` without `--no-wait`, then rerun `mda channel add slack .`. The CLI needs the deployed Agent Server URL.
+- **MDA does not write the final manifest**: Run `mda deploy` without `--no-wait`, then rerun `mda channel add slack`. The CLI needs the deployed Agent Server URL.
 - **Slack cannot verify the request URL**: Confirm the deployment is healthy, the URL on the app's **Event Subscriptions** page matches `https://<agent-server>/channels/<name>/events`, and `SLACK_SIGNING_SECRET` belongs to that app. Redeploy after adding the Slack credentials, then apply the regenerated final manifest.
 - **Mentions do not start runs**: Subscribe to `app_mention`, add `app_mentions:read`, invite the bot to the conversation, and reinstall the app after changing scopes.
 - **Direct messages do not start runs**: Subscribe to `message.im` and add `im:history`.

--- a/src/langsmith/managed-deep-agents-cli.mdx
+++ b/src/langsmith/managed-deep-agents-cli.mdx
@@ -163,7 +163,7 @@ Eval tasks are opt-in and are not created by `mda init`. Managed Deep Agents eva
 Use `mda build` to compile a project into a managed LangGraph app without deploying it:
 
 ```bash
-mda build .
+mda build
 ```
 
 | Argument or flag | Use |
@@ -177,7 +177,7 @@ mda build .
 
 ```bash
 mda evals init smoke
-mda evals compile .
+mda evals compile
 # then run the printed `harbor run` command
 ```
 
@@ -202,7 +202,7 @@ For Harbor task authoring, optional scaffolding, credentials, and running trials
 Use `mda dev` to compile a project and run the local LangGraph dev server:
 
 ```bash
-mda dev .
+mda dev
 ```
 
 | Argument or flag | Use |
@@ -238,7 +238,7 @@ For local development, `mda dev` stages the project `.env` file into `.mda/build
 Use `mda deploy` to compile and deploy a project to LangSmith:
 
 ```bash
-mda deploy .
+mda deploy
 ```
 
 :::python
@@ -274,7 +274,7 @@ Deploy runs these steps:
 9. Poll the revision until it reaches `DEPLOYED` unless `--no-wait` is set.
 10. Reconcile the managed LangSmith cron jobs for schedules unless `--no-wait` is set.
 
-Deploy does not configure Slack. Run `mda channel add slack .` after the deployment finishes. For the complete workflow, see [Slack channels](/langsmith/managed-deep-agents-channels-slack#create-and-deploy-the-slack-app).
+Deploy does not configure Slack. Run `mda channel add slack` after the deployment finishes. For the complete workflow, see [Slack channels](/langsmith/managed-deep-agents-channels-slack#create-and-deploy-the-slack-app).
 
 On success, the CLI prints the LangSmith deployment dashboard URL. For secrets routing and deploy tips, see [Deploy an agent](/langsmith/managed-deep-agents-deploy).
 
@@ -283,7 +283,7 @@ On success, the CLI prints the LangSmith deployment dashboard URL. For secrets r
 Use `mda logs` to tail Agent Server logs for a deployed agent:
 
 ```bash
-mda logs .
+mda logs
 ```
 
 | Argument or flag | Use |
@@ -301,7 +301,7 @@ mda logs .
 Use `mda delete` to delete a deployed Managed Deep Agent and the LangSmith resources it created. `mda destroy` is an alias.
 
 ```bash
-mda delete .
+mda delete
 ```
 
 :::python

--- a/src/langsmith/managed-deep-agents-deploy.mdx
+++ b/src/langsmith/managed-deep-agents-deploy.mdx
@@ -37,7 +37,7 @@ The CLI targets US LangSmith Cloud by default.
 Deploy the local project:
 
 ```bash
-mda deploy .
+mda deploy
 ```
 
 <Tip>
@@ -54,19 +54,19 @@ schedules/**                 -> LangSmith cron jobs after the deployment is live
 Set the deployment name explicitly when the directory name is not the name you want:
 
 ```bash
-mda deploy . --name research-assistant
+mda deploy --name research-assistant
 ```
 
 Use `--deployment-type prod` when creating a production deployment:
 
 ```bash
-mda deploy . --deployment-type prod
+mda deploy --deployment-type prod
 ```
 
 Use `--no-wait` to trigger the build without polling for completion:
 
 ```bash
-mda deploy . --no-wait
+mda deploy --no-wait
 ```
 
 When `--no-wait` is set, schedule reconciliation is skipped for that deploy invocation because the CLI exits before the deployment reaches `DEPLOYED`.

--- a/src/langsmith/managed-deep-agents-evals.mdx
+++ b/src/langsmith/managed-deep-agents-evals.mdx
@@ -171,13 +171,13 @@ test("answer.txt contains exactly PONG", () => {
 Compile every scaffold under `evals/scaffold/`:
 
 ```bash
-mda evals compile .
+mda evals compile
 ```
 
 To refresh specific scaffolds, repeat `--task`:
 
 ```bash
-mda evals compile . --task smoke --task regression
+mda evals compile --task smoke --task regression
 ```
 
 For each selected scaffold, MDA:

--- a/src/langsmith/managed-deep-agents-local-development.mdx
+++ b/src/langsmith/managed-deep-agents-local-development.mdx
@@ -21,7 +21,7 @@ Python projects also require [`uv`](https://docs.astral.sh/uv/).
 From the project root, run:
 
 ```bash
-mda dev .
+mda dev
 ```
 
 The CLI prints the local server and Studio URLs and opens Studio in your browser. Send messages in Studio to inspect model responses, tool calls, state, and interrupts.

--- a/src/langsmith/managed-deep-agents-quickstart.mdx
+++ b/src/langsmith/managed-deep-agents-quickstart.mdx
@@ -236,14 +236,14 @@ Install the project dependencies and start the agent:
 :::python
 ```bash
 uv sync
-mda dev .
+mda dev
 ```
 :::
 
 :::js
 ```bash
 npm install
-mda dev .
+mda dev
 ```
 :::
 
@@ -265,7 +265,7 @@ For more information, see [Develop locally with LangSmith Studio](/langsmith/man
 Deploy the project by running:
 
 ```bash
-mda deploy .
+mda deploy
 ```
 
 Managed Deep Agents packages the project and runs it as a hosted deployment on [LangSmith Agent Server](/langsmith/agent-server). When deployment finishes, the CLI prints the deployment dashboard URL.

--- a/src/langsmith/managed-deep-agents-schedules.mdx
+++ b/src/langsmith/managed-deep-agents-schedules.mdx
@@ -225,7 +225,7 @@ Schedule declarations are extracted at compile time. Keep schedule configuration
 When the deployment reaches `DEPLOYED`, `mda deploy` searches for existing MDA-owned cron jobs on the deployed Agent Server, deletes them, and creates cron jobs for the current `schedules/` declarations. Removing a local schedule file and redeploying removes the corresponding managed cron.
 
 <Warning>
-If you deploy with `--no-wait`, the CLI triggers the remote build and exits before the deployment reaches `DEPLOYED`, so it does not reconcile schedules during that invocation. Run `mda deploy .` without `--no-wait` when adding, changing, or removing schedules.
+If you deploy with `--no-wait`, the CLI triggers the remote build and exits before the deployment reaches `DEPLOYED`, so it does not reconcile schedules during that invocation. Run `mda deploy` without `--no-wait` when adding, changing, or removing schedules.
 </Warning>
 
 ## Troubleshoot schedules

--- a/src/langsmith/managed-deep-agents-tutorial.mdx
+++ b/src/langsmith/managed-deep-agents-tutorial.mdx
@@ -238,7 +238,7 @@ For thread behavior and constraints, see [Schedules](/langsmith/managed-deep-age
 Deploy the project to LangSmith:
 
 ```bash
-mda deploy .
+mda deploy
 ```
 
 On success, the CLI prints the deployment dashboard URL. The deploy syncs the instructions to Context Hub, uploads the compiled project, and reconciles the daily schedule.


### PR DESCRIPTION
removes redundant `.` arguments from mda documentation examples 