### PR TITLE
docs: explain Context Hub sync conflict handling

### DIFF
--- a/src/langsmith/managed-deep-agents-cli.mdx
+++ b/src/langsmith/managed-deep-agents-cli.mdx
@@ -248,6 +248,7 @@ mda deploy .
 | `--name NAME` | Deployment name. Defaults to the agent `name` from `define_deep_agent`. |
 | `--deployment-type dev\|prod` | Deployment type when creating a deployment. Defaults to `dev`. |
 | `--workspace-id WORKSPACE_ID` | Workspace ID to deploy into. Overrides `LANGSMITH_WORKSPACE_ID`. |
+| `--context-strategy overwrite\|keep-hub` | Resolve instructions or skills changed in Context Hub without prompting. `overwrite` applies local files; `keep-hub` preserves Hub-edited sections. Requires `managed-deepagents>=0.5.3`. |
 | `--no-wait` | Trigger the remote build and exit without polling for deployment completion. |
 :::
 
@@ -258,6 +259,7 @@ mda deploy .
 | `--name NAME` | Deployment name. Defaults to the agent `name` from `defineDeepAgent`. |
 | `--deployment-type dev\|prod` | Deployment type when creating a deployment. Defaults to `dev`. |
 | `--workspace-id WORKSPACE_ID` | Workspace ID to deploy into. Overrides `LANGSMITH_WORKSPACE_ID`. |
+| `--context-strategy overwrite\|keep-hub` | Resolve instructions or skills changed in Context Hub without prompting. `overwrite` applies local files; `keep-hub` preserves Hub-edited sections. Requires `managed-deepagents>=0.5.3`. |
 | `--no-wait` | Trigger the remote build and exit without polling for deployment completion. |
 :::
 
@@ -333,7 +335,8 @@ mda delete .
 | `No LangSmith API key found` | Set `LANGSMITH_API_KEY` or add it to the project `.env`. |
 | Deploy fails with 401 or 403 | Confirm the API key belongs to a workspace with beta access. |
 | Deploy reports a missing model provider API key | Add the provider key, such as `OPENAI_API_KEY`, to `.env`, export it in your shell, or configure it as a LangSmith workspace secret. |
-| Deploy reports a Context Hub conflict | The Context Hub repo changed during deploy. Re-run `mda deploy`. |
+| Deploy reports that Context Hub instructions or skills changed since the last sync | Choose whether to preserve or overwrite the Hub edits. For a non-interactive deploy, pass `--context-strategy keep-hub` or `--context-strategy overwrite`. |
+| Deploy reports that the Context Hub repo changed during deploy | Re-run `mda deploy` to retry against the latest Context Hub commit. |
 | The build exceeds 200 MB | Remove generated artifacts or large files from the project before deploying. |
 | Deployment reaches `BUILD_FAILED` or `DEPLOY_FAILED` | Open the printed deployment URL in LangSmith and inspect the revision logs. |
 :::
@@ -346,7 +349,8 @@ mda delete .
 | `No LangSmith API key found` | Set `LANGSMITH_API_KEY` or add it to the project `.env`. |
 | Deploy fails with 401 or 403 | Confirm the API key belongs to a workspace with beta access. |
 | Deploy reports a missing model provider API key | Add the provider key, such as `OPENAI_API_KEY`, to `.env`, export it in your shell, or configure it as a LangSmith workspace secret. |
-| Deploy reports a Context Hub conflict | The Context Hub repo changed during deploy. Re-run `mda deploy`. |
+| Deploy reports that Context Hub instructions or skills changed since the last sync | Choose whether to preserve or overwrite the Hub edits. For a non-interactive deploy, pass `--context-strategy keep-hub` or `--context-strategy overwrite`. |
+| Deploy reports that the Context Hub repo changed during deploy | Re-run `mda deploy` to retry against the latest Context Hub commit. |
 | The build exceeds 200 MB | Remove generated artifacts or large files from the project before deploying. |
 | Deployment reaches `BUILD_FAILED` or `DEPLOY_FAILED` | Open the printed deployment URL in LangSmith and inspect the revision logs. |
 :::

