### PR TITLE
docs(sandboxes): document sandbox download links

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -1838,6 +1838,7 @@
                   "langsmith/sandboxes",
                   "langsmith/sandbox-snapshots",
                   "langsmith/sandbox-service-urls",
+                  "langsmith/sandbox-download-links",
                   "langsmith/sandbox-auth-proxy",
                   "langsmith/sandbox-mounts",
                   "langsmith/sandbox-permissions",

--- a/src/langsmith/sandbox-cli.mdx
+++ b/src/langsmith/sandbox-cli.mdx
@@ -181,6 +181,16 @@ langsmith sandbox console my-vm --forward-ssh-agent
 
 `--forward-ssh-agent` requires `SSH_AUTH_SOCK` to be set locally. Interactive console sessions are not supported on Windows; use SSH access instead.
 
+## Share a file as a link
+
+Mint a link that downloads a single file from the sandbox with no LangSmith credential, for a browser tab or anything else that cannot send an API key:
+
+```bash
+langsmith sandbox generate-download-url my-vm --path /app/report.csv
+```
+
+Without `--expires-in-seconds` the link never expires. Add `--content-type` and `--content-disposition inline` to have the browser render the file instead of downloading it. See [Sandbox download links](/langsmith/sandbox-download-links).
+
 ## Tunnel TCP ports
 
 Use `sandbox tunnel` when you need a local TCP port that forwards to a service listening inside the sandbox. This is useful for databases, language servers, custom protocols, or local tools that expect `localhost`.
@@ -258,5 +268,6 @@ The sandbox image must run `sshd` on port `22`. If `sshd` is not running, `ssh-s
 | `langsmith sandbox delete <name>` | Delete a sandbox. |
 | `langsmith sandbox exec <name> -- <command>` | Run a one-off command inside a sandbox. |
 | `langsmith sandbox console <name>` | Open an interactive shell inside a sandbox. |
+| `langsmith sandbox generate-download-url <name> --path <path>` | Mint a link that downloads one sandbox file with no credential. |
 | `langsmith sandbox tunnel <name> --remote-port <port>` | Forward a local TCP port to a sandbox port. |
 | `langsmith sandbox ssh-setup <name>` | Configure local SSH access through `sandbox tunnel --stdio`. |

--- a/src/langsmith/sandbox-cli.mdx
+++ b/src/langsmith/sandbox-cli.mdx
@@ -189,7 +189,7 @@ Mint a link that downloads a single file from the sandbox with no LangSmith cred
 langsmith sandbox generate-download-url my-vm --path /app/report.csv
 ```
 
-Without `--expires-in-seconds` the link never expires. Add `--content-type` and `--content-disposition inline` to have the browser render the file instead of downloading it. See [Sandbox download links](/langsmith/sandbox-download-links).
+Without `--expires-in-seconds` the link never expires. Add `--content-type` and `--content-disposition inline` to have the browser render the file instead of downloading it. Do not modify the file afterwards: a link is pinned to a path, not to a snapshot of the contents, so a later write may or may not be reflected in what the link serves. See [Sandbox download links](/langsmith/sandbox-download-links).
 
 ## Tunnel TCP ports
 

--- a/src/langsmith/sandbox-download-links.mdx
+++ b/src/langsmith/sandbox-download-links.mdx
@@ -1,0 +1,175 @@
+---
+title: Sandbox download links
+sidebarTitle: Download links
+description: Share a single file from a sandbox as a link that needs no LangSmith credential.
+---
+
+A download link hands one sandbox file to something that cannot carry a LangSmith credential: a browser tab, an `<a href>` in an email, a webhook consumer, or a third-party service that fetches a URL you give it.
+
+The link carries its own token. Reading a file with the SDK's `read()` needs a workspace API key on every request; a download link needs nothing beyond the URL itself.
+
+## Quick start
+
+```python
+from langsmith.sandbox import SandboxClient
+
+client = SandboxClient()
+
+with client.sandbox() as sb:
+    sb.run("python -c \"open('/app/report.csv','w').write('a,b\\n1,2\\n')\"")
+
+    link = sb.generate_download_url("/app/report.csv")
+    print(link.download_url)
+```
+
+Anyone can then fetch it with no credential:
+
+```bash
+curl -LO "<download_url>"
+```
+
+## What a link is pinned to
+
+The token encodes the sandbox, the tenant, the exact file path, and the response headers, so a link cannot be edited to point at a different file or a different sandbox. Each link serves exactly one path.
+
+Links are served from the sandbox service domain, on the sandbox's own host, never from the LangSmith API host. Downloaded content is therefore isolated from your LangSmith session.
+
+## Create a link
+
+<CodeGroup>
+
+```python Python
+# Never expires
+link = sb.generate_download_url("/app/report.csv")
+
+# Expires in an hour
+link = sb.generate_download_url("/app/report.csv", expires_in_seconds=3600)
+
+# Rendered in the browser instead of downloaded
+link = sb.generate_download_url(
+    "/app/page.html",
+    content_type="text/html",
+    content_disposition="inline",
+)
+
+print(link.download_url)
+print(link.expires_at)  # None when the link never expires
+```
+
+```ts TypeScript
+// Never expires
+let link = await sandbox.generateDownloadURL("/app/report.csv");
+
+// Expires in an hour
+link = await sandbox.generateDownloadURL("/app/report.csv", {
+  expiresInSeconds: 3600,
+});
+
+// Rendered in the browser instead of downloaded
+link = await sandbox.generateDownloadURL("/app/page.html", {
+  contentType: "text/html",
+  contentDisposition: "inline",
+});
+
+console.log(link.download_url);
+console.log(link.expires_at); // null when the link never expires
+```
+
+</CodeGroup>
+
+Call it on the client instead of a sandbox instance to mint a link by sandbox name:
+
+<CodeGroup>
+
+```python Python
+link = client.generate_download_url("my-sandbox", "/app/report.csv")
+```
+
+```ts TypeScript
+const link = await client.generateDownloadURL("my-sandbox", "/app/report.csv");
+```
+
+</CodeGroup>
+
+### Options
+
+| Option | Default | Effect |
+|--------|---------|--------|
+| `expires_in_seconds` | Omitted, so the link never expires | Link lifetime in seconds |
+| `content_type` | inferred from the file extension | `Content-Type` the link responds with |
+| `content_disposition` | `attachment` | `attachment` downloads the file; `inline` renders it in the browser |
+
+## Create a link from the CLI
+
+```bash
+langsmith sandbox generate-download-url my-sandbox --path /app/report.csv
+```
+
+```bash
+langsmith sandbox generate-download-url my-sandbox \
+  --path /app/page.html \
+  --expires-in-seconds 3600 \
+  --content-disposition inline
+```
+
+## Create a link via the REST API
+
+```bash
+curl -X POST \
+  "$LANGSMITH_ENDPOINT/api/v2/sandboxes/boxes/{sandbox_name}/download-url" \
+  -H "x-api-key: $LANGSMITH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"path": "/app/report.csv", "expires_in_seconds": 3600}'
+```
+
+Response:
+
+```json
+{
+  "download_url": "https://{sandbox-id}--dl.smithbox.dev/ey...",
+  "token": "ey...",
+  "expires_at": "2026-04-08T15:30:00Z"
+}
+```
+
+`expires_at` is `null` when `expires_in_seconds` was omitted.
+
+Minting a link requires the `sandboxes:exec` permission, the same access a credentialed download needs. See [Sandbox permissions](/langsmith/sandbox-permissions).
+
+## Fetch a link
+
+`GET` and `HEAD` are supported, along with `Range` (for resumable and partial downloads), `If-Range`, and `If-None-Match`. No headers, query string, or body are needed or accepted.
+
+Fetching a link **wakes a stopped sandbox**, so the first request after an idle stop takes as long as a start. The sandbox does not need to be running when you mint the link.
+
+## Security considerations
+
+<Warning>
+A download link is a bearer credential embedded in a URL. Anyone who obtains it can read that one file until it expires. Treat a link like a password: send it over a channel you trust, and prefer a short `expires_in_seconds` for anything sensitive.
+</Warning>
+
+- **Links cannot be revoked.** A minted link stays valid until it expires, even if the API key that created it is deleted or loses `sandboxes:exec`. Set an expiry when that matters.
+- **Links die with the sandbox.** Deleting the sandbox invalidates every link into it.
+- **Guest headers are dropped.** The response is rebuilt from an allowlist of content, range, and validator headers. Cookies or other headers set by code inside the sandbox are never forwarded.
+- **Rendered content is sandboxed.** Every response carries `X-Content-Type-Options: nosniff` and `Content-Security-Policy: sandbox`, so a file served with `content_disposition=inline` renders with no capabilities and no access to your LangSmith session.
+
+## Download links vs other file access
+
+| | Download links | `read()` | [Service URLs](/langsmith/sandbox-service-urls) |
+|---|---|---|---|
+| **Credential needed** | None | Workspace API key | Service token or browser cookie |
+| **Scope** | One file, one path | Any file | Any HTTP service in the sandbox |
+| **Sandbox must be running** | No (fetching wakes it) | No (waking on demand) | No (fetching wakes it) |
+| **Shareable** | Yes | No | Yes |
+| **Revocable before expiry** | No | Yes (rotate the key) | No |
+
+Use a download link to hand one file to an outside consumer. Use `read()` to pull file bytes into your own code. Use a service URL to reach an HTTP server running inside the sandbox.
+
+## Troubleshoot
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| **`501` on mint** | Download links are not configured for this deployment | Self-hosted deployments need a sandbox service domain configured; see [Sandbox service URLs](/langsmith/sandbox-service-urls) |
+| **`403` on fetch** | The link expired, was altered, or was presented on the wrong host | Mint a fresh link; copy the URL verbatim |
+| **`404` on fetch** | The file no longer exists at that path | Links are pinned to a path, not to file contents. Mint a link for a path that exists |
+| **Browser downloads instead of rendering** | Default disposition is `attachment` | Mint with `content_disposition="inline"` and an explicit `content_type` |

--- a/src/langsmith/sandbox-download-links.mdx
+++ b/src/langsmith/sandbox-download-links.mdx
@@ -32,6 +32,12 @@ curl -LO "<download_url>"
 
 The token encodes the sandbox, the tenant, the exact file path, and the response headers, so a link cannot be edited to point at a different file or a different sandbox. Each link serves exactly one path.
 
+A link is pinned to that path, not to a snapshot of the file. The file itself is not captured or copied when the link is minted.
+
+<Warning>
+Do not modify a file after minting a link for it. A later write to that path may or may not be reflected in what the link serves, so treat the file as immutable for the life of the link. When the contents change, write a new file and mint a new link for it.
+</Warning>
+
 Links are served from the sandbox service domain, on the sandbox's own host, never from the LangSmith API host. Downloaded content is therefore isolated from your LangSmith session.
 
 ## Create a link
@@ -150,6 +156,7 @@ A download link is a bearer credential embedded in a URL. Anyone who obtains it 
 
 - **Links cannot be revoked.** A minted link stays valid until it expires, even if the API key that created it is deleted or loses `sandboxes:exec`. Set an expiry when that matters.
 - **Links die with the sandbox.** Deleting the sandbox invalidates every link into it.
+- **The file must not change.** A link is pinned to a path, so a write to that path after minting may or may not be reflected in what the link serves.
 - **Guest headers are dropped.** The response is rebuilt from an allowlist of content, range, and validator headers. Cookies or other headers set by code inside the sandbox are never forwarded.
 - **Rendered content is sandboxed.** Every response carries `X-Content-Type-Options: nosniff` and `Content-Security-Policy: sandbox`, so a file served with `content_disposition=inline` renders with no capabilities and no access to your LangSmith session.
 
@@ -173,3 +180,4 @@ Use a download link to hand one file to an outside consumer. Use `read()` to pul
 | **`403` on fetch** | The link expired, was altered, or was presented on the wrong host | Mint a fresh link; copy the URL verbatim |
 | **`404` on fetch** | The file no longer exists at that path | Links are pinned to a path, not to file contents. Mint a link for a path that exists |
 | **Browser downloads instead of rendering** | Default disposition is `attachment` | Mint with `content_disposition="inline"` and an explicit `content_type` |
+| **Stale or partial contents** | The file was written or replaced after the link was minted | Do not modify a file that a link points at. Write a new file and mint a new link |

--- a/src/langsmith/sandbox-sdk.mdx
+++ b/src/langsmith/sandbox-sdk.mdx
@@ -353,7 +353,7 @@ console.log(link.download_url);
 
 </CodeGroup>
 
-Omit the expiry for a link that never expires. See [Sandbox download links](/langsmith/sandbox-download-links) for options and security considerations.
+Omit the expiry for a link that never expires. Do not modify the file afterwards: a link is pinned to a path, not to a snapshot of the contents, so a later write may or may not be reflected in what the link serves. See [Sandbox download links](/langsmith/sandbox-download-links) for options and security considerations.
 
 ## Mount a Context Hub repo
 

--- a/src/langsmith/sandbox-sdk.mdx
+++ b/src/langsmith/sandbox-sdk.mdx
@@ -333,6 +333,28 @@ try {
 
 </CodeGroup>
 
+### Share a file as a link
+
+To hand one file to something that cannot send an API key, such as a browser tab, an `<a href>`, or a webhook consumer, mint a download link instead of reading the bytes yourself:
+
+<CodeGroup>
+
+```python Python
+link = sb.generate_download_url("/app/report.csv", expires_in_seconds=3600)
+print(link.download_url)
+```
+
+```ts TypeScript
+const link = await sandbox.generateDownloadURL("/app/report.csv", {
+  expiresInSeconds: 3600,
+});
+console.log(link.download_url);
+```
+
+</CodeGroup>
+
+Omit the expiry for a link that never expires. See [Sandbox download links](/langsmith/sandbox-download-links) for options and security considerations.
+
 ## Mount a Context Hub repo
 
 Mount a [Context Hub](/langsmith/use-the-context-hub) repo to give sandbox code filesystem access to your agents and skills. The repo's latest commit tree is mirrored into the mount path and kept in sync for the sandbox's lifetime, so a new commit shows up in the running sandbox without a restart.
@@ -401,7 +423,7 @@ try {
 
 `repo` is the repo handle, optionally qualified as `owner/repo`, where `-` is the current workspace.
 
-`mount_path` must be an absolute, clean path, and cannot be the filesystem root or sit at or under a system directory such as `/etc` or `/usr`. Any other path works — unlike bucket and Git mounts, Context Hub mounts are not restricted to `/mnt/mounts`.
+`mount_path` must be an absolute, clean path, and cannot be the filesystem root or sit at or under a system directory such as `/etc` or `/usr`. Any other path works—unlike bucket and Git mounts, Context Hub mounts are not restricted to `/mnt/mounts`.
 
 Pass `initial_pull_only` / `initialPullOnly` to sync once at startup instead of polling for repo updates.
 
@@ -714,7 +736,7 @@ try {
 Inside the sandbox, any LangSmith-instrumented code (`@traceable`, LangChain, LangGraph) automatically picks up the tracing configuration from the injected environment variables.
 
 <Warning>
-Always call `flush()` before the sandbox process exits — `langsmith.Client().flush()` in Python or `await new Client().flush()` in TypeScript. Without it, traces may be lost because the container is destroyed when the command finishes.
+Always call `flush()` before the sandbox process exits—`langsmith.Client().flush()` in Python or `await new Client().flush()` in TypeScript. Without it, traces may be lost because the container is destroyed when the command finishes.
 </Warning>
 
 ## Error handling

--- a/src/langsmith/sandbox-service-urls.mdx
+++ b/src/langsmith/sandbox-service-urls.mdx
@@ -185,13 +185,15 @@ def create_item(item: dict):
 | | Service URLs | TCP tunnels |
 |---|---|---|
 | **Protocol** | HTTP | Any TCP (databases, Redis, SSH, HTTP) |
-| **Setup** | Zero — just a URL | Requires SDK or CLI |
+| **Setup** | Zero—just a URL | Requires SDK or CLI |
 | **Access from** | Browser, scripts, CI, anywhere | Local machine only |
 | **Sharing** | Copy the URL and send it | Not shareable |
 | **Multi-page web apps** | Full support (subdomain routing) | Full support (local port) |
 | **Non-HTTP services** | Not supported | Full support |
 
 Use **service URLs** for HTTP services you want to access from a browser or share with others. Use **[TCP tunnels](/langsmith/sandbox-sdk#tcp-tunnels-python)** for non-HTTP protocols (like `psql` or `redis-cli`) or when you need local-only access.
+
+To share a single file rather than a running service, use a **[download link](/langsmith/sandbox-download-links)**.
 
 ## Troubleshoot
 


### PR DESCRIPTION
## Overview

Documents sandbox download links, a tokenized link that serves one file from a sandbox with no LangSmith credential attached. Adds `src/langsmith/sandbox-download-links.mdx` and wires it into the Sandboxes tab after Service URLs.

The new page covers minting a link from the SDK (Python and TypeScript), the CLI, and the REST API; the options that control expiry and response headers; the security posture of a bearer credential in a URL, including that a minted link cannot be revoked before it expires; and how download links differ from `read()` and service URLs.

Also cross-links the new page from the SDK usage, CLI, and service URL pages, each of which already had a natural place to point at it.

## Type of change

**Type:** New documentation page

## Related issues/PRs
- Feature PR: langchain-ai/langchainplus#34271 (server), langchain-ai/langsmith-sdk#3419 (Python/JS SDK), langchain-ai/langsmith-cli#265 (CLI)

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

Two checklist boxes are left unchecked deliberately. `docs dev` was not run; the pipeline build (`make build`) succeeds and `make lint_prose` and `make check-cross-refs` both pass on the changed files. `make broken-links` could not complete locally because `mint` is not installed in this environment; the pipeline build step it depends on succeeds, and every internal link the new page adds targets an existing page (`sandbox-service-urls`, `sandbox-permissions`, `sandbox-download-links`).

The code examples are written against the API contract and the SDK/CLI signatures in the linked PRs, and were not executed against a live sandbox. The SDK and CLI snippets use the method and command names shipping in the PRs linked above (`generate_download_url` / `generateDownloadURL`, `langsmith sandbox generate-download-url`), so this page should merge alongside or after them.
