### PR TITLE
[deepagents]: em dashes in backends.mdx use spaces (violates LangChain.DashesSpaces Vale rule)

### DIFF
--- a/src/oss/deepagents/backends.mdx
+++ b/src/oss/deepagents/backends.mdx
@@ -296,25 +296,25 @@ NamespaceFactory = Callable[[Runtime], tuple[str, ...]]
 ```
 
 The `Runtime` provides:
-- `rt.context` — User-supplied context passed via LangGraph's [context schema](https://langchain-ai.github.io/langgraph/concepts/runtime/) (for example, `user_id`)
+- `rt.context`—User-supplied context passed via LangGraph's [context schema](https://langchain-ai.github.io/langgraph/concepts/runtime/) (for example, `user_id`)
 :::python
-- `rt.server_info` — Server-specific metadata when running on LangGraph Server (assistant ID, graph ID, authenticated user)
-- `rt.execution_info` — Execution identity information (thread ID, run ID, checkpoint ID)
+- `rt.server_info`—Server-specific metadata when running on LangGraph Server (assistant ID, graph ID, authenticated user)
+- `rt.execution_info`—Execution identity information (thread ID, run ID, checkpoint ID)
 :::
 :::js
-- `rt.serverInfo` — Server-specific metadata when running on LangGraph Server (assistant ID, graph ID, authenticated user)
-- `rt.executionInfo` — Execution identity information (thread ID, run ID, checkpoint ID)
+- `rt.serverInfo`—Server-specific metadata when running on LangGraph Server (assistant ID, graph ID, authenticated user)
+- `rt.executionInfo`—Execution identity information (thread ID, run ID, checkpoint ID)
 :::
 
 :::python
 <Note>
-The `Runtime` argument is available in `deepagents>=0.5.2`. Earlier 0.5.x releases passed a `BackendContext` instead — see [migrating from `BackendContext`](#migrating-from-backendcontext) below. `rt.server_info` and `rt.execution_info` require `deepagents>=0.5.0`.
+The `Runtime` argument is available in `deepagents>=0.5.2`. Earlier 0.5.x releases passed a `BackendContext` instead—see [migrating from `BackendContext`](#migrating-from-backendcontext) below. `rt.server_info` and `rt.execution_info` require `deepagents>=0.5.0`.
 </Note>
 :::
 
 :::js
 <Note>
-The `Runtime` argument is available in `deepagents>=1.9.1`. Earlier 1.9.x releases passed a `BackendContext` instead — see [migrating from `BackendContext`](#migrating-from-backendcontext) below. `rt.serverInfo` and `rt.executionInfo` require `deepagents>=1.9.0`.
+The `Runtime` argument is available in `deepagents>=1.9.1`. Earlier 1.9.x releases passed a `BackendContext` instead—see [migrating from `BackendContext`](#migrating-from-backendcontext) below. `rt.serverInfo` and `rt.executionInfo` require `deepagents>=1.9.0`.
 </Note>
 :::
 
@@ -366,7 +366,7 @@ const backend = new StoreBackend({
 ```
 :::
 
-You can combine multiple components to create more specific scopes — for example, `(user_id, thread_id)` for per-user per-conversation isolation, or append a suffix like `"filesystem"` to disambiguate when the same scope uses multiple store namespaces.
+You can combine multiple components to create more specific scopes—for example, `(user_id, thread_id)` for per-user per-conversation isolation, or append a suffix like `"filesystem"` to disambiguate when the same scope uses multiple store namespaces.
 
 Namespace components must contain only alphanumeric characters, hyphens, underscores, dots, `@`, `+`, colons, and tildes. Wildcards (`*`, `?`) are rejected to prevent glob injection.
 
@@ -450,7 +450,7 @@ Set `LANGSMITH_API_KEY` before using `ContextHubBackend`.
 
 :::js
 - Pass a backend instance to `createDeepAgent({ backend: ... })`. The filesystem middleware uses it for all tooling.
-- The backend must implement `AnyBackendProtocol` (`BackendProtocolV1` or `BackendProtocolV2`) — for example, `new StateBackend()`, `new FilesystemBackend({ rootDir: "." })`, `new StoreBackend()`.
+- The backend must implement `AnyBackendProtocol` (`BackendProtocolV1` or `BackendProtocolV2`)—for example, `new StateBackend()`, `new FilesystemBackend({ rootDir: "." })`, `new StoreBackend()`.
 - If omitted, the default is `new StateBackend()`.
 
 <Note>
@@ -544,7 +544,7 @@ Implement @[`BackendProtocol`] (`BackendProtocolV2`) and provide the following m
 
 To also support the `execute` tool (running shell commands), implement @[`SandboxBackendProtocol`] instead, which extends `BackendProtocolV2` with an `execute` method.
 
-All methods must return structured Result objects with an optional `error` field — do not throw on missing files or invalid patterns.
+All methods must return structured Result objects with an optional `error` field—do not throw on missing files or invalid patterns.
 :::
 
 <Accordion title="Example: S3-style backend skeleton">
@@ -988,7 +988,7 @@ In `deepagents>=0.5.2` (Python) and `deepagents>=1.9.1` (TypeScript), namespace 
 **What changed:**
 
 - The factory argument is now a `Runtime`, not a `BackendContext`.
-- Drop the `.runtime` accessor — for example, `ctx.runtime.context.user_id` becomes `rt.server_info.user.identity`.
+- Drop the `.runtime` accessor—for example, `ctx.runtime.context.user_id` becomes `rt.server_info.user.identity`.
 - There is no direct replacement for `ctx.state`. Namespace info should be read-only and stable for the lifetime of a run, whereas state is mutable and changes step-to-step—deriving a namespace from it risks data ending up under inconsistent keys. If you have a use case that requires reading agent state, please [open an issue](https://github.com/langchain-ai/deepagents/issues).
 
 :::python
@@ -1038,10 +1038,10 @@ Required methods:
     - Enforce uniqueness of `old_string` unless `replace_all=True`. If not found, return error. Include `occurrences` on success.
 
 Supporting types:
-- `LsResult(error, entries)` — `entries` is a `list[FileInfo]` on success, `None` on failure.
-- `ReadResult(error, file_data)` — `file_data` is a `FileData` dict on success, `None` on failure.
-- `GrepResult(error, matches)` — `matches` is a `list[GrepMatch]` on success, `None` on failure.
-- `GlobResult(error, matches)` — `matches` is a `list[FileInfo]` on success, `None` on failure.
+- `LsResult(error, entries)`—`entries` is a `list[FileInfo]` on success, `None` on failure.
+- `ReadResult(error, file_data)`—`file_data` is a `FileData` dict on success, `None` on failure.
+- `GrepResult(error, matches)`—`matches` is a `list[GrepMatch]` on success, `None` on failure.
+- `GlobResult(error, matches)`—`matches` is a `list[FileInfo]` on success, `None` on failure.
 - `WriteResult(error, path, files_update)`
 - `EditResult(error, path, files_update, occurrences)`
 - `FileInfo` with fields: `path` (required), optionally `is_dir`, `size`, `modified_at`.
@@ -1077,8 +1077,8 @@ Backends implement `BackendProtocolV2`. All query methods return structured Resu
 
 ### Optional methods
 
-- **`uploadFiles(files: Array<[string, Uint8Array]>) → FileUploadResponse[]`** — Upload multiple files (for sandbox backends).
-- **`downloadFiles(paths: string[]) → FileDownloadResponse[]`** — Download multiple files (for sandbox backends).
+- **`uploadFiles(files: Array<[string, Uint8Array]>) → FileUploadResponse[]`**—Upload multiple files (for sandbox backends).
+- **`downloadFiles(paths: string[]) → FileDownloadResponse[]`**—Download multiple files (for sandbox backends).
 
 ### Result types
 
@@ -1094,16 +1094,16 @@ Backends implement `BackendProtocolV2`. All query methods return structured Resu
 
 ### Supporting types
 
-- **`FileInfo`** — `path` (required), optionally `is_dir`, `size`, `modified_at`.
-- **`GrepMatch`** — `path`, `line` (1-indexed), `text`.
-- **`FileData`** — File content with timestamps. See [FileData format](#filedata-format).
+- **`FileInfo`**—`path` (required), optionally `is_dir`, `size`, `modified_at`.
+- **`GrepMatch`**—`path`, `line` (1-indexed), `text`.
+- **`FileData`**—File content with timestamps. See [FileData format](#filedata-format).
 
 ### Sandbox extension
 
 `SandboxBackendProtocolV2` extends `BackendProtocolV2` with:
 
-- **`execute(command: string) → ExecuteResponse`** — Run a shell command in the sandbox.
-- **`readonly id: string`** — Unique identifier for the sandbox instance.
+- **`execute(command: string) → ExecuteResponse`**—Run a shell command in the sandbox.
+- **`readonly id: string`**—Unique identifier for the sandbox instance.
 :::
 
 :::js


### PR DESCRIPTION
`src/oss/deepagents/backends.mdx` contains 22 em dashes written as
`word — word` (with surrounding spaces), which violates the
`LangChain.DashesSpaces` Vale rule enforced by `make lint_prose` (CI).

Per AGENTS.md: "Add spaces around em dashes — write word—word not
word — word (make lint_prose enforces this)."

Fix: replace all 22 instances of ` — ` with `—` in prose lines
(the 2 instances inside code block comments are untouched).
1 file changed, 23 lines. Pipeline build clean. Fix ready.