### PR TITLE
docs(graphs): update deprecated OpenAI model strings in graph integration examples

### DIFF
--- a/src/oss/python/integrations/graphs/memgraph.mdx
+++ b/src/oss/python/integrations/graphs/memgraph.mdx
@@ -155,9 +155,8 @@ Next, create `MemgraphQAChain`, which will be utilized in the question-answering
 
 ```python
 chain = MemgraphQAChain.from_llm(
-    ChatOpenAI(temperature=0),
+    ChatOpenAI(temperature=0, model="gpt-4o"),
     graph=graph,
-    model_name="gpt-4-turbo",
     allow_dangerous_requests=True,
 )
 ```
@@ -197,11 +196,10 @@ The `return_direct` modifier specifies whether to return the direct results of t
 ```python
 # Return the result of querying the graph directly
 chain = MemgraphQAChain.from_llm(
-    ChatOpenAI(temperature=0),
+    ChatOpenAI(temperature=0, model="gpt-4o"),
     graph=graph,
     return_direct=True,
     allow_dangerous_requests=True,
-    model_name="gpt-4-turbo",
 )
 
 response = chain.invoke("Which studio published Baldur's Gate 3?")
@@ -221,11 +219,10 @@ The `return_intermediate_steps` chain modifier enhances the returned response by
 ```python
 # Return all the intermediate steps of query execution
 chain = MemgraphQAChain.from_llm(
-    ChatOpenAI(temperature=0),
+    ChatOpenAI(temperature=0, model="gpt-4o"),
     graph=graph,
     allow_dangerous_requests=True,
     return_intermediate_steps=True,
-    model_name="gpt-4-turbo",
 )
 
 response = chain.invoke("Is Baldur's Gate 3 an Adventure game?")
@@ -247,11 +244,10 @@ The `top_k` modifier can be used when you want to restrict the maximum number of
 ```python
 # Limit the maximum number of results returned by query
 chain = MemgraphQAChain.from_llm(
-    ChatOpenAI(temperature=0),
+    ChatOpenAI(temperature=0, model="gpt-4o"),
     graph=graph,
     top_k=2,
     allow_dangerous_requests=True,
-    model_name="gpt-4-turbo",
 )
 
 response = chain.invoke("What genres are associated with Baldur's Gate 3?")
@@ -272,9 +268,8 @@ Let's instantiate our chain once again and attempt to ask some questions that us
 
 ```python
 chain = MemgraphQAChain.from_llm(
-    ChatOpenAI(temperature=0),
+    ChatOpenAI(temperature=0, model="gpt-4o"),
     graph=graph,
-    model_name="gpt-4-turbo",
     allow_dangerous_requests=True,
 )
 
@@ -327,10 +322,9 @@ MEMGRAPH_GENERATION_PROMPT = PromptTemplate(
 )
 
 chain = MemgraphQAChain.from_llm(
-    ChatOpenAI(temperature=0),
+    ChatOpenAI(temperature=0, model="gpt-4o"),
     cypher_prompt=MEMGRAPH_GENERATION_PROMPT,
     graph=graph,
-    model_name="gpt-4-turbo",
     allow_dangerous_requests=True,
 )
 
