### PR TITLE
docs(langsmith): document the new audit logs UI

### DIFF
--- a/src/langsmith/audit-logs.mdx
+++ b/src/langsmith/audit-logs.mdx
@@ -26,6 +26,22 @@ Audit logs are useful for security reviews, compliance requirements, and general
 
 Audit logs record changes to organization settings, membership, credentials, workspaces, and other resources. Each event includes the timestamp, the actor, the operation name, the affected resources, and whether it succeeded. For the complete list of operation names, see the [tracked operations reference](#tracked-operations-reference).
 
+## View audit logs in the UI
+
+Organization Admins and Organization Operators can browse audit logs from **Organization Settings > Audit logs**.
+
+The table shows the time, actor, workspace, operation, status, and affected resources for each event. Click a row's timestamp to open the full raw event as JSON in a side panel.
+
+Use the filters above the table to narrow results:
+
+- **Time range**
+- **Workspace**
+- **Operation**
+- **Actor** — a specific user, API key, or service key
+- **Resource ID**
+
+Audit logs are also available via the [API](#query-audit-logs-via-api).
+
 ## Retention
 
 Audit logs are retained for up to **400 days**. Events older than 400 days may be removed automatically.
@@ -181,7 +197,7 @@ No. Audit logs are an Enterprise feature. See [pricing](https://www.langchain.co
 </Accordion>
 
 <Accordion title="Is there a UI for viewing audit logs?">
-Not currently. Audit logs are available via the [API](#query-audit-logs-via-api).
+Yes. See [View audit logs in the UI](#view-audit-logs-in-the-ui). Audit logs are also available via the [API](#query-audit-logs-via-api).
 </Accordion>
 
 <Accordion title="Are read operations logged?">

--- a/src/langsmith/audit-logs.mdx
+++ b/src/langsmith/audit-logs.mdx
@@ -37,7 +37,7 @@ Use the filters above the table to narrow results:
 - **Time range**
 - **Workspace**
 - **Operation**
-- **Actor** — a specific user, API key, or service key
+- **Actor**—a specific user, API key, or service key
 - **Resource ID**
 
 Audit logs are also available via the [API](#query-audit-logs-via-api).


### PR DESCRIPTION
## Summary
- Audit logs shipped a UI (Organization Settings > Audit logs) in addition to the existing API. The page previously said no UI existed.
- Adds a "View audit logs in the UI" section covering the table columns and available filters (time range, workspace, operation, actor, resource ID).
- Updates the "Is there a UI for viewing audit logs?" FAQ answer from "Not currently" to point at the new section.

Related: closes ENT-1480 follow-up docs gap (ENT-740 covered the original API-only docs).

## Test plan
- [x] Content reviewed against shipped UI filters in smith-frontend/src/Pages/Settings/AuditLogs/AuditLogs.tsx