### PR TITLE
docs(langsmith): document the Threads item type for automation rules

### DIFF
--- a/src/langsmith/administration-overview.mdx
+++ b/src/langsmith/administration-overview.mdx
@@ -254,7 +254,7 @@ Retention behavior by action:
 
 * **Feedback via API or SDK**: Feedback is added to any run on the trace (or any trace in the thread) through an API or SDK call that explicitly passes `extend_trace_retention=true` (`extendTraceRetention: true` in TypeScript). For more information, see [Attach user feedback](/langsmith/attach-user-feedback). The LangSmith UI sends feedback and notes without extending retention.
 * **Online evaluators**: An online evaluator scores the trace and its retention setting is enabled. Both trace-level and thread-level evaluators can opt out of this upgrade.
-* **Automation rules**: An [automation rule](/langsmith/rules#create-a-rule) with retention extension enabled matches any run within a trace.
+* **Automation rules**: An [automation rule](/langsmith/rules#create-a-rule) with retention extension enabled matches any run within a trace. Matching a single run upgrades the entire trace, not just that run. A rule whose [item type](/langsmith/rules#set-the-item-type-to-runs-or-threads) is **Threads** upgrades every trace in the matched thread, not only the most recent one.
 * **Manual annotation queue adds** (no upgrade): Manually adding runs or threads to an [annotation queue](/langsmith/annotation-queues#assign-runs-and-threads-to-a-single-run-queue) does not upgrade retention by default.
 
 This change applies to new actions only. Traces that were already upgraded by a previous action keep their extended retention.

--- a/src/langsmith/annotation-queues.mdx
+++ b/src/langsmith/annotation-queues.mdx
@@ -33,7 +33,7 @@ Run items and thread items support different capabilities:
 | Assertions | Yes | No |
 | Add to Dataset | Yes | No |
 | Default dataset | Yes | No |
-| Automation rules | Yes | No |
+| Automation rules | Yes | Yes |
 
 ### Create a single-run queue
 
@@ -151,10 +151,10 @@ There are several ways to populate a single-run queue with items:
       alt="Threads tab with selected threads and the Add to Annotation Queue bulk action."
     />
 
-- **Automation rules**: [Set up a rule](/langsmith/rules) to automatically assign **runs** that match a filter (for example, errors or low user scores) into a queue.
+- **Automation rules**: [Set up a rule](/langsmith/rules) to automatically assign **runs** or **threads** that match a filter (for example, errors or low user scores) into a queue.
 
     <Note>
-    Automation rules enqueue run items only. They do not add entire threads as thread items.
+    What a rule enqueues depends on its [item type](/langsmith/rules#set-the-item-type-to-runs-or-threads). A rule whose item type is **Runs** enqueues run items. A rule whose item type is **Threads** enqueues the entire conversation as a thread item, once the thread goes idle.
     </Note>
 - **Datasets & Experiments**: Select one or more [experiments](/langsmith/evaluation-concepts#experiment) within a dataset and click **<Icon icon="pencil"/> Annotate**. Select **Add to Annotation Queue**, then choose an existing queue or create a new one. Experiment annotate flows add run items.
 
@@ -173,7 +173,7 @@ There are several ways to populate a single-run queue with items:
 <Note>
 You can add at most **100** runs or threads to an annotation queue in a single action. To enqueue more, repeat the add flow in batches of 100 or fewer.
 
-Manually adding runs or threads to an annotation queue does not change trace retention by default. The trace keeps the retention configured for its project unless another action explicitly extends retention. For the full retention model, see [data retention auto-upgrades](/langsmith/usage-and-billing#data-retention-auto-upgrades).
+Manually adding runs or threads to an annotation queue does not change trace retention by default. The trace keeps the retention configured for its project unless another action explicitly extends retention. Adds performed by an [automation rule](/langsmith/rules) are different: the rule's **Extend Data Retention** toggle is enabled by default for annotation queue actions. A run rule upgrades the whole trace that contains each matched run, and a thread rule upgrades every trace in the matched thread. For the full retention model, see [data retention auto-upgrades](/langsmith/usage-and-billing#data-retention-auto-upgrades).
 </Note>
 
 ### Review a single-run queue

--- a/src/langsmith/online-evaluations-multi-turn.mdx
+++ b/src/langsmith/online-evaluations-multi-turn.mdx
@@ -47,9 +47,12 @@ Please refer to the [troubleshooting](/langsmith/online-evaluations-multi-turn#t
 4. Apply **Filters** or a **Sampling Rate**. <br />
 Use filters or sampling to control evaluator cost. For example, evaluate only threads under *N* turns or sample 10% of all threads.
 5. **Configure an idle time**. <br />
-The first time you configure a thread level evaluator, you'll define the idle time—the amount of time after the last trace in a thread before it's considered complete and ready for evaluation. This value should reflect the expected length of user interactions in your app. It applies across all evaluators in the project.
+The first time you configure a thread-level evaluator, you can define the idle time, the amount of time after the last trace in a thread before it is considered complete and ready for evaluation. This value should reflect the expected length of user interactions in your app. The idle time defaults to 10 minutes and cannot be set below 2 minutes.
+<Note>
+The idle time is a project-level setting. It applies to every thread-level evaluator in the project and to every [automation rule](/langsmith/rules#set-the-thread-idle-time) whose item type is **Threads**.
+</Note>
 <Tip>
-When first testing your evaluator, use a short idle time so you can see results quickly. Once validated, increase it to match the expected length of user interactions.
+When first testing your evaluator, use a short idle time so you can see results quickly, subject to the 2-minute minimum. Once validated, increase it to match the expected length of user interactions.
 </Tip>
 6. **Configure your model.**<br />
 Select the provider and model you want to use for your evaluator. Threads tend to get long, so you should use a model with a higher context window in order to avoid running into limits. For example, OpenAI's GPT-5.4 mini or Gemini 2.5 Flash are good options as they both have 1M+ token context windows.
@@ -73,10 +76,10 @@ After saving, your evaluator will appear in the **Evaluators** tab. You can test
 
 ## Limits
 
-These are the current limits for multi-turn online evaluators (subject to change). Please reach out if you are running into any of these limits.
+These are the current limits for thread-level processing (subject to change). They apply to multi-turn online evaluators and to [automation rules](/langsmith/rules#set-the-item-type-to-runs-or-threads) whose item type is **Threads**. Reach out if you are running into any of these limits.
 
 - **Runs must be less than one week old**: When a thread becomes idle, only runs within the past 7 days are eligible for evaluation.
-- **Maximum of 500 threads evaluated at once**: If you have more than 500 threads marked as idle in a five minute period, we will automatically sample beyond 500.
+- **Maximum of 500 threads processed at once**: A single execution processes at most 500 matching threads, ordered by most recent activity.
 - **Maximum of 10 multi-turn online evaluators per workspace**
 
 ## Troubleshooting

--- a/src/langsmith/online-evaluations-multi-turn.mdx
+++ b/src/langsmith/online-evaluations-multi-turn.mdx
@@ -44,35 +44,41 @@ Please refer to the [troubleshooting](/langsmith/online-evaluations-multi-turn#t
 1. Navigate to the **Tracing** page and select a tracing project.
 2. Click the **Evaluators** tab, then click **+ Evaluator**. Select **LLM-as-a-Judge Evaluator** under **Create from scratch**. Under **Source**, select **Threads**.
 3. **Name your evaluator**.
-4. Apply **Filters** or a **Sampling Rate**. <br />
-Use filters or sampling to control evaluator cost. For example, evaluate only threads under *N* turns or sample 10% of all threads.
-5. **Configure an idle time**. <br />
-The first time you configure a thread-level evaluator, you can define the idle time, the amount of time after the last trace in a thread before it is considered complete and ready for evaluation. This value should reflect the expected length of user interactions in your app. The idle time defaults to 10 minutes and cannot be set below 2 minutes.
-<Note>
-The idle time is a project-level setting. It applies to every thread-level evaluator in the project and to every [automation rule](/langsmith/rules#set-the-thread-idle-time) whose item type is **Threads**.
-</Note>
-<Tip>
-When first testing your evaluator, use a short idle time so you can see results quickly, subject to the 2-minute minimum. Once validated, increase it to match the expected length of user interactions.
-</Tip>
-6. **Configure your model.**<br />
-Select the provider and model you want to use for your evaluator. Threads tend to get long, so you should use a model with a higher context window in order to avoid running into limits. For example, OpenAI's GPT-5.4 mini or Gemini 2.5 Flash are good options as they both have 1M+ token context windows.
+4. Apply **Filters** or a **Sampling Rate**.
 
-7. **Configure your LLM-as-a-judge prompt.**<br />
-Define what you want to evaluate. This prompt will be used to evaluate the thread. You can also configure which parts of the assembled conversation are passed to the evaluator through the `all_messages` variable to control the content it receives:
-    - All messages: Send the full conversation as a list of JSON message objects in OpenAI chat format (`{"role": ..., "content": ...}`), with each message rendered as indented JSON and separated by a blank line.
-    - Human and AI pairs: Send only user and assistant messages, formatted as `<user>...</user>` and `<assistant>...</assistant>` and excluding system messages, tool calls, and other roles.
-    - First human and last AI: Send only the first user message and the last assistant reply.
+    Use filters or sampling to control evaluator cost. For example, evaluate only threads under *N* turns or sample 10% of all threads.
+5. **Configure an idle time**.
 
-9. **Set up your feedback configuration**.<br />
-Configure a name for the feedback key, the format for the feedback you want to collect and optionally enable reasoning on the feedback.
+    The first time you configure a thread-level evaluator, you can define the idle time, the amount of time after the last trace in a thread before it is considered complete and ready for evaluation. This value should reflect the expected length of user interactions in your app. The idle time defaults to 10 minutes and cannot be set below 2 minutes.
+    <Note>
+    The idle time is a project-level setting. It applies to every thread-level evaluator in the project and to every [automation rule](/langsmith/rules#set-the-thread-idle-time) whose item type is **Threads**.
+    </Note>
+    <Tip>
+    When first testing your evaluator, use a short idle time so you can see results quickly, subject to the 2-minute minimum. Once validated, increase it to match the expected length of user interactions.
+    </Tip>
 
-<Warning>
-We don't recommend using the same feedback key for a thread-level evaluator and a run-level evaluator as it can be hard to distinguish between the two.
-</Warning>
+6. **Configure your model.**
 
-8. **Save your evaluator.**
+    Select the provider and model you want to use for your evaluator. Threads tend to get long, so you should use a model with a higher context window in order to avoid running into limits. For example, OpenAI's GPT-5.4 mini or Gemini 2.5 Flash are good options as they both have 1M+ token context windows.
 
-After saving, your evaluator will appear in the **Evaluators** tab. You can test it once the idle time has passed for any new threads created after saving.
+7. **Configure your LLM-as-a-judge prompt.**
+
+    Define what you want to evaluate. This prompt will be used to evaluate the thread. You can also configure which parts of the assembled conversation are passed to the evaluator through the `all_messages` variable to control the content it receives:
+        - All messages: Send the full conversation as a list of JSON message objects in OpenAI chat format (`{"role": ..., "content": ...}`), with each message rendered as indented JSON and separated by a blank line.
+        - Human and AI pairs: Send only user and assistant messages, formatted as `<user>...</user>` and `<assistant>...</assistant>` and excluding system messages, tool calls, and other roles.
+        - First human and last AI: Send only the first user message and the last assistant reply.
+
+8. **Set up your feedback configuration**.
+
+    Configure a name for the feedback key, the format for the feedback you want to collect and optionally enable reasoning on the feedback.
+
+    <Warning>
+    Using the same feedback key for a thread-level evaluator and a run-level evaluator is **not recommended** as it can be hard to distinguish between the two.
+    </Warning>
+
+9. **Save your evaluator.**
+
+    After saving, your evaluator will appear in the **Evaluators** tab. You can test it once the idle time has passed for any new threads created after saving.
 
 ## Limits
 
@@ -84,10 +90,12 @@ These are the current limits for thread-level processing (subject to change). Th
 
 ## Troubleshooting
 
-**Checking the status of your evaluator** <br />
-You can check when your evaluator was last run by heading to the **Evaluators** tab within a tracing project and clicking the **Logs** button for the evaluator you created to view its run history.
+**Checking the status of your evaluator**
 
-**Inspect the data sent to the evaluator** <br />
-Inspect the data sent to the evaluator by heading to the **Evaluators** tab within a tracing project, clicking on the evaluator you created and clicking the **Evaluator traces** tab.
+    You can check when your evaluator was last run by heading to the **Evaluators** tab within a tracing project and clicking the **Logs** button for the evaluator you created to view its run history.
 
-In this tab, you can see the inputs passed into the LLM-as-a-judge evaluator. If your messages are not being passed in correctly, you will see blank values in the inputs. This can happen if your messages are not formatted in one of [the expected formats](/langsmith/online-evaluations-multi-turn#prerequisites).
+**Inspect the data sent to the evaluator**
+
+    Inspect the data sent to the evaluator by heading to the **Evaluators** tab within a tracing project, clicking on the evaluator you created and clicking the **Evaluator traces** tab.
+
+    In this tab, you can see the inputs passed into the LLM-as-a-judge evaluator. If your messages are not being passed in correctly, you will see blank values in the inputs. This can happen if your messages are not formatted in one of [the expected formats](/langsmith/online-evaluations-multi-turn#prerequisites).

--- a/src/langsmith/rules.mdx
+++ b/src/langsmith/rules.mdx
@@ -9,8 +9,9 @@ Automation rules can trigger actions such as: adding traces to a dataset, adding
 
 - Send all traces with negative feedback to an annotation queue for human review.
 - Send 10% of all traces to an annotation queue for human review to spot check for issues.
+- Send 10% of all conversations to an annotation queue once their threads go idle.
+- Post all traces with a low evaluator score to your webhook endpoint.
 - Upgrade all traces with errors for extended data retention.
-- Send each conversation to an annotation queue once its thread goes idle.
 
 <Info>
 To configure online evaluations, visit the [online evaluations](/langsmith/online-evaluations-llm-as-judge) page.

--- a/src/langsmith/rules.mdx
+++ b/src/langsmith/rules.mdx
@@ -3,13 +3,14 @@ title: Set up automation rules
 sidebarTitle: Set up automation rules
 ---
 
-While you can manually sift through and process production logs from your LLM application, it often becomes difficult as your application scales to more users. LangSmith provides **Automations** that allow you to trigger certain actions on your trace data. You can define an automations by a **filter**, **sampling rate**, and **action**.
+While you can manually sift through and process production logs from your LLM application, it often becomes difficult as your application scales to more users. LangSmith provides **Automations** that allow you to trigger certain actions on your trace data. You define an automation by an **item type**, **filter**, **sampling rate**, and **action**.
 
-Automation rules can trigger actions such as: adding traces to a dataset, adding to an annotation queue, triggering a webhook (e.g., for remote evaluations) or extending data retention. Some examples of automations you can set up:
+Automation rules can trigger actions such as: adding traces to a dataset, adding to an annotation queue, triggering a webhook (for example, for remote evaluations) or extending data retention. A rule matches either individual runs or entire [threads](/langsmith/observability-concepts#threads), depending on the item type you select. Some examples of automations you can set up:
 
 - Send all traces with negative feedback to an annotation queue for human review.
 - Send 10% of all traces to an annotation queue for human review to spot check for issues.
 - Upgrade all traces with errors for extended data retention.
+- Send each conversation to an annotation queue once its thread goes idle.
 
 <Info>
 To configure online evaluations, visit the [online evaluations](/langsmith/online-evaluations-llm-as-judge) page.
@@ -30,40 +31,80 @@ Within a single rule, if multiple actions are configured, they execute in this o
 1. Trigger webhook.
 1. Run online evaluator.
 1. Run custom code evaluator.
+1. Extend data retention.
 1. Trigger alert.
 
 If your workflow requires data produced by one rule to be present when another fires—for example, you want a webhook to include an evaluation score—use a filter on the downstream rule to create that dependency explicitly. For an example, refer to [Ensuring evaluations complete before the webhook fires](/langsmith/webhooks#ensuring-evaluations-complete-before-the-webhook-fires).
 
+## Set the item type to runs or threads
+
+The **Item Type** control determines what a rule matches. Set it to **Runs** and the rule evaluates each matching run as it arrives. Set it to **Threads** and the rule waits until a conversation is complete, then applies its action once to the whole thread. Choose **Threads** when the unit you want to review or export is the full conversation rather than a single turn.
+
+Thread rules require a tracing project that groups traces into threads. For more information, refer to [Configure threads](/langsmith/threads).
+
+### Configure a thread rule
+
+Selecting **Threads** changes three parts of the rule form:
+
+- **Thread Filters**: The filter builder adds **Trace Count** and **Thread ID** to the available fields. Filter on **Trace Count** to scope a rule to conversations of a given length. The other fields evaluate each trace in the thread rather than the thread as a whole, so a thread matches when any of its traces match. For example, a filter on **Status** selects every thread that contains an errored trace, not only threads whose last trace errored.
+- **Action**: The form offers one action, either **Add to Annotation Queue** or **Trigger Webhooks**. **Add to Dataset** is currently not available.
+- **Apply to Past Runs**: Backfill is not currently offered for thread rules.
+
+The two thread actions behave as follows:
+
+- **Add to Annotation Queue**: Adds the thread to the queue as a thread item. Thread items display the conversation transcript and support rubric feedback only. For what differs between run items and thread items, refer to the [annotation queue capability table](/langsmith/annotation-queues#single-run-annotation-queues).
+- **Trigger Webhooks**: Sends a payload whose top-level `threads` array holds every matching thread. For more information, refer to [Read a thread rule payload](/langsmith/webhooks#read-a-thread-rule-payload).
+
+### Set the thread idle time
+
+A thread rule acts only after the thread goes idle. Once the last trace in a thread is ingested, LangSmith waits for the tracing project's configured idle time to elapse, which signals that the conversation is complete. The idle time defaults to 10 minutes and cannot be set below 2 minutes.
+
+The idle time is a project-level setting shared with [multi-turn online evaluators](/langsmith/online-evaluations-multi-turn). Creating the first thread rule on a project applies the default without overwriting a value already set for that project, and changing the value affects every thread evaluator and thread rule in it.
+
+These limits bound what a thread rule processes:
+
+- **Runs must be less than one week old**: When a thread becomes idle, only runs from the past 7 days are eligible.
+- **Maximum of 500 threads per execution**: A single execution processes at most 500 matching threads, ordered by most recent activity.
+
+### Extend data retention for a thread
+
+[Data retention](/langsmith/usage-and-billing#data-retention-auto-upgrades) is a property of a trace, not of a thread. When a thread rule has **Extend Data Retention** enabled, it upgrades **every trace in the matched thread** to extended retention, not only the most recent one.
+
+Because each trace is upgraded individually, a longer conversation costs more to retain. In exchange, the entire conversation is preserved for investigation instead of expiring turn by turn.
+
 ## View automation rules
 
-In the [UI](https://smith.langchain.com), navigate to the **Tracing** in the sidebar and select a tracing project. To view existing automation rules for that tracing project, click on the **Automations** tab.
+In the [UI](https://smith.langchain.com), navigate to **Tracing** in the sidebar and select a tracing project. To view existing automation rules for that tracing project, click on the **Automations** tab.
 
 ## Create a rule
 
-1. In the [UI](https://smith.langchain.com), navigate to the **Tracing** in the sidebar and select a tracing project. Click on **+ New** in the top right corner of the tracing project page, then click on **New Automation**.
+1. In the [UI](https://smith.langchain.com), navigate to **Tracing** in the sidebar and select a tracing project. Click on **+ New** in the top right corner of the tracing project page, then click on **New Automation**.
 1. Name your rule.
+1. Select an **Item Type**, either **Runs** or **Threads**. The item type determines which filter fields and actions are available, so set it before configuring either. For more information, refer to [Set the item type to runs or threads](#set-the-item-type-to-runs-or-threads).
 1. Create a filter. Automation rule filters work the same way as filters applied to traces in the project. For more information on filters, you can refer to [Filter traces](/langsmith/filter-traces-in-application).
-1. Configure a **Sampling Rate** to control the percentage of filtered runs that trigger the automation action. You can specify a sampling rate between 0 and 1 for automations. This will control the percent of the filtered runs that are sent to an automation action. For example, if you set the sampling rate to 0.5, then 50% of the traces that pass the filter will be sent to the action.
-1. (Optional) Apply rule to past runs by toggling the **Apply to past runs** and entering a **Backfill from** date. This is only possible upon rule creation.
+1. Configure a **Sampling Rate** to control what percentage of the filtered items trigger the automation action. The form accepts a percentage from 0 to 100. For example, a sampling rate of 50% sends half of the items that pass the filter to the action. The equivalent API field, `sampling_rate`, takes a decimal from 0 to 1.
+1. (Optional) Apply rule to past runs by toggling the **Apply to Past Runs** and entering a **Backfill From** date. This is only possible upon rule creation, and is not offered for rules whose item type is **Threads**.
 
     <Note>
     The backfill is processed as a background job, so you will not see the results immediately. In order to track progress of the backfill, you can [view logs for your automations](#view-logs-for-your-automations).
     </Note>
 
-1. Select an action to trigger when the rule is applied. There are four actions you can take with an automation rule:
+1. Select an action to trigger when the rule is applied. Rules whose item type is **Runs** offer all of the following actions. Rules whose item type is **Threads** offer **Add to Annotation Queue** and **Trigger Webhooks** only.
 
-    - **Add to dataset**: Add the inputs and outputs of the trace to a [dataset](/langsmith/evaluation-concepts#datasets).
-    - **Add to annotation queue**: Add the matching run/trace to an [annotation queue](/langsmith/annotation-queues) as a **run** item. Automation rules do not enqueue entire [threads](/langsmith/observability-concepts#threads) as thread items; to review a full conversation, add the thread from the UI ([Assign runs and threads](/langsmith/annotation-queues#assign-runs-and-threads-to-a-single-run-queue)).
-    - **Trigger webhook**: Trigger a [webhook](/langsmith/use-webhooks) with the trace data.
-    - **Extend data retention**: Extends the data retention period on matching traces that use base retention [(refer to the data retention docs for more details)](/langsmith/usage-and-billing#data-retention).
+    - **Add to Dataset**: Add the inputs and outputs of the trace to a [dataset](/langsmith/evaluation-concepts#datasets).
+    - **Add to Annotation Queue**: Add the matching run or trace to an [annotation queue](/langsmith/annotation-queues) as a run item. A thread rule adds the entire conversation as a thread item instead. To add a thread by hand, refer to [Assign runs and threads](/langsmith/annotation-queues#assign-runs-and-threads-to-a-single-run-queue).
+    - **Trigger Webhooks**: Post the matched items to every [webhook](/langsmith/webhooks) URL configured on the rule.
+    - **Extend Data Retention**: Extends the data retention period on matching traces that use base retention [(refer to the data retention docs for more details)](/langsmith/usage-and-billing#data-retention).
 
         <Note>
-        Each action has an independent **Extend data retention** toggle that controls whether matching traces are upgraded to extended retention:
+        Each action has an independent **Extend Data Retention** toggle that controls whether matching traces are upgraded to extended retention. The defaults are the same for both item types:
 
-        - **Add to dataset**: opt-in (default: off). Enable the toggle to upgrade matching traces.
-        - **Add to annotation queue**: opt-out (default: on). Disable the toggle to skip upgrading matching traces.
-        - **Trigger webhook**: opt-in (default: off). Enable the toggle to upgrade matching traces.
-        - **Extend data retention** action and online/code evaluators: unchanged; always upgrade matching traces.
+        - **Add to Dataset**: opt-in (default: off). Enable the toggle to upgrade matching traces.
+        - **Add to Annotation Queue**: opt-out (default: on). Disable the toggle to skip upgrading matching traces.
+        - **Trigger Webhooks**: opt-in (default: off). Enable the toggle to upgrade matching traces.
+        - **Extend Data Retention** action and online/code evaluators: unchanged; always upgrade matching traces.
+
+        For a thread rule, an enabled toggle upgrades every trace in the matched thread. For more information, refer to [Extend data retention for a thread](#extend-data-retention-for-a-thread).
 
         The retention toggle for each action is an admin-only control, gated by the [`rules:configure-retention`](/langsmith/organization-workspace-operations#rules) permission. Non-admin workspace members see the toggles as disabled and cannot change them, but can still create and edit rules without affecting retention settings. For the full retention model, refer to [data retention auto-upgrades](/langsmith/usage-and-billing#data-retention-auto-upgrades).
         </Note>

--- a/src/langsmith/rules.mdx
+++ b/src/langsmith/rules.mdx
@@ -8,8 +8,7 @@ While you can manually sift through and process production logs from your LLM ap
 Automation rules can trigger actions such as: adding traces to a dataset, adding to an annotation queue, triggering a webhook (for example, for remote evaluations) or extending data retention. A rule matches either individual runs or entire [threads](/langsmith/observability-concepts#threads), depending on the item type you select. Some examples of automations you can set up:
 
 - Send all traces with negative feedback to an annotation queue for human review.
-- Send 10% of all traces to an annotation queue for human review to spot check for issues.
-- Send 10% of all conversations to an annotation queue once their threads go idle.
+- Send 10% of all traces or threads to an annotation queue for human review to spot check for issues.
 - Post all traces with a low evaluator score to your webhook endpoint.
 - Upgrade all traces with errors for extended data retention.
 

--- a/src/langsmith/usage-and-billing.mdx
+++ b/src/langsmith/usage-and-billing.mdx
@@ -51,7 +51,7 @@ Retention behavior by action:
 
 * **Feedback via API or SDK**: Feedback is added to any run on the trace (or any trace in the thread) through an API or SDK call that explicitly passes `extend_trace_retention=true` (`extendTraceRetention: true` in TypeScript). For more information, see [Attach user feedback](/langsmith/attach-user-feedback). The LangSmith UI sends feedback and notes without extending retention.
 * **Online evaluators**: An online evaluator scores the trace and its retention setting is enabled. Both trace-level and thread-level evaluators can opt out of this upgrade.
-* **Automation rules**: An [automation rule](/langsmith/rules#create-a-rule) with retention extension enabled matches any run within a trace.
+* **Automation rules**: An [automation rule](/langsmith/rules#create-a-rule) with retention extension enabled matches any run within a trace. Matching a single run upgrades the entire trace, not just that run. A rule whose [item type](/langsmith/rules#set-the-item-type-to-runs-or-threads) is **Threads** upgrades every trace in the matched thread, not only the most recent one.
 * **Manual annotation queue adds** (no upgrade): Manually adding runs or threads to an [annotation queue](/langsmith/annotation-queues#assign-runs-and-threads-to-a-single-run-queue) does not upgrade retention by default.
 
 This change applies to new actions only. Traces that were already upgraded by a previous action keep their extended retention.

--- a/src/langsmith/webhooks.mdx
+++ b/src/langsmith/webhooks.mdx
@@ -1,10 +1,10 @@
 ---
 title: Configure webhook notifications for rules
 sidebarTitle: Configure webhook notifications for rules
-description: Configure webhook notifications to receive POST requests when automation rules match new runs in LangSmith.
+description: Configure webhook notifications to receive POST requests when automation rules match new runs or threads in LangSmith.
 ---
 
-When you add a webhook URL on an automation action, LangSmith makes a POST request to your webhook endpoint any time the rules you defined match any new runs.
+When you add a webhook URL on an automation action, LangSmith makes a POST request to your webhook endpoint any time the rules you defined match any new runs or threads.
 
 ![Webhook](/langsmith/images/webhook.png)
 
@@ -13,9 +13,10 @@ When you add a webhook URL on an automation action, LangSmith makes a POST reque
 The payload LangSmith sends to your webhook endpoint contains:
 
 - `"rule_id"`: this is the ID of the automation that sent this payload.
-- `"start_time"` and `"end_time"`: these are the time boundaries where LangSmith found matching runs.
-- `"runs"`: this is an array of runs, where each run is a dictionary. If you need more information about each run, use the SDK in your endpoint to fetch it from the API.
-- `"feedback_stats"`: this is a dictionary with the feedback statistics for the runs. An example payload for this field is shown in the following code block.
+- `"start_time"` and `"end_time"`: these are the time boundaries where LangSmith found matching items.
+- `"runs"`: this is an array of runs, where each run is a dictionary. If you need more information about each run, use the SDK in your endpoint to fetch it from the API. Each run dictionary includes:
+    - `"feedback_stats"`: a dictionary with the feedback statistics for that run. An example of this field is shown in the following code block.
+- `"threads"`: this is an array of threads, sent in place of `"runs"` when the rule's [item type](/langsmith/rules#set-the-item-type-to-runs-or-threads) is **Threads**. A payload carries one array or the other, never both. For more information, refer to [Read a thread rule payload](#read-a-thread-rule-payload).
 
 ```json
 "feedback_stats": {
@@ -99,6 +100,53 @@ This is an example of the entire payload LangSmith sends to your webhook endpoin
       "feedback_stats": null,
       "serialized": null,
       "share_token": null
+    }
+  ]
+}
+```
+
+### Handle batched payloads
+
+A payload covers a polling window rather than a single match. LangSmith collects every item the rule matched between `"start_time"` and `"end_time"` and delivers them in one POST, instead of sending one POST per item.
+
+Write your endpoint to iterate the array rather than reading only the first element. A thread rule delivers at most 500 threads per execution.
+
+### Read a thread rule payload
+
+A rule whose [item type](/langsmith/rules#set-the-item-type-to-runs-or-threads) is **Threads** replaces the top-level `"runs"` array with a `"threads"` array. Each entry in that array contains:
+
+- `"thread_id"`: the ID of the thread that went idle and matched the rule.
+- `"session_id"`: the ID of the tracing project the thread belongs to.
+- `"runs"`: an array of the thread's root runs, one per trace, each with the traced inputs and outputs. Child runs such as tool and model calls are not included. These run dictionaries also omit `"feedback_stats"`, which is present only on runs in a `"runs"` payload.
+
+This example is abbreviated, showing one thread with a single root run:
+
+```json
+{
+  "rule_id": "7f3e9c21-5b48-4a6d-8e12-9f0a1b2c3d4e",
+  "start_time": "2026-08-14T09:00:00.000000+00:00",
+  "end_time": "2026-08-14T09:01:00.000000+00:00",
+  "threads": [
+    {
+      "thread_id": "019a1b2c-3d4e-7f80-9a1b-2c3d4e5f6071",
+      "session_id": "2a9d6e4b-1c37-4f58-b0e9-6d5c4a3b2f10",
+      "runs": [
+        {
+          "trace_id": "019a1b2c-3d4e-7f80-9a1b-2c3d4e5f6072",
+          "start_time": "2026-08-14T08:57:12.412000",
+          "inputs": {
+            "messages": [
+              {
+                "type": "human",
+                "id": "019a1b2c-3d4e-7f80-9a1b-2c3d4e5f6073",
+                "content": "How do I group traces into a thread?",
+                "additional_kwargs": {},
+                "response_metadata": {}
+              }
+            ]
+          }
+        }
+      ]
     }
   ]
 }

--- a/src/snippets/langsmith/retention-downstream-features.mdx
+++ b/src/snippets/langsmith/retention-downstream-features.mdx
@@ -1,7 +1,7 @@
 The following features interact with retention differently:
 
 - **Experiments**: Runs are created at extended retention by default.
-- **Automation rules and evaluators**: Upgrade matching traces to extended retention when their retention setting is enabled.
+- **Automation rules and evaluators**: Upgrade matching traces to extended retention when their retention setting is enabled. Thread-level rules and evaluators upgrade every trace in the matched thread.
 - **UI feedback, notes, and annotation queues**: Leave a trace's retention tier unchanged.
 
 Other features behave independently of a trace's retention tier:


### PR DESCRIPTION
Adds docs for thread automation rules.