### PR TITLE
[navigation] retrieval nav links point to redirect sources instead of canonical URLs

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -423,7 +423,7 @@
                               "oss/python/langchain/multi-agent/custom-workflow"
                             ]
                           },
-                          "oss/python/langchain/retrieval",
+                          "oss/python/deepagents/retrieval",
                           "oss/python/langchain/long-term-memory"
                         ]
                       },
@@ -976,7 +976,7 @@
                               "oss/javascript/langchain/multi-agent/custom-workflow"
                             ]
                           },
-                          "oss/javascript/langchain/retrieval",
+                          "oss/javascript/deepagents/retrieval",
                           "oss/javascript/langchain/long-term-memory"
                         ]
                       },


### PR DESCRIPTION
Two entries in the sidebar navigation (`src/docs.json`) point to pages that
immediately redirect the user elsewhere:

- `oss/python/langchain/retrieval` redirects to `/oss/python/deepagents/retrieval`
- `oss/javascript/langchain/retrieval` redirects to `/oss/javascript/deepagents/retrieval`

The content was moved to the `deepagents/` path and redirects were added
correctly, but the navigation was not updated. Every user clicking the nav
link gets an unnecessary redirect hop instead of landing directly on the
canonical page.

Fix: update the 2 nav entries in `src/docs.json` to point directly to
`oss/python/deepagents/retrieval` and `oss/javascript/deepagents/retrieval`.
Verified with a full pipeline build (no warnings, JSON valid). Fix ready.