### PR TITLE
docs: document the dcode Python extensions API

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -2506,6 +2506,7 @@
               "oss/deepagents/code/approval-modes",
               "oss/deepagents/code/goals-and-rubrics",
               "oss/deepagents/code/plugins",
+              "oss/deepagents/code/extensions",
               "oss/deepagents/code/memory-and-skills",
               "oss/deepagents/code/remote-sandboxes",
               "oss/deepagents/code/subagents",

--- a/src/oss/deepagents/code/cli-reference.mdx
+++ b/src/oss/deepagents/code/cli-reference.mdx
@@ -331,6 +331,7 @@ Run OAuth login for MCP servers marked `auth: "oauth"` with `dcode mcp login <se
 | `--no-mcp`             | Disable all MCP tool loading                                |
 | `--trust-project-mcp`  | Trust project-level MCP servers without prompting for the current run. Explicit denies still apply. |
 | `--trust-project-extensions` | Trust project-level [Python extensions](/oss/deepagents/code/extensions) in `.deepagents/extensions/` for the current run. Requires `DEEPAGENTS_CODE_EXPERIMENTAL=1` |
+| `-e`, `--extension PATH` | Load a Python extension file or directory for the current run. Repeatable. Requires `DEEPAGENTS_CODE_EXPERIMENTAL=1` |
 | `--interpreter`        | Enable the JS interpreter (`js_eval`) middleware on the main agent when it has been disabled in config. `js_eval` is enabled by default. |
 | `--interpreter-tools VALUE` | PTC allowlist for `js_eval`: `safe`, `all`, or a comma-separated list of tool names. Default: no PTC (pure REPL) |
 | `--profile-override JSON` | Override model profile fields as a JSON string (e.g., `'{"max_input_tokens": 4096}'`). Merged on top of config file profile overrides |

--- a/src/oss/deepagents/code/cli-reference.mdx
+++ b/src/oss/deepagents/code/cli-reference.mdx
@@ -330,6 +330,7 @@ Run OAuth login for MCP servers marked `auth: "oauth"` with `dcode mcp login <se
 | `--mcp-config PATH`    | Add an explicit MCP config as the highest-precedence source (merged with auto-discovered configs) |
 | `--no-mcp`             | Disable all MCP tool loading                                |
 | `--trust-project-mcp`  | Trust project-level MCP servers without prompting for the current run. Explicit denies still apply. |
+| `--trust-project-extensions` | Trust project-level [Python extensions](/oss/deepagents/code/extensions) in `.deepagents/extensions/` for the current run. Requires `DEEPAGENTS_CODE_EXPERIMENTAL=1` |
 | `--interpreter`        | Enable the JS interpreter (`js_eval`) middleware on the main agent when it has been disabled in config. `js_eval` is enabled by default. |
 | `--interpreter-tools VALUE` | PTC allowlist for `js_eval`: `safe`, `all`, or a comma-separated list of tool names. Default: no PTC (pure REPL) |
 | `--profile-override JSON` | Override model profile fields as a JSON string (e.g., `'{"max_input_tokens": 4096}'`). Merged on top of config file profile overrides |

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -342,6 +342,14 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
     Comma-separated project MCP server names to pre-approve by name for any project. This is a process-wide escape hatch: A different project, command change, or URL change under the same server name still matches. When set, this variable replaces saved approvals for the process. Prefer saved approvals from the project MCP prompt when possible.
 </ResponseField>
 
+<ResponseField name="DEEPAGENTS_CODE_EXTENSIONS" type="string" post={["optional"]}>
+    Enable or disable [Python extensions](/oss/deepagents/code/extensions). Overrides `[extensions].enabled` in `config.toml`. Extensions also require `DEEPAGENTS_CODE_EXPERIMENTAL=1`.
+</ResponseField>
+
+<ResponseField name="DEEPAGENTS_CODE_EXTENSIONS_TRUST" type="string" post={["optional"]}>
+    Trust policy for project-authored Python extensions: `ask` (default), `always`, or `never`. Overrides `[extensions].trust` in `config.toml`.
+</ResponseField>
+
 <ResponseField name="DEEPAGENTS_CODE_EXTRA_SKILLS_DIRS" type="string" post={["optional"]}>
     Colon-separated paths added to the [skill containment allowlist](#skill-directory-allowlist).
 </ResponseField>

--- a/src/oss/deepagents/code/extensions.mdx
+++ b/src/oss/deepagents/code/extensions.mdx
@@ -21,7 +21,7 @@ from deepagents.backends import StoreBackend
 from deepagents_code.extensions import ExtensionAPI
 
 
-def extension(d: ExtensionAPI) -> None:
+async def extension(d: ExtensionAPI) -> None:
     """Add shared storage under `/memories/`."""
     d.register_backend_route(
         "/memories/",
@@ -29,9 +29,7 @@ def extension(d: ExtensionAPI) -> None:
     )
 ```
 
-Setup can be synchronous or asynchronous. Deep Agents Code imports every enabled extension and awaits every setup function before it builds the agent and its storage routes.
-
-Registration is allowed only while `extension(d)` runs. Calling a `register_*` method after setup returns raises an error.
+Declare the factory with `async def`. Deep Agents Code imports every enabled extension and awaits every factory before it builds the agent and its storage routes.
 
 Do not open long-lived connections or start background tasks during module import. Connect lazily on first use instead, and register an idempotent `on_shutdown` callback for any session resource that setup opens.
 
@@ -44,7 +42,16 @@ Do not open long-lived connections or start background tasks during module impor
 | `register_backend_route(prefix, backend)` | Serve file operations under a virtual path from a `BackendProtocol` storage provider. |
 | `on_shutdown(callback)` | Release session resources when the agent server stops. Synchronous and asynchronous callbacks are both supported. |
 
-The registrar also exposes read-only session context: `d.cwd` is the session working directory, `d.mode` is `interactive` or `headless`, and `d.path` is the extension entry file. Mutable terminal and thread state is not exposed, and custom slash commands are not part of this API.
+The registrar also exposes read-only session context: `d.cwd` is the session working directory, `d.mode` is `interactive` or `headless`, `d.has_ui` reports whether the session has a terminal UI, and `d.path` is the extension entry file. Mutable terminal and thread state is not exposed, and custom slash commands are not part of this API.
+
+### Register units after startup
+
+The registrar stays valid for callbacks that outlive the factory, so an extension can register more units while a session runs. When each kind takes effect differs:
+
+- **Tools**: Available on the next model request.
+- **Middleware and backend routes**: Recorded immediately, applied after the next server rebuild. Run `/restart` to apply them.
+
+Run `/extensions` to list loaded registrations with their kind, name, scope, and source file. The output also reports load failures and whether a restart is pending.
 
 ### Route files to a storage backend
 
@@ -54,11 +61,28 @@ Shell `execute` stays attached to the default local or sandbox storage, so shell
 
 A route makes shared storage available to file operations. It does not move the built-in `AGENTS.md` memory. To put shared content in the model's prompt, also register middleware that reads the routed location.
 
-The first extension registration of a route prefix wins. Built-in tools, middleware, and internal storage routes always take precedence over extension registrations with conflicting names or paths.
+Local agents can mount `FilesystemBackend` and `LocalShellBackend`. Sandboxed agents reject both classes, including subclasses, because they would expose host storage while `execute` runs inside the sandbox. Other implementations such as `StateBackend`, `StoreBackend`, and `ContextHubBackend` are supported everywhere. The check is shallow: Deep Agents Code does not inspect custom or composite backend wrappers, whose authors own their isolation contract.
+
+The first registration of a route prefix or unit name wins. Extension tools and middleware replace same-named built-ins and log a warning. A route that is a parent or child of internal artifact or conversation-history storage fails agent construction or runtime registration immediately, because internal routes cannot be replaced.
+
+## Load extensions from a source
+
+Deep Agents Code resolves sources in this order and skips duplicate files:
+
+| Source | Authorization |
+| --- | --- |
+| `~/.deepagents/extensions/` | User-owned loose files. Implicitly authorized. |
+| `[extensions].extra_files` and `[extensions].extra_dirs` | Explicit paths in trusted user configuration. |
+| `-e PATH`, `--extension PATH` | File or directory authorized for one run. Repeat the flag for several paths. |
+| Enabled installed plugins | Installing and enabling the plugin authorizes its code. |
+| `dcode.extensions` entry points | Modules exposed by installed Python distributions. |
+| `{project_root}/.deepagents/extensions/` | Loaded only after the project is trusted. |
+
+Directory scans are shallow: direct `*.py` files are extensions, and a direct subdirectory is a package extension when it contains `__init__.py` or `extension.py`.
 
 ## Package an extension in a plugin
 
-Plugins are the supported way to distribute extensions. The plugin owns the extension's identity, version, installation, updates, and durable data directory. Declare one or more entry files in the plugin manifest:
+Plugins are the preferred way to distribute extensions. The plugin owns the extension's identity, version, installation, updates, and durable data directory. Declare one or more entry files in the plugin manifest:
 
 ```json title="plugin.json"
 {
@@ -72,7 +96,7 @@ Plugins are the supported way to distribute extensions. The plugin owns the exte
 }
 ```
 
-Install and enable the plugin with the usual [plugin commands](/oss/deepagents/code/plugins#manage-plugins-from-the-command-line), then run `/reload`. Deep Agents Code installs the plugin into a versioned cache and reloads the agent server from the enabled plugin set. A separately managed remote agent server must be restarted or redeployed by its operator.
+Install and enable the plugin with the usual [plugin commands](/oss/deepagents/code/plugins#manage-plugins-from-the-command-line), then run `/restart`. Backend composition happens while the agent graph is built, so `/reload` cannot apply backend route changes. A separately managed remote agent server must be restarted or redeployed by its operator.
 
 Manifest paths must start with `./` and resolve inside the installed plugin snapshot. Traversal, absolute paths, symlink escapes, missing files, and non-Python files are rejected, and Python entries are ignored when the manifest has no non-empty `version`.
 
@@ -80,15 +104,11 @@ Installing and enabling a plugin authorizes its extension code, so review a plug
 
 ## Develop extensions in a project
 
-`{project_root}/.deepagents/extensions/` is the local development escape hatch for extensions that are versioned with a repository. The scan is shallow: direct `*.py` files are extensions, and a direct subdirectory is a package extension when it contains `__init__.py` or `extension.py`.
-
-Project extensions execute repository-authored Python, so the directory is not scanned before trust resolves:
+`{project_root}/.deepagents/extensions/` is the local development escape hatch for extensions that are versioned with a repository. Project extensions execute repository-authored Python, so the directory is not scanned before trust resolves:
 
 - Interactive sessions prompt before loading project extensions and can remember the decision for that project root under `~/.deepagents/.state/extension_trust.json`.
-- Declining the prompt skips project extensions and continues with plugin extensions.
+- Declining the prompt skips project extensions and continues with the other sources.
 - Headless and CI runs never prompt. Pass `--trust-project-extensions` to opt in for that run.
-
-Enabled plugins load before project extensions.
 
 ## Configure extensions
 
@@ -96,22 +116,22 @@ Enabled plugins load before project extensions.
 [extensions]
 enabled = true
 trust = "ask"  # "ask" (default), "always", or "never"
+extra_files = ["~/src/policy.py"]
+extra_dirs = ["~/src/company-extensions"]
 ```
 
-`trust` sets the fallback decision for project extensions: `always` loads them without prompting, and `never` skips them even when the project root has a persisted grant.
+`trust` sets the fallback decision for project extensions: `always` loads them without prompting, and `never` skips them even when the project root has a persisted grant. Relative `extra_files` and `extra_dirs` paths resolve from `~/.deepagents/`.
 
 Two environment variables override the file:
 
 - `DEEPAGENTS_CODE_EXTENSIONS`: Enable or disable all extension loading.
 - `DEEPAGENTS_CODE_EXTENSIONS_TRUST`: Override the project trust policy.
 
-There is no separate user extension path setting. Use an installed plugin for user-wide extensions and the project directory for local development.
-
 ## Failure and security behavior
 
-Each setup function is transactional. If import or initialization fails, all of that extension's partial registrations are discarded and the remaining extensions still load. Failures are written to the debug log.
+Each setup function is transactional. If import or initialization fails, all of that extension's partial registrations are discarded and the remaining extensions still load. Failures are written to the debug log and listed by `/extensions`.
 
-Extension tools are appended after built-in tools and are not added to the human-approval map automatically. An extension that performs sensitive work must enforce its own approval or policy through middleware. See [Approval modes](/oss/deepagents/code/approval-modes).
+Extension tools override same-named built-ins and are not added to the human-approval map automatically. An extension that performs sensitive work must enforce its own approval or policy through middleware. See [Approval modes](/oss/deepagents/code/approval-modes).
 
 Every registration retains its plugin ID, version, installed root, and source scope. That attribution records which extension added a storage route, but it does not make an arbitrary storage provider safe: a provider can reach the network or host files. Install plugins only from trusted sources, and choose shared namespaces that preserve tenant and user isolation.
 

--- a/src/oss/deepagents/code/extensions.mdx
+++ b/src/oss/deepagents/code/extensions.mdx
@@ -1,0 +1,122 @@
+---
+title: Python extensions
+sidebarTitle: Extensions
+description: Extend Deep Agents Code with Python middleware, tools, storage routes, and shutdown hooks
+---
+
+Python extensions customize the Deep Agents Code agent server from your own code, without forking `dcode`. An extension adds LangChain middleware, tools the model can call, virtual storage routes, and shutdown callbacks, so a team can ship shared behavior as an installable [plugin](/oss/deepagents/code/plugins).
+
+<Warning>
+    Extensions are experimental. They load only when `DEEPAGENTS_CODE_EXPERIMENTAL=1` is set before `dcode` starts, and the API can change without notice.
+</Warning>
+
+An extension runs arbitrary Python with your user permissions. Load extensions only from sources you trust.
+
+## Write an extension
+
+An extension is a Python file that defines a setup function named `extension`. Deep Agents Code calls it once during startup with an `ExtensionAPI` registrar:
+
+```python title="extension.py"
+from deepagents.backends import StoreBackend
+from deepagents_code.extensions import ExtensionAPI
+
+
+def extension(d: ExtensionAPI) -> None:
+    """Add shared storage under `/memories/`."""
+    d.register_backend_route(
+        "/memories/",
+        StoreBackend(namespace=lambda _runtime: ("filesystem",)),
+    )
+```
+
+Setup can be synchronous or asynchronous. Deep Agents Code imports every enabled extension and awaits every setup function before it builds the agent and its storage routes.
+
+Registration is allowed only while `extension(d)` runs. Calling a `register_*` method after setup returns raises an error.
+
+Do not open long-lived connections or start background tasks during module import. Connect lazily on first use instead, and register an idempotent `on_shutdown` callback for any session resource that setup opens.
+
+### Registration API
+
+| Method | Purpose |
+| --- | --- |
+| `register_middleware(class_or_instance)` | Install a LangChain `AgentMiddleware` on the agent. A class is instantiated with no arguments, so pass an instance when construction needs configuration. |
+| `register_tool(function_or_tool)` | Expose a `BaseTool` or a plain callable to the model. Callables are converted using LangChain tool schema inference. |
+| `register_backend_route(prefix, backend)` | Serve file operations under a virtual path from a `BackendProtocol` storage provider. |
+| `on_shutdown(callback)` | Release session resources when the agent server stops. Synchronous and asynchronous callbacks are both supported. |
+
+The registrar also exposes read-only session context: `d.cwd` is the session working directory, `d.mode` is `interactive` or `headless`, and `d.path` is the extension entry file. Mutable terminal and thread state is not exposed, and custom slash commands are not part of this API.
+
+### Route files to a storage backend
+
+`register_backend_route` mounts a storage provider under a virtual path, which makes its content available through the model's file tools. Route prefixes are lowercase absolute paths with leading and trailing slashes, such as `/memories/` or `/company/knowledge/`. Deep Agents Code rejects traversal, empty segments, backslashes, URL query or fragment syntax, and overlaps with internal routes.
+
+Shell `execute` stays attached to the default local or sandbox storage, so shell commands cannot read virtual routed content.
+
+A route makes shared storage available to file operations. It does not move the built-in `AGENTS.md` memory. To put shared content in the model's prompt, also register middleware that reads the routed location.
+
+The first extension registration of a route prefix wins. Built-in tools, middleware, and internal storage routes always take precedence over extension registrations with conflicting names or paths.
+
+## Package an extension in a plugin
+
+Plugins are the supported way to distribute extensions. The plugin owns the extension's identity, version, installation, updates, and durable data directory. Declare one or more entry files in the plugin manifest:
+
+```json title="plugin.json"
+{
+  "name": "shared-memory",
+  "version": "1.0.0",
+  "extensions": {
+    "com.langchain.deepagents.code": {
+      "pythonExtensions": "./extension.py"
+    }
+  }
+}
+```
+
+Install and enable the plugin with the usual [plugin commands](/oss/deepagents/code/plugins#manage-plugins-from-the-command-line), then run `/reload`. Deep Agents Code installs the plugin into a versioned cache and reloads the agent server from the enabled plugin set. A separately managed remote agent server must be restarted or redeployed by its operator.
+
+Manifest paths must start with `./` and resolve inside the installed plugin snapshot. Traversal, absolute paths, symlink escapes, missing files, and non-Python files are rejected, and Python entries are ignored when the manifest has no non-empty `version`.
+
+Installing and enabling a plugin authorizes its extension code, so review a plugin before enabling it.
+
+## Develop extensions in a project
+
+`{project_root}/.deepagents/extensions/` is the local development escape hatch for extensions that are versioned with a repository. The scan is shallow: direct `*.py` files are extensions, and a direct subdirectory is a package extension when it contains `__init__.py` or `extension.py`.
+
+Project extensions execute repository-authored Python, so the directory is not scanned before trust resolves:
+
+- Interactive sessions prompt before loading project extensions and can remember the decision for that project root under `~/.deepagents/.state/extension_trust.json`.
+- Declining the prompt skips project extensions and continues with plugin extensions.
+- Headless and CI runs never prompt. Pass `--trust-project-extensions` to opt in for that run.
+
+Enabled plugins load before project extensions.
+
+## Configure extensions
+
+```toml title="~/.deepagents/config.toml"
+[extensions]
+enabled = true
+trust = "ask"  # "ask" (default), "always", or "never"
+```
+
+`trust` sets the fallback decision for project extensions: `always` loads them without prompting, and `never` skips them even when the project root has a persisted grant.
+
+Two environment variables override the file:
+
+- `DEEPAGENTS_CODE_EXTENSIONS`: Enable or disable all extension loading.
+- `DEEPAGENTS_CODE_EXTENSIONS_TRUST`: Override the project trust policy.
+
+There is no separate user extension path setting. Use an installed plugin for user-wide extensions and the project directory for local development.
+
+## Failure and security behavior
+
+Each setup function is transactional. If import or initialization fails, all of that extension's partial registrations are discarded and the remaining extensions still load. Failures are written to the debug log.
+
+Extension tools are appended after built-in tools and are not added to the human-approval map automatically. An extension that performs sensitive work must enforce its own approval or policy through middleware. See [Approval modes](/oss/deepagents/code/approval-modes).
+
+Every registration retains its plugin ID, version, installed root, and source scope. That attribution records which extension added a storage route, but it does not make an arbitrary storage provider safe: a provider can reach the network or host files. Install plugins only from trusted sources, and choose shared namespaces that preserve tenant and user isolation.
+
+## See also
+
+- [Plugins and marketplaces](/oss/deepagents/code/plugins)
+- [Hooks](/oss/deepagents/code/hooks)
+- [Configuration](/oss/deepagents/code/configuration)

--- a/src/oss/deepagents/code/plugins.mdx
+++ b/src/oss/deepagents/code/plugins.mdx
@@ -164,6 +164,10 @@ For supported MCP transports and fields, see [MCP tools](/oss/deepagents/code/mc
 
 Place a hook document at `hooks/hooks.json`, declare a relative `hooks` path, or define hooks inline in the plugin manifest. Hook commands receive the path variables above. See [Hooks](/oss/deepagents/code/hooks) for the configuration and event reference.
 
+### Add Python extensions
+
+Declare a relative `pythonExtensions` path in the plugin manifest to ship middleware, tools, and storage routes with the plugin. See [Python extensions](/oss/deepagents/code/extensions#package-an-extension-in-a-plugin).
+
 ## Create a marketplace
 
 A marketplace is a JSON catalog with a name and a `plugins` array. Store it at one of these paths in the marketplace root:


### PR DESCRIPTION
## Description

External-facing docs for the experimental Deep Agents Code Python extensions API landing in the deepagents extensions stack (langchain-ai/deepagents#5631 through #5634). Adds a new Extensions page covering the `extension(d)` setup function, the four registrations (middleware, tools, backend routes, shutdown hooks), plugin packaging via `pythonExtensions`, project trust, config and environment keys, and failure/security behavior. Cross-links from the plugins, CLI reference, and configuration pages.

## Release Note

none

## Test Plan

- [ ] `make lint_prose` passes on the changed files (verified locally, 0 findings).
- [ ] Extensions page renders under Deep Agents → Code in the nav.

Made by [Open SWE](https://openswe.vercel.app/agents/01a02f8c-2a14-774a-8173-c11f5f4f4b96)