### PR TITLE
docs: Revamp Managed Deep Agents Slack setup

### DIFF
--- a/src/langsmith/managed-deep-agents-channels-slack.mdx
+++ b/src/langsmith/managed-deep-agents-channels-slack.mdx
@@ -1,16 +1,36 @@
 ---
 title: Make your agent available in Slack
 sidebarTitle: Slack
-description: Make a managed deep agent available in Slack and let Managed Deep Agents provision the Slack app during deployment.
+description: Start Managed Deep Agents runs from Slack messages and send responses to Slack conversations.
 ---
 
 import ManagedDeepAgentsPrivateBetaNote from '/snippets/langsmith/managed-deep-agents-private-beta-note.mdx';
 
-A Slack channel makes a managed deep agent available to people in a Slack workspace. Messages sent to the Slack app start agent runs, and the agent's final responses return to the originating Slack conversations.
+A Slack channel lets people invoke a managed deep agent through app mentions, direct messages, and replies in an active Slack thread. Managed Deep Agents verifies Slack events, maps each conversation to a thread, runs the agent as the resolved caller, and posts the response back to Slack.
 
 Managed Deep Agents creates the Slack app and connects it to the deployed agent. Add a channel declaration to the agent project, then deploy.
 
 <ManagedDeepAgentsPrivateBetaNote />
+
+## Project structure
+
+:::python
+```text
+my-agent/
+  agent.py
+  channels/
+    slack.py
+```
+:::
+
+:::js
+```text
+my-agent/
+  agent.ts
+  channels/
+    slack.ts
+```
+:::
 
 ## Add a Slack channel
 
@@ -28,16 +48,11 @@ To add Slack to an existing project, run the channel initialization command from
 mda channel init slack
 ```
 
-The command creates the language-specific channel file and uses the agent name and a default description as the initial Slack app details.
-
 :::python
 ```python channels/slack.py
 from managed_deepagents import channels
 
-channel = channels.slack(
-    name="support-agent",
-    description="Answers support questions",
-)
+channel = channels.slack()
 ```
 :::
 
@@ -45,38 +60,35 @@ channel = channels.slack(
 ```ts channels/slack.ts
 import { channels } from "managed-deepagents";
 
-export const channel = channels.slack({
-  name: "support-agent",
-  description: "Answers support questions",
-});
+export const channel = channels.slack();
 ```
 :::
 
-## Configure the Slack app appearance
+## Configure your agent's appearance in Slack
 
 Edit the channel declaration to control how the agent appears in Slack.
 
-<ParamField path="name" type="string" required>
+<ParamField path="name" type="string">
   The Slack app name. The name must contain 1–35 characters and can contain letters, numbers, spaces, underscores, dashes, and periods. It cannot start or end with a space or dash.
 </ParamField>
 
 <ParamField path="description" type="string">
-  A description of what the agent does. The description can contain up to 139 characters and defaults to an empty string.
+  A description of what the agent does. The description can contain up to 139 characters.
 </ParamField>
 
 <ParamField path="icon" type="string">
-  A path to the Slack app icon, relative to the `channels/` directory. The icon must be a 512 by 512 pixel PNG file no larger than 1 MB. If you omit this parameter, Managed Deep Agents uses the bundled default icon.
+  A path to the Slack app icon, relative to the `channels/` directory. The icon must be a 512 by 512 pixel PNG file no larger than 1 MB. If you omit this parameter, Managed Deep Agents will generate an icon for you.
 </ParamField>
 
 :::python
 <ParamField path="background_color" type="string">
-  The app background color as a six-digit hexadecimal color, such as `#1d4ed8`. The default is `#09090f`.
+  The app background color as a six-digit hexadecimal color, such as `#1d4ed8`.
 </ParamField>
 :::
 
 :::js
 <ParamField path="backgroundColor" type="string">
-  The app background color as a six-digit hexadecimal color, such as `#1d4ed8`. The default is `#09090f`.
+  The app background color as a six-digit hexadecimal color, such as `#1d4ed8`.
 </ParamField>
 :::
 
@@ -96,7 +108,7 @@ from managed_deepagents import channels
 
 channel = channels.slack(
     name="Support Agent",
-    description="Answers support questions",
+    description="Answers customer questions about orders and returns",
     icon="support-agent.png",
     background_color="#1d4ed8",
 )
@@ -117,7 +129,7 @@ import { channels } from "managed-deepagents";
 
 export const channel = channels.slack({
   name: "Support Agent",
-  description: "Answers support questions",
+  description: "Answers customer questions about orders and returns",
   icon: "support-agent.png",
   backgroundColor: "#1d4ed8",
 });
@@ -139,7 +151,7 @@ Deploying the agent also provisions its Slack app and connects the app to the de
     Managed Deep Agents deploys the agent and configures the Slack app from the channel declaration.
   </Step>
   <Step title="Authorize Slack if prompted">
-    If your LangSmith workspace is not authorized to create the Slack app, the CLI displays an HTTPS authorization link. Open the link, select the Slack workspace, and approve the requested access.
+    If you haven't authorized LangSmith before, the CLI displays an HTTPS authorization link. Open the link, select the Slack workspace, and approve the requested access.
 
     Return to the terminal and press Enter. The CLI checks the authorization again and continues provisioning. If the Slack workspace requires admin approval, complete that approval before continuing.
   </Step>
@@ -148,17 +160,9 @@ Deploying the agent also provisions its Slack app and connects the app to the de
   </Step>
 </Steps>
 
-If Slack is already authorized, deployment completes without an authorization prompt. In a non-interactive environment, the CLI prints the required authorization or approval action and asks you to rerun `mda deploy` after completing it.
+If Slack is already authorized, deployment completes without an authorization prompt.
 
-Run `mda deploy` again after changing the channel declaration. Slack channel provisioning requires the deployment to finish, so `mda deploy --no-wait` is not supported for a project with a Slack channel.
-
-## Troubleshoot Slack setup
-
-- **The channel file already exists**: Edit `channels/slack.py` or `channels/slack.ts` instead of running `mda channel init slack` again.
-- **The CLI asks for workspace approval**: Ask a Slack workspace administrator to approve the app, then return to the terminal and continue the deployment.
-- **A non-interactive deployment stops for authorization**: Open the HTTPS link printed by the CLI, complete authorization, and rerun `mda deploy`.
-- **The icon is rejected**: Confirm the path is relative to `channels/`, does not use symlinks or parent-directory segments, and points to a regular 512 by 512 pixel PNG file no larger than 1 MB.
-- **Deployment reports more than one Slack channel**: Keep one Slack channel declaration in the project.
+Changes to the Slack channel declaration will be visible the next time you deploy your agent.
 
 ## See also
 

