### PR TITLE
docs(dcode): document cold prompt-cache warning and trusted endpoints

### DIFF
--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -49,14 +49,12 @@ session_cost_threshold_usd = 25
 
 ## Cold prompt-cache warning
 
-Anthropic and OpenAI cache the conversation prefix between turns, so a follow-up sent while the cache is warm re-processes only new tokens. That cache expires after a provider-specific idle window. When an interactive chat message would be sent to a thread whose cache has likely expired (or whose model or cache settings changed since the last turn), Deep Agents Code estimates the re-warm cost and, if it reaches a threshold, asks before sending:
+Some LLM providers automatically cache the conversation prefix between turns, so a follow-up sent while the cache is warm re-processes only new tokens. That cache expires after a provider-specific idle window. Deep Agents Code currently detects this for Anthropic and OpenAI models: when an interactive chat message would be sent to a thread whose cache has likely expired (or whose model or cache settings changed since the last turn), it estimates the re-warm cost and, if it reaches a threshold, asks before sending:
 
 - **Send anyway**: send this turn; the warning still appears on future cold-cache turns.
 - **Send and don't warn again this session**: mute the warning until the app restarts.
 - **Send and never warn again**: persistently suppress the warning. Re-enable it from the `/notifications` settings screen.
 - **Don't send (keep draft)**: restore the message to the chat input so you can `/clear` first.
-
-The warning applies to Anthropic and OpenAI models with a documented cache policy. Slash commands and programmatic prompts (for example, through [ACP](/oss/deepagents/acp)) never trigger the warning.
 
 Set the minimum estimated extra cost (cold versus warm cache) that triggers the warning, in USD. The default is `0.50`; set it to `0` to disable:
 

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -52,24 +52,20 @@ session_cost_threshold_usd = 25
 Anthropic and OpenAI cache the conversation prefix between turns, so a follow-up sent while the cache is warm re-processes only new tokens. That cache expires after a provider-specific idle window. When an interactive chat message would be sent to a thread whose cache has likely expired (or whose model or cache settings changed since the last turn), Deep Agents Code estimates the re-warm cost and, if it reaches a threshold, asks before sending:
 
 - **Send anyway**: send this turn; the warning still appears on future cold-cache turns.
-- **Send and don't warn again this session**: send this turn and mute the warning until the app restarts.
-- **Send and never warn again**: send this turn and persistently suppress the warning by adding `cold-cache` to `[warnings].suppress` in `config.toml`. Re-enable it from the `/notifications` settings screen.
+- **Send and don't warn again this session**: mute the warning until the app restarts.
+- **Send and never warn again**: persistently suppress the warning. Re-enable it from the `/notifications` settings screen.
 - **Don't send (keep draft)**: restore the message to the chat input so you can `/clear` first.
 
-Use the arrow keys or `Tab` to move between choices, `Enter` to select, and `Esc` to cancel.
+The warning fires only for Anthropic and OpenAI models on endpoints with a documented cache policy:
 
-The estimate prices the current context against the provider's documented cache behavior, so the warning fires only when the endpoint and retention window are known:
+| Provider | Condition | Retention window |
+|----------|-----------|------------------|
+| Anthropic | Any | 5 minutes |
+| OpenAI | GPT-5.6 or newer | 30 minutes |
+| OpenAI | `prompt_cache_retention: in_memory` | 1 hour |
+| OpenAI | `prompt_cache_retention: 24h` | 24 hours |
 
