### PR TITLE
fix: document MDA delete filesystem tool

### DIFF
--- a/src/langsmith/managed-deep-agents-sandboxes.mdx
+++ b/src/langsmith/managed-deep-agents-sandboxes.mdx
@@ -94,7 +94,7 @@ Use `idleTtlSeconds` to control when an idle sandbox can be reclaimed. Use `defa
 
 ## How the agent uses the sandbox
 
-The agent uses filesystem tools such as `ls`, `read_file`, `write_file`, `edit_file`, `glob`, and `grep`, and runs shell commands with `execute`. Use `instructions.md` to specify where the agent should work and what it must not modify.
+The agent uses filesystem tools such as `ls`, `read_file`, `write_file`, `edit_file`, `delete`, `glob`, and `grep`, and runs shell commands with `execute`. Use `instructions.md` to specify where the agent should work and what it must not modify.
 
 ## Sandbox lifecycle
 


### PR DESCRIPTION
## Description
Add the supported `delete` operation to the Managed Deep Agents sandbox filesystem-tool inventory while leaving the narrower memory-tool list unchanged.

## Test Plan
- [x] Verify the sandbox inventory matches the current MDA backend surface.

Made by [Open SWE](https://openswe.vercel.app/agents/80bf7834-2d3a-ec03-c4d9-36d84b664cb2)