### PR TITLE
docs: fix @[] auto-links pointing to vitest instead of jest module in vitest-jest.mdx

### DIFF
--- a/src/langsmith/vitest-jest.mdx
+++ b/src/langsmith/vitest-jest.mdx
@@ -246,14 +246,14 @@ ls.describe("generate sql demo", () => {
 });
 ```
 
-You can think of each @[ls.test][ls.test] case as corresponding to a dataset example, and @[`ls.describe()`][ls.describe] as defining a LangSmith dataset. If you have LangSmith [tracing environment variables](#setup) set when you run the test suite, the SDK does the following:
+You can think of each [ls.test](https://reference.langchain.com/javascript/langsmith/jest/test) case as corresponding to a dataset example, and [`ls.describe()`](https://reference.langchain.com/javascript/langsmith/jest/describe) as defining a LangSmith dataset. If you have LangSmith [tracing environment variables](#setup) set when you run the test suite, the SDK does the following:
 
 * Creates a [dataset](/langsmith/evaluation-concepts#datasets) with the same name as the name passed to `ls.describe()` in LangSmith if it does not exist.
 * Creates an [example](/langsmith/evaluation-concepts#datasets) in the dataset for each input and expected output passed into a test case if a matching one does not already exist.
 * Creates a new [experiment](/langsmith/evaluation-concepts#experiment) with one result for each test case.
 * Collects the pass/fail rate under the `pass` feedback key for each test case.
 
-When you run this test it will have a default `pass` boolean feedback key based on the test case passing / failing. It will also track any outputs that you log with @[`ls.logOutputs()`][ls.logOutputs] or return from the test function as "actual" result values from your app for the experiment.
+When you run this test it will have a default `pass` boolean feedback key based on the test case passing / failing. It will also track any outputs that you log with [`ls.logOutputs()`](https://reference.langchain.com/javascript/langsmith/jest/logOutputs) or return from the test function as "actual" result values from your app for the experiment.
 
 Create a `.env` file with your `OPENAI_API_KEY` and LangSmith credentials if you don't already have one:
 
@@ -291,7 +291,7 @@ Here's what an experiment against that test suite looks like:
 
 ## Trace feedback
 
-By default LangSmith collects the pass/fail rate under the `pass` feedback key for each test case. You can add additional feedback with either @[`ls.logFeedback()`][ls.logFeedback] or @[`ls.wrapEvaluator()`][ls.wrapEvaluator]. To do so, try the following as your `sql.eval.ts` file (or `sql.eval.js` if you are using Jest without TypeScript):
+By default LangSmith collects the pass/fail rate under the `pass` feedback key for each test case. You can add additional feedback with either [`ls.logFeedback()`](https://reference.langchain.com/javascript/langsmith/jest/logFeedback) or [`ls.wrapEvaluator()`](https://reference.langchain.com/javascript/langsmith/jest/wrapEvaluator). To do so, try the following as your `sql.eval.ts` file (or `sql.eval.js` if you are using Jest without TypeScript):
 
 ```typescript
 import * as ls from "langsmith/vitest";
@@ -398,13 +398,13 @@ ls.describe("generate sql demo", () => {
 });
 ```
 
-Note the use of @[`ls.wrapEvaluator()`][ls.wrapEvaluator] around the `myEvaluator` function. This makes it so that the LLM-as-judge call is traced separately from the rest of the test case to avoid clutter, and conveniently creates feedback if the return value from the wrapped function matches `{ key: string; score: number | boolean }`. In this case, instead of showing up in the main test case run, the evaluator trace will instead show up in a trace associated with the `correctness` feedback key.
+Note the use of [`ls.wrapEvaluator()`](https://reference.langchain.com/javascript/langsmith/jest/wrapEvaluator) around the `myEvaluator` function. This makes it so that the LLM-as-judge call is traced separately from the rest of the test case to avoid clutter, and conveniently creates feedback if the return value from the wrapped function matches `{ key: string; score: number | boolean }`. In this case, instead of showing up in the main test case run, the evaluator trace will instead show up in a trace associated with the `correctness` feedback key.
 
 You can see the evaluator runs in LangSmith by clicking their corresponding feedback chips in the UI.
 
 ## Running multiple examples against a test case
 
-You can run the same test case over multiple examples and parameterize your tests using @[`ls.test.each()`][ls.test.each]. This is useful when you want to evaluate your app the same way against different inputs:
+You can run the same test case over multiple examples and parameterize your tests using [`ls.test.each()`](https://reference.langchain.com/javascript/langsmith/jest/test). This is useful when you want to evaluate your app the same way against different inputs:
 
 ```typescript
 import * as ls from "langsmith/vitest";
@@ -443,7 +443,7 @@ Instead of defining [examples](/langsmith/evaluation-concepts#examples) inline, 
 
 - Use @[`client.listExamples()`][Client.listExamples] to fetch examples from a dataset that already exists in LangSmith.
 - Collect the examples into an array (e.g., `testExamples`) by iterating through the async generator.
-- Pass the array to @[`ls.test.each()`][ls.test.each] to run your test logic against each example from the dataset.
+- Pass the array to [`ls.test.each()`](https://reference.langchain.com/javascript/langsmith/jest/test) to run your test logic against each example from the dataset.
 
 ```typescript {3,30-43,47}
 import * as ls from "langsmith/vitest";
@@ -506,7 +506,7 @@ ls.describe(
 
 ## Log outputs
 
-Every time we run a test we're syncing it to a dataset example and tracing it as a run. To trace final outputs for the run, you can use @[`ls.logOutputs()`][ls.logOutputs] like this:
+Every time we run a test we're syncing it to a dataset example and tracing it as a run. To trace final outputs for the run, you can use [`ls.logOutputs()`](https://reference.langchain.com/javascript/langsmith/jest/logOutputs) like this:
 
 ```typescript
 import * as ls from "langsmith/vitest";


### PR DESCRIPTION
The page covers the Jest/Vitest integration but all 9 @[] auto-links for
ls.test, ls.describe, ls.logOutputs, ls.logFeedback, ls.wrapEvaluator, and
ls.test.each resolved to the langsmith.vitest module instead of the
langsmith/jest module.

Root cause: the page has no :::python/:::js scope fences, so the
preprocessor defaults to Python scope, which maps these ls.* keys to
the vitest module URL rather than the jest module URL.

The vitest and jest APIs share the same function names but have different
module paths and potentially different signatures, so readers clicking
these links were being directed to the wrong API reference.

Replaced all 9 occurrences with hardcoded links to the correct
langsmith/jest module URLs, verified against SCOPE_LINK_MAPS['js'].