-| Provider | Condition | Retention window | Warning wording |
-|----------|-----------|------------------|-----------------|
-| Anthropic | Any | 5 minutes | "likely expired" |
-| OpenAI | GPT-5.6 or newer | 30 minutes (documented minimum) | "may be cold" |
-| OpenAI | `prompt_cache_retention: in_memory` | 1 hour | "likely expired" |
-| OpenAI | `prompt_cache_retention: 24h` | 24 hours | "likely expired" |
-
-A 30-minute window is a guaranteed minimum that OpenAI may exceed, so past it the cache is only "may be cold". The other windows are documented maximums, so past them the entry is gone. For Anthropic, the window is always 5 minutes: Deep Agents Code's prompt-caching middleware sets the `cache_control` TTL itself, so a `cache_control.ttl` value in [model constructor params](#model-constructor-params) never reaches the API.
-
-The warning is skipped entirely for slash commands, prompts sent programmatically (for example, through [ACP](/oss/deepagents/acp) from an editor), contexts below the provider's minimum cacheable size, custom endpoints that are not [trusted](#trust-a-gateway-endpoint-for-cache-policies), and models without pricing information. When the warning cannot be displayed, the message is not sent and the draft is restored instead.
+Slash commands and programmatic prompts (for example, through [ACP](/oss/deepagents/acp)) never trigger the warning.
 
 Set the minimum estimated extra cost (cold versus warm cache) that triggers the warning, in USD. The default is `0.50`; set it to `0` to disable:
 
@@ -80,16 +76,14 @@ cold_cache_min_delta_usd = 1.00
 
 ### Trust a gateway endpoint for cache policies
 
-If requests reach the provider through a gateway or corporate proxy instead of the official API, the cold-cache warning stays silent, because the warning's dollar estimates are only accurate when the endpoint forwards cache settings (`cache_control`, `prompt_cache_key`, `prompt_cache_retention`) untouched and honors the provider's documented retention. Declare the endpoints you have verified with `[warnings].trusted_cache_endpoints`:
+If requests reach the provider through a gateway or proxy instead of the official API, the cold-cache warning stays silent. Declaring an endpoint trusted asserts that it forwards cache settings untouched and honors the provider's documented retention:
 
 ```toml title="~/.deepagents/config.toml"
 [warnings]
 trusted_cache_endpoints = ["smith.langchain.com"]
 ```
 