--- a/src/langsmith/managed-deep-agents-instructions.mdx
+++ b/src/langsmith/managed-deep-agents-instructions.mdx
@@ -46,9 +46,27 @@ Use this file to define the agent's role, behavior, constraints, and guidance fo
 
 Instructions are inserted into the agents system prompt on every run. They are always present and help guide the agents behavior.
 
-## Syncing to Context Hub
+## Sync with Context Hub
 
-When you run `mda deploy` to deploy the agent, instructions are automatically synced to the agent's [Context Hub](/langsmith/use-the-context-hub) repo. You can then edit the instructions in the LangSmith UI and have your changes automatically propagated to the agent.
+When you run `mda deploy`, Managed Deep Agents syncs `instructions.md` to the agent's [Context Hub](/langsmith/use-the-context-hub) repo. You can edit the deployed instructions in the LangSmith UI, and the running agent uses the updated Context Hub version without another deploy.
+
+<Note>
+Context Hub change detection requires `managed-deepagents>=0.5.3`.
+</Note>
+
+On later deploys, the CLI compares the current Context Hub instructions with the version from the last Managed Deep Agents sync. If the instructions changed in Context Hub, an interactive deploy asks whether to overwrite the Hub edits with the local `instructions.md`:
+
+- Choose **No** to keep the Context Hub version. The deploy continues without applying the local instructions.
+- Choose **Yes** to overwrite the Context Hub version with the local instructions.
+
+For a non-interactive deploy, set the resolution explicitly:
+
+```bash
+mda deploy . --context-strategy keep-hub
+mda deploy . --context-strategy overwrite
+```
+
+If the instructions did not change in Context Hub, the local `instructions.md` remains the source for the next deploy and syncs automatically.
 
 ## How instructions compare to other concepts
 

--- a/src/langsmith/managed-deep-agents-skills.mdx
+++ b/src/langsmith/managed-deep-agents-skills.mdx
@@ -61,11 +61,27 @@ At startup, the agent sees each skill's `name` and `description`. When a task ma
 
 This progressive disclosure gives the agent access to detailed procedures without adding every skill's full contents to its context.
 
-## Syncing to Context Hub
+## Sync with Context Hub
 
-When you run `mda deploy`, every UTF-8 file under `skills/` is automatically synced to the agent's [Context Hub](/langsmith/use-the-context-hub) repo. You can then edit skills in the LangSmith UI and make the changes available to the agent.
+When you run `mda deploy`, Managed Deep Agents syncs every UTF-8 file under `skills/` to the agent's [Context Hub](/langsmith/use-the-context-hub) repo. You can edit the deployed skills in the LangSmith UI, and the running agent uses the updated Context Hub files without another deploy.
 
-A later deployment syncs the project copies again and removes deployed skill files that no longer exist locally.
+<Note>
+Context Hub change detection requires `managed-deepagents>=0.5.3`.
+</Note>
+
+On later deploys, the CLI compares the current Context Hub skills with the version from the last Managed Deep Agents sync. If any skill file changed in Context Hub, an interactive deploy asks whether to overwrite the Hub edits with the local `skills/` directory:
+
+- Choose **No** to keep all Context Hub skill files. The deploy continues without applying local skill changes.
+- Choose **Yes** to overwrite the Context Hub skills with the local files.
+
+For a non-interactive deploy, set the resolution explicitly:
+
+```bash
+mda deploy . --context-strategy keep-hub
+mda deploy . --context-strategy overwrite
+```
+
+If the skills did not change in Context Hub, the local `skills/` directory remains the source for the next deploy. The sync applies local changes and removes deployed skill files that no longer exist locally. Instructions are checked separately, so preserving Hub-edited skills does not prevent unchanged local instructions from syncing.
 
 ## How skills compare to other concepts
 


### PR DESCRIPTION
## Description
Document how Managed Deep Agents 0.5.3 detects instructions and skills edited in Context Hub and lets deploys preserve or overwrite those changes. Add the non-interactive context strategy options to the CLI reference and distinguish prior edits from concurrent deploy conflicts.

## Test Plan
- [x] Run Vale on the three changed MDX files

Made by [Open SWE](https://openswe.vercel.app/agents/17b4299b-e8bd-5cd1-bcb3-b59221417503)