### PR TITLE
chore: link to LangChain tools guide

### DIFF
--- a/src/langsmith/managed-deep-agents-tools.mdx
+++ b/src/langsmith/managed-deep-agents-tools.mdx
@@ -17,6 +17,7 @@ Define LangChain tools in your project, import them into `agent.py`, and pass th
 Define LangChain tools in your project, import them into `agent.ts`, and pass them to `defineDeepAgent`.
 :::
 
+For more about LangChain tool definitions, see [Tools](/oss/langchain/tools).
 To load tools from a remote MCP server instead, use an [MCP connector](/langsmith/managed-deep-agents-mcp-connectors).
 
 <ManagedDeepAgentsPrivateBetaNote />

--- a/src/langsmith/managed-deep-agents-tools.mdx
+++ b/src/langsmith/managed-deep-agents-tools.mdx
@@ -43,12 +43,6 @@ my-agent/
 ```
 :::
 
-## Add authored tools
-
-Use authored tools for business logic, private APIs, database access, and other code that belongs in your agent project. Managed Deep Agents copies the source into the compiled build and passes the tools to Deep Agents.
-
-For more about LangChain tool definitions, see [Tools](/oss/langchain/tools).
-
 ## Add a tool module
 
 :::python


### PR DESCRIPTION
## Description
Add a link to the LangChain tools guide from the Managed Deep Agents tools page introduction so readers can find deeper tool-definition guidance after the redundant subsection was removed.

## Test Plan
- [x] Run scoped Vale prose lint on `managed-deep-agents-tools.mdx`
- [x] Run the broken-link checker

Made by [Open SWE](https://openswe.vercel.app/agents/f021d759-cb90-50a9-bb5a-ed6b219f7b04)