### PR TITLE
docs: fix @[JS][ThreadsClient.*] links resolving to Python SDK reference in use-threads.mdx

### DIFF
--- a/src/langsmith/use-threads.mdx
+++ b/src/langsmith/use-threads.mdx
@@ -103,7 +103,7 @@ curl --request POST \
 ```
 </CodeGroup>
 
-For more information, refer to the @[Python][ThreadsClient.create] and @[JS][ThreadsClient.create] SDK docs, or the [REST API](/langsmith/agent-server-api/threads/create-thread) reference.
+For more information, refer to the @[Python][ThreadsClient.create] and [JS](https://reference.langchain.com/javascript/classes/_langchain_langgraph-sdk.client.ThreadsClient.html#create) SDK docs, or the [REST API](/langsmith/agent-server-api/threads/create-thread) reference.
 
 Output:
 
@@ -141,7 +141,7 @@ curl --request POST --url <DEPLOYMENT_URL>/threads/thread["thread_id"]/copy \
 ```
 </CodeGroup>
 
-For more information, refer to the @[Python][ThreadsClient.copy] and @[JS][ThreadsClient.copy] SDK docs, or the [REST API](/langsmith/agent-server-api/threads/copy-thread) reference.
+For more information, refer to the @[Python][ThreadsClient.copy] and [JS](https://reference.langchain.com/javascript/classes/_langchain_langgraph-sdk.client.ThreadsClient.html#copy) SDK docs, or the [REST API](/langsmith/agent-server-api/threads/copy-thread) reference.
 
 ### Prepopulated state
 
@@ -360,7 +360,7 @@ curl --request POST \
 ```
 </CodeGroup>
 
-For more information, refer to the @[Python][ThreadsClient.search] and @[JS][ThreadsClient.search] SDK docs, or the [REST API](/langsmith/agent-server-api/threads/search-threads) reference.
+For more information, refer to the @[Python][ThreadsClient.search] and [JS](https://reference.langchain.com/javascript/classes/_langchain_langgraph-sdk.client.ThreadsClient.html#search) SDK docs, or the [REST API](/langsmith/agent-server-api/threads/search-threads) reference.
 
 Output:
 
@@ -512,7 +512,7 @@ This will load a table of all threads in your deployment.
 
 ### Get thread
 
-To view a specific thread given its `thread_id`, use the @[`get`][ThreadsClient.get] method:
+To view a specific thread given its `thread_id`, use the [`get`](https://reference.langchain.com/javascript/classes/_langchain_langgraph-sdk.client.ThreadsClient.html#get) method:
 
 <CodeGroup>
 ```python Python
@@ -551,11 +551,11 @@ Output:
 }
 ```
 
-For more information, refer to the @[Python][ThreadsClient.get] and @[JS][ThreadsClient.get] SDK docs, or the [REST API](/langsmith/agent-server-api/threads/get-thread) reference.
+For more information, refer to the @[Python][ThreadsClient.get] and [JS](https://reference.langchain.com/javascript/classes/_langchain_langgraph-sdk.client.ThreadsClient.html#get) SDK docs, or the [REST API](/langsmith/agent-server-api/threads/get-thread) reference.
 
 ### Inspect thread state
 
-To view the current state of a given thread, use the @[`get_state`][ThreadsClient.get_state] method. This returns the current values, next nodes to execute, and checkpoint information:
+To view the current state of a given thread, use the [`get_state`](https://reference.langchain.com/javascript/classes/_langchain_langgraph-sdk.client.ThreadsClient.html#getstate) method. This returns the current values, next nodes to execute, and checkpoint information:
 
 <CodeGroup>
 ```python Python
@@ -642,7 +642,7 @@ Output:
 }
 ```
 
-For more information, refer to the @[Python][ThreadsClient.get_state] and @[JS][ThreadsClient.get_state] SDK docs, or the [REST API](/langsmith/agent-server-api/threads/get-thread-state) reference.
+For more information, refer to the @[Python][ThreadsClient.get_state] and [JS](https://reference.langchain.com/javascript/classes/_langchain_langgraph-sdk.client.ThreadsClient.html#getstate) SDK docs, or the [REST API](/langsmith/agent-server-api/threads/get-thread-state) reference.
 
 Optionally, to view the state of a thread at a given checkpoint, pass in the checkpoint ID. This is useful for inspecting the thread state at a specific point in its execution history.
 
@@ -697,7 +697,7 @@ curl --request GET \
 
 ### Inspect full thread history
 
-To view a thread's history, use the @[`get_history`][ThreadsClient.get_history] method. This returns a list of every state the thread experienced, allowing you to trace the full execution path:
+To view a thread's history, use the [`get_history`](https://reference.langchain.com/javascript/classes/_langchain_langgraph-sdk.client.ThreadsClient.html#gethistory) method. This returns a list of every state the thread experienced, allowing you to trace the full execution path:
 
 <CodeGroup>
 ```python Python
@@ -743,7 +743,7 @@ This method is particularly useful for:
 - Auditing conversation history and state changes.
 - Replaying or analyzing past interactions.
 
-For more information, refer to the @[Python][ThreadsClient.get_history] and @[JS][ThreadsClient.get_history] SDK docs, or the [REST API](/langsmith/agent-server-api/threads/get-thread-history) reference.
+For more information, refer to the @[Python][ThreadsClient.get_history] and [JS](https://reference.langchain.com/javascript/classes/_langchain_langgraph-sdk.client.ThreadsClient.html#gethistory) SDK docs, or the [REST API](/langsmith/agent-server-api/threads/get-thread-history) reference.
 
 </Tab>
 <Tab title="UI">


### PR DESCRIPTION
The page uses @[Python][ThreadsClient.X] and @[JS][ThreadsClient.X] side
by side to link to both language SDKs. Because the page has no :::js scope
fence, the preprocessor defaults to Python scope for all @[] links, so the
JS-labeled links were silently pointing to the Python SDK reference instead
of the JavaScript one.

Affected methods (6 JS reference links + 3 inline method links):
- ThreadsClient.create, .copy, .search, .get, .get_state, .get_history

For each, @[JS][ThreadsClient.X] rendered as [JS](python_url) -- the
correct label 'JS' was shown, but the destination was the Python docs.
A JS developer clicking 'JS' would land in the Python SDK reference.

Replaced the @[JS][...] usages with hardcoded links to the correct
JavaScript SDK URLs (verified via SCOPE_LINK_MAPS['js']), leaving the
@[Python][...] usages untouched since those resolve correctly.