### PR TITLE
docs(deepagents): document OpenAI Responses API default on models page

### DIFF
--- a/src/oss/deepagents/models.mdx
+++ b/src/oss/deepagents/models.mdx
@@ -100,6 +100,26 @@ See [Profiles](/oss/deepagents/profiles) for the full field list, merge semantic
     For shaping how the *agent* behaves once the model is built, use a [harness profile](/oss/deepagents/profiles#harness-profiles).
 </Tip>
 
+### OpenAI Responses API default
+
+:::python
+When you pass an OpenAI model as a `provider:model` string (for example `openai:gpt-5.4`), Deep Agents applies a built-in provider profile that sets `use_responses_api=True`. This means the agent calls the [OpenAI Responses API](https://platform.openai.com/docs/api-reference/responses) instead of Chat Completions, and it applies whenever a string is passed — it does not depend on your own profile registrations.
+
+To use Chat Completions instead, initialize the model yourself with `use_responses_api=False` and pass the resulting model instance to @[`create_deep_agent`] rather than a string. Passing a preconfigured instance skips the built-in OpenAI profile, so its default no longer applies:
+
+```python
+from langchain.chat_models import init_chat_model
+from deepagents import create_deep_agent
+
+model = init_chat_model("openai:gpt-5.4", use_responses_api=False)
+agent = create_deep_agent(model=model)
+```
+
+<Note>
+    The Responses API can retain request and response data on OpenAI's side. To keep using the Responses API but disable that retention, initialize the model with `use_responses_api=True, store=False, include=["reasoning.encrypted_content"]` and pass the instance to @[`create_deep_agent`] the same way.
+</Note>
+:::
+
 ## Select a model at runtime
 
 If your application lets users choose a model (for example using a dropdown in the UI), use [middleware](/oss/langchain/middleware) to swap the model at runtime without rebuilding the agent.


### PR DESCRIPTION
Fixes #3730

Documents that Deep Agents applies `use_responses_api=True` by default
for all `openai:` model strings via the built-in OpenAI provider profile.
Adds guidance on how to opt into Chat Completions and how to disable
Responses API data retention.