### PR TITLE
docs(mda): rewrite managed deep agents evals around coding agents

### DIFF
--- a/src/langsmith/harbor-integrations.mdx
+++ b/src/langsmith/harbor-integrations.mdx
@@ -286,6 +286,7 @@ harbor run -d "<org/name>" \
 
 ## See also
 
+- [Evaluate Managed Deep Agents](/langsmith/managed-deep-agents-evals)
 - [Deep Agents documentation](/oss/deepagents/overview)
 - [Datasets & Experiments](/langsmith/manage-datasets)
 - [Analyze an experiment](/langsmith/analyze-an-experiment)

--- a/src/langsmith/managed-deep-agents-cli.mdx
+++ b/src/langsmith/managed-deep-agents-cli.mdx
@@ -75,7 +75,7 @@ The LangSmith API key authenticates the deploy. The agent's model provider also 
 | `mda --version` | Show the installed CLI version. |
 | `mda init <name>` | Scaffold a Python Managed Deep Agents project. |
 | `mda build [path]` | Compile a project into a managed LangGraph app without deploying. |
-| `mda eval …` / `mda evals …` | Scaffold optional Harbor tasks and compile the agent into a Harbor handoff. |
+| `mda eval …` / `mda evals …` | Initialize a Harbor workspace and continue eval authoring in a coding agent. |
 | `mda dev [path]` | Compile a project and run it on the local LangGraph dev server. |
 | `mda deploy [path]` | Compile, sync Context Hub context, upload, and deploy to LangSmith. |
 | `mda channel add slack [path]` | Configure Slack for a deployed agent. |
@@ -90,7 +90,7 @@ The LangSmith API key authenticates the deploy. The agent's model provider also 
 | `mda --version` | Show the installed CLI version. |
 | `mda init <name>` | Scaffold a TypeScript Managed Deep Agents project. |
 | `mda build [path]` | Compile a project into a managed LangGraph app without deploying. |
-| `mda eval …` / `mda evals …` | Scaffold optional Harbor tasks and compile the agent into a Harbor handoff. |
+| `mda eval …` / `mda evals …` | Initialize a Harbor workspace and continue eval authoring in a coding agent. |
 | `mda dev [path]` | Compile a project and run it on the local LangGraph dev server. |
 | `mda deploy [path]` | Compile, sync Context Hub context, upload, and deploy to LangSmith. |
 | `mda channel add slack [path]` | Configure Slack for a deployed agent. |
@@ -156,7 +156,7 @@ The scaffold creates:
 | `.gitignore` | Ignores `.env`, `.env.*`, `.mda/`, and dependency caches. |
 :::
 
-Eval tasks are opt-in and are not created by `mda init`. Managed Deep Agents evals are Harbor tasks under `evals/tasks/`. Run `mda evals init <name>` only when you want an optional starter task under `evals/scaffold/`.
+Eval tasks are opt-in and are not created by `mda init`. Run `mda evals init -i` from the project root to initialize the Harbor workspace and continue in a coding agent with the `eval-engineering` skill.
 
 ## Build projects
 
@@ -173,29 +173,22 @@ mda build .
 
 ## Evaluate projects
 
-`evals/tasks/` is the canonical Harbor dataset. Author complete Harbor tasks there directly. The `mda eval` command, also available as `mda evals`, can scaffold a starter task and package the managed agent for Harbor. Managed Deep Agents prints a `harbor run` command but does not run trials.
+Use `mda evals init` to initialize a Harbor workspace. The command is also available as `mda eval`. Use the interactive handoff to develop complete tasks with a coding agent and the `eval-engineering` skill.
 
 ```bash
-mda evals init smoke
-mda evals compile .
-# then run the printed `harbor run` command
+mda evals init -i
 ```
 
-| Subcommand | Use |
+| Command or flag | Use |
 | --- | --- |
-| `mda evals init <name>` | Create `evals/scaffold/<name>/` with an instruction and a language-native test. Run this command from the project root. |
-| `mda evals compile [path]` | Compile the managed agent, copy selected scaffolds into `evals/tasks/`, and write the Harbor handoff under `evals/`. |
+| `mda evals init` | Create `evals/harbor-job.json` when missing and generate the Harbor adapter and runtime settings under `.mda/evals/`. Run this command from the project root. |
+| `-i`, `--interactive` | Start a detected coding agent with the eval-engineering prompt, or copy the prompt for another agent. |
 
-Task names passed to `mda evals init` can contain ASCII letters, numbers, `_`, and `-`.
+The handoff asks the coding agent to install the `eval-engineering` skill, inspect the managed agent, and write complete Harbor tasks under `evals/<task>/`. It also includes the pinned Harbor command that loads the MDA job plugin and LangSmith plugin.
 
-`mda evals compile` flags:
+`mda evals compile` is an internal command used by the Harbor job plugin. The plugin runs it when a Harbor job starts, so you do not compile eval artifacts separately.
 
-| Flag | Use |
-| --- | --- |
-| `--task <name>` | Select one task. Repeat to select multiple tasks. A selected scaffold refreshes the matching task under `evals/tasks/`. If omitted, all tasks are selected and every scaffold is refreshed. Existing canonical tasks are preserved unless a selected scaffold has the same name. |
-| `--model <provider:model>` | Record a model in the artifact manifest. Repeat to record multiple models; the generated job config uses the first value. |
-
-For Harbor task authoring, optional scaffolding, credentials, and running trials, see [Evals](/langsmith/managed-deep-agents-evals).
+For workflow guidance, see [Evals](/langsmith/managed-deep-agents-evals).
 
 ## Develop locally
 

--- a/src/langsmith/managed-deep-agents-evals.mdx
+++ b/src/langsmith/managed-deep-agents-evals.mdx
@@ -8,7 +8,7 @@ import ManagedDeepAgentsPrivateBetaNote from '/snippets/langsmith/managed-deep-a
 
 Managed Deep Agents evals are [Harbor](https://www.harborframework.com/docs/tasks) tasks. Use a coding agent with the [`eval-engineering` skill](https://github.com/langchain-ai/langchain-skills/blob/main/config/skills/eval-engineering/SKILL.md) to inspect the project, draft a Task Spec for your review, and write complete tasks under `evals/`.
 
-Managed Deep Agents initializes the Harbor workspace. Harbor compiles the managed agent when a job starts, runs each task in an isolated environment, and records the result.
+Managed Deep Agents initializes the Harbor workspace. Harbor runs the managed agent against each task in an isolated environment and records the result.
 
 <ManagedDeepAgentsPrivateBetaNote />
 
@@ -113,23 +113,7 @@ evals/
         └── <verifier>
 ```
 
-`Task.md` is the human-reviewed control-plane spec. Do not copy or mount it into the evaluated agent's environment. `instruction.md` tells the agent what to do. Harbor builds the task environment, runs the managed agent, and then runs `tests/test.sh`. The verifier writes a numeric reward to `/logs/verifier/reward.txt` or numeric metrics to `/logs/verifier/reward.json`.
-
-:::python
-Use a `python:3.12` task image and pytest verifier files named `tests/test_*.py`. Invoke them from `tests/test.sh` with:
-
-```bash
-python -m pytest /tests -q
-```
-:::
-
-:::js
-Use a `node:24` task image and Node test files named `tests/*.test.ts`. Invoke them from `tests/test.sh` with:
-
-```bash
-node --experimental-strip-types --test /tests/*.test.ts
-```
-:::
+`Task.md` is the human-reviewed spec. `instruction.md` tells the agent what to do. Harbor builds the task environment, runs the managed agent, and then runs `tests/test.sh`. The verifier writes a numeric reward to `/logs/verifier/reward.txt` or numeric metrics to `/logs/verifier/reward.json`.
 
 For the full task format, see the [Harbor task documentation](https://www.harborframework.com/docs/tasks).
 
@@ -150,9 +134,9 @@ uv run --env-file .env --python 3.12 --with 'harbor[langsmith]==0.21.0' harbor r
   --plugin mda_harbor.langsmith_plugin:LangSmithPlugin
 ```
 
-Replace `my-agent` with the project directory name. If the project has no `.env` file, omit `--env-file .env`. The generated command handles both details automatically and uses PowerShell syntax on Windows.
+Replace `my-agent` with the project directory name. The generated command fills in the name and uses PowerShell syntax on Windows.
 
-The MDA job plugin compiles a job-scoped agent artifact before Harbor starts any trials. Re-running the command after editing the agent picks up the project changes without a separate compile step.
+Re-running the command after editing the agent picks up the project changes.
 
   </Step>
 
@@ -174,23 +158,9 @@ Review failed trials with your coding agent. Update the task or verifier when th
 
 Edit `evals/harbor-job.json` to change datasets, attempts, concurrency, environment settings, or agent environment variables. Managed Deep Agents preserves the file when you run `mda evals init` again.
 
-Check in `evals/harbor-job.json` and the task directories under `evals/`. Do not check in `.mda/evals/` or Harbor job results.
+## Record runs in LangSmith
 
-## How the managed agent runs
-
-Harbor loads the generated `MDAJobPlugin` before it starts trials. The plugin invokes the internal Managed Deep Agents compiler and creates an isolated artifact for the Harbor job.
-
-:::python
-The custom Harbor adapter then runs the compiled Python managed graph inside each task environment.
-:::
-
-:::js
-The custom Harbor adapter then runs the compiled TypeScript managed graph inside each task environment.
-:::
-
-This keeps the eval on the same authored agent files, instructions, tools, middleware, connectors, and runtime wiring used by Managed Deep Agents. You do not maintain a separate agent implementation for evals.
-
-When `LANGSMITH_API_KEY` is available, the companion LangSmith plugin records the Harbor runs in the dataset named by `HARBOR_LANGSMITH_DATASET`.
+When `LANGSMITH_API_KEY` is available, the LangSmith plugin records the Harbor runs in the dataset named by `HARBOR_LANGSMITH_DATASET`.
 
 ## See also
 

--- a/src/langsmith/managed-deep-agents-evals.mdx
+++ b/src/langsmith/managed-deep-agents-evals.mdx
@@ -1,239 +1,201 @@
 ---
 title: Evaluate Managed Deep Agents
 sidebarTitle: Evals
-description: Create and run Harbor evals for Managed Deep Agents.
+description: Develop Harbor evals for Managed Deep Agents with a coding agent and the eval-engineering skill.
 ---
 
 import ManagedDeepAgentsPrivateBetaNote from '/snippets/langsmith/managed-deep-agents-private-beta-note.mdx';
 
-Managed Deep Agents evals are [Harbor](https://www.harborframework.com/docs/tasks) evals. `evals/tasks/` is the canonical Harbor dataset. Author complete tasks there with Harbor's task format, environments, and verifiers.
+Managed Deep Agents evals are [Harbor](https://www.harborframework.com/docs/tasks) tasks. Use a coding agent with the [`eval-engineering` skill](https://github.com/langchain-ai/langchain-skills/blob/main/config/skills/eval-engineering/SKILL.md) to inspect the project, draft a Task Spec for your review, and write complete tasks under `evals/`.
 
-The `mda evals` commands do not introduce a separate eval format or run trials. They package the managed agent for Harbor and can optionally turn a minimal starter task under `evals/scaffold/` into a complete task under `evals/tasks/`.
+Managed Deep Agents initializes the Harbor workspace. Harbor compiles the managed agent when a job starts, runs each task in an isolated environment, and records the result.
 
 <ManagedDeepAgentsPrivateBetaNote />
 
-## Project structure
-
-Keep all eval files under one top-level `evals/` directory:
-
-:::python
-```text
-my-agent/
-├── agent.py
-└── evals/                          # Harbor workspace
-    ├── tasks/                      # Canonical Harbor dataset
-    │   └── <task>/
-    └── scaffold/                   # Optional starter tasks
-        └── <task>/
-```
-:::
-
-:::js
-```text
-my-agent/
-├── agent.ts
-└── evals/                          # Harbor workspace
-    ├── tasks/                      # Canonical Harbor dataset
-    │   └── <task>/
-    └── scaffold/                   # Optional starter tasks
-        └── <task>/
-```
-:::
-
-An optional scaffold has a one-way relationship with its canonical Harbor task:
-
-```text
-evals/scaffold/<task>/ → mda evals compile → evals/tasks/<task>/
-```
-
-<Note>
-`evals/scaffold/` is not a second eval system. Harbor runs the tasks under `evals/tasks/`. Use scaffolding only when you want Managed Deep Agents to create a minimal starting point.
-</Note>
-
-## Choose an authoring workflow
-
-Use one of the following ways to populate the canonical Harbor dataset:
-
-- **Author a Harbor task directly**: Create a complete task under `evals/tasks/` and manage it with Harbor. Use this workflow when you need the full Harbor task format.
-- **Start from an optional scaffold**: Run `mda evals init <name>` to create a minimal task under `evals/scaffold/`, then compile it into `evals/tasks/` with the agent artifact and Harbor adapter.
-
 ## Prerequisites
 
+Before you evaluate, make sure you have:
+
 - A Managed Deep Agents project created with `mda init`, or an existing project with an agent entry.
-- [Docker](https://docs.docker.com/get-docker/) running locally when using Harbor's default `docker` environment.
-- The `mda` CLI from `managed-deepagents`. See the [CLI reference](/langsmith/managed-deep-agents-cli#install).
-- [Harbor](https://www.harborframework.com/docs) on your `PATH`, or [`uv`](https://docs.astral.sh/uv/) so you can run `uv run --with harbor …`.
-- Model and tool credentials exported in the shell that runs Harbor.
+- [`uv`](https://docs.astral.sh/uv/), which runs the pinned Harbor version and plugins.
+- [Docker](https://docs.docker.com/get-docker/), which Harbor uses for task environments.
+- A coding agent. Agents that support Agent Skills can install `eval-engineering` directly. For other agents, provide the skill instructions in the session.
 
-<Note>
-Harbor does not load values from the project `.env` file. When Managed Deep Agents generates a Harbor job config, it writes `${VAR}` placeholders for eligible `.env` keys, not their values. Export the required variables before you run Harbor.
-</Note>
+## Add the `eval-engineering` skill
 
-## Author Harbor evals directly
-
-Use Harbor's complete task format when you need full control. A task can define its instruction, environment, verifier, metadata, and other Harbor configuration:
-
-```text
-evals/
-  tasks/
-    my-task/
-      instruction.md
-      task.toml
-      environment/
-        Dockerfile
-      tests/
-        test.sh
-```
-
-Each task describes what the agent should do. Harbor runs the agent in the task environment, then runs `tests/test.sh` to grade the result. During grading, the main paths are:
-
-| Path | Purpose |
-| --- | --- |
-| `/app` | Agent working directory and task output. |
-| `/tests` | Task verifier files. |
-| `/logs/verifier/` | Verifier reward output. |
-
-The verifier must write a numeric reward to `/logs/verifier/reward.txt` or numeric metrics to `/logs/verifier/reward.json`. For the full task format and verifier options, see the [Harbor task documentation](https://www.harborframework.com/docs/tasks).
-
-Files you author directly under `evals/tasks/` are preserved when Managed Deep Agents compiles scaffolds with other names.
-
-## Scaffold a Harbor task
-
-This optional workflow creates a minimal source task that Managed Deep Agents can complete and copy into the canonical Harbor dataset.
+The [`eval-engineering` skill](https://github.com/langchain-ai/langchain-skills/blob/main/config/skills/eval-engineering/SKILL.md) walks a coding agent through discovering the agent, proposing a Task Spec, and building a reviewed Harbor task. To add it to the current project, run:
 
 :::python
-Managed Deep Agents scaffolds the task from an instruction and a Python test.
-:::
-
-:::js
-Managed Deep Agents scaffolds the task from an instruction and a TypeScript test.
-:::
-
-Run the following command from the Managed Deep Agents project root:
-
 ```bash
-mda evals init smoke
-```
-
-The task name can contain ASCII letters, numbers, `_`, and `-`. Run the command with another name to add another task. `mda init` does not create eval tasks automatically.
-
-The command creates the following layout:
-
-:::python
-```text
-evals/
-  scaffold/
-    smoke/
-      instruction.md
-      tests/
-        test_answer.py
+uvx --from npx-skills skills add langchain-ai/langchain-skills --skill eval-engineering --yes
 ```
 :::
 
 :::js
-```text
-evals/
-  scaffold/
-    smoke/
-      instruction.md
-      tests/
-        answer.test.ts
+```bash
+npx skills add langchain-ai/langchain-skills --skill eval-engineering --yes
 ```
 :::
 
-The starter task asks the agent to write `answer.txt` containing `PONG`. Replace the instruction and test with behavior that represents your application.
+You can use any coding agent.
+
+<Tip>
+To use [Deep Agents Code](/oss/deepagents/code/overview) (`dcode`), install it with:
+
+```bash
+curl -LsSf https://langch.in/dcode | bash
+```
+
+See the [Deep Agents Code quickstart](/oss/deepagents/code/quickstart) for provider setup and interactive use.
+</Tip>
+
+## Develop evals with a coding agent
+
+<Steps>
+  <Step title="Initialize the eval workspace" id="initialize-the-eval-workspace">
+
+From the project root, run:
+
+```bash
+mda evals init -i
+```
+
+The interactive handoff lists detected coding agents, including Deep Agents Code, Claude Code, Codex, and Cursor. Selecting an agent starts that agent in the project directory and runs the eval-engineering prompt. You can also copy the prompt for another agent, or exit and return later.
+
+Initialization creates:
+
+```text
+my-agent/
+├── evals/
+│   └── harbor-job.json
+└── .mda/
+    └── evals/
+        ├── runtime.json
+        └── harbor-adapter/
+```
+
+`evals/harbor-job.json` is user-owned. Managed Deep Agents writes it only when it is missing, so later edits are preserved. Files under `.mda/evals/` are generated.
+
+  </Step>
+
+  <Step title="Start the coding-agent session" id="start-the-coding-agent-session">
+
+The handoff asks the selected coding agent to install the `eval-engineering` skill and use it for the project. If you already added the skill, continue in that session.
+
+Ask the coding agent to follow the skill's review flow and use the Managed Deep Agents task layout:
+
+```text
+Use the eval-engineering skill to develop Harbor evals for this Managed
+Deep Agent. Inspect the project and existing evals first. Draft the Task
+Spec and wait for my review before implementing the approved task directly
+under evals/<task>/.
+```
+
+Work with the coding agent to review the Task Spec, task instruction, environment, verifier, and reusable project knowledge. The coding agent writes the runnable task after you approve the design.
+
+  </Step>
+
+  <Step title="Review the Harbor task" id="review-the-harbor-task">
+
+Each direct child of `evals/` that contains an instruction and tests is a Harbor task:
+
+```text
+evals/
+├── harbor-job.json
+└── <task>/
+    ├── Task.md
+    ├── instruction.md
+    ├── task.toml
+    ├── environment/
+    │   └── Dockerfile
+    └── tests/
+        ├── test.sh
+        └── <verifier>
+```
+
+`Task.md` is the human-reviewed control-plane spec. Do not copy or mount it into the evaluated agent's environment. `instruction.md` tells the agent what to do. Harbor builds the task environment, runs the managed agent, and then runs `tests/test.sh`. The verifier writes a numeric reward to `/logs/verifier/reward.txt` or numeric metrics to `/logs/verifier/reward.json`.
 
 :::python
-```python
-from pathlib import Path
+Use a `python:3.12` task image and pytest verifier files named `tests/test_*.py`. Invoke them from `tests/test.sh` with:
 
-
-def test_answer_is_pong():
-    assert Path("/app/answer.txt").read_text().strip() == "PONG"
+```bash
+python -m pytest /tests -q
 ```
 :::
 
 :::js
-```ts
-import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { test } from "node:test";
+Use a `node:24` task image and Node test files named `tests/*.test.ts`. Invoke them from `tests/test.sh` with:
 
-test("answer.txt contains exactly PONG", () => {
-  const text = readFileSync("/app/answer.txt", "utf8").trim();
-  assert.equal(text, "PONG");
-});
+```bash
+node --experimental-strip-types --test /tests/*.test.ts
 ```
 :::
 
-### Compile scaffolded tasks
+For the full task format, see the [Harbor task documentation](https://www.harborframework.com/docs/tasks).
 
-Compile every scaffold under `evals/scaffold/`:
+  </Step>
 
-```bash
-mda evals compile .
-```
+  <Step title="Run the evals" id="run-the-evals">
 
-To refresh specific scaffolds, repeat `--task`:
+The coding-agent handoff includes a command configured for the project and current shell. Run that command from the project root.
 
-```bash
-mda evals compile . --task smoke --task regression
-```
-
-For each selected scaffold, Managed Deep Agents:
-
-1. Replaces the matching directory under `evals/tasks/`.
-2. Copies the complete scaffold from `evals/scaffold/`.
-3. Adds `tests/test.sh` when the scaffold does not provide one. The wrapper runs the language-native tests and writes a `1` or `0` reward.
-
-Unselected tasks under `evals/tasks/` are preserved, including tasks authored directly as Harbor tasks. The generated Harbor job uses all tasks under `evals/tasks/` as its dataset.
-
-<Warning>
-Treat `evals/scaffold/<name>/` as the source of truth for a scaffolded task. Compiling that scaffold replaces the entire matching `evals/tasks/<name>/` directory, including changes made only to the canonical copy.
-</Warning>
-
-You can add Harbor files such as `task.toml`, `environment/`, or a custom `tests/test.sh` to a scaffold under `evals/scaffold/<name>/`. Managed Deep Agents copies them into the canonical Harbor task during compilation.
-
-### Inspect the compiled handoff
-
-Compilation writes or updates the Harbor workspace:
-
-| Path | Contents |
-| --- | --- |
-| `evals/artifact/` | Compiled managed agent and artifact manifest. |
-| `evals/harbor-adapter/` | Embedded `mda_harbor` adapter that Harbor imports to run the agent. |
-| `evals/tasks/` | Canonical Harbor dataset, including compiled scaffolds and directly authored tasks. |
-| `evals/harbor-job.json` | Ready-to-edit Harbor job config. |
-| `evals/harbor-jobs/<id>/` | Local trial results for this compile. |
-
-Compile supports the following repeatable flags:
-
-| Flag | Purpose |
-| --- | --- |
-| `--task <name>` | Select one task. Repeat to select more tasks. If a selected task has a source under `evals/scaffold/`, Managed Deep Agents refreshes its canonical copy. Omit the flag to select all tasks and refresh every scaffold. |
-| `--model <provider:model>` | Record a model in the artifact manifest. The generated job config uses the first model. If omitted, Managed Deep Agents uses the agent's model when available. |
-
-Check in the Harbor definitions and configuration under `evals/` that your project uses. Keep local run output under `evals/harbor-jobs/` out of version control. The `evals/` directory is not included in the deployed agent build.
-
-## Run trials with Harbor
-
-`mda evals compile` prints a Harbor command configured for the compiled agent. Export the variables listed in the compile summary, then run the command from the project root:
+On macOS or Linux, it has the following form:
 
 ```bash
-export OPENAI_API_KEY="<OPENAI_API_KEY>"
-
-PYTHONPATH=evals/harbor-adapter \
-  uv run --with harbor harbor run --config evals/harbor-job.json --yes
+HARBOR_LANGSMITH_DATASET=mda-my-agent-evals \
+PYTHONPATH=.mda/evals/harbor-adapter \
+uv run --env-file .env --python 3.12 --with 'harbor[langsmith]==0.21.0' harbor run \
+  --config evals/harbor-job.json --yes \
+  --plugin mda_harbor.job_plugin:MDAJobPlugin \
+  --plugin mda_harbor.langsmith_plugin:LangSmithPlugin
 ```
 
-If `harbor` is already on your `PATH`, the printed command uses `harbor run` directly instead of `uv run --with harbor`.
+Replace `my-agent` with the project directory name. If the project has no `.env` file, omit `--env-file .env`. The generated command handles both details automatically and uses PowerShell syntax on Windows.
 
-Edit `evals/harbor-job.json` to change the task dataset, model, environment, concurrency, or attempts. Harbor owns trial orchestration, environments, and reporting. For job configuration and run options, see the [Harbor documentation](https://www.harborframework.com/docs).
+The MDA job plugin compiles a job-scoped agent artifact before Harbor starts any trials. Re-running the command after editing the agent picks up the project changes without a separate compile step.
 
-Running the same command again resumes the jobs directory referenced by the config. Recompile, or pass Harbor a fresh `--job-name`, to start a new run.
+  </Step>
 
-## Next steps
+  <Step title="Inspect the results" id="inspect-the-results">
 
-- [CLI reference](/langsmith/managed-deep-agents-cli): Review all `mda evals` commands and flags.
-- [Deploy an agent](/langsmith/managed-deep-agents-deploy): Deploy the agent after its evals pass.
-- [Harbor documentation](https://www.harborframework.com/docs): Configure tasks, environments, jobs, and verifiers.
+Open the Harbor results:
+
+```bash
+uv run --python 3.12 --with 'harbor[langsmith]==0.21.0' \
+  harbor view .mda/evals/jobs
+```
+
+Review failed trials with your coding agent. Update the task or verifier when the eval does not measure the intended behavior. Update the managed agent when the eval exposes a product failure, then run the same Harbor command again.
+
+  </Step>
+</Steps>
+
+## Edit the Harbor job
+
+Edit `evals/harbor-job.json` to change datasets, attempts, concurrency, environment settings, or agent environment variables. Managed Deep Agents preserves the file when you run `mda evals init` again.
+
+Check in `evals/harbor-job.json` and the task directories under `evals/`. Do not check in `.mda/evals/` or Harbor job results.
+
+## How the managed agent runs
+
+Harbor loads the generated `MDAJobPlugin` before it starts trials. The plugin invokes the internal Managed Deep Agents compiler and creates an isolated artifact for the Harbor job.
+
+:::python
+The custom Harbor adapter then runs the compiled Python managed graph inside each task environment.
+:::
+
+:::js
+The custom Harbor adapter then runs the compiled TypeScript managed graph inside each task environment.
+:::
+
+This keeps the eval on the same authored agent files, instructions, tools, middleware, connectors, and runtime wiring used by Managed Deep Agents. You do not maintain a separate agent implementation for evals.
+
+When `LANGSMITH_API_KEY` is available, the companion LangSmith plugin records the Harbor runs in the dataset named by `HARBOR_LANGSMITH_DATASET`.
+
+## See also
+
+- [CLI reference](/langsmith/managed-deep-agents-cli): review `mda evals init` and related flags.
+- [Deploy an agent](/langsmith/managed-deep-agents-deploy): deploy the agent after its evals pass.
+- [Deep Agents Code quickstart](/oss/deepagents/code/quickstart): install and run `dcode`.
+- [Harbor integrations](/langsmith/harbor-integrations): record Harbor jobs in LangSmith.
+- [Harbor task documentation](https://www.harborframework.com/docs/tasks): configure tasks, environments, and verifiers.

--- a/src/langsmith/managed-deep-agents-overview.mdx
+++ b/src/langsmith/managed-deep-agents-overview.mdx
@@ -159,7 +159,7 @@ Each part of the agent maps to a file or directory. Add the ones your agent need
 | [Identity](/langsmith/managed-deep-agents-identity) | `identity.py` | Per-caller private threads, memory, and credentials for multi-user deployments. |
 | [Channels](/langsmith/managed-deep-agents-channels) | `channels/` | Connections to messaging services, such as Slack, that start runs and receive responses. |
 | [Schedules](/langsmith/managed-deep-agents-schedules) | `schedules/` | Managed cron schedules that run the agent on a recurring basis. |
-| [Evals](/langsmith/managed-deep-agents-evals) | `evals/` | Harbor-style tasks that test the agent. |
+| [Evals](/langsmith/managed-deep-agents-evals) | `evals/` | Harbor tasks that test the agent. |
 :::
 
 :::js
@@ -176,7 +176,7 @@ Each part of the agent maps to a file or directory. Add the ones your agent need
 | [Identity](/langsmith/managed-deep-agents-identity) | `identity.ts` | Per-caller private threads, memory, and credentials for multi-user deployments. |
 | [Channels](/langsmith/managed-deep-agents-channels) | `channels/` | Connections to messaging services, such as Slack, that start runs and receive responses. |
 | [Schedules](/langsmith/managed-deep-agents-schedules) | `schedules/` | Managed cron schedules that run the agent on a recurring basis. |
-| [Evals](/langsmith/managed-deep-agents-evals) | `evals/` | Harbor-style tasks that test the agent. |
+| [Evals](/langsmith/managed-deep-agents-evals) | `evals/` | Harbor tasks that test the agent. |
 :::
 
 For the full layout, see [Project structure](/langsmith/managed-deep-agents-project-structure).

--- a/src/langsmith/managed-deep-agents-project-structure.mdx
+++ b/src/langsmith/managed-deep-agents-project-structure.mdx
@@ -40,7 +40,7 @@ Use only one agent entry in a project. See [Agent definition](/langsmith/managed
 - **Application code**: Files under `tools/` and `middleware/` are ordinary project modules. Import them from the agent entry. Other local modules work the same way.
 - **Managed configuration**: Root `identity.py` and `memory.py`, direct children of `channels/`, `connectors/`, and `schedules/`, and `sandbox/__init__.py` enable their corresponding capabilities. MCP connector modules export a module-level `connector`.
 - **Dependencies and secrets**: Declare dependencies in `pyproject.toml`. Managed Deep Agents loads `.env` locally and forwards eligible values as deployment secrets, but never includes `.env` files in the build archive.
-- **Evals**: Managed Deep Agents evals are Harbor evals. `evals/tasks/` is the canonical Harbor task dataset. Author tasks there directly, or run `mda evals init <name>` to create an optional starter under `evals/scaffold/`. `mda evals compile` copies scaffolds into `evals/tasks/` and packages the agent for Harbor. The `evals/` directory is not included in the deployed agent build.
+- **Evals**: Managed Deep Agents evals are Harbor evals. Run `mda evals init -i` and develop tasks with a coding agent and the `eval-engineering` skill. Generated runtime files stay under `.mda/evals/` and are not included in the deployed agent build.
 :::
 
 :::js
@@ -48,7 +48,7 @@ Use only one agent entry in a project. See [Agent definition](/langsmith/managed
 - **Application code**: Files under `tools/` and `middleware/` are ordinary project modules. Import them from the agent entry. Other local modules work the same way.
 - **Managed configuration**: Root `identity.ts` and `memory.ts`, direct children of `channels/`, `connectors/`, and `schedules/`, and `sandbox/index.ts` enable their corresponding capabilities. MCP connector modules export a named `connector`.
 - **Dependencies and secrets**: Declare dependencies in `package.json`. Managed Deep Agents loads `.env` locally and forwards eligible values as deployment secrets, but never includes `.env` files in the build archive.
-- **Evals**: Managed Deep Agents evals are Harbor evals. `evals/tasks/` is the canonical Harbor task dataset. Author tasks there directly, or run `mda evals init <name>` to create an optional starter under `evals/scaffold/`. `mda evals compile` copies scaffolds into `evals/tasks/` and packages the agent for Harbor. The `evals/` directory is not included in the deployed agent build.
+- **Evals**: Managed Deep Agents evals are Harbor evals. Run `mda evals init -i` and develop tasks with a coding agent and the `eval-engineering` skill. Generated runtime files stay under `.mda/evals/` and are not included in the deployed agent build.
 :::
 
 :::python

--- a/src/langsmith/managed-deep-agents-tutorial.mdx
+++ b/src/langsmith/managed-deep-agents-tutorial.mdx
@@ -264,6 +264,6 @@ For deploy flags and troubleshooting, see [Deploy an agent](/langsmith/managed-d
     Authenticate callers and use verified identity in tools and middleware.
   </Card>
   <Card title="Evals" icon="flask" href="/langsmith/managed-deep-agents-evals">
-    Author Harbor tasks and compile the managed agent for Harbor.
+    Develop Harbor evals with a coding agent and the eval-engineering skill.
   </Card>
 </CardGroup>

--- a/src/snippets/langsmith/managed-deep-agents-project-layout.mdx
+++ b/src/snippets/langsmith/managed-deep-agents-project-layout.mdx
@@ -26,10 +26,12 @@ my-agent/
 ├── .env
 
 └── evals/                          # Harbor workspace
-    ├── tasks/                      # Canonical Harbor tasks
-    │   └── <task>/
-    └── scaffold/                   # Optional task scaffolds
-        └── <task>/
+    ├── harbor-job.json
+    └── <task>/                     # Harbor task
+        ├── Task.md
+        ├── instruction.md
+        ├── environment/
+        └── tests/
 ```
 :::
 
@@ -61,9 +63,11 @@ my-agent/
 ├── .env
 
 └── evals/                          # Harbor workspace
-    ├── tasks/                      # Canonical Harbor tasks
-    │   └── <task>/
-    └── scaffold/                   # Optional task scaffolds
-        └── <task>/
+    ├── harbor-job.json
+    └── <task>/                     # Harbor task
+        ├── Task.md
+        ├── instruction.md
+        ├── environment/
+        └── tests/
 ```
 :::


### PR DESCRIPTION
## Overview
Rewrite Managed Deep Agents evals around coding-agent collaboration and the eval-engineering skill. Drop the old scaffold/compile flow and update the CLI, layout, tutorial, and Harbor pages to match.
## Type of change
**Type:** Update existing documentation
## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