-Entries are hostnames (full `http(s)` URLs are also accepted and reduced to their host). Matching is per exact host: trusting `example.com` does not trust `gw.example.com`, so list each host requests may actually reach. One entry covers every provider routed through that endpoint. Malformed entries are ignored and logged.
-
-One case stays silent even on a trusted endpoint: the LangSmith gateway can translate between API formats, such as an OpenAI-format request answered by an Anthropic model (the model name carries a cross-provider prefix like `anthropic/claude-...` in OpenAI format). Translation rewrites or drops the cache settings the estimate assumes, so Deep Agents Code skips the warning for cross-format routes rather than show numbers built on wrong assumptions. Same-format routes are forwarded untranslated, and their warnings are exactly as accurate as going direct.
+Entries are hostnames matched exactly — trusting `example.com` does not trust `gw.example.com`. One entry covers every provider routed through that endpoint. Cross-format routes through the LangSmith gateway (for example, an OpenAI-format request routed to an Anthropic model) stay silent even when trusted, because translation rewrites the cache settings the estimate assumes.
 
 ## Diff line numbers
 

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -7,6 +7,7 @@ description: Configure model providers, defaults, retries, and gateways in confi
 `~/.deepagents/config.toml` lets you customize model providers, set defaults, and pass extra parameters to model constructors. For environment variables and inspection commands, see [Configuration](/oss/deepagents/code/configuration). This page covers:
 
 - **Defaults**: pin a [default model](#default-and-recent-model) or [agent](#default-and-recent-agent).
+- **Warnings**: [session cost](#session-cost-warning) and [cold prompt-cache](#cold-prompt-cache-warning) thresholds, and [trusted gateway endpoints](#trust-a-gateway-endpoint-for-cache-policies).
 - **Provider setup**: the [`[models.providers.<name>]` table](#provider-configuration), [constructor params](#model-constructor-params), [retries](#retries), [profile overrides](#profile-overrides-advanced), and [adding models to the `/model` switcher](#adding-models-to-the-interactive-switcher).
 - **Auto mode**: the [auto classifier timeout](#auto-classifier-timeout).
 - **Custom endpoints and providers**: [custom base URLs](#custom-base-url), [OpenAI- or Anthropic-compatible APIs](#compatible-apis), and [arbitrary providers](#arbitrary-providers).
@@ -45,6 +46,50 @@ Deep Agents Code warns once per thread when its cumulative estimated cost exceed
 [warnings]
 session_cost_threshold_usd = 25
 ```
+
+## Cold prompt-cache warning
+
+Anthropic and OpenAI cache the conversation prefix between turns, so a follow-up sent while the cache is warm re-processes only new tokens. That cache expires after a provider-specific idle window. When an interactive chat message would be sent to a thread whose cache has likely expired (or whose model or cache settings changed since the last turn), Deep Agents Code estimates the re-warm cost and, if it reaches a threshold, asks before sending:
+
+- **Send anyway**: send this turn; the warning still appears on future cold-cache turns.
+- **Send and don't warn again this session**: send this turn and mute the warning until the app restarts.
+- **Send and never warn again**: send this turn and persistently suppress the warning by adding `cold-cache` to `[warnings].suppress` in `config.toml`. Re-enable it from the `/notifications` settings screen.
+- **Don't send (keep draft)**: restore the message to the chat input so you can `/clear` first.
+
+Use the arrow keys or `Tab` to move between choices, `Enter` to select, and `Esc` to cancel.
+
+The estimate prices the current context against the provider's documented cache behavior, so the warning fires only when the endpoint and retention window are known:
+
+| Provider | Condition | Retention window | Warning wording |
+|----------|-----------|------------------|-----------------|
+| Anthropic | Any | 5 minutes | "likely expired" |
+| OpenAI | GPT-5.6 or newer | 30 minutes (documented minimum) | "may be cold" |
+| OpenAI | `prompt_cache_retention: in_memory` | 1 hour | "likely expired" |
+| OpenAI | `prompt_cache_retention: 24h` | 24 hours | "likely expired" |
+
+A 30-minute window is a guaranteed minimum that OpenAI may exceed, so past it the cache is only "may be cold". The other windows are documented maximums, so past them the entry is gone. For Anthropic, the window is always 5 minutes: Deep Agents Code's prompt-caching middleware sets the `cache_control` TTL itself, so a `cache_control.ttl` value in [model constructor params](#model-constructor-params) never reaches the API.
+
+The warning is skipped entirely for slash commands, prompts sent programmatically (for example, through [ACP](/oss/deepagents/acp) from an editor), contexts below the provider's minimum cacheable size, custom endpoints that are not [trusted](#trust-a-gateway-endpoint-for-cache-policies), and models without pricing information. When the warning cannot be displayed, the message is not sent and the draft is restored instead.
+
+Set the minimum estimated extra cost (cold versus warm cache) that triggers the warning, in USD. The default is `0.50`; set it to `0` to disable:
+
+```toml title="~/.deepagents/config.toml"
+[warnings]
+cold_cache_min_delta_usd = 1.00
+```
+
+### Trust a gateway endpoint for cache policies
+
+If requests reach the provider through a gateway or corporate proxy instead of the official API, the cold-cache warning stays silent, because the warning's dollar estimates are only accurate when the endpoint forwards cache settings (`cache_control`, `prompt_cache_key`, `prompt_cache_retention`) untouched and honors the provider's documented retention. Declare the endpoints you have verified with `[warnings].trusted_cache_endpoints`:
+
+```toml title="~/.deepagents/config.toml"
+[warnings]
+trusted_cache_endpoints = ["smith.langchain.com"]
+```
+
+Entries are hostnames (full `http(s)` URLs are also accepted and reduced to their host). Matching is per exact host: trusting `example.com` does not trust `gw.example.com`, so list each host requests may actually reach. One entry covers every provider routed through that endpoint. Malformed entries are ignored and logged.
+
+One case stays silent even on a trusted endpoint: the LangSmith gateway can translate between API formats, such as an OpenAI-format request answered by an Anthropic model (the model name carries a cross-provider prefix like `anthropic/claude-...` in OpenAI format). Translation rewrites or drops the cache settings the estimate assumes, so Deep Agents Code skips the warning for cross-format routes rather than show numbers built on wrong assumptions. Same-format routes are forwarded untranslated, and their warnings are exactly as accurate as going direct.
 
 ## Diff line numbers
 

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -56,16 +56,7 @@ Anthropic and OpenAI cache the conversation prefix between turns, so a follow-up
 - **Send and never warn again**: persistently suppress the warning. Re-enable it from the `/notifications` settings screen.
 - **Don't send (keep draft)**: restore the message to the chat input so you can `/clear` first.
 
-The warning fires only for Anthropic and OpenAI models on endpoints with a documented cache policy:
-
-| Provider | Condition | Retention window |
-|----------|-----------|------------------|
-| Anthropic | Any | 5 minutes |
-| OpenAI | GPT-5.6 or newer | 30 minutes |
-| OpenAI | `prompt_cache_retention: in_memory` | 1 hour |
-| OpenAI | `prompt_cache_retention: 24h` | 24 hours |
-
-Slash commands and programmatic prompts (for example, through [ACP](/oss/deepagents/acp)) never trigger the warning.
+The warning applies to Anthropic and OpenAI models with a documented cache policy. Slash commands and programmatic prompts (for example, through [ACP](/oss/deepagents/acp)) never trigger the warning.
 
 Set the minimum estimated extra cost (cold versus warm cache) that triggers the warning, in USD. The default is `0.50`; set it to `0` to disable:
 

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -322,6 +322,10 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
     Enable verbose debug logging to a file. Accepts `1`, `true`, `yes`, `on` (case-insensitive) as enabled; `0`, `false`, `no`, `off`, empty string, or unset disables it. When enabled, the per-session server log file is preserved on shutdown and its path is printed to stderr for triage.
 </ResponseField>
 
+<ResponseField name="DEEPAGENTS_CODE_DEBUG_COLD_CACHE" type="string" post={["optional"]}>
+    Force the [cold prompt-cache warning](/oss/deepagents/code/config-file#cold-prompt-cache-warning) modal on the next interactive send, bypassing the provider-policy, token-floor, cache-window, and cost-threshold gates as well as session and persisted suppression. Accepts `1`, `true`, `yes`, `on` (case-insensitive) as enabled; `0`, `false`, `no`, `off`, empty string, or unset disables it. When the active model has no documented cache policy, a stand-in policy is used so the modal stays reachable, and the dollar figures are illustrative rather than real estimates.
+</ResponseField>
+
 <ResponseField name="DEEPAGENTS_CODE_EXPERIMENTAL" type="string" post={["optional"]}>
     Opt into experimental, unstable Deep Agents Code behavior. Set to `1` (or any truthy value) to enable experimental features.
 </ResponseField>

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -322,10 +322,6 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
     Enable verbose debug logging to a file. Accepts `1`, `true`, `yes`, `on` (case-insensitive) as enabled; `0`, `false`, `no`, `off`, empty string, or unset disables it. When enabled, the per-session server log file is preserved on shutdown and its path is printed to stderr for triage.
 </ResponseField>
 
-<ResponseField name="DEEPAGENTS_CODE_DEBUG_COLD_CACHE" type="string" post={["optional"]}>
-    Force the [cold prompt-cache warning](/oss/deepagents/code/config-file#cold-prompt-cache-warning) modal on the next interactive send, bypassing the provider-policy, token-floor, cache-window, and cost-threshold gates as well as session and persisted suppression. Accepts `1`, `true`, `yes`, `on` (case-insensitive) as enabled; `0`, `false`, `no`, `off`, empty string, or unset disables it. When the active model has no documented cache policy, a stand-in policy is used so the modal stays reachable, and the dollar figures are illustrative rather than real estimates.
-</ResponseField>
-
 <ResponseField name="DEEPAGENTS_CODE_EXPERIMENTAL" type="string" post={["optional"]}>
     Opt into experimental, unstable Deep Agents Code behavior. Set to `1` (or any truthy value) to enable experimental features.
 </ResponseField>


### PR DESCRIPTION
Draft documentation for two `deepagents-code` features:

- [langchain-ai/deepagents#5439](https://github.com/langchain-ai/deepagents/pull/5439) — warn before expensive cold-cache turns
- [langchain-ai/deepagents#5462](https://github.com/langchain-ai/deepagents/pull/5462) — trust user-declared endpoints for cold-cache policies

Generated with AI assistance (Deep Agents Code).