--- a/src/langsmith/managed-deep-agents-channels-slack.mdx
+++ b/src/langsmith/managed-deep-agents-channels-slack.mdx
@@ -190,6 +190,10 @@ During deployment, Managed Deep Agents provisions your agent in Slack from the c
   </Step>
 </Steps>
 
+<Note>
+Human-in-the-loop requests in Slack support only the `approve` and `reject` [decision types](/langsmith/managed-deep-agents-tools#human-in-the-loop).
+</Note>
+
 If Slack is already authorized, deployment completes without an authorization prompt.
 
 After you change the agent's name, description, icon, or background color in the Slack channel declaration, redeploy the agent to apply the changes in Slack.

--- a/src/langsmith/managed-deep-agents-channels-slack.mdx
+++ b/src/langsmith/managed-deep-agents-channels-slack.mdx
@@ -1,20 +1,86 @@
 ---
-title: Connect a Managed Deep Agent to Slack
+title: Make your agent available in Slack
 sidebarTitle: Slack
-description: Start Managed Deep Agents runs from Slack messages and send responses to Slack conversations.
+description: Make a managed deep agent available in Slack and let Managed Deep Agents provision the Slack app during deployment.
 ---
 
 import ManagedDeepAgentsPrivateBetaNote from '/snippets/langsmith/managed-deep-agents-private-beta-note.mdx';
 
-A Slack channel lets people invoke a managed deep agent through app mentions, direct messages, and replies in an active Slack thread. Managed Deep Agents verifies Slack events, maps each conversation to a thread, runs the agent as the resolved caller, and posts the response back to Slack.
+A Slack channel makes a managed deep agent available to people in a Slack workspace. Messages sent to the Slack app start agent runs, and the agent's final responses return to the originating Slack conversations.
 
-Slack is a bring-your-own-app integration. You define a Slack app manifest in the agent project.
+Managed Deep Agents creates the Slack app and connects it to the deployed agent. Add a channel declaration to the agent project, then deploy.
 
 <ManagedDeepAgentsPrivateBetaNote />
 
-## Project structure
+## Add a Slack channel
 
-Slack setup uses a channel declaration, an editable manifest template, and a generated manifest:
+A managed deep agent deployment supports one Slack channel. The channel declaration lives at `channels/slack.py` or `channels/slack.ts`.
+
+To include Slack when you create a project, pass `--channel slack`:
+
+```bash
+mda init my-agent --channel slack
+```
+
+To add Slack to an existing project, run the channel initialization command from the project root:
+
+```bash
+mda channel init slack
+```
+
+The command creates the language-specific channel file and uses the agent name and a default description as the initial Slack app details.
+
+:::python
+```python channels/slack.py
+from managed_deepagents import channels
+
+channel = channels.slack(
+    name="support-agent",
+    description="Answers support questions",
+)
+```
+:::
+
+:::js
+```ts channels/slack.ts
+import { channels } from "managed-deepagents";
+
+export const channel = channels.slack({
+  name: "support-agent",
+  description: "Answers support questions",
+});
+```
+:::
+
+## Configure the Slack app appearance
+
+Edit the channel declaration to control how the agent appears in Slack.
+
+<ParamField path="name" type="string" required>
+  The Slack app name. The name must contain 1–35 characters and can contain letters, numbers, spaces, underscores, dashes, and periods. It cannot start or end with a space or dash.
+</ParamField>
+
+<ParamField path="description" type="string">
+  A description of what the agent does. The description can contain up to 139 characters and defaults to an empty string.
+</ParamField>
+
+<ParamField path="icon" type="string">
+  A path to the Slack app icon, relative to the `channels/` directory. The icon must be a 512 by 512 pixel PNG file no larger than 1 MB. If you omit this parameter, Managed Deep Agents uses the bundled default icon.
+</ParamField>
+
+:::python
+<ParamField path="background_color" type="string">
+  The app background color as a six-digit hexadecimal color, such as `#1d4ed8`. The default is `#09090f`.
+</ParamField>
+:::
+
+:::js
+<ParamField path="backgroundColor" type="string">
+  The app background color as a six-digit hexadecimal color, such as `#1d4ed8`. The default is `#09090f`.
+</ParamField>
+:::
+
+For example, put an icon next to the channel declaration:
 
 :::python
 ```text
@@ -22,10 +88,18 @@ my-agent/
   agent.py
   channels/
     slack.py
-  slack-app-manifest.json
-  .mda/
-    slack/
-      app-manifest.json
+    support-agent.png
+```
+
+```python channels/slack.py
+from managed_deepagents import channels
+
+channel = channels.slack(
+    name="Support Agent",
+    description="Answers support questions",
+    icon="support-agent.png",
+    background_color="#1d4ed8",
+)
 ```
 :::
 
@@ -35,328 +109,59 @@ my-agent/
   agent.ts
   channels/
     slack.ts
-  slack-app-manifest.json
-  .mda/
-    slack/
-      app-manifest.json
-```
-:::
-
-## Add a Slack channel
-
-:::python
-Export a channel created with `channels.slack()`:
-
-```python channels/slack.py
-from managed_deepagents import channels
-
-channel = channels.slack()
-```
-:::
-
-:::js
-Export a channel created with `channels.slack()`:
-
-```ts channels/slack.ts
-import { channels } from "managed-deepagents";
-
-export const channel = channels.slack();
-```
-:::
-
-The file name sets the channel name to `slack` and mounts its Events API route at `/channels/slack/events`. You can use another file name when you need a different configured name.
-
-## Create and deploy the Slack app
-
-After setting up the Slack channel, you need to create and deploy your Slack app.
-
-<Steps>
-  <Step title="Deploy your managed deep agent">
-  First, [deploy your managed deep agent](/langsmith/managed-deep-agents-deploy).
-  
-  ```
-  mda deploy .
-  ```
-  
-  Wait for the deployment to finish. The agent is deployed even though Slack is
-not active yet.
-  </Step>
-  <Step title="Generate the app manifest template">
-    Run a command to generate the Slack app manifest template.
-    
-    ```bash
-    mda channel add slack .
-    ```
-    Managed Deep Agents finds the existing deployment and writes two files:
-    - A "template" manifest to `slack-app-manifest.json`
-    - The full manifest to `.mda/slack/app-manifest.json`
-    
-    The template manifest is what you should edit directly to change scopes, etc. The full manifest is generated from this template manifest and includes information about the deployment.
-    If you make changes to the template manifest, you will need rerun `mda channel add slack .` to regenerate the full template. 
-    Do not directly edit the generated file at `.mda/slack/app-manifest.json`
-    
-  </Step>
-  <Step title="Create and install the Slack app once">
-    1. Open https://api.slack.com/apps.
-    2. Select **Create New App**.
-    3. Select **From an app manifest**.
-    4. Choose the target Slack workspace.
-    5. Import `.mda/slack/app-manifest.json` and create the app.
-    6. Open **OAuth & Permissions** and select **Install to Workspace**.
-    7. Approve the requested permissions.
-    8. Copy the **Bot User OAuth Token** from **OAuth & Permissions**.
-    9. Copy the **Signing Secret** from **Basic Information → App Credentials**.
-    
-    The Events request URL is already in the generated manifest, so there is no
-    bootstrap manifest and no second manifest import.  
-  </Step>
-  <Step title="Add the Slack credentials">
-    Add the two values to the project .env:
-    
-    ```
-    SLACK_SIGNING_SECRET=...
-    SLACK_BOT_TOKEN=xoxb-...
-    ```
-    
-    Do not commit .env and do not copy these values into either manifest.
-  </Step>
-  <Step title="Redeploy to activate Slack">
-  
-  ```
-  mda deploy .
-  ```
-  
-  This deployment forwards the Slack credentials to the managed runtime and
-enables authenticated event handling.
-    
-  </Step>
-  <Step title="Updating Slack Bot Configurations">
-    The previous steps guide you through deploying the first iteration of your Managed Deepagent as a Slack bot. If you want to make any updates to the agent, you just simply rerun `mda deploy .` to update the deployed app.
-
-    If you want to make any configuration changes to the Slack application itself, the recommended steps are:
-    
-    1. Update the `slack-app-manifest.json` file locally
-    2. Run `mda channel add slack .` — this will regenerate the manifest with the latest changes. These changes are written to the `.mda/slack/app-manifest.json` file
-    3. On https://api.slack.com/apps → locate your app → App Manifest 
-    4. Replace the contents of the manifest with the new `.mda/slack/app-manifest.json` file → Click **Save Changes**
-    5. Navigate to the **OAuth & Permissions** tab. Click on **Reinstall to Workspace**
-    
-    This ensures the manifest in your mda filesystem remains as the source of truth for the Slack app.
-  </Step>
-</Steps>
-
-Treat `slack-app-manifest.json` as the source of truth. When you change its scopes, bot events, branding, or other settings, rerun `mda channel add slack .`, apply the regenerated `.mda/slack/app-manifest.json`, and reinstall the app if Slack requests it. The generated files under `.mda/` are build artifacts; do not commit them.
-
-## Configure Slack behavior
-
-Pass options to `channels.slack(...)` to control Managed Deep Agents runtime behavior. Configure OAuth scopes and delivered event types in the Slack app, not in the channel declaration.
-
-:::python
-```python channels/slack.py
-from managed_deepagents import channels
-
-channel = channels.slack(
-    auto_reply=True,
-    mention_behavior="strip",
-    filters={
-        "include_conversations": ["C0123456789"],
-        "exclude_users": ["slack:T0123456789:U0123456789"],
-    },
-    conversation={
-        "app_mention": "thread",
-        "direct_message": "conversation",
-    },
-)
+    support-agent.png
 ```
 
-| Option | Default | Description |
-| --- | --- | --- |
-| `auto_reply` | `True` | Post the agent's final response to the originating Slack thread or conversation. |
-| `mention_behavior` | `"strip"` | Remove Slack mention tokens before passing text to the agent. Set it to `"preserve"` to keep them. |
-| `filters.include_conversations` | All | Accept events only from the listed Slack conversation IDs. |
-| `filters.exclude_conversations` | No exclusions | Ignore events from the listed Slack conversation IDs. |
-| `filters.include_users` | All | Accept events only from the listed fully qualified users, such as `slack:T123:U456`. |
-| `filters.exclude_users` | No exclusions | Ignore events from the listed fully qualified users. |
-| `filters.allow_shared_conversations` | `False` | Controls Slack Connect shared conversations. Setting this to `True` is not currently supported. |
-| `conversation.app_mention` | `"thread"` | Select how app mentions and their follow-up replies map to Managed Deep Agents threads. |
-| `conversation.direct_message` | `"conversation"` | Select how direct messages map to Managed Deep Agents threads. |
-:::
-
-:::js
 ```ts channels/slack.ts
 import { channels } from "managed-deepagents";
 
 export const channel = channels.slack({
-  autoReply: true,
-  mentionBehavior: "strip",
-  filters: {
-    includeConversations: ["C0123456789"],
-    excludeUsers: ["slack:T0123456789:U0123456789"],
-  },
-  conversation: {
-    appMention: "thread",
-    directMessage: "conversation",
-  },
+  name: "Support Agent",
+  description: "Answers support questions",
+  icon: "support-agent.png",
+  backgroundColor: "#1d4ed8",
 });
 ```
-
-| Option | Default | Description |
-| --- | --- | --- |
-| `autoReply` | `true` | Post the agent's final response to the originating Slack thread or conversation. |
-| `mentionBehavior` | `"strip"` | Remove Slack mention tokens before passing text to the agent. Set it to `"preserve"` to keep them. |
-| `filters.includeConversations` | All | Accept events only from the listed Slack conversation IDs. |
-| `filters.excludeConversations` | No exclusions | Ignore events from the listed Slack conversation IDs. |
-| `filters.includeUsers` | All | Accept events only from the listed fully qualified users, such as `slack:T123:U456`. |
-| `filters.excludeUsers` | No exclusions | Ignore events from the listed fully qualified users. |
-| `filters.allowSharedConversations` | `false` | Controls Slack Connect shared conversations. Setting this to `true` is not currently supported. |
-| `conversation.appMention` | `"thread"` | Select how app mentions and their follow-up replies map to Managed Deep Agents threads. |
-| `conversation.directMessage` | `"conversation"` | Select how direct messages map to Managed Deep Agents threads. |
 :::
 
-Conversation mappings accept:
+## Deploy the agent and Slack app
 
-- **`"thread"`**: Reuse one Managed Deep Agents thread for a Slack thread.
-- **`"conversation"`**: Reuse one Managed Deep Agents thread for the Slack conversation.
-- **`"message"`**: Start a separate Managed Deep Agents thread for each message.
+Deploying the agent also provisions its Slack app and connects the app to the deployed agent.
 
-## Understand event and thread behavior
+<Steps>
+  <Step title="Deploy the managed deep agent">
+    Run the deployment command from the project root:
 
-The Slack app controls which events reach the deployment. The Slack channel normalizes supported events and applies the configured filters and conversation mapping.
+    ```bash
+    mda deploy
+    ```
 
-| Slack interaction | Event subscription | Default Managed Deep Agents behavior |
-| --- | --- | --- |
-| App mention | `app_mention` | Start or continue a thread associated with the Slack thread. |
-| Direct message | `message.im` | Reuse a thread associated with the direct-message conversation. |
-| Non-mention reply in a public channel | `message.channels` | Continue the thread only when the agent already has a corresponding Managed Deep Agents thread. |
-| Non-mention reply in a private channel | `message.groups` | Continue the thread only when the agent already has a corresponding Managed Deep Agents thread. |
+    Managed Deep Agents deploys the agent and configures the Slack app from the channel declaration.
+  </Step>
+  <Step title="Authorize Slack if prompted">
+    If your LangSmith workspace is not authorized to create the Slack app, the CLI displays an HTTPS authorization link. Open the link, select the Slack workspace, and approve the requested access.
 
-Top-level channel messages that do not mention the bot are ignored. Bot messages, the app's own messages, unsupported message subtypes, and events rejected by channel filters do not start runs.
+    Return to the terminal and press Enter. The CLI checks the authorization again and continues provisioning. If the Slack workspace requires admin approval, complete that approval before continuing.
+  </Step>
+  <Step title="Use the agent in Slack">
+    Open the provisioned app in Slack and send it a message. The message starts an agent run, and the final response appears in the Slack conversation.
+  </Step>
+</Steps>
 
-When Slack delivers the same mention through both `app_mention` and `message.*`, Managed Deep Agents drops the duplicate message event. Subscribe to `app_mention` for mentions and use `message.channels` or `message.groups` for non-mention follow-up replies.
+If Slack is already authorized, deployment completes without an authorization prompt. In a non-interactive environment, the CLI prints the required authorization or approval action and asks you to rerun `mda deploy` after completing it.
 
-## Send responses to Slack
+Run `mda deploy` again after changing the channel declaration. Slack channel provisioning requires the deployment to finish, so `mda deploy --no-wait` is not supported for a project with a Slack channel.
 
-:::python
-With `auto_reply` enabled, Managed Deep Agents extracts the final assistant response and posts it to the originating Slack conversation after the run completes.
-:::
+## Troubleshoot Slack setup
 
-:::js
-With `autoReply` enabled, Managed Deep Agents extracts the final assistant response and posts it to the originating Slack conversation after the run completes.
-:::
-
-Channel-originated runs also expose `runtime.channel` in tools and middleware. Use it to inspect the normalized event, post an intermediate or final message, or update a previously posted message. It is absent for ordinary HTTP and scheduled runs.
-
-The following tool posts the final response explicitly:
-
-:::python
-```python tools/send_channel_reply.py
-from langchain.tools import tool
-from managed_deepagents import ManagedDeepAgentRuntime
-
-
-@tool
-async def send_channel_reply(
-    text: str,
-    runtime: ManagedDeepAgentRuntime,
-) -> str:
-    """Send the final response to the originating messaging channel."""
-    if runtime.channel is None:
-        return "This run did not originate from a messaging channel."
-    posted = await runtime.channel.post({"text": text}, {"final": True})
-    return posted["id"]
-```
-:::
-
-:::js
-```ts tools/send-channel-reply.ts
-import { tool } from "langchain";
-import type { ManagedDeepAgentRuntime } from "managed-deepagents";
-import { z } from "zod";
-
-export const sendChannelReply = tool(
-  async ({ text }, runtime: ManagedDeepAgentRuntime) => {
-    if (!runtime.channel) {
-      return "This run did not originate from a messaging channel.";
-    }
-    const posted = await runtime.channel.post({ text }, { final: true });
-    return posted.id;
-  },
-  {
-    name: "send_channel_reply",
-    description: "Send the final response to the originating messaging channel.",
-    schema: z.object({ text: z.string() }),
-  },
-);
-```
-:::
-
-:::python
-Pass `{"final": True}` only when the posted message is the final response. It suppresses the automatic reply so the user does not receive the final response twice. A post without that option is an intermediate message and does not suppress auto-reply.
-:::
-
-:::js
-Pass `{ final: true }` only when the posted message is the final response. It suppresses the automatic reply so the user does not receive the final response twice. A post without that option is an intermediate message and does not suppress auto-reply.
-:::
-
-:::python
-`runtime.channel.post(...)` can post only to the originating Slack thread. Explicit destinations are not supported for channel-originated runs. To send a scheduled result to a specific Slack conversation, use [`deliver_to`](/langsmith/managed-deep-agents-schedules#deliver-results-to-slack).
-:::
-
-:::js
-`runtime.channel.post(...)` can post only to the originating Slack thread. Explicit destinations are not supported for channel-originated runs. To send a scheduled result to a specific Slack conversation, use [`deliverTo`](/langsmith/managed-deep-agents-schedules#deliver-results-to-slack).
-:::
-
-## Understand Slack caller identity
-
-A Slack event runs as an identity derived from the Slack workspace and user, such as `slack:T123:U456`. This identity is separate from caller identities used for HTTP requests. Slack account linking is not supported.
-
-## Deploy changes
-
-Redeploy after changing the channel declaration, secrets, or identity configuration. Rerun `mda channel add slack .` when you change `slack-app-manifest.json`, the channel name, or the deployment so Managed Deep Agents can regenerate the final manifest with the current Events URL. Apply the generated manifest to the existing Slack app after the deployment completes.
-
-Avoid making lasting configuration changes only in the Slack dashboard. A later manifest update can replace settings that are not present in the checked-in template.
-
-## Review security and current limits
-
-- Managed Deep Agents verifies every Slack request against its raw body and rejects signatures outside Slack's five-minute replay window.
-- Slack Connect shared conversations are not supported.
-- `runtime.channel` does not expose `SLACK_BOT_TOKEN` or other provider credentials.
-- Event deduplication is currently process-local. A multi-replica deployment can invoke the agent more than once when Slack retries an event.
-
-<Warning>
-Design channel-triggered tools as idempotent when they perform external side effects. Slack retries and multi-replica processing can produce more than one run for the same logical event.
-</Warning>
-
-## Troubleshoot Slack channels
-
-:::python
-- **`mda channel add slack` reports that it needs exactly one channel**: Keep exactly one `channels.slack(...)` declaration in the project when using the manifest workflow.
-- **Managed Deep Agents cannot read the template**: Confirm `slack-app-manifest.json` is a regular JSON file at the project root. Remove credentials and any `settings.event_subscriptions.request_url`, and keep Socket Mode disabled.
-- **The first deploy writes a bootstrap manifest and exits**: This is expected when the Slack credentials do not exist yet. Create and install the app, add both credentials, then rerun the same command.
-- **Managed Deep Agents does not write the final manifest**: Run `mda deploy .` without `--no-wait`, then rerun `mda channel add slack .`. The CLI needs the deployed Agent Server URL.
-- **Slack cannot verify the request URL**: Confirm the deployment is healthy, the URL on the app's **Event Subscriptions** page matches `https://<agent-server>/channels/<name>/events`, and `SLACK_SIGNING_SECRET` belongs to that app. Redeploy after adding the Slack credentials, then apply the regenerated final manifest.
-- **Mentions do not start runs**: Subscribe to `app_mention`, add `app_mentions:read`, invite the bot to the conversation, and reinstall the app after changing scopes.
-- **Direct messages do not start runs**: Subscribe to `message.im` and add `im:history`.
-- **Thread replies do not start runs**: Reply inside a thread where the agent previously participated. Subscribe to `message.channels` or `message.groups`, add the matching history scope, and confirm the bot remains in the conversation.
-- **The agent runs but does not reply**: Confirm `auto_reply` is enabled and `SLACK_BOT_TOKEN` has `chat:write`.
-:::
-
-:::js
-- **`mda channel add slack` reports that it needs exactly one channel**: Keep exactly one `channels.slack(...)` declaration in the project when using the manifest workflow.
-- **Managed Deep Agents cannot read the template**: Confirm `slack-app-manifest.json` is a regular JSON file at the project root. Remove credentials and any `settings.event_subscriptions.request_url`, and keep Socket Mode disabled.
-- **The first deploy writes a bootstrap manifest and exits**: This is expected when the Slack credentials do not exist yet. Create and install the app, add both credentials, then rerun the same command.
-- **Managed Deep Agents does not write the final manifest**: Run `mda deploy .` without `--no-wait`, then rerun `mda channel add slack .`. The CLI needs the deployed Agent Server URL.
-- **Slack cannot verify the request URL**: Confirm the deployment is healthy, the URL on the app's **Event Subscriptions** page matches `https://<agent-server>/channels/<name>/events`, and `SLACK_SIGNING_SECRET` belongs to that app. Redeploy after adding the Slack credentials, then apply the regenerated final manifest.
-- **Mentions do not start runs**: Subscribe to `app_mention`, add `app_mentions:read`, invite the bot to the conversation, and reinstall the app after changing scopes.
-- **Direct messages do not start runs**: Subscribe to `message.im` and add `im:history`.
-- **Thread replies do not start runs**: Reply inside a thread where the agent previously participated. Subscribe to `message.channels` or `message.groups`, add the matching history scope, and confirm the bot remains in the conversation.
-- **The agent runs but does not reply**: Confirm `autoReply` is enabled and `SLACK_BOT_TOKEN` has `chat:write`.
-:::
+- **The channel file already exists**: Edit `channels/slack.py` or `channels/slack.ts` instead of running `mda channel init slack` again.
+- **The CLI asks for workspace approval**: Ask a Slack workspace administrator to approve the app, then return to the terminal and continue the deployment.
+- **A non-interactive deployment stops for authorization**: Open the HTTPS link printed by the CLI, complete authorization, and rerun `mda deploy`.
+- **The icon is rejected**: Confirm the path is relative to `channels/`, does not use symlinks or parent-directory segments, and points to a regular 512 by 512 pixel PNG file no larger than 1 MB.
+- **Deployment reports more than one Slack channel**: Keep one Slack channel declaration in the project.
 
 ## See also
 
-- [Channels overview](/langsmith/managed-deep-agents-channels): understand the provider-neutral channel model.
-- [Identity](/langsmith/managed-deep-agents-identity): configure authentication and caller ownership.
-- [Schedules](/langsmith/managed-deep-agents-schedules): deliver scheduled results to Slack.
-- [Custom tools](/langsmith/managed-deep-agents-tools): attach a tool that uses `runtime.channel`.
-- [Deploy an agent](/langsmith/managed-deep-agents-deploy): configure deployment secrets and inspect builds.
+- [Channels overview](/langsmith/managed-deep-agents-channels): understand how channels connect messaging services to an agent.
+- [Deploy an agent](/langsmith/managed-deep-agents-deploy): configure and deploy a managed deep agent.
+- [CLI reference](/langsmith/managed-deep-agents-cli): review Managed Deep Agents commands and flags.

--- a/src/langsmith/managed-deep-agents-channels-slack.mdx
+++ b/src/langsmith/managed-deep-agents-channels-slack.mdx
@@ -1,5 +1,5 @@
 ---
-title: Make your agent available in Slack
+title: Connect a Managed Deep Agent to Slack
 sidebarTitle: Slack
 description: Start Managed Deep Agents runs from Slack messages and send responses to Slack conversations.
 ---
@@ -8,7 +8,7 @@ import ManagedDeepAgentsPrivateBetaNote from '/snippets/langsmith/managed-deep-a
 
 A Slack channel lets people invoke a managed deep agent through app mentions, direct messages, and replies in an active Slack thread. Managed Deep Agents verifies Slack events, maps each conversation to a thread, runs the agent as the resolved caller, and posts the response back to Slack.
 
-Managed Deep Agents creates the Slack app and connects it to the deployed agent. Add a channel declaration to the agent project, then deploy.
+Managed Deep Agents creates and configures the resources that connect Slack to the deployed agent. Add a channel declaration to the agent project, then deploy.
 
 <ManagedDeepAgentsPrivateBetaNote />
 
@@ -34,7 +34,15 @@ my-agent/
 
 ## Add a Slack channel
 
-A managed deep agent deployment supports one Slack channel. The channel declaration lives at `channels/slack.py` or `channels/slack.ts`.
+A managed deep agent deployment supports one Slack channel.
+
+:::python
+The channel declaration lives at `channels/slack.py`.
+:::
+
+:::js
+The channel declaration lives at `channels/slack.ts`.
+:::
 
 To include Slack when you create a project, pass `--channel slack`:
 
@@ -69,7 +77,7 @@ export const channel = channels.slack();
 Edit the channel declaration to control how the agent appears in Slack.
 
 <ParamField path="name" type="string">
-  The Slack app name. The name must contain 1–35 characters and can contain letters, numbers, spaces, underscores, dashes, and periods. It cannot start or end with a space or dash.
+  The agent name in Slack. The name must contain 1–35 characters and can contain letters, numbers, spaces, underscores, dashes, and periods. It cannot start or end with a space or dash.
 </ParamField>
 
 <ParamField path="description" type="string">
@@ -77,18 +85,18 @@ Edit the channel declaration to control how the agent appears in Slack.
 </ParamField>
 
 <ParamField path="icon" type="string">
-  A path to the Slack app icon, relative to the `channels/` directory. The icon must be a 512 by 512 pixel PNG file no larger than 1 MB. If you omit this parameter, Managed Deep Agents will generate an icon for you.
+  A path to the agent icon shown in Slack, relative to the `channels/` directory. The icon must be a 512 by 512 pixel PNG file no larger than 1 MB. If you omit this parameter, Managed Deep Agents will generate an icon for you.
 </ParamField>
 
 :::python
 <ParamField path="background_color" type="string">
-  The app background color as a six-digit hexadecimal color, such as `#1d4ed8`.
+  The background color behind the agent icon as a six-digit hexadecimal color, such as `#1d4ed8`.
 </ParamField>
 :::
 
 :::js
 <ParamField path="backgroundColor" type="string">
-  The app background color as a six-digit hexadecimal color, such as `#1d4ed8`.
+  The background color behind the agent icon as a six-digit hexadecimal color, such as `#1d4ed8`.
 </ParamField>
 :::
 
@@ -136,19 +144,41 @@ export const channel = channels.slack({
 ```
 :::
 
-## Deploy the agent and Slack app
+### Configure which messages start runs
 
-Deploying the agent also provisions its Slack app and connects the app to the deployed agent.
+:::python
+<ParamField path="trigger_on_all_messages" type="bool" default="False">
+  Whether every new channel message can start an agent run. When `False`, channel messages start runs only when they mention the agent; direct messages still start runs.
+</ParamField>
+
+<ParamField path="allow_bot_triggers" type="bool" default="False">
+  Whether messages from other Slack bots can start agent runs.
+</ParamField>
+:::
+
+:::js
+<ParamField path="triggerOnAllMessages" type="boolean" default="false">
+  Whether every new channel message can start an agent run. When `false`, channel messages start runs only when they mention the agent; direct messages still start runs.
+</ParamField>
+
+<ParamField path="allowBotTriggers" type="boolean" default="false">
+  Whether messages from other Slack bots can start agent runs.
+</ParamField>
+:::
+
+## Deploy the agent
+
+During deployment, Managed Deep Agents provisions your agent in Slack from the channel declaration.
 
 <Steps>
-  <Step title="Deploy the managed deep agent">
+  <Step title="Deploy your agent">
     Run the deployment command from the project root:
 
     ```bash
     mda deploy
     ```
 
-    Managed Deep Agents deploys the agent and configures the Slack app from the channel declaration.
+    Managed Deep Agents deploys the agent and sets up the resources it needs to appear in Slack.
   </Step>
   <Step title="Authorize Slack if prompted">
     If you haven't authorized LangSmith before, the CLI displays an HTTPS authorization link. Open the link, select the Slack workspace, and approve the requested access.
@@ -156,13 +186,13 @@ Deploying the agent also provisions its Slack app and connects the app to the de
     Return to the terminal and press Enter. The CLI checks the authorization again and continues provisioning. If the Slack workspace requires admin approval, complete that approval before continuing.
   </Step>
   <Step title="Use the agent in Slack">
-    Open the provisioned app in Slack and send it a message. The message starts an agent run, and the final response appears in the Slack conversation.
+    After the first deployment, your agent sends you a direct message in Slack. Reply to the message to start an agent run. The final response appears in the Slack conversation.
   </Step>
 </Steps>
 
 If Slack is already authorized, deployment completes without an authorization prompt.
 
-Changes to the Slack channel declaration will be visible the next time you deploy your agent.
+After you change the agent's name, description, icon, or background color in the Slack channel declaration, redeploy the agent to apply the changes in Slack.
 
 ## See also
 

--- a/src/langsmith/managed-deep-agents-channels.mdx
+++ b/src/langsmith/managed-deep-agents-channels.mdx
@@ -34,9 +34,9 @@ my-agent/
 
 ## Understand channels
 
-A channel combines three parts of a messaging integration:
+A channel combines three parts of an external messaging integration:
 
-- **Inbound messages**: Receive and normalize provider messages, then start an agent run.
+- **Inbound events**: Verify and normalize provider events, then start an agent run.
 - **Outbound messaging**: Send the agent's response back to the originating conversation.
 - **Provisioning**: Create and configure the provider resources that connect the service to the deployed agent.
 
@@ -60,7 +60,7 @@ flowchart LR
     class Reply output;
 ```
 
-Provider adapters determine which messages are accepted, how provider conversations map to Managed Deep Agents threads, and how responses are delivered. The channel declaration exposes the supported configuration for that provider. During deployment, Managed Deep Agents provisions the provider integration.
+Provider adapters determine which events are accepted, how provider conversations map to Managed Deep Agents threads, and how responses are delivered. The channel declaration exposes the supported configuration for that provider.
 
 ## Declare channels in a project
 
@@ -113,5 +113,6 @@ A channel receives messages that start agent runs and delivers responses. An [MC
 ## See also
 
 - [Identity](/langsmith/managed-deep-agents-identity): authenticate callers and scope channel runs to the resolved user.
+- [Schedules](/langsmith/managed-deep-agents-schedules): deliver scheduled results through a configured channel.
 - [Deploy an agent](/langsmith/managed-deep-agents-deploy): deploy project changes and configure secrets.
 - [CLI reference](/langsmith/managed-deep-agents-cli): review channel project-file conventions.

--- a/src/langsmith/managed-deep-agents-channels.mdx
+++ b/src/langsmith/managed-deep-agents-channels.mdx
@@ -6,20 +6,20 @@ description: Connect Managed Deep Agents to external messaging services that can
 
 import ManagedDeepAgentsPrivateBetaNote from '/snippets/langsmith/managed-deep-agents-private-beta-note.mdx';
 
-A channel connects a managed deep agent to an external messaging service. Messages from the service can start agent runs, and the agent can respond through the same service without a separate application server.
+A channel makes a managed deep agent available in an external messaging service. Messages from the service can start agent runs, and the agent's final responses return through the same service.
 
 <ManagedDeepAgentsPrivateBetaNote />
 
 ## Project structure
 
-Channel declarations live in the project-level `channels/` directory, with one channel per file:
+Channel declarations live in the project-level `channels/` directory:
 
 :::python
 ```text
 my-agent/
   agent.py
   channels/
-    support.py
+    slack.py
 ```
 :::
 
@@ -28,17 +28,17 @@ my-agent/
 my-agent/
   agent.ts
   channels/
-    support.ts
+    slack.ts
 ```
 :::
 
 ## Understand channels
 
-A channel combines three parts of an external messaging integration:
+A channel combines three parts of a messaging integration:
 
-- **Inbound events**: Verify and normalize provider events, then start an agent run.
+- **Inbound messages**: Receive and normalize provider messages, then start an agent run.
 - **Outbound messaging**: Send the agent's response back to the originating conversation.
-- **Deployment requirements**: Declare the secrets and provider configuration that the deployment needs.
+- **Provisioning**: Create and configure the provider resources that connect the service to the deployed agent.
 
 In Managed Deep Agents, a channel connects a deployed agent to a messaging provider.
 
@@ -60,7 +60,7 @@ flowchart LR
     class Reply output;
 ```
 
-Provider adapters determine which events are accepted, how provider conversations map to Managed Deep Agents threads, and how responses are delivered. The channel declaration exposes the supported configuration for that provider.
+Provider adapters determine which messages are accepted, how provider conversations map to Managed Deep Agents threads, and how responses are delivered. The channel declaration exposes the supported configuration for that provider. During deployment, Managed Deep Agents provisions the provider integration.
 
 ## Declare channels in a project
 
@@ -74,19 +74,7 @@ Export a module-level `channel` from each file.
 Export a named `channel` from each file.
 :::
 
-The file name becomes the configured channel name. It identifies the channel at runtime and forms part of its inbound route.
-
-:::python
-For example, a declaration in `channels/support.py` receives events at:
-:::
-
-:::js
-For example, a declaration in `channels/support.ts` receives events at:
-:::
-
-```text
-POST /channels/support/events
-```
+The file name becomes the configured channel name and identifies the channel within the deployment.
 
 :::python
 Do not name a declaration `channels/channel.py`.
@@ -108,31 +96,7 @@ For example, `channels.slack()` creates a Slack channel.
 For example, `channels.slack()` creates a Slack channel.
 :::
 
-See the provider guide for its complete declaration and setup procedure.
-
-## Access the originating channel at runtime
-
-:::python
-Channel-originated runs expose `runtime.channel` to tools and middleware.
-:::
-
-:::js
-Channel-originated runs expose `runtime.channel` to tools and middleware.
-:::
-
-It contains the normalized event and conversation address, plus methods for posting and updating messages.
-
-:::python
-Ordinary HTTP runs and scheduled runs do not have an originating channel, so `runtime.channel` is absent for those runs.
-:::
-
-:::js
-Ordinary HTTP runs and scheduled runs do not have an originating channel, so `runtime.channel` is absent for those runs.
-:::
-
-By default, the managed runner posts the agent's final response to the originating conversation. Provider guides describe how to customize that behavior and send intermediate messages.
-
-Scheduled runs can deliver results through a named channel even though they do not originate from one. See [Schedules](/langsmith/managed-deep-agents-schedules#deliver-results-to-slack).
+See the provider guide for its declaration, app configuration, and deployment procedure.
 
 ## Distinguish channels from connectors
 
@@ -149,6 +113,5 @@ A channel receives messages that start agent runs and delivers responses. An [MC
 ## See also
 
 - [Identity](/langsmith/managed-deep-agents-identity): authenticate callers and scope channel runs to the resolved user.
-- [Schedules](/langsmith/managed-deep-agents-schedules): deliver scheduled results through a configured channel.
 - [Deploy an agent](/langsmith/managed-deep-agents-deploy): deploy project changes and configure secrets.
 - [CLI reference](/langsmith/managed-deep-agents-cli): review channel project-file conventions.

--- a/src/langsmith/managed-deep-agents-cli.mdx
+++ b/src/langsmith/managed-deep-agents-cli.mdx
@@ -115,7 +115,7 @@ mda init my-agent
 | `--memory agent\|none` | Optionally write a root memory declaration. If omitted, no memory file is created and durable memory is off. |
 | `--model SPEC` | Model the agent runs on, as `provider:model`. |
 | `--no-sandbox` | Leave out the managed sandbox declaration. |
-| `--channel slack` | Add `channels/slack.py` or `channels/slack.ts` so the agent can be made available in Slack. Repeatable. `--channels` is an alias. |
+| `--channel slack` | Initialize the agent with a Slack channel declaration. Repeatable; `--channels` is an alias. |
 
 To include Slack in a new project:
 
@@ -173,7 +173,7 @@ Run the following command from the root of an existing managed deep agent projec
 mda channel init slack
 ```
 
-The command creates `channels/slack.py` or `channels/slack.ts`. The next `mda deploy` provisions the Slack app. For the complete workflow, see [Make your agent available in Slack](/langsmith/managed-deep-agents-channels-slack).
+The command creates a Slack channel declaration in the `channels/` directory. The next `mda deploy` provisions the Slack app. For the complete workflow, see [Make your agent available in Slack](/langsmith/managed-deep-agents-channels-slack).
 
 ## Build projects
 

--- a/src/langsmith/managed-deep-agents-cli.mdx
+++ b/src/langsmith/managed-deep-agents-cli.mdx
@@ -78,7 +78,7 @@ The LangSmith API key authenticates the deploy. The agent's model provider also 
 | `mda eval …` / `mda evals …` | Scaffold optional Harbor tasks and compile the agent into a Harbor handoff. |
 | `mda dev [path]` | Compile a project and run it on the local LangGraph dev server. |
 | `mda deploy [path]` | Compile, sync Context Hub context, upload, and deploy to LangSmith. |
-| `mda channel add slack [path]` | Configure Slack for a deployed agent. |
+| `mda channel init slack` | Add a Slack channel declaration to the current project. |
 | `mda logs [path]` | Tail Agent Server logs for a deployed agent. |
 | `mda delete [path]` / `mda destroy [path]` | Delete a deployed agent and the LangSmith resources it created. |
 :::
@@ -93,7 +93,7 @@ The LangSmith API key authenticates the deploy. The agent's model provider also 
 | `mda eval …` / `mda evals …` | Scaffold optional Harbor tasks and compile the agent into a Harbor handoff. |
 | `mda dev [path]` | Compile a project and run it on the local LangGraph dev server. |
 | `mda deploy [path]` | Compile, sync Context Hub context, upload, and deploy to LangSmith. |
-| `mda channel add slack [path]` | Configure Slack for a deployed agent. |
+| `mda channel init slack` | Add a Slack channel declaration to the current project. |
 | `mda logs [path]` | Tail Agent Server logs for a deployed agent. |
 | `mda delete [path]` / `mda destroy [path]` | Delete a deployed agent and the LangSmith resources it created. |
 :::
@@ -115,6 +115,13 @@ mda init my-agent
 | `--memory agent\|none` | Optionally write a root memory declaration. If omitted, no memory file is created and durable memory is off. |
 | `--model SPEC` | Model the agent runs on, as `provider:model`. |
 | `--no-sandbox` | Leave out the managed sandbox declaration. |
+| `--channel slack` | Add `channels/slack.py` or `channels/slack.ts` so the agent can be made available in Slack. Repeatable. `--channels` is an alias. |
+
+To include Slack in a new project:
+
+```bash
+mda init my-agent --channel slack
+```
 
 The command detects the language from the current directory:
 
@@ -157,6 +164,16 @@ The scaffold creates:
 :::
 
 Eval tasks are opt-in and are not created by `mda init`. Managed Deep Agents evals are Harbor tasks under `evals/tasks/`. Run `mda evals init <name>` only when you want an optional starter task under `evals/scaffold/`.
+
+## Initialize a Slack channel
+
+Run the following command from the root of an existing managed deep agent project:
+
+```bash
+mda channel init slack
+```
+
+The command creates `channels/slack.py` or `channels/slack.ts`. The next `mda deploy` provisions the Slack app. For the complete workflow, see [Make your agent available in Slack](/langsmith/managed-deep-agents-channels-slack).
 
 ## Build projects
 
@@ -268,13 +285,14 @@ Deploy runs these steps:
 3. Collect non-reserved `.env` values as hosted deployment secrets.
 4. Verify the model provider API key is available from `.env`, the shell environment, or LangSmith workspace secrets.
 5. Sync deploy-owned context to Context Hub.
-6. Compile the project into `.mda/build` and extract optional `schedules/` declarations.
+6. Compile the project into `.mda/build` and extract optional `schedules/` and `channels/` declarations.
 7. Create or find a LangSmith hosted deployment by name.
 8. Archive the build, upload it, and trigger a remote build.
 9. Poll the revision until it reaches `DEPLOYED` unless `--no-wait` is set.
 10. Reconcile the managed LangSmith cron jobs for schedules unless `--no-wait` is set.
+11. Provision the declared Slack channel. If Slack authorization or workspace approval is required, display the action and continue after you complete it.
 
-Deploy does not configure Slack. Run `mda channel add slack .` after the deployment finishes. For the complete workflow, see [Slack channels](/langsmith/managed-deep-agents-channels-slack#create-and-deploy-the-slack-app).
+A project with a Slack channel cannot use `--no-wait` because Slack provisioning requires the deployed Agent Server URL. For the complete workflow, see [Make your agent available in Slack](/langsmith/managed-deep-agents-channels-slack).
 
 On success, the CLI prints the LangSmith deployment dashboard URL. For secrets routing and deploy tips, see [Deploy an agent](/langsmith/managed-deep-agents-deploy).
 

--- a/src/langsmith/managed-deep-agents-cli.mdx
+++ b/src/langsmith/managed-deep-agents-cli.mdx
@@ -173,7 +173,7 @@ Run the following command from the root of an existing managed deep agent projec
 mda channel init slack
 ```
 
-The command creates a Slack channel declaration in the `channels/` directory. The next `mda deploy` provisions the Slack app. For the complete workflow, see [Make your agent available in Slack](/langsmith/managed-deep-agents-channels-slack).
+The command creates a Slack channel declaration in the `channels/` directory. The next `mda deploy` sets up the resources the agent needs to appear in Slack. For the complete workflow, see [Connect a Managed Deep Agent to Slack](/langsmith/managed-deep-agents-channels-slack).
 
 ## Build projects
 
@@ -292,7 +292,7 @@ Deploy runs these steps:
 10. Reconcile the managed LangSmith cron jobs for schedules unless `--no-wait` is set.
 11. Provision the declared Slack channel. If Slack authorization or workspace approval is required, display the action and continue after you complete it.
 
-A project with a Slack channel cannot use `--no-wait` because Slack provisioning requires the deployed Agent Server URL. For the complete workflow, see [Make your agent available in Slack](/langsmith/managed-deep-agents-channels-slack).
+A project with a Slack channel cannot use `--no-wait` because Slack provisioning requires the deployed Agent Server URL. For the complete workflow, see [Connect a Managed Deep Agent to Slack](/langsmith/managed-deep-agents-channels-slack).
 
 On success, the CLI prints the LangSmith deployment dashboard URL. For secrets routing and deploy tips, see [Deploy an agent](/langsmith/managed-deep-agents-deploy).
 


### PR DESCRIPTION
updates the managed deep agents channel docs for the new slack setup flow, where channel resources are created automatically during deployment. it also documents slack appearance and message behavior options, authorization, first-deploy messaging, and how redeploys apply configuration changes.

this pr was prepared with codex.