### PR TITLE
docs: fix client.runs.cancel Python scope entry pointing to JS reference URL

### DIFF
--- a/pipeline/preprocessors/link_map.py
+++ b/pipeline/preprocessors/link_map.py
@@ -515,7 +515,6 @@ LINK_MAPS: list[LinkMap] = [
             "Client.listExamples": "https://reference.langchain.com/javascript/classes/langsmith.client.Client.html#listexamples",
             "evaluate()": "https://reference.langchain.com/javascript/langsmith/evaluation/evaluate",
             "Example": "https://reference.langchain.com/javascript/interfaces/langsmith.Example.html",
-            "HITLRequest": "https://reference.langchain.com/javascript/langchain/index/HITLRequest",
             "MessageMetadata": "https://reference.langchain.com/javascript/langchain-react/MessageMetadata",
             "SubagentDiscoverySnapshot": "https://reference.langchain.com/javascript/langchain-react/SubagentDiscoverySnapshot",
             "SubgraphDiscoverySnapshot": "https://reference.langchain.com/javascript/langchain-react/SubgraphDiscoverySnapshot",
@@ -526,8 +525,10 @@ LINK_MAPS: list[LinkMap] = [
             "useChannel": "https://reference.langchain.com/javascript/langchain-react/useChannel",
             "StreamTransformer": "langgraph/stream/_types/StreamTransformer",
             "StreamChannel": "langgraph/stream/stream_channel/StreamChannel",
-            "client.runs.cancel": "langsmith/deployment/sdk/#langgraph_sdk.client.RunsClient.cancel",
             "ThreadStateJS": "https://reference.langchain.com/javascript/langchain-langgraph-sdk/index/ThreadState",
+            # END JS references
+            "HITLRequest": "langchain/agents/middleware/human_in_the_loop/HITLRequest",
+            "client.runs.cancel": "langgraph-sdk/_async/runs/RunsClient/cancel",
         },
     },
     {

--- a/pipeline/preprocessors/link_map.py
+++ b/pipeline/preprocessors/link_map.py
@@ -526,7 +526,7 @@ LINK_MAPS: list[LinkMap] = [
             "useChannel": "https://reference.langchain.com/javascript/langchain-react/useChannel",
             "StreamTransformer": "langgraph/stream/_types/StreamTransformer",
             "StreamChannel": "langgraph/stream/stream_channel/StreamChannel",
-            "client.runs.cancel": "https://reference.langchain.com/javascript/langchain-langgraph-sdk/client/RunsClient/cancel",
+            "client.runs.cancel": "langsmith/deployment/sdk/#langgraph_sdk.client.RunsClient.cancel",
             "ThreadStateJS": "https://reference.langchain.com/javascript/langchain-langgraph-sdk/index/ThreadState",
         },
     },

--- a/src/oss/langchain/human-in-the-loop.mdx
+++ b/src/oss/langchain/human-in-the-loop.mdx
@@ -672,7 +672,7 @@ The middleware defines an `after_model` hook that runs after the model generates
 
 1. The agent invokes the model to generate a response.
 2. The middleware inspects the response for tool calls.
-3. If any calls require human input, the middleware builds a `HITLRequest` with `action_requests` and `review_configs` and calls @[interrupt].
+3. If any calls require human input, the middleware builds a @[HITLRequest] with `action_requests` and `review_configs` and calls @[interrupt].
 4. The agent waits for human decisions.
 5. Based on the `HITLResponse` decisions, the middleware executes approved or edited calls, synthesizes @[ToolMessage]'s for rejected calls, returns human replies directly as @[ToolMessage]'s for `respond` decisions, and resumes execution.
 


### PR DESCRIPTION
## Summary

In the Python scope block of `pipeline/preprocessors/link_map.py`
(host: `reference.langchain.com/python/`), every `client.runs.*` and
`client.threads.*` sibling uses a relative path under the Python SDK: