### PR TITLE
docs: fix retrieval nav entries to point to canonical deepagents paths

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -423,7 +423,7 @@
                               "oss/python/langchain/multi-agent/custom-workflow"
                             ]
                           },
-                          "oss/python/langchain/retrieval",
+                          "oss/python/deepagents/retrieval",
                           "oss/python/langchain/long-term-memory"
                         ]
                       },
@@ -976,7 +976,7 @@
                               "oss/javascript/langchain/multi-agent/custom-workflow"
                             ]
                           },
-                          "oss/javascript/langchain/retrieval",
+                          "oss/javascript/deepagents/retrieval",
                           "oss/javascript/langchain/long-term-memory"
                         ]
                       },


### PR DESCRIPTION
### Summary
Fix two sidebar navigation entries in src/docs.json that point to pages which immediately redirect elsewhere.

- oss/python/langchain/retrieval redirects to /oss/python/deepagents/retrieval
- oss/javascript/langchain/retrieval redirects to /oss/javascript/deepagents/retrieval

The retrieval content was moved to the deepagents/ path and redirects were added, but the navigation was not updated. Every user clicking the nav link gets an unnecessary redirect hop instead of landing directly on the canonical page.

### Changes
Update the 2 nav entries in src/docs.json to point directly to the canonical pages:

- oss/python/langchain/retrieval -> oss/python/deepagents/retrieval
- oss/javascript/langchain/retrieval -> oss/javascript/deepagents/retrieval

### Testing
- Verified src/docs.json is valid JSON.
- No redirect source entries were touched (the redirect rules remain intact).
- Diff is limited to 2 lines in a single file.

Closes #5552
