### PR TITLE
docs(langsmith): describe Engine issue tracking instead of custom evaluators

### DIFF
--- a/src/langsmith/engine-issue-categories.mdx
+++ b/src/langsmith/engine-issue-categories.mdx
@@ -113,4 +113,4 @@ A better-fit tool existed but the agent chose the wrong one for the user's reque
 - [Find and fix your agent's issues](/langsmith/engine): Set up Engine, work through the issue lifecycle, and control costs.
 - [Engine](/langsmith/engine-overview): Product overview and where Engine fits in the development lifecycle.
 - [Engine webhook events](/langsmith/engine-webhooks): Forward detected issues to your incident-management, paging, or chat tools.
-- [Evaluators](/langsmith/evaluators): Deploy the suggested evaluator Engine generates for each issue.
+- [Manage datasets](/langsmith/manage-datasets): Turn the traces Engine links to an issue into ground truth examples for offline evaluation.

--- a/src/langsmith/engine-overview.mdx
+++ b/src/langsmith/engine-overview.mdx
@@ -1,27 +1,27 @@
 ---
 title: LangSmith Engine
 sidebarTitle: Overview
-description: LangSmith Engine is the agent for agent engineering, turning production traces into fixes, evaluators, and datasets across the development lifecycle.
+description: LangSmith Engine is the agent for agent engineering, turning production traces into tracked issues, fixes, and datasets across the development lifecycle.
 mode: wide
 ---
 
 LangSmith Engine is the LangSmith Agent for agent engineering. It works from your production traces to surface recurring issues, diagnose their root cause, and drive the fix across every stage of the development lifecycle.
 
-Each issue moves through a closed loop: a recurring issue is detected in your traces, the root cause is diagnosed, a fix is proposed, an evaluator is deployed to catch regressions, and if the issue resurfaces after being closed, Engine reopens it automatically.
+Each issue moves through a closed loop: a recurring issue is detected in your traces, the root cause is diagnosed, a fix is proposed, the issue is tracked as new traces matching the same pattern arrive, and if the issue resurfaces after being closed, Engine reopens it automatically.
 
 ## Engine across the lifecycle
 
-For each issue, Engine surfaces the contributing traces, proposes a fix, generates a custom evaluator to prevent regressions, and creates ground truth dataset examples from the production trace inputs.
+For each issue, Engine surfaces the contributing traces, proposes a fix, keeps the issue current by attaching new traces that match the same failure pattern, and creates ground truth dataset examples from the production trace inputs.
 
 <CardGroup cols={3}>
   <Card title="Build: Open a pull request" icon="git-pull-request" href="/langsmith/engine#open-a-pull-request">
     Apply the proposed fix by opening a pull request in your connected repository. Engine can propose code changes to agents built with Deep Agents, LangChain, and LangGraph.
   </Card>
-  <Card title="Test: Generate evaluators and datasets" icon="database" href="/langsmith/engine#add-offline-examples">
-    Deploy a custom evaluator to catch regressions, and create ground truth dataset examples from production traces for offline evaluation.
+  <Card title="Test: Generate datasets" icon="database" href="/langsmith/engine#add-offline-examples">
+    Create ground truth dataset examples from production traces for offline evaluation, so you can verify a fix before it ships.
   </Card>
-  <Card title="Monitor: Detect recurring issues" icon="chart-line" href="/langsmith/engine#browse-and-filter-issues">
-    Scan your tracing projects on a schedule to surface, prioritize, and diagnose recurring issues.
+  <Card title="Monitor: Track recurring issues" icon="chart-line" href="/langsmith/engine#browse-and-filter-issues">
+    Scan your tracing projects on a schedule to surface, prioritize, and diagnose recurring issues, and add new matching traces to each issue as they appear.
   </Card>
 </CardGroup>
 

--- a/src/langsmith/engine-security.mdx
+++ b/src/langsmith/engine-security.mdx
@@ -26,7 +26,7 @@ Engine operates on data you have already chosen to share with LangChain: the tra
 
 Trace content sent to Engine can include user messages, tool outputs, and PII, and this content is sent to model subprocessors under zero data retention for each analysis task. To remove sensitive fields before traces reach LangSmith, use [client-side masking](/langsmith/mask-inputs-outputs).
 
-Engine outputs are advisory. It surfaces issues, proposes pull requests, and recommends evaluation assets such as evaluators and dataset examples. Your engineers and your branch-protection and review policies decide what ships.
+Engine outputs are advisory. It surfaces and tracks issues, proposes pull requests, and recommends dataset examples for offline evaluation. Your engineers and your branch-protection and review policies decide what ships.
 
 ## GitHub integration
 

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -13,14 +13,14 @@ Each issue moves through a closed loop in which Engine:
 1. Detects a recurring issue in your traces.
 2. Diagnoses the root cause against your traces and connected source code.
 3. Proposes a fix as a pull request.
-4. Generates an evaluator and ground truth [dataset examples](/langsmith/manage-datasets) to catch regressions.
+4. Tracks the issue over time, automatically adding new traces that match the same pattern, and generates ground truth [dataset examples](/langsmith/manage-datasets) so you can verify a fix.
 5. Reopens the issue automatically if it resurfaces after being closed.
 
 ```mermaid
 flowchart LR
     detect["Detect recurring issue"]:::trigger --> diagnose["Diagnose root cause"]:::process
     diagnose --> fix["Propose fix as PR"]:::process
-    fix --> prevent["Generate evaluator and dataset examples"]:::output
+    fix --> prevent["Track matching traces and generate dataset examples"]:::output
     prevent --> close["Close issue"]:::decision
     close -->|"resurfaces"| detect
 
@@ -177,6 +177,8 @@ If no issues appear after setup completes, Engine found no recurring patterns in
 Click any issue in the list to open its detail panel. At the top, a diagnosis describes the problem and its impact.
 
 The **Linked Traces** section lists the traces that support the diagnosis. Click any trace to open its detail panel. For more information, see [Manage a trace](/langsmith/manage-trace). Click [**Add offline examples**](#add-offline-examples) at the top right of this section to generate custom ground truth [dataset examples](/langsmith/manage-datasets) from the production trace inputs for offline evaluation.
+
+Engine keeps tracking an issue after it is filed. On later scans, any new trace that matches the issue's failure pattern is added to **Linked Traces** automatically, so the issue reflects how often the failure is still happening without you re-running anything.
 
 The **Proposed Fix** section describes the issue and suggests how to address it, which may include specific code or prompt changes if a repository is connected.
 

--- a/src/langsmith/evaluators.mdx
+++ b/src/langsmith/evaluators.mdx
@@ -9,7 +9,7 @@ boost: 3
 [Evaluators](/langsmith/evaluation-concepts#evaluators) in LangSmith are [workspace-level](/langsmith/administration-overview#workspaces) resources. You can attach a single evaluator to multiple [tracing projects](/langsmith/observability-concepts#projects) and [datasets](/langsmith/evaluation-concepts#datasets), so you can apply consistent evaluation logic across your work without recreating it each time.
 
 <Tip>
-The [LangSmith Engine](/langsmith/engine) suggests custom evaluators for detected issues and can deploy them with one click.
+Evaluator scores are a high-priority signal for the [LangSmith Engine](/langsmith/engine): it pulls low-scoring traces when choosing what to analyze, so attaching an evaluator to a project sharpens the issues Engine finds there.
 </Tip>
 
 ## View evaluators


### PR DESCRIPTION
The Engine pages presented a generated custom evaluator as a user-facing deliverable ("generates a custom evaluator to prevent regressions", "Deploy the suggested evaluator Engine generates for each issue"). Engine does author regression evaluators internally, but what a user sees is issue upkeep: once an issue is filed, later scans attach new traces matching the same failure pattern to that issue. These pages now say that.

## What changed

- `engine-overview.mdx`: closed-loop sentence, lifecycle intro, frontmatter description, and the Test/Monitor cards.
- `engine.mdx`: step 4 of the loop and the matching mermaid node. Added a paragraph under **Linked Traces** explaining that new matching traces are attached automatically on later scans, which is where a reader looks for this behavior.
- `engine-issue-categories.mdx`: the See also entry pointed at Evaluators for a per-issue evaluator; it now points at Manage datasets.
- `engine-security.mdx`: the advisory-outputs sentence no longer lists evaluators among recommended assets.
- `evaluators.mdx`: the Engine tip claimed one-click evaluator deployment. Rewritten to state the real relationship, which is the reverse: evaluator scores are a high-priority signal when Engine picks traces to analyze.

Dataset examples stay throughout, since Engine does propose grounded regression examples.

## Deliberately unchanged

- `engine.mdx` lines on feedback sampling and the scope-filter limitation, and the `engine-security.mdx` data table: these describe *your* evaluators as an input signal, which is accurate.
- `engine-self-hosted.mdx` "generate fixes, and write evaluators": this is the LCU cost driver and model-role breakdown. Engine still spends model calls authoring regression evaluators, so removing it would misstate where cost goes.

## Review focus

Whether "tracks the issue as new matching traces arrive" is the framing we want in the closed loop, given the loop already ends with automatic reopening after a close. The two are distinct (attaching to an open issue vs. reopening a closed one) and both are now stated.

Drafted with Claude Code; every claim checked against the Engine implementation rather than the previous copy.

## Test Plan
- [ ] `make lint_prose` on the five changed files — clean (0 errors, 0 warnings, 0 suggestions).
- [ ] Preview the Engine overview and Engine pages and confirm the mermaid node renders and the three lifecycle cards still read coherently.
- [ ] Confirm the new `/langsmith/manage-datasets` link in Engine issue categories resolves.