### PR TITLE
fix: simplify managed Deep Agents tools intro

### DIFF
--- a/src/langsmith/managed-deep-agents-tools.mdx
+++ b/src/langsmith/managed-deep-agents-tools.mdx
@@ -7,7 +7,7 @@ description: Define authored tools for Managed Deep Agents projects.
 import ManagedDeepAgentsPrivateBetaNote from '/snippets/langsmith/managed-deep-agents-private-beta-note.mdx';
 import ManagedDeepAgentsTestAndDeploy from '/snippets/langsmith/managed-deep-agents-test-and-deploy.mdx';
 
-Managed Deep Agents support the Deep Agents `tools` configuration surface.
+Tools add custom capabilities to your agent.
 
 :::python
 Define LangChain tools in your project, import them into `agent.py`, and pass them to `define_deep_agent`.


### PR DESCRIPTION
## Description
Replaces the jargon-heavy Managed Deep Agents tools intro with a direct explanation: “Tools add custom capabilities to your agent.”

## Test Plan
- [ ] Preview the Python and JavaScript variants and confirm the updated intro renders correctly.

Made by [Open SWE](https://openswe.vercel.app/agents/ebe40242-f005-5164-94cc-e15258acc7f1)