### PR TITLE
docs(polardbx): add feature flags to PolarDBX vector store entry

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -1298,6 +1298,14 @@ python:
   - name: PolarDBXVectorStore
     pypi: langchain-polardbx
     docs_url: https://github.com/polardb/langchain-polardbx
+    delete_by_id: true
+    filtering: true
+    search_by_vector: true
+    search_with_score: true
+    async_api: true
+    passes_standard_tests: true
+    multi_tenancy: false
+    ids_in_add_documents: true
   - name: PolarDBPGVector
     pypi: langchain-polardb-pg
     docs_url: https://github.com/polardb/langchain-polardb-pg


### PR DESCRIPTION
The PolarDBXVectorStore entry in integration_external_docs.yaml was
added in #5139 without capability flags, so the vectorstore downloads
table shows empty cells for all feature columns.

This PR declares the supported capabilities, verified against the
langchain-polardbx 0.4.1 source and its test suite (which subclasses
VectorStoreIntegrationTests from langchain-tests):

- delete_by_id, filtering, search_by_vector, search_with_score,
  async_api, passes_standard_tests, ids_in_add_documents: true
- multi_tenancy: false (not supported)

The downloads table will pick these up on the next scheduled
refresh_integration_downloads.py run.

Follow-up to #5139.