@@ -388,7 +382,7 @@ text = """
 The next step is to initialize `LLMGraphTransformer` from the desired LLM and convert the document to the graph structure.
 
 ```python
-llm = ChatOpenAI(temperature=0, model_name="gpt-4-turbo")
+llm = ChatOpenAI(temperature=0, model="gpt-4o")
 llm_transformer = LLMGraphTransformer(llm=llm)
 documents = [Document(page_content=text)]
 graph_documents = llm_transformer.convert_to_graph_documents(documents)
@@ -476,9 +470,8 @@ In the end, you can query the knowledge graph, as explained in the section befor
 
 ```python
 chain = MemgraphQAChain.from_llm(
-    ChatOpenAI(temperature=0),
+    ChatOpenAI(temperature=0, model="gpt-4o"),
     graph=graph,
-    model_name="gpt-4-turbo",
     allow_dangerous_requests=True,
 )
 print(chain.invoke("Who Charles Robert Darwin collaborated with?")["result"])

--- a/src/oss/python/integrations/graphs/neo4j_cypher.mdx
+++ b/src/oss/python/integrations/graphs/neo4j_cypher.mdx
@@ -321,8 +321,8 @@ You can use the `cypher_llm` and `qa_llm` parameters to define different llms
 ```python
 chain = GraphCypherQAChain.from_llm(
     graph=graph,
-    cypher_llm=ChatOpenAI(temperature=0, model="gpt-3.5-turbo"),
-    qa_llm=ChatOpenAI(temperature=0, model="gpt-3.5-turbo-16k"),
+    cypher_llm=ChatOpenAI(temperature=0, model="gpt-4o-mini"),
+    qa_llm=ChatOpenAI(temperature=0, model="gpt-4o-mini"),
     verbose=True,
     allow_dangerous_requests=True,
 )
@@ -356,8 +356,8 @@ You can use `include_types` or `exclude_types` to ignore parts of the graph sche
 ```python
 chain = GraphCypherQAChain.from_llm(
     graph=graph,
-    cypher_llm=ChatOpenAI(temperature=0, model="gpt-3.5-turbo"),
-    qa_llm=ChatOpenAI(temperature=0, model="gpt-3.5-turbo-16k"),
+    cypher_llm=ChatOpenAI(temperature=0, model="gpt-4o-mini"),
+    qa_llm=ChatOpenAI(temperature=0, model="gpt-4o-mini"),
     verbose=True,
     exclude_types=["Movie"],
     allow_dangerous_requests=True,
@@ -383,7 +383,7 @@ You can use the `validate_cypher` parameter to validate and correct relationship
 
 ```python
 chain = GraphCypherQAChain.from_llm(
-    llm=ChatOpenAI(temperature=0, model="gpt-3.5-turbo"),
+    llm=ChatOpenAI(temperature=0, model="gpt-4o-mini"),
     graph=graph,
     verbose=True,
     validate_cypher=True,
@@ -419,7 +419,7 @@ _You will need to use an LLM with native function calling support to use this fe
 
 ```python
 chain = GraphCypherQAChain.from_llm(
-    llm=ChatOpenAI(temperature=0, model="gpt-3.5-turbo"),
+    llm=ChatOpenAI(temperature=0, model="gpt-4o-mini"),
     graph=graph,
     verbose=True,
     use_function_response=True,
@@ -451,7 +451,7 @@ _Note that `qa_prompt` will have no effect when using `use_function_response`_
 
 ```python
 chain = GraphCypherQAChain.from_llm(
-    llm=ChatOpenAI(temperature=0, model="gpt-3.5-turbo"),
+    llm=ChatOpenAI(temperature=0, model="gpt-4o-mini"),
     graph=graph,
     verbose=True,
     use_function_response=True,


### PR DESCRIPTION
Replace deprecated OpenAI model identifiers in Memgraph and Neo4j Cypher
integration docs. Users copy-pasting these examples get deprecation warnings
or errors on current OpenAI deployments.

**neo4j_cypher.mdx** (7 occurrences):
- `gpt-3.5-turbo` → `gpt-4o-mini`
- `gpt-3.5-turbo-16k` → `gpt-4o-mini`

**memgraph.mdx** (8 occurrences):
- `gpt-4-turbo` → `gpt-4o`
- Fix `model_name=` being passed to `MemgraphQAChain.from_llm()` instead
  of `ChatOpenAI()` — the correct kwarg is `model=` on the model constructor

## Type of change
Update existing documentation

## Checklist
- [x] I have read the contributing guidelines
- [x] All code examples have been tested and work correctly
- [x] I have used *root relative* paths for internal links