### PR TITLE
oss(js): rewrite PDFLoader integration guide, fix WebPDFLoader docs

### DIFF
--- a/src/oss/javascript/integrations/document_loaders/file_loaders/pdf.mdx
+++ b/src/oss/javascript/integrations/document_loaders/file_loaders/pdf.mdx
@@ -4,173 +4,77 @@ description: "Integrate with the PDFLoader document loader using LangChain JavaS
 ---
 
 <Tip>
-**Compatibility**: Only available on Node.js.
+**Compatibility**: Only available on Node.js. To load PDFs in the browser or another environment without filesystem access, use [`WebPDFLoader`](/oss/integrations/document_loaders/web_loaders/pdf).
 </Tip>
 
-This notebook provides a quick overview for getting started with `PDFLoader` [document loaders](/oss/integrations/document_loaders). For detailed documentation of all `PDFLoader` features and configurations head to the [API reference](https://api.js.langchain.com/classes/langchain_community_document_loaders_fs_pdf.PDFLoader.html).
+`PDFLoader` reads a PDF from the local filesystem and returns one @[Document] per page. For detailed documentation of all `PDFLoader` features and configurations, head to the [API reference](https://reference.langchain.com/javascript/classes/_langchain_community.document_loaders_fs_pdf.PDFLoader.html).
 
 ## Overview
 
 ### Integration details
 
 | Class | Package | Compatibility | Local | PY support |
-| :--- | :--- | :---: | :---: |  :---: |
-| [PDFLoader](https://api.js.langchain.com/classes/langchain_community_document_loaders_fs_pdf.PDFLoader.html) | [@langchain/community](https://api.js.langchain.com/modules/langchain_community_document_loaders_fs_pdf.html) | Node-only | ✅ | 🟠 (See note below) |
+| :--- | :--- | :---: | :---: | :---: |
+| [PDFLoader](https://reference.langchain.com/javascript/classes/_langchain_community.document_loaders_fs_pdf.PDFLoader.html) | [@langchain/community](https://reference.langchain.com/javascript/modules/_langchain_community.html) | Node-only | ✅ | ❌ |
+
+Python has a separate set of PDF loaders, so there is no Python equivalent of this class.
 
 ## Setup
 
-To access `PDFLoader` document loader you'll need to install the `@langchain/community` integration, along with the `pdf-parse` package.
-
-### Credentials
-
 ### Installation
 
-The LangChain PDFLoader integration lives in the `@langchain/community` package:
+The LangChain `PDFLoader` integration lives in the `@langchain/community` package. Parsing is delegated to [`pdf-parse`](https://www.npmjs.com/package/pdf-parse), which is an optional peer dependency you install yourself:
 
 <CodeGroup>
 ```bash npm
-npm install @langchain/community @langchain/core pdf-parse
+npm install @langchain/community@^1 @langchain/core@^1 pdf-parse@^2
 ```
 ```bash yarn
-yarn add @langchain/community @langchain/core pdf-parse
+yarn add @langchain/community@^1 @langchain/core@^1 pdf-parse@^2
 ```
 ```bash pnpm
-pnpm add @langchain/community @langchain/core pdf-parse
+pnpm add @langchain/community@^1 @langchain/core@^1 pdf-parse@^2
 ```
 </CodeGroup>
 
+<Note>
+Pin `@langchain/core` to `^1`. Without an explicit range, npm can resolve an older `0.3.x` core through a transitive optional peer dependency and fail with an `ERESOLVE` error.
+</Note>
+
+Both major versions of `pdf-parse` are supported (`^1.0.0 || ^2.0.0`), and the loader detects which one is installed. See [Choose a `pdf-parse` version](#choose-a-pdf-parse-version) for the differences. If neither is installed, `load()` throws:
+
+```text
+Failed to load pdf-parse. Please install pdf-parse v1 or v2, e.g. `npm install pdf-parse@^1` or `npm install pdf-parse@^2`.
+```
+
 ## Instantiation
 
-Now we can instantiate our model object and load documents:
-
-```typescript
-import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf"
-
-const nike10kPdfPath = "../../../../data/nke-10k-2023.pdf"
-
-const loader = new PDFLoader(nike10kPdfPath)
-```
-
-## Load
-
-```typescript
-const docs = await loader.load()
-docs[0]
-```
-
-```javascript
-Document {
-  pageContent: 'Table of Contents\n' +
-    'UNITED STATES\n' +
-    'SECURITIES AND EXCHANGE COMMISSION\n' +
-    'Washington, D.C. 20549\n' +
-    'FORM 10-K\n' +
-    '(Mark One)\n' +
-    '☑ ANNUAL REPORT PURSUANT TO SECTION 13 OR 15(D) OF THE SECURITIES EXCHANGE ACT OF 1934\n' +
-    'FOR THE FISCAL YEAR ENDED MAY 31, 2023\n' +
-    'OR\n' +
-    '☐ TRANSITION REPORT PURSUANT TO SECTION 13 OR 15(D) OF THE SECURITIES EXCHANGE ACT OF 1934\n' +
-    'FOR THE TRANSITION PERIOD FROM                         TO                         .\n' +
-    'Commission File No. 1-10635\n' +
-    'NIKE, Inc.\n' +
-    '(Exact name of Registrant as specified in its charter)\n' +
-    'Oregon93-0584541\n' +
-    '(State or other jurisdiction of incorporation)(IRS Employer Identification No.)\n' +
-    'One Bowerman Drive, Beaverton, Oregon 97005-6453\n' +
-    '(Address of principal executive offices and zip code)\n' +
-    '(503) 671-6453\n' +
-    "(Registrant's telephone number, including area code)\n" +
-    'SECURITIES REGISTERED PURSUANT TO SECTION 12(B) OF THE ACT:\n' +
-    'Class B Common StockNKENew York Stock Exchange\n' +
-    '(Title of each class)(Trading symbol)(Name of each exchange on which registered)\n' +
-    'SECURITIES REGISTERED PURSUANT TO SECTION 12(G) OF THE ACT:\n' +
-    'NONE\n' +
-    'Indicate by check mark:YESNO\n' +
-    '•if the registrant is a well-known seasoned issuer, as defined in Rule 405 of the Securities Act.þ ̈\n' +
-    '•if the registrant is not required to file reports pursuant to Section 13 or Section 15(d) of the Act. ̈þ\n' +
-    '•whether the registrant (1) has filed all reports required to be filed by Section 13 or 15(d) of the Securities Exchange Act of 1934 during the preceding\n' +
-    '12 months (or for such shorter period that the registrant was required to file such reports), and (2) has been subject to such filing requirements for the\n' +
-    'past 90 days.\n' +
-    'þ ̈\n' +
-    '•whether the registrant has submitted electronically every Interactive Data File required to be submitted pursuant to Rule 405 of Regulation S-T\n' +
-    '(§232.405 of this chapter) during the preceding 12 months (or for such shorter period that the registrant was required to submit such files).\n' +
-    'þ ̈\n' +
-    '•whether the registrant is a large accelerated filer, an accelerated filer, a non-accelerated filer, a smaller reporting company or an emerging growth company. See the definitions of “large accelerated filer,”\n' +
-    '“accelerated filer,” “smaller reporting company,” and “emerging growth company” in Rule 12b-2 of the Exchange Act.\n' +
-    'Large accelerated filerþAccelerated filer☐Non-accelerated filer☐Smaller reporting company☐Emerging growth company☐\n' +
-    '•if an emerging growth company, if the registrant has elected not to use the extended transition period for complying with any new or revised financial\n' +
-    'accounting standards provided pursuant to Section 13(a) of the Exchange Act.\n' +
-    ' ̈\n' +
-    "•whether the registrant has filed a report on and attestation to its management's assessment of the effectiveness of its internal control over financial\n" +
-    'reporting under Section 404(b) of the Sarbanes-Oxley Act (15 U.S.C. 7262(b)) by the registered public accounting firm that prepared or issued its audit\n' +
-    'report.\n' +
-    'þ\n' +
-    '•if securities are registered pursuant to Section 12(b) of the Act, whether the financial statements of the registrant included in the filing reflect the\n' +
-    'correction of an error to previously issued financial statements.\n' +
-    ' ̈\n' +
-    '•whether any of those error corrections are restatements that required a recovery analysis of incentive-based compensation received by any of the\n' +
-    "registrant's executive officers during the relevant recovery period pursuant to § 240.10D-1(b).\n" +
-    ' ̈\n' +
-    '•\n' +
-    'whether the registrant is a shell company (as defined in Rule 12b-2 of the Act).☐þ\n' +
-    "As of November 30, 2022, the aggregate market values of the Registrant's Common Stock held by non-affiliates were:\n" +
-    'Class A$7,831,564,572 \n' +
-    'Class B136,467,702,472 \n' +
-    '$144,299,267,044 ',
-  metadata: {
-    source: '../../../../data/nke-10k-2023.pdf',
-    pdf: {
-      version: '1.10.100',
-      info: [Object],
-      metadata: null,
-      totalPages: 107
-    },
-    loc: { pageNumber: 1 }
-  },
-  id: undefined
-}
-```
-
-```typescript
-console.log(docs[0].metadata)
-```
-
-```javascript
-{
-  source: '../../../../data/nke-10k-2023.pdf',
-  pdf: {
-    version: '1.10.100',
-    info: {
-      PDFFormatVersion: '1.4',
-      IsAcroFormPresent: false,
-      IsXFAPresent: false,
-      Title: '0000320187-23-000039',
-      Author: 'EDGAR Online, a division of Donnelley Financial Solutions',
-      Subject: 'Form 10-K filed on 2023-07-20 for the period ending 2023-05-31',
-      Keywords: '0000320187-23-000039; ; 10-K',
-      Creator: 'EDGAR Filing HTML Converter',
-      Producer: 'EDGRpdf Service w/ EO.Pdf 22.0.40.0',
-      CreationDate: "D:20230720162200-04'00'",
-      ModDate: "D:20230720162208-04'00'"
-    },
-    metadata: null,
-    totalPages: 107
-  },
-  loc: { pageNumber: 1 }
-}
-```
-
-## Usage, one document per file
+Now we can instantiate our loader. The examples below use [a sample Nike 10-K filing from 2023](https://github.com/langchain-ai/langchain/blob/v0.3/docs/docs/example_data/nke-10k-2023.pdf):
 
 ```typescript
 import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf";
 
-const singleDocPerFileLoader = new PDFLoader(nike10kPdfPath, {
-  splitPages: false,
-});
+const loader = new PDFLoader("./nke-10k-2023.pdf");
+```
 
-const singleDoc = await singleDocPerFileLoader.load();
-console.log(singleDoc[0].pageContent.slice(0, 100))
+## Load
+
+By default, one `Document` is created per page:
+
+```typescript
+const docs = await loader.load();
+
+console.log(docs.length);
+```
+
+```text
+107
+```
+
+Each `Document` has a `pageContent` string and a `metadata` object:
+
+```typescript
+console.log(docs[0].pageContent.slice(0, 120));
 ```
 
 ```text
@@ -179,14 +83,144 @@ UNITED STATES
 SECURITIES AND EXCHANGE COMMISSION
 Washington, D.C. 20549
 FORM 10-K
+(Mark One)
 ```
 
-## Usage, custom `pdfjs` build
+```typescript
+console.log(docs[0].metadata);
+```
 
-By default we use the `pdfjs` build bundled with `pdf-parse`, which is compatible with most environments, including Node.js and modern browsers. If you want to use a more recent version of `pdfjs-dist` or if you want to use a custom build of `pdfjs-dist`, you can do so by providing a custom `pdfjs` function that returns a promise that resolves to the `PDFJS` object.
+```javascript
+{
+  source: './nke-10k-2023.pdf',
+  pdf: {
+    version: 'unknown',
+    info: {
+      PDFFormatVersion: '1.4',
+      Producer: 'EDGRpdf Service w/ EO.Pdf 22.0.40.0',
+      Creator: 'EDGAR Filing HTML Converter',
+      Title: '0000320187-23-000039',
+      // ...remaining fields from the PDF's info dictionary
+    },
+    metadata: null,
+    totalPages: 107
+  },
+  loc: { pageNumber: 1 }
+}
+```
 
-In the following example we use the "legacy" (see [pdfjs docs](https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#which-browsersenvironments-are-supported)) build of `pdfjs-dist`, which includes several polyfills not included in the default build.
+| Field | Description |
+| :--- | :--- |
+| `source` | The file path passed to the constructor, or `blob` when loading from a `Blob`. |
+| `pdf.version` | Parser version. See [Choose a `pdf-parse` version](#choose-a-pdf-parse-version). |
+| `pdf.info` | The PDF's info dictionary. `PDFFormatVersion` holds the PDF specification version. |
+| `pdf.metadata` | XMP metadata, or `null` if the PDF has none. |
+| `pdf.totalPages` | Total number of pages in the PDF. |
+| `loc.pageNumber` | 1-indexed page the content came from. Omitted when `splitPages` is `false`. |
 
+<Note>
+Pages with no extractable text are skipped, so `docs.length` can be smaller than `pdf.totalPages`.
+</Note>
+
+## Options
+
+| Option | Type | Default | Description |
+| :--- | :--- | :--- | :--- |
+| `splitPages` | `boolean` | `true` | Return one `Document` per page. Set to `false` to return a single `Document` for the whole file. |
+| `parsedItemSeparator` | `string` | `""` | String used to join text items within a page. Only applies when `pdf-parse` v1 is installed. |
+| `pdfjs` | `() => Promise` | Auto-detects `pdf-parse` | Supply a custom PDF.js build. See [Use a custom PDF.js build](#use-a-custom-pdfjs-build). |
+
+## Usage, one document per file
+
+Set `splitPages` to `false` to get a single `Document` whose content is every page joined with a blank line. The `loc` field is omitted, since the content no longer maps to one page:
+
+```typescript
+import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf";
+
+const singleDocPerFileLoader = new PDFLoader("./nke-10k-2023.pdf", {
+  splitPages: false,
+});
+
+const singleDoc = await singleDocPerFileLoader.load();
+
+console.log(singleDoc.length);
+```
+
+```text
+1
+```
+
+## Usage, loading from a `Blob`
+
+`PDFLoader` also accepts a `Blob`, which is useful for a file you already hold in memory, such as an upload:
+
+```typescript
+import { readFile } from "node:fs/promises";
+import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf";
+
+const blob = new Blob([await readFile("./nke-10k-2023.pdf")], {
+  type: "application/pdf",
+});
+
+const blobDocs = await new PDFLoader(blob).load();
+
+console.log(blobDocs[0].metadata.source, blobDocs[0].metadata.blobType);
+```
+
+```text
+blob application/pdf
+```
+
+## Loading directories
+
+Pair `PDFLoader` with [`DirectoryLoader`](/oss/integrations/document_loaders/file_loaders/directory) to load every PDF in a folder, then split the results into chunks for retrieval:
+
+```typescript
+import { DirectoryLoader } from "@langchain/classic/document_loaders/fs/directory";
+import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf";
+import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
+
+const directoryLoader = new DirectoryLoader("./pdfs", {
+  ".pdf": (path: string) => new PDFLoader(path),
+});
+
+const directoryDocs = await directoryLoader.load();
+
+console.log(directoryDocs.length);
+
+const textSplitter = new RecursiveCharacterTextSplitter({
+  chunkSize: 1000,
+  chunkOverlap: 200,
+});
+
+const splitDocs = await textSplitter.splitDocuments(directoryDocs);
+
+console.log(splitDocs.length);
+```
+
+```text
+116
+544
+```
+
+`DirectoryLoader` records an absolute path in `metadata.source`, and skips file types that have no mapping.
+
+## Choose a `pdf-parse` version
+
+The loader works with either major version of `pdf-parse`, but they behave differently:
+
+| | `pdf-parse@^1` | `pdf-parse@^2` |
+| :--- | :--- | :--- |
+| `metadata.pdf.version` | Bundled PDF.js version, such as `1.10.100` | XMP format version, or `unknown` when the PDF has no XMP metadata |
+| `parsedItemSeparator` | Applied when joining text items | Not applied; text is returned as `pdf-parse` extracts it |
+
+To read the PDF specification version regardless of which one you install, use `metadata.pdf.info.PDFFormatVersion`.
+
+## Use a custom PDF.js build
+
+The `pdfjs` option replaces the parser with your own PDF.js build. Return an object tagged with `isV2` so the loader knows which API to call: `{ isV2: false, getDocument, version }` for a PDF.js build, or `{ isV2: true, PDFParse }` for the `pdf-parse` v2 class.
+
+The example below uses the ["legacy" build](https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#which-browsersenvironments-are-supported) of `pdfjs-dist`, which includes polyfills that the default build omits:
 
 <CodeGroup>
 ```bash npm
@@ -200,169 +234,33 @@ pnpm add pdfjs-dist
 ```
 </CodeGroup>
 
-
 ```typescript
 import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf";
 
-const customBuildLoader = new PDFLoader(nike10kPdfPath, {
-  // you may need to add `.then(m => m.default)` to the end of the import
-  // @lc-ts-ignore
-  pdfjs: () => import("pdfjs-dist/legacy/build/pdf.js"),
-});
-```
-
-## Eliminating extra spaces
-
-PDFs come in many varieties, which makes reading them a challenge. The loader parses individual text elements and joins them together with a space by default, but
-if you are seeing excessive spaces, this may not be the desired behavior. In that case, you can override the separator with an empty string like this:
-
-```typescript
-import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf";
-
-const noExtraSpacesLoader = new PDFLoader(nike10kPdfPath, {
-  parsedItemSeparator: "",
+const customBuildLoader = new PDFLoader("./nke-10k-2023.pdf", {
+  pdfjs: async () => {
+    const mod = await import("pdfjs-dist/legacy/build/pdf.mjs");
+    return { isV2: false, getDocument: mod.getDocument, version: mod.version };
+  },
 });
 
-const noExtraSpacesDocs = await noExtraSpacesLoader.load();
-console.log(noExtraSpacesDocs[0].pageContent.slice(100, 250))
+const customBuildDocs = await customBuildLoader.load();
+
+console.log(customBuildDocs[0].metadata.pdf.version);
 ```
 
 ```text
-(Mark One)
-☑ ANNUAL REPORT PURSUANT TO SECTION 13 OR 15(D) OF THE SECURITIES EXCHANGE ACT OF 1934
-FOR THE FISCAL YEAR ENDED MAY 31, 2023
-OR
-☐ TRANSITI
+6.2.108
 ```
 
-## Loading directories
+## Limitations
 
-```typescript
-import { DirectoryLoader } from "@langchain/classic/document_loaders/fs/directory";
-import { PDFLoader } from "@langchain/community/document_loaders/fs/pdf";
-import { RecursiveCharacterTextSplitter } from "@langchain/textsplitters";
-
-const exampleDataPath = "../../../../../../examples/src/document_loaders/example_data/";
-
-/* Load all PDFs within the specified directory */
-const directoryLoader = new DirectoryLoader(
-  exampleDataPath,
-  {
-    ".pdf": (path: string) => new PDFLoader(path),
-  }
-);
-
-const directoryDocs = await directoryLoader.load();
-
-console.log(directoryDocs[0]);
-
-/* Additional steps : Split text into chunks with any TextSplitter. You can then use it as context or save it to memory afterwards. */
-const textSplitter = new RecursiveCharacterTextSplitter({
-  chunkSize: 1000,
-  chunkOverlap: 200,
-});
-
-const splitDocs = await textSplitter.splitDocuments(directoryDocs);
-console.log(splitDocs[0]);
-
-```
-
-```text
-Unknown file type: Star_Wars_The_Clone_Wars_S06E07_Crisis_at_the_Heart.srt
-Unknown file type: example.txt
-Unknown file type: notion.md
-Unknown file type: bad_frontmatter.md
-Unknown file type: frontmatter.md
-Unknown file type: no_frontmatter.md
-Unknown file type: no_metadata.md
-Unknown file type: tags_and_frontmatter.md
-Unknown file type: test.mp3
-```
-```javascript
-Document {
-  pageContent: 'Bitcoin: A Peer-to-Peer Electronic Cash System\n' +
-    'Satoshi Nakamoto\n' +
-    'satoshin@gmx.com\n' +
-    'www.bitcoin.org\n' +
-    'Abstract.   A  purely   peer-to-peer   version   of   electronic   cash   would   allow   online \n' +
-    'payments   to   be   sent   directly   from   one   party   to   another   without   going   through   a \n' +
-    'financial institution.   Digital signatures provide part of the solution, but the main \n' +
-    'benefits are lost if a trusted third party is still required to prevent double-spending. \n' +
-    'We propose a solution to the double-spending problem using a peer-to-peer network. \n' +
-    'The   network   timestamps   transactions   by   hashing   them   into   an   ongoing   chain   of \n' +
-    'hash-based proof-of-work, forming a record that cannot be changed without redoing \n' +
-    'the proof-of-work.   The longest chain not only serves as proof of the sequence of \n' +
-    'events witnessed, but proof that it came from the largest pool of CPU power.   As \n' +
-    'long as a majority of CPU power is controlled by nodes that are not cooperating to \n' +
-    "attack the network,  they'll  generate the  longest  chain  and  outpace attackers.   The \n" +
-    'network itself requires minimal structure.   Messages are broadcast on a best effort \n' +
-    'basis,   and   nodes   can   leave   and   rejoin   the   network   at   will,   accepting   the   longest \n' +
-    'proof-of-work chain as proof of what happened while they were gone.\n' +
-    '1.Introduction\n' +
-    'Commerce on the Internet has come to rely almost exclusively on financial institutions serving as \n' +
-    'trusted third  parties  to process electronic payments.   While the  system works  well enough for \n' +
-    'most   transactions,   it   still   suffers   from   the   inherent   weaknesses   of   the   trust   based   model. \n' +
-    'Completely non-reversible transactions are not really possible, since financial institutions cannot \n' +
-    'avoid   mediating   disputes.     The   cost   of   mediation   increases   transaction   costs,   limiting   the \n' +
-    'minimum practical transaction size and cutting off the possibility for small casual transactions, \n' +
-    'and   there   is   a   broader   cost   in   the   loss   of   ability   to   make   non-reversible   payments   for   non-\n' +
-    'reversible services.  With the possibility of reversal, the need for trust spreads.  Merchants must \n' +
-    'be wary of their customers, hassling them for more information than they would otherwise need. \n' +
-    'A certain percentage of fraud is accepted as unavoidable.  These costs and payment uncertainties \n' +
-    'can be avoided in person by using physical currency, but no mechanism exists to make payments \n' +
-    'over a communications channel without a trusted party.\n' +
-    'What is needed is an electronic payment system based on cryptographic proof instead of trust, \n' +
-    'allowing any two willing parties to transact directly with each other without the need for a trusted \n' +
-    'third  party.    Transactions  that  are  computationally  impractical  to   reverse   would  protect  sellers \n' +
-    'from fraud, and routine escrow mechanisms could easily be implemented to protect buyers.   In \n' +
-    'this paper, we propose a solution to the double-spending problem using a peer-to-peer distributed \n' +
-    'timestamp server to generate computational proof of the chronological order of transactions.  The \n' +
-    'system   is   secure   as   long   as   honest   nodes   collectively   control   more   CPU   power   than   any \n' +
-    'cooperating group of attacker nodes.\n' +
-    '1',
-  metadata: {
-    source: '/Users/bracesproul/code/lang-chain-ai/langchainjs/examples/src/document_loaders/example_data/bitcoin.pdf',
-    pdf: {
-      version: '1.10.100',
-      info: [Object],
-      metadata: null,
-      totalPages: 9
-    },
-    loc: { pageNumber: 1 }
-  },
-  id: undefined
-}
-Document {
-  pageContent: 'Bitcoin: A Peer-to-Peer Electronic Cash System\n' +
-    'Satoshi Nakamoto\n' +
-    'satoshin@gmx.com\n' +
-    'www.bitcoin.org\n' +
-    'Abstract.   A  purely   peer-to-peer   version   of   electronic   cash   would   allow   online \n' +
-    'payments   to   be   sent   directly   from   one   party   to   another   without   going   through   a \n' +
-    'financial institution.   Digital signatures provide part of the solution, but the main \n' +
-    'benefits are lost if a trusted third party is still required to prevent double-spending. \n' +
-    'We propose a solution to the double-spending problem using a peer-to-peer network. \n' +
-    'The   network   timestamps   transactions   by   hashing   them   into   an   ongoing   chain   of \n' +
-    'hash-based proof-of-work, forming a record that cannot be changed without redoing \n' +
-    'the proof-of-work.   The longest chain not only serves as proof of the sequence of \n' +
-    'events witnessed, but proof that it came from the largest pool of CPU power.   As \n' +
-    'long as a majority of CPU power is controlled by nodes that are not cooperating to',
-  metadata: {
-    source: '/Users/bracesproul/code/lang-chain-ai/langchainjs/examples/src/document_loaders/example_data/bitcoin.pdf',
-    pdf: {
-      version: '1.10.100',
-      info: [Object],
-      metadata: null,
-      totalPages: 9
-    },
-    loc: { pageNumber: 1, lines: [Object] }
-  },
-  id: undefined
-}
-```
+- **Node.js only.** Loading from a file path reads through `node:fs/promises`. Use [`WebPDFLoader`](/oss/integrations/document_loaders/web_loaders/pdf) in the browser and other environments without filesystem access.
+- **Text layers only.** Scanned or image-only PDFs contain no extractable text, so their pages are skipped. Run OCR before loading, or use a loader backed by a document-parsing service such as [`UnstructuredLoader`](/oss/integrations/document_loaders/file_loaders/unstructured).
+- **Layout is not preserved.** Text is extracted in the PDF's internal order, so tables and multi-column pages can come back interleaved.
 
 ---
 
 ## API reference
 
-For detailed documentation of all PDFLoader features and configurations head to the [API reference](https://api.js.langchain.com/classes/langchain_community_document_loaders_fs_pdf.PDFLoader.html).
+For detailed documentation of all `PDFLoader` features and configurations head to the [API reference](https://reference.langchain.com/javascript/classes/_langchain_community.document_loaders_fs_pdf.PDFLoader.html).

--- a/src/oss/javascript/integrations/document_loaders/web_loaders/pdf.mdx
+++ b/src/oss/javascript/integrations/document_loaders/web_loaders/pdf.mdx
@@ -4,19 +4,19 @@ description: "Integrate with the WebPDFLoader document loader using LangChain Ja
 ---
 
 
-This notebook provides a quick overview for getting started with [WebPDFLoader](/oss/integrations/document_loaders/). For detailed documentation of all WebPDFLoader features and configurations head to the [API reference](https://api.js.langchain.com/classes/langchain_community_document_loaders_web_pdf.WebPDFLoader.html).
+This notebook provides a quick overview for getting started with [WebPDFLoader](/oss/integrations/document_loaders/). For detailed documentation of all WebPDFLoader features and configurations head to the [API reference](https://reference.langchain.com/javascript/classes/_langchain_community.document_loaders_web_pdf.WebPDFLoader.html).
 
 ## Overview
 
 ### Integration details
 
 | Class | Package | Local | Serializable | PY support |
-| :--- | :--- | :---: | :---: |  :---: |
-| [WebPDFLoader](https://api.js.langchain.com/classes/langchain_community_document_loaders_web_pdf.WebPDFLoader.html) | [@langchain/community](https://api.js.langchain.com/modules/langchain_community_document_loaders_web_pdf.html) | ✅ | beta | ❌ |
+| :--- | :--- | :---: | :---: | :---: |
+| [WebPDFLoader](https://reference.langchain.com/javascript/classes/_langchain_community.document_loaders_web_pdf.WebPDFLoader.html) | [@langchain/community](https://reference.langchain.com/javascript/modules/_langchain_community.html) | ✅ | beta | ❌ |
 
 ### Loader features
 
-| Source | Web Loader | Node Envs Only
+| Source | Web Loader | Node Envs Only |
 | :---: | :---: | :---: |
 | WebPDFLoader | ✅ | ❌ |
 
@@ -183,7 +183,7 @@ console.log(docs[0].metadata)
 
 ## Usage, custom `pdfjs` build
 
-By default we use the `pdfjs` build bundled with `pdf-parse`, which is compatible with most environments, including Node.js and modern browsers. If you want to use a more recent version of `pdfjs-dist` or if you want to use a custom build of `pdfjs-dist`, you can do so by providing a custom `pdfjs` function that returns a promise that resolves to the `PDFJS` object.
+By default we use the parser bundled with `pdf-parse`, which is compatible with most environments, including Node.js and modern browsers. If you want to use a more recent version of `pdfjs-dist` or a custom build of it, provide a `pdfjs` function that resolves to an object tagged with `isV2`: `{ isV2: false, getDocument, version }` for a PDF.js build, or `{ isV2: true, PDFParse }` for the `pdf-parse` v2 class.
 
 In the following example we use the "legacy" (see [pdfjs docs](https://github.com/mozilla/pdf.js/wiki/Frequently-Asked-Questions#which-browsersenvironments-are-supported)) build of `pdfjs-dist`, which includes several polyfills not included in the default build.
 
@@ -199,35 +199,38 @@ pnpm add pdfjs-dist
 ```
 </CodeGroup>
 
-
 ```typescript
 import { WebPDFLoader } from "@langchain/community/document_loaders/web/pdf";
 
 const blob = new Blob(); // e.g. from a file input
 
 const customBuildLoader = new WebPDFLoader(blob, {
-  // you may need to add `.then(m => m.default)` to the end of the import
-  // @lc-ts-ignore
-  pdfjs: () => import("pdfjs-dist/legacy/build/pdf.js"),
+  pdfjs: async () => {
+    const mod = await import("pdfjs-dist/legacy/build/pdf.mjs");
+    return { isV2: false, getDocument: mod.getDocument, version: mod.version };
+  },
 });
 ```
 
-## Eliminating extra spaces
+## Joining text items
 
-PDFs come in many varieties, which makes reading them a challenge. The loader parses individual text elements and joins them together with a space by default, but
-if you are seeing excessive spaces, this may not be the desired behavior. In that case, you can override the separator with an empty string like this:
+PDFs come in many varieties, which makes reading them a challenge. On the `pdf-parse` v1 code path, the loader parses individual text elements and joins them with `parsedItemSeparator`, which defaults to an empty string. Set it to a space if elements are being run together:
 
 ```typescript
 import { WebPDFLoader } from "@langchain/community/document_loaders/web/pdf";
 
 // new Blob(); e.g. from a file input
-const eliminatingExtraSpacesLoader = new WebPDFLoader(new Blob(), {
-  parsedItemSeparator: "",
+const spacedItemsLoader = new WebPDFLoader(new Blob(), {
+  parsedItemSeparator: " ",
 });
 ```
+
+<Note>
+`parsedItemSeparator` has no effect when `pdf-parse` v2 is installed. On that code path, text is returned as `pdf-parse` extracts it.
+</Note>
 
 ---
 
 ## API reference
 
-For detailed documentation of all WebPDFLoader features and configurations head to the [API reference](https://api.js.langchain.com/classes/langchain_community_document_loaders_web_pdf.WebPDFLoader.html).
+For detailed documentation of all WebPDFLoader features and configurations head to the [API reference](https://reference.langchain.com/javascript/classes/_langchain_community.document_loaders_web_pdf.WebPDFLoader.html).


### PR DESCRIPTION
## Overview

Issue #5627 reports that there is no `PDFLoader` guide for LangChain.js. A page does exist at `src/oss/javascript/integrations/document_loaders/file_loaders/pdf.mdx`, but its content had drifted far enough from the current `@langchain/community` implementation that following it does not work, which is a reasonable explanation for why the reporter concluded it was missing.

I installed `@langchain/community` 1.1.29 with `@langchain/core` 1.2.9 and `pdf-parse` 2.4.5 (plus a separate project on `pdf-parse` 1.x) and ran every example on the page. Each of the following was reproduced, not inferred from reading source:

* **`parsedItemSeparator` does not do what the page says.** The default is `""`, not a space, and the option is ignored entirely on the `pdf-parse` v2 code path. The page's featured "Eliminating extra spaces" fix was therefore a no-op. `parseWithV2()` never reads the field, which looks like an upstream bug worth filing separately against `langchainjs-community`.
* **The custom build example cannot run.** `pdfjs-dist` v6 ships `legacy/build/pdf.mjs`; `legacy/build/pdf.js` no longer exists. The `pdfjs` option also expects an object tagged with `isV2`.
* **The documented install command fails.** `npm install @langchain/community @langchain/core pdf-parse` errors with `ERESOLVE` on a clean project, because npm resolves `@langchain/core` `0.3.x` through a transitive optional peer dependency. Pinning `@langchain/core` to `^1` fixes it.
* **`pdf.version` is misleading.** It reports `unknown` under `pdf-parse` v2. `info.PDFFormatVersion` is the reliable source for the PDF specification version.
* Reference links pointed at the retired `api.js.langchain.com` host.

The rewrite also covers what the issue explicitly asked for and the page did not have: the `Document` metadata shape returned by `load()`, an options table, `Blob` input, and the Node.js only limitation with a pointer to `WebPDFLoader`.

Housekeeping in the same pass: removed roughly 200 lines of raw Nike 10-K output dumps (one of which leaked a contributor's absolute home directory path), an empty `### Credentials` heading, and a dangling "(See note below)" marker in the integration details table that had no matching note.

The second commit applies the same corrections to the `WebPDFLoader` page, which shares a parser implementation and carried the same broken `pdfjs-dist` path, the same `parsedItemSeparator` claim, and the same dead reference links. That change is deliberately limited to what is demonstrably wrong rather than a full rewrite.

### Areas that need careful review

* **The `pdf-parse` v1 vs v2 comparison table** in "Choose a `pdf-parse` version" is the most opinionated part of this PR. It documents observed behavior on both majors, including the `parsedItemSeparator` discrepancy. If maintainers would rather fix that upstream and leave it undocumented here, that section should come out.
* **`docs.json` navigation is untouched.** No individual document loader integration page is listed in navigation today, so adding only this one would break the existing pattern. See the note below about discoverability.
* I did not rewrite the `WebPDFLoader` page's example output blocks, so they still show `pdf-parse` v1 metadata (`version: '1.10.100'`). That is still correct for v1 users, but it is inconsistent with the sibling page now.

### Separate problem, not fixed here

Most JavaScript document loader integration pages return 404 on the live site even though they are present in `src/` and land correctly in `build/`:

| URL under `/oss/javascript/integrations/document_loaders/` | Live |
| :--- | :---: |
| `file_loaders/pdf` | 404 |
| `file_loaders/csv` | 404 |
| `file_loaders/docx` | 404 |
| `web_loaders/pdf` | 404 |
| `file_loaders/text` | 200 |
| `file_loaders/json` | 200 |

I confirmed `make build` writes `pdf.mdx` to `build/oss/javascript/integrations/document_loaders/file_loaders/`, and the page renders correctly under `make dev`, so this looks like a publishing gap rather than a content one. It is very likely the direct cause of the issue as filed, and this PR alone will not resolve it. Happy to open a separate issue if that is useful.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: closes #5627
- Feature PR:

## Checklist

- [x] I have read the [contributing guidelines](README.md)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed (no change needed, see above)

## Additional notes

Verification run locally:

* `make build` succeeds, with no autolink or link map warnings for either changed file.
* `make dev` serves both pages with the expected titles, matching a known good sibling page.
* `make test` passes (103 tests).
* `markdownlint` is clean on both files, including two pre-existing table style violations that are fixed here.
* In-page anchors were checked against the generated heading slugs in `build/`.

**AI disclosure:** an AI coding agent (Claude Code) was used for this contribution. It performed the codebase and upstream source investigation, executed the verification described above, and drafted the page text and this description. Every factual claim in the rewritten page was checked against output from a real run rather than accepted from the model, and the findings, scope decisions, and final wording were reviewed by me before opening this PR.
