### PR TITLE
docs(tools): fix outdated create_react_agent usage in CDP AgentKit example

### DIFF
--- a/src/oss/python/integrations/tools/cdp_agentkit.mdx
+++ b/src/oss/python/integrations/tools/cdp_agentkit.mdx
@@ -80,12 +80,12 @@ Available actions depend on the action providers configured on `AgentKit`. Commo
 ## Use within an agent
 
 ```python
+from langchain.agents import create_agent
 from langchain_openai import ChatOpenAI
-from langgraph.prebuilt import create_react_agent
 
 llm = ChatOpenAI(model="gpt-4o-mini")
 
-agent = create_react_agent(llm=llm, tools=tools)
+agent = create_agent(model=llm, tools=tools)
 ```
 
 For a full runnable example with a CDP smart wallet, see the [AgentKit LangChain chatbot example](https://github.com/coinbase/agentkit/blob/main/python/examples/langchain-cdp-smart-wallet-chatbot/chatbot.py).


### PR DESCRIPTION
Fixes the "Use within an agent" example in the CDP AgentKit integration
docs, which used the pre-v1 pattern:

- `from langgraph.prebuilt import create_react_agent` — moved to
  `langchain.agents.create_agent` in LangChain v1
- `create_react_agent(llm=llm, ...)` — the parameter is `model=`,
  not `llm=`, on both `create_react_agent` and `create_agent`

Copy-pasting the example as written raises a TypeError for the
unexpected `llm` keyword argument.

## Checklist
- [x] I have read the contributing guidelines
- [x] All code examples have been tested and work correctly
- [x] I have used *root relative* paths for internal links