### PR TITLE
docs(integrations): add Reserp search tool

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -775,6 +775,9 @@ python:
   - name: SerpApi Search Tools
     pypi: serpapi-search-tools
     docs_url: https://serpapi.github.io/serpapi-search-tools-python/docs/sdk-examples/langchain.html
+  - name: ReserpSearchTool
+    pypi: langchain-reserp
+    docs_url: https://reserp.ai/docs
   - name: ApprovalRequiredTool
     pypi: langchain-agentgate
     docs_url: https://useagentgate.com/docs


### PR DESCRIPTION
Adds the external langchain-reserp search tool to the Python tools catalog.

The package accepts a complete Google Search URL, makes one request to the public Reserp API, and returns its JSON response without retries or orchestration.

Validation:
- package is published on PyPI: https://pypi.org/project/langchain-reserp/
- repository CI passes: https://github.com/reserp-ai/langchain-reserp/actions
- refresh_integration_downloads.py --check-docs-urls passes

Package source: https://github.com/reserp-ai/langchain-reserp
API documentation: https://reserp.ai/docs