### PR TITLE
docs: backfill self-hosted release notes dropped by the changelog bot

### DIFF
--- a/src/langsmith/self-hosted-changelog.mdx
+++ b/src/langsmith/self-hosted-changelog.mdx
@@ -14,7 +14,7 @@ rss: true
 <Update label="2026-08-16" tags={["self-hosted"]} rss={{ title: "2026-08-16 - self-hosted" }}>
 ## langsmith-0.16.7
 
-- Internal improvements and maintenance updates
+- LangSmith workers using Microsoft Entra ID authentication for standalone Redis started successfully and continued refreshing credentials after the event loop starts.
 
 **Download the Helm chart:** [`langsmith-0.16.7.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.16.7/langsmith-0.16.7.tgz)
 {/* langsmith-release-image: 0.16.7 0.16.38 */}
@@ -77,7 +77,7 @@ rss: true
 <Update label="2026-08-11" tags={["self-hosted"]} rss={{ title: "2026-08-11 - self-hosted" }}>
 ## langsmith-0.16.2
 
-- Internal improvements and maintenance updates
+- Self-hosted Fleet agents can use sandbox-backed computer access without requiring a cloud billing plan tier.
 
 **Download the Helm chart:** [`langsmith-0.16.2.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.16.2/langsmith-0.16.2.tgz)
 {/* langsmith-release-image: 0.16.2 0.16.36 */}
@@ -176,7 +176,11 @@ If you want to book time for your upgrade, feel free to contact LangChain suppor
 <Update label="2026-08-04" tags={["self-hosted"]} rss={{ title: "2026-08-04 - self-hosted" }}>
 ## langsmith-0.16.0-rc.29
 
-- Internal improvements and maintenance updates
+- Dataset and run attachments resolved relative signed download URLs before previewing, opening, or downloading them in self-hosted deployments.
+- Fixed dynamic client registration for the LangSmith MCP server so that clients requesting a confidential authentication method are issued a public client instead of an error.
+- Online self-hosted installations reported finalized sandbox uptime and resource usage for billing when phone-home usage reporting is enabled. Offline and opted-out installations do not send sandbox usage.
+- Self-hosted LangSmith enabled sandbox API and UI access only when the deployment license includes sandbox access.
+- Added Redis CPU and memory requests and limits to self-hosted deployment forms, applied to the Redis workload managed by the Kubernetes operator.
 
 **Download the Helm chart:** [`langsmith-0.16.0-rc.29.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.16.0-rc.29/langsmith-0.16.0-rc.29.tgz)
 {/* langsmith-release-image: 0.16.0-rc.29 0.16.33rc1 */}
@@ -185,7 +189,10 @@ If you want to book time for your upgrade, feel free to contact LangChain suppor
 <Update label="2026-08-04" tags={["self-hosted"]} rss={{ title: "2026-08-04 - self-hosted" }}>
 ## langsmith-0.16.0-rc.28
 
-- Internal improvements and maintenance updates
+- Correcting an evaluator score from the experiment results grid updated the cell and its popover immediately, without requiring a page refresh.
+- Engine run webhooks and sandbox links resolved the externally reachable API base from `LANGSMITH_PUBLIC_API_ENDPOINT`, falling back to `LANGCHAIN_PLATFORM_ENDPOINT` and then `LANGCHAIN_ENDPOINT`. Installations that set only `LANGSMITH_PUBLIC_API_ENDPOINT` previously built relative URLs, which caused every non-shadow Engine run to fail.
+- Added a streaming sandbox execute request that returns stdout and stderr as Server-Sent Events, for clients that cannot hold a WebSocket. Passing a command ID reuses a running command, and a separate resume request continues an interrupted stream.
+- Self-hosted deployments with an online license key showed the monthly organization usage graph automatically, without the `enable_monthly_usage_charts` organization config. Offline deployments now point to the Granular usage tab for locally recorded billable usage.
 
 **Download the Helm chart:** [`langsmith-0.16.0-rc.28.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.16.0-rc.28/langsmith-0.16.0-rc.28.tgz)
 {/* langsmith-release-image: 0.16.0-rc.28 0.16.32rc1 */}
@@ -194,7 +201,8 @@ If you want to book time for your upgrade, feel free to contact LangChain suppor
 <Update label="2026-08-01" tags={["self-hosted"]} rss={{ title: "2026-08-01 - self-hosted" }}>
 ## langsmith-0.16.0-rc.27
 
-- Internal improvements and maintenance updates
+- The Configure Evaluator pane header and templates navigation painted the same background as the pane itself in dark mode.
+- Self-hosted deployments caught up missing tracing project last-run timestamps, so project sorting reflects recent historical activity.
 
 **Download the Helm chart:** [`langsmith-0.16.0-rc.27.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.16.0-rc.27/langsmith-0.16.0-rc.27.tgz)
 {/* langsmith-release-image: 0.16.0-rc.27 0.16.31rc1 */}
@@ -221,7 +229,12 @@ If you want to book time for your upgrade, feel free to contact LangChain suppor
 <Update label="2026-07-31" tags={["self-hosted"]} rss={{ title: "2026-07-31 - self-hosted" }}>
 ## langsmith-0.16.0-rc.24
 
-- Internal improvements and maintenance updates
+- Tracing project activity and sorting stayed up to date for self-hosted deployments using Redis versions before 6.2.
+- Dataset example views restored clear spacing between the example details and tab navigation.
+- The evaluator onboarding navigation matched the background of the surrounding pane.
+- The evaluator spend view listed only gateway-routed providers as tracked.
+- Metadata columns in the experiment comparison grid, including `example.metadata.<key>`, rendered their values instead of staying empty.
+- Uploading a `.csv` or `.jsonl` dataset worked regardless of the Content-Type reported by the browser. Windows browsers label `.csv` files as an Excel type, which previously caused valid uploads to fail. Uppercase filenames such as `DATASET.CSV` are also accepted.
 
 **Download the Helm chart:** [`langsmith-0.16.0-rc.24.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.16.0-rc.24/langsmith-0.16.0-rc.24.tgz)
 {/* langsmith-release-image: 0.16.0-rc.24 0.16.28rc1 */}
@@ -230,7 +243,8 @@ If you want to book time for your upgrade, feel free to contact LangChain suppor
 <Update label="2026-07-31" tags={["self-hosted"]} rss={{ title: "2026-07-31 - self-hosted" }}>
 ## langsmith-0.16.0-rc.23
 
-- Internal improvements and maintenance updates
+- Updated the `langsmith` CLI in sandboxes to v0.2.44. Its requests now resolve on self-hosted deployments that serve the API under `/api`, where commands such as `trace messages` and the project issues commands previously failed.
+- Negative feedback-key filters returned matching traces correctly when ClickHouse uses optimized runs tables.
 
 **Download the Helm chart:** [`langsmith-0.16.0-rc.23.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.16.0-rc.23/langsmith-0.16.0-rc.23.tgz)
 {/* langsmith-release-image: 0.16.0-rc.23 0.16.27rc1 */}
@@ -239,7 +253,7 @@ If you want to book time for your upgrade, feel free to contact LangChain suppor
 <Update label="2026-07-29" tags={["self-hosted"]} rss={{ title: "2026-07-29 - self-hosted" }}>
 ## langsmith-0.16.0-rc.22
 
-- Internal improvements and maintenance updates
+- The Granular usage page showed a notice that long-lived trace usage is not tracked in self-hosted deployments, so the Long-lived only filter is expected to return zero results.
 
 **Download the Helm chart:** [`langsmith-0.16.0-rc.22.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.16.0-rc.22/langsmith-0.16.0-rc.22.tgz)
 {/* langsmith-release-image: 0.16.0-rc.22 0.16.25rc1 */}
@@ -284,7 +298,7 @@ If you want to book time for your upgrade, feel free to contact LangChain suppor
 <Update label="2026-07-27" tags={["self-hosted"]} rss={{ title: "2026-07-27 - self-hosted" }}>
 ## langsmith-0.17.0-rc.1
 
-- Internal improvements and maintenance updates
+- Engine worked in supported self-hosted deployments without Eppo rollout configuration, while organization enablement and existing permissions remain enforced.
 
 **Download the Helm chart:** [`langsmith-0.17.0-rc.1.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.17.0-rc.1/langsmith-0.17.0-rc.1.tgz)
 {/* langsmith-release-image: 0.17.0-rc.1 0.17.1-ed94ed999b0247a39e3b5942ce6fcd1024ecaec7 */}
@@ -329,7 +343,16 @@ If you want to book time for your upgrade, feel free to contact LangChain suppor
 <Update label="2026-07-25" tags={["self-hosted"]} rss={{ title: "2026-07-25 - self-hosted" }}>
 ## langsmith-0.16.0-rc.16
 
-- Internal improvements and maintenance updates
+- Giving feedback on a thread annotation queue item recorded the last reviewed time using the queue membership ID, so review progress is saved for both runs and threads.
+- The LLM Gateway spend chart and table labeled spend from service keys as "Unaffiliated with any user" instead of showing a blank name, with a tooltip explaining that the spend came from a workspace-scoped or organization-scoped key.
+- Hybrid deployments remained compatible with older listeners during control plane upgrades, preventing new deployments from staying queued.
+- The Spend share column on the LLM Gateway monitoring spend dashboard no longer cut off its header text.
+- Stat card and table headers in the Spend tab of the LLM Gateway monitoring page capitalized every word, matching the header style used elsewhere.
+- Selecting a specific start and end date in the LLM Gateway monitoring date range picker showed the dates in UTC and appended "(UTC)" to the button. Relative ranges such as Last 7 days are unaffected.
+- Fresh deployments tolerated an unmigrated billing configuration.
+- Custom output renderer URLs were restricted to HTTPS.
+- Fixed routing for `/api/v1/info` in single-origin deployments.
+- Bulk-adding runs from a tracing project listed the default dataset of that project first in the dataset picker.
 
 **Download the Helm chart:** [`langsmith-0.16.0-rc.16.tgz`](https://github.com/langchain-ai/helm/releases/download/langsmith-0.16.0-rc.16/langsmith-0.16.0-rc.16.tgz)
 {/* langsmith-release-image: 0.16.0-rc.16 0.16.21-320f1d6ced0904aa8b9af51fc6d6bd346df16c6e */}


### PR DESCRIPTION
## Why

Ten self-hosted releases published with only the `Internal improvements and maintenance updates` placeholder even though they shipped real customer-facing changes. This restores 33 notes.

**Root cause:** the deployed `helm-changelog-bot` runs code from before 2026-06-25, so it only scrapes the legacy `## Self-Hosted Release Note` PR-body section. Three features merged that day were never deployed (the repo has no CI, deploys are manual):

- `f3cd4f3` read `.changelog/*.yaml` fragments
- `2537c64` PR-title fallback for fragment-less PRs
- `2bbda07` honor the `skip-changelog` label

As `langchainplus` migrated to fragments, every fragment-sourced note was silently dropped. Evidence: langsmith-0.16.1 published the polished *legacy* Release Note from langchainplus#33020, not that PR's fragment body.

## What changed

Notes re-derived from the fragments and PR titles, following the resolution order in the bot's current `main`.

| Release | Notes restored |
|---|---|
| 0.16.7 | 1 |
| 0.16.2 | 1 |
| 0.16.0-rc.29 | 5 |
| 0.16.0-rc.28 | 4 |
| 0.16.0-rc.27 | 2 |
| 0.16.0-rc.24 | 6 |
| 0.16.0-rc.23 | 2 |
| 0.16.0-rc.22 | 1 |
| 0.16.0-rc.16 | 10 |
| 0.17.0-rc.1 | 1 |

The fix propagates through the image-dedup links: 0.16.3 and 0.16.4 point at 0.16.2, and 0.17.0-rc.2 through rc.6 point at 0.17.0-rc.1.

## Please review carefully

**Wording.** These were condensed from fragment bodies by hand, not by the bot's LLM polish step. Past tense per the changelog's established voice.

**Deliberate exclusions:**

- Two `status: held` fragments still gated behind Eppo flags (`forge_issue_board_enabled` on 0.16.0-rc.29, `threads_aq` on 0.17.0-rc.1). Worth noting the bot does not check `status` at all, so once redeployed it would publish gated features early.
- Notes referencing SmithDB, which was not available for self-hosted at those versions. Matches `SELF_HOSTED_EXCLUDED_TERMS` and the precedent in #4476.
- Raw internal PR titles with no customer meaning (CI pinning, token minting, service co-hosting, internal flag gating).

**Untouched and correct:** 0.16.5, 0.16.0-rc.25, rc.20, rc.18, 0.15.17, and 0.15.16 shipped only chore bumps or opted-out PRs, so their placeholders are accurate.

## Follow-up outside this PR

1. Redeploy the bot from `main`, and add deploy automation so merges cannot silently fail to ship again.
2. Teach `get_pr_release_notes` to skip fragments where `status != "ready"`.
3. Backport PRs into `v16-stable` carry `self_hosted: false` fragments authored for Cloud (langchainplus#33187, #33719, and six rc.16 PRs), so genuinely self-hosted changes are marked Cloud-only.
4. Security fixes are being labeled `skip-changelog` (langchainplus#33480, vulnerable Python dependency bumps). Self-hosted operators generally want those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
