### PR TITLE
docs: mention managed-deep-agents skill in MDA quickstart

### DIFF
--- a/src/langsmith/managed-deep-agents-quickstart.mdx
+++ b/src/langsmith/managed-deep-agents-quickstart.mdx
@@ -19,17 +19,13 @@ After this quickstart, the [tutorial](/langsmith/managed-deep-agents-tutorial) a
 
 <ManagedDeepAgentsPrerequisites />
 
-## Add the managed-deep-agents skill
+## Add the `managed-deep-agents` skill
 
-The [`managed-deep-agents` skill](https://github.com/langchain-ai/langchain-skills/blob/main/config/skills/managed-deep-agents/SKILL.md) is an Agent Skill that walks a coding agent through building, testing, and deploying a Managed Deep Agent with the `mda` CLI. Add it so your coding agent follows the project layout and CLI workflow described in this quickstart.
-
-To add the skill to the current project, run:
+The [`managed-deep-agents` skill](https://github.com/langchain-ai/langchain-skills/blob/main/config/skills/managed-deep-agents/SKILL.md) walks a coding agent through building, testing, and deploying a Managed Deep Agent with the `mda` CLI. To add it to the current project, run:
 
 ```bash
-npx skills add langchain-ai/langchain-skills --skill '*' --yes
+npx skills add langchain-ai/langchain-skills --skill managed-deep-agents --yes
 ```
-
-This installs every skill from the [`langchain-skills` repository](https://github.com/langchain-ai/langchain-skills), including `managed-deep-agents`. For skills that work with LangSmith traces, datasets, and evaluators, see [LangSmith skills](/langsmith/skills).
 
 ## Create and deploy an agent
 

--- a/src/langsmith/managed-deep-agents-quickstart.mdx
+++ b/src/langsmith/managed-deep-agents-quickstart.mdx
@@ -19,6 +19,18 @@ After this quickstart, the [tutorial](/langsmith/managed-deep-agents-tutorial) a
 
 <ManagedDeepAgentsPrerequisites />
 
+## Add the managed-deep-agents skill
+
+The [`managed-deep-agents` skill](https://github.com/langchain-ai/langchain-skills/blob/main/config/skills/managed-deep-agents/SKILL.md) is an Agent Skill that walks a coding agent through building, testing, and deploying a Managed Deep Agent with the `mda` CLI. Add it so your coding agent follows the project layout and CLI workflow described in this quickstart.
+
+To add the skill to the current project, run:
+
+```bash
+npx skills add langchain-ai/langchain-skills --skill '*' --yes
+```
+
+This installs every skill from the [`langchain-skills` repository](https://github.com/langchain-ai/langchain-skills), including `managed-deep-agents`. For skills that work with LangSmith traces, datasets, and evaluators, see [LangSmith skills](/langsmith/skills).
+
 ## Create and deploy an agent
 
 <Steps>


### PR DESCRIPTION
## Description

Adds an "Add the `managed-deep-agents` skill" section to the Managed Deep Agents quickstart, between Prerequisites and the build steps. Readers who build with a coding agent get better results with the [`managed-deep-agents` skill](https://github.com/langchain-ai/langchain-skills/blob/main/config/skills/managed-deep-agents/SKILL.md) installed, so the section links the skill and gives the `npx skills add langchain-ai/langchain-skills --skill managed-deep-agents --yes` install command.

Placement is the main thing worth a look: the skill is most useful before the reader starts scaffolding, but it can move to Next steps if that reads better.

Docs-only change; no new pages, so `src/docs.json` is untouched. `make lint_prose` passes on the changed file. Written by an AI agent (Open SWE) at the requester's direction.

## Test Plan

- [ ] Preview the quickstart page and confirm the new section renders with the heading in code formatting.

Made by [Open SWE](https://openswe.vercel.app/agents/25e9b868-246d-5f0a-afc6-dffbd06e42a5)