### PR TITLE
chore: link Managed Deep Agents changelog

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -325,7 +325,8 @@
                           "langsmith/python/managed-deep-agents-local-development",
                           "langsmith/python/managed-deep-agents-tutorial",
                           "langsmith/python/managed-deep-agents-deploy",
-                          "langsmith/python/managed-deep-agents-cli"
+                          "langsmith/python/managed-deep-agents-cli",
+                          "langsmith/python/managed-deep-agents-changelog"
                         ]
                       }
                     ]
@@ -878,7 +879,8 @@
                           "langsmith/javascript/managed-deep-agents-local-development",
                           "langsmith/javascript/managed-deep-agents-tutorial",
                           "langsmith/javascript/managed-deep-agents-deploy",
-                          "langsmith/javascript/managed-deep-agents-cli"
+                          "langsmith/javascript/managed-deep-agents-cli",
+                          "langsmith/javascript/managed-deep-agents-changelog"
                         ]
                       }
                     ]

--- a/src/langsmith/managed-deep-agents-changelog.mdx
+++ b/src/langsmith/managed-deep-agents-changelog.mdx
@@ -1,0 +1,4 @@
+---
+title: Changelog
+url: "https://github.com/langchain-ai/managed-deepagents/blob/main/CHANGELOG.md"
+---


### PR DESCRIPTION
## Description
Links the Managed Deep Agents documentation to the public changelog that release automation will maintain. Adds the link to both Python and TypeScript navigation.

## Test Plan
- [x] `make lint_prose FILES="src/langsmith/managed-deep-agents-changelog.mdx"`
- [x] `make broken-links`

Made by [Open SWE](https://openswe.vercel.app/agents/0bd35b60-e7cc-55fc-93e6-0e108bbc7d80)