### PR TITLE
docs: note dual-stack (IPv4 + IPv6) support in self-hosted guides

### DIFF
--- a/src/langsmith/deploy-standalone-server.mdx
+++ b/src/langsmith/deploy-standalone-server.mdx
@@ -85,6 +85,10 @@ Non-Kubernetes deployments have known gaps that you must implement and maintain 
   5. `LANGSMITH_ENDPOINT`: To send traces to a [self-hosted LangSmith](/langsmith/self-hosted) instance, set `LANGSMITH_ENDPOINT` to the hostname of the self-hosted LangSmith instance. Do not add a trailing slash to the URL, as this can cause authentication errors.
 4. Egress to `https://beacon.langchain.com` from your network. This is required for license verification and usage reporting if not running in air-gapped mode. See the [Egress documentation](/langsmith/self-host-egress) for more details.
 
+<Note>
+Agent Server services listen on both IPv4 and IPv6 by default. No additional configuration is required for IPv4-only, IPv6-only, or dual-stack clusters.
+</Note>
+
 <a id="helm"></a>
 ## Kubernetes
 

--- a/src/langsmith/deploy-standalone-server.mdx
+++ b/src/langsmith/deploy-standalone-server.mdx
@@ -86,7 +86,7 @@ Non-Kubernetes deployments have known gaps that you must implement and maintain 
 4. Egress to `https://beacon.langchain.com` from your network. This is required for license verification and usage reporting if not running in air-gapped mode. See the [Egress documentation](/langsmith/self-host-egress) for more details.
 
 <Note>
-Agent Server services listen on both IPv4 and IPv6 by default. No additional configuration is required for IPv4-only, IPv6-only, or dual-stack clusters.
+Agent Server services listen on both IPv4 and IPv6 by default as of 0.14.0. No additional configuration is required for dual-stack clusters.
 </Note>
 
 <a id="helm"></a>

--- a/src/langsmith/deploy-standalone-server.mdx
+++ b/src/langsmith/deploy-standalone-server.mdx
@@ -86,7 +86,7 @@ Non-Kubernetes deployments have known gaps that you must implement and maintain 
 4. Egress to `https://beacon.langchain.com` from your network. This is required for license verification and usage reporting if not running in air-gapped mode. See the [Egress documentation](/langsmith/self-host-egress) for more details.
 
 <Note>
-Agent Server services listen on both IPv4 and IPv6 by default as of 0.14.0. No additional configuration is required for dual-stack clusters.
+Agent Server services listen on both IPv4 and IPv6 by default as of 0.14.0. No additional configuration is required for dual-stack clusters. To listen on a single address family, set `LANGGRAPH_SERVER_HOST` to `0.0.0.0` for IPv4 only or `::` for IPv6 only. See [Self-hosted Agent Server environment variables](/langsmith/env-var-self-hosted).
 </Note>
 
 <a id="helm"></a>

--- a/src/langsmith/kubernetes.mdx
+++ b/src/langsmith/kubernetes.mdx
@@ -115,7 +115,7 @@ For the minimum supported version of each datastore, refer to [Minimum versions 
    1. LangSmith requires egress to `https://beacon.langchain.com` for license verification and usage reporting. This is required for LangSmith to function properly. You can find more information on egress requirements in the [Egress](/langsmith/self-host-egress) section.
 
 <Note>
-LangSmith services listen on both IPv4 and IPv6 by default. No additional configuration is required for IPv4-only, IPv6-only, or dual-stack clusters.
+LangSmith services listen on both IPv4 and IPv6 by default as of 0.14.0. No additional configuration is required for IPv4-only, IPv6-only, or dual-stack clusters.
 </Note>
 
 ## Configure your Helm charts:

--- a/src/langsmith/kubernetes.mdx
+++ b/src/langsmith/kubernetes.mdx
@@ -114,6 +114,9 @@ For the minimum supported version of each datastore, refer to [Minimum versions 
 
    1. LangSmith requires egress to `https://beacon.langchain.com` for license verification and usage reporting. This is required for LangSmith to function properly. You can find more information on egress requirements in the [Egress](/langsmith/self-host-egress) section.
 
+<Note>
+LangSmith services listen on both IPv4 and IPv6 by default. No additional configuration is required for IPv4-only, IPv6-only, or dual-stack clusters.
+</Note>
 
 ## Configure your Helm charts:
 

--- a/src/snippets/langsmith/env-vars/self-hosted-only.mdx
+++ b/src/snippets/langsmith/env-vars/self-hosted-only.mdx
@@ -10,6 +10,16 @@ Set `AGENT_REDIS_IAM_AUTH_PROVIDER` to `aws`, `azure`, or `gcp` to authenticate 
 
 For provider prerequisites and connection URI requirements, see [Configure IAM authentication for data stores](/langsmith/configure-iam-auth).
 
+## `LANGGRAPH_SERVER_HOST`
+
+Set `LANGGRAPH_SERVER_HOST` to control which address families the Agent Server listens on:
+
+* **Empty string**: Listen on both IPv4 and IPv6. This is the default as of `langgraph-api>=0.14.0`.
+* **`0.0.0.0`**: Listen on IPv4 only.
+* **`::`**: Listen on IPv6 only.
+
+Versions before `langgraph-api` 0.14.0 default to `0.0.0.0`, which listens on IPv4 only.
+
 ## `LANGSMITH_API_KEY`
 
 To send traces to a self-hosted LangSmith instance, set `LANGSMITH_API_KEY` to an API key created from the self-hosted instance.


### PR DESCRIPTION
## Summary

Add a note to the Kubernetes self-hosted guide (`kubernetes.mdx`) and the standalone server guide (`deploy-standalone-server.mdx`) that services listen on both IPv4 and IPv6 by default

Related PRs:
- https://github.com/langchain-ai/helm/pull/952 (merged)
- https://github.com/langchain-ai/langchainplus/pull/33616 (merged)
- https://github.com/langchain-ai/langgraph-api/pull/3985

## Test plan

- [ ] Verify notes render correctly on both pages
- [ ] Run `make broken-links` to confirm no link regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)