### PR TITLE
chore: clarify managed deep agents middleware

### DIFF
--- a/src/langsmith/managed-deep-agents-middleware.mdx
+++ b/src/langsmith/managed-deep-agents-middleware.mdx
@@ -7,9 +7,16 @@ description: Add built-in or custom middleware to Managed Deep Agents projects.
 import ManagedDeepAgentsPrivateBetaNote from '/snippets/langsmith/managed-deep-agents-private-beta-note.mdx';
 import ManagedDeepAgentsTestAndDeploy from '/snippets/langsmith/managed-deep-agents-test-and-deploy.mdx';
 
-Middleware is reusable logic that runs at defined points in the agent loop. It lets you observe or change model calls, tool calls, and lifecycle events without adding that cross-cutting behavior to the agent's instructions or individual tools. Common uses include logging, guardrails, data redaction, retries, model fallbacks, and rate limits.
+Middleware gives you more control over what happens inside your agent. It adds behavior at key points in the agent's work, such as before or after the agent calls a model or tool.
 
-A middleware can be prebuilt by LangChain or custom logic that you write. Add middleware to the agent definition as a list. During each run, the agent invokes the applicable middleware hooks around the corresponding model calls, tool calls, or lifecycle events.
+Middleware is useful when a behavior should apply consistently across the whole agent instead of being repeated in the agent's instructions or every tool. For example, middleware can:
+
+- Track agent behavior with logging and analytics.
+- Change prompts, tool selection, or output formatting.
+- Retry failed calls or fall back to another model.
+- Apply rate limits, guardrails, or sensitive data redaction.
+
+Use prebuilt LangChain middleware for common behaviors, or write custom middleware for your own logic. Add middleware to the agent definition as a list. During each run, the agent invokes it at the appropriate points shown below.
 
 <img
     src="/oss/images/middleware_final.png"

--- a/src/langsmith/managed-deep-agents-middleware.mdx
+++ b/src/langsmith/managed-deep-agents-middleware.mdx
@@ -11,6 +11,13 @@ Middleware is reusable logic that runs at defined points in the agent loop. It l
 
 A middleware can be prebuilt by LangChain or custom logic that you write. Add middleware to the agent definition as a list. During each run, the agent invokes the applicable middleware hooks around the corresponding model calls, tool calls, or lifecycle events.
 
+<img
+    src="/oss/images/middleware_final.png"
+    alt="Middleware hooks around the agent lifecycle, model calls, and tool calls"
+    style={{height: "300px", width: "auto", justifyContent: "center"}}
+    className="rounded-lg mx-auto"
+/>
+
 :::python
 Pass the list to `define_deep_agent` with the `middleware` parameter.
 :::

--- a/src/langsmith/managed-deep-agents-middleware.mdx
+++ b/src/langsmith/managed-deep-agents-middleware.mdx
@@ -7,16 +7,7 @@ description: Add built-in or custom middleware to Managed Deep Agents projects.
 import ManagedDeepAgentsPrivateBetaNote from '/snippets/langsmith/managed-deep-agents-private-beta-note.mdx';
 import ManagedDeepAgentsTestAndDeploy from '/snippets/langsmith/managed-deep-agents-test-and-deploy.mdx';
 
-Middleware gives you more control over what happens inside your agent. It adds behavior at key points in the agent's work, such as before or after the agent calls a model or tool.
-
-Middleware is useful when a behavior should apply consistently across the whole agent instead of being repeated in the agent's instructions or every tool. For example, middleware can:
-
-- Track agent behavior with logging and analytics.
-- Change prompts, tool selection, or output formatting.
-- Retry failed calls or fall back to another model.
-- Apply rate limits, guardrails, or sensitive data redaction.
-
-Use prebuilt LangChain middleware for common behaviors, or write custom middleware for your own logic. Add middleware to the agent definition as a list. During each run, the agent invokes it at the appropriate points shown below.
+Middleware gives you more control over what happens inside your agent. During each run, middleware can control behavior at the points shown below: around the overall agent, model calls, and tool calls.
 
 <img
     src="/oss/images/middleware_final.png"
@@ -25,13 +16,14 @@ Use prebuilt LangChain middleware for common behaviors, or write custom middlewa
     className="rounded-lg mx-auto"
 />
 
-:::python
-Pass the list to `define_deep_agent` with the `middleware` parameter.
-:::
+Middleware is useful when a behavior should apply consistently across the whole agent instead of being repeated in the agent's instructions or every tool. For example, middleware can:
 
-:::js
-Pass the list to `defineDeepAgent` with the `middleware` property.
-:::
+- Track agent behavior with logging and analytics.
+- Change prompts, tool selection, or output formatting.
+- Retry failed calls or fall back to another model.
+- Apply rate limits, guardrails, or sensitive data redaction.
+
+Prebuilt middleware is ready-to-use behavior that LangChain provides for common needs, such as sensitive data redaction and model call limits. If those options do not cover your use case, custom middleware lets you run your own logic at the same points in agent execution.
 
 <ManagedDeepAgentsPrivateBetaNote />
 

--- a/src/langsmith/managed-deep-agents-middleware.mdx
+++ b/src/langsmith/managed-deep-agents-middleware.mdx
@@ -7,14 +7,16 @@ description: Add built-in or custom middleware to Managed Deep Agents projects.
 import ManagedDeepAgentsPrivateBetaNote from '/snippets/langsmith/managed-deep-agents-private-beta-note.mdx';
 import ManagedDeepAgentsTestAndDeploy from '/snippets/langsmith/managed-deep-agents-test-and-deploy.mdx';
 
-Managed Deep Agents support the Deep Agents `middleware` configuration surface.
+Middleware is reusable logic that runs at defined points in the agent loop. It lets you observe or change model calls, tool calls, and lifecycle events without adding that cross-cutting behavior to the agent's instructions or individual tools. Common uses include logging, guardrails, data redaction, retries, model fallbacks, and rate limits.
+
+A middleware can be prebuilt by LangChain or custom logic that you write. Add middleware to the agent definition as a list. During each run, the agent invokes the applicable middleware hooks around the corresponding model calls, tool calls, or lifecycle events.
 
 :::python
-Add LangChain middleware to `define_deep_agent` to monitor tool calls, add guardrails, redact data, retry transient failures, or customize model calls.
+Pass the list to `define_deep_agent` with the `middleware` parameter.
 :::
 
 :::js
-Add LangChain middleware to `defineDeepAgent` to monitor tool calls, add guardrails, redact data, retry transient failures, or customize model calls.
+Pass the list to `defineDeepAgent` with the `middleware` property.
 :::
 
 <ManagedDeepAgentsPrivateBetaNote />


### PR DESCRIPTION
## Description
Clarifies what middleware is at the start of the Managed Deep Agents middleware page so readers can understand the concept without leaving the page. The introduction now explains where middleware runs, what it can affect, common uses, and how to configure prebuilt or custom middleware.

## Test Plan
- [x] Run `make lint_prose FILES="src/langsmith/managed-deep-agents-middleware.mdx"`

Made by [Open SWE](https://openswe.vercel.app/agents/67b8ecc2-159e-5f1a-8dbf-bd108a9aab6d)