### PR TITLE
docs(mda): link to prebuilt middleware docs

### DIFF
--- a/src/langsmith/managed-deep-agents-middleware.mdx
+++ b/src/langsmith/managed-deep-agents-middleware.mdx
@@ -47,7 +47,7 @@ For deeper hook, state, and context details, see [custom middleware](/oss/langch
 
 ## Use prebuilt middleware
 
-You can use [LangChain prebuilt middleware](/oss/langchain/middleware/built-in) directly in the agent definition.
+You can use LangChain [prebuilt middleware](/oss/langchain/middleware/built-in) directly in the agent definition.
 
 :::python
 ```python agent.py

--- a/src/langsmith/managed-deep-agents-middleware.mdx
+++ b/src/langsmith/managed-deep-agents-middleware.mdx
@@ -47,7 +47,7 @@ For deeper hook, state, and context details, see [custom middleware](/oss/langch
 
 ## Use prebuilt middleware
 
-You can use LangChain prebuilt middleware directly in the agent definition.
+You can use [LangChain prebuilt middleware](/oss/langchain/middleware/built-in) directly in the agent definition.
 
 :::python
 ```python agent.py


### PR DESCRIPTION
Link "prebuilt middleware" to the prebuilt middleware documentation.
