### PR TITLE
Add MicroScrape to providers directory

### DIFF
--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -1544,6 +1544,14 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
+        title="MicroScrape"
+        href="https://github.com/Luci-hue/microscrape"
+        icon="link"
+    >
+        Pay-per-request webpage-to-Markdown extraction for AI agents via x402 (USDC on Solana).
+    </Card>
+
+    <Card
         title="Microsoft"
         href="/oss/integrations/providers/microsoft"
         icon="brand-windows"


### PR DESCRIPTION
## Overview
Adds MicroScrape to the Python providers directory (`all_providers.mdx`) as a link-card entry, matching the format of the other x402-enabled tools already listed there (NodeProxy, Skim, x402, Ampersend, etc.).

MicroScrape is a pay-per-request webpage-to-Markdown extraction API for AI agents, priced and paid entirely via the x402 protocol (USDC on Solana) - no API key, account, or subscription required.

## Type of change
**Type:** New documentation page (entry addition to existing page)

## Related issues/PRs
- GitHub issue: N/A - small, self-contained content addition following an established pattern (other x402 provider entries in the same file)
- Feature PR: N/A

## Checklist
- [x] I have read the contributing guidelines, including the language policy
- [x] I have used root relative paths for internal links (N/A - this entry links to the project's external GitHub repo, consistent with how several existing x402 entries link out to their own docs/repos)
- [x] No navigation changes needed - this adds a card to an existing page, not a new page

## Additional notes
This is a docs-only listing (a `<Card>` entry), not a published `langchain-microscrape` PyPI package, so it intentionally does not touch `python-tools-downloads.mdx`, `integration_external_docs.yaml`, or the finance tools table in `integrations/tools/index.mdx` - those track packages that are actually published to PyPI, which this is not (matching how NodeProxy/Skim/x402 are also card-only entries without those files being touched).