### PR TITLE
docs(deepagents): add Anthropic Vertex provider setup

### DIFF
--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -119,10 +119,6 @@ Your sign-in persists across sessions. To check your status or sign out, run `/a
 
 The `google_anthropic_vertex` provider runs Claude through Anthropic's Messages API on Vertex AI. It uses Google Cloud Application Default Credentials (ADC) instead of an Anthropic API key.
 
-<Note>
-    The `google_anthropic_vertex` provider requires `deepagents-code>=0.1.61`.
-</Note>
-
 To use the provider:
 
 1. Install the Vertex AI extra:

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -50,7 +50,7 @@ Using a provider not listed here? See [Arbitrary providers](/oss/deepagents/code
 | Provider | Package | Credential env var | Model profiles |
 | --- | --- | --- | --- |
 | OpenAI | [`langchain-openai`](/oss/integrations/chat/openai) | `OPENAI_API_KEY` | ✅ |
-| OpenAI (Codex) | [`langchain-openai`](/oss/integrations/chat/openai) | None — [sign in with ChatGPT](#sign-in-with-chatgpt) | ✅ |
+| OpenAI (Codex) | [`langchain-openai`](/oss/integrations/chat/openai) | None; [sign in with ChatGPT](#sign-in-with-chatgpt) | ✅ |
 | Azure OpenAI | [`langchain-openai`](/oss/integrations/chat/azure_chat_openai) | `AZURE_OPENAI_API_KEY` | ✅ |
 | Anthropic | [`langchain-anthropic`](/oss/integrations/chat/anthropic) | `ANTHROPIC_API_KEY` | ✅ |
 | Google Gemini API | [`langchain-google-genai`](/oss/integrations/chat/google_generative_ai) | `GOOGLE_API_KEY` | ✅ |

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -55,6 +55,7 @@ Using a provider not listed here? See [Arbitrary providers](/oss/deepagents/code
 | Anthropic | [`langchain-anthropic`](/oss/integrations/chat/anthropic) | `ANTHROPIC_API_KEY` | ✅ |
 | Google Gemini API | [`langchain-google-genai`](/oss/integrations/chat/google_generative_ai) | `GOOGLE_API_KEY` | ✅ |
 | Google Vertex AI | [`langchain-google-genai`](/oss/integrations/chat/google_generative_ai#credentials) | `GOOGLE_CLOUD_PROJECT` | ✅ |
+| Google Vertex AI (Anthropic) | [`langchain-google-vertexai`](/oss/integrations/chat/google_anthropic_vertex) | `GOOGLE_CLOUD_PROJECT`, `GOOGLE_CLOUD_LOCATION` | ✅ |
 | Baseten | [`langchain-baseten`](https://github.com/basetenlabs/langchain-baseten) | `BASETEN_API_KEY` | ✅ |
 | AWS Bedrock | [`langchain-aws`](/oss/integrations/chat/bedrock) | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | ✅ |
 | AWS Bedrock Converse | [`langchain-aws`](/oss/integrations/chat/bedrock) | `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` | ✅ |
@@ -113,6 +114,57 @@ Your sign-in persists across sessions. To check your status or sign out, run `/a
 <Note>
     Some provider-specific account types or key scopes may not work for API access. If a provider appears configured in `/auth` but requests still fail, verify that the account plan and API-key permissions match the provider's API requirements.
 </Note>
+
+### Use Anthropic models on Vertex AI
+
+The `google_anthropic_vertex` provider runs Claude through Anthropic's Messages API on Vertex AI. It uses Google Cloud Application Default Credentials (ADC) instead of an Anthropic API key.
+
+<Note>
+    The `google_anthropic_vertex` provider requires `deepagents-code>=0.1.61`.
+</Note>
+
+To use the provider:
+
+1. Install the Vertex AI extra:
+
+    <CodeGroup>
+        ```txt In session
+        /install vertex
+        ```
+
+        ```bash Shell
+        dcode --install vertex
+        ```
+    </CodeGroup>
+
+2. [Enable a Claude model in your Google Cloud project](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude), then configure ADC:
+
+    ```bash
+    gcloud auth application-default login
+    ```
+
+3. Set your Google Cloud project and location:
+
+    ```bash
+    export GOOGLE_CLOUD_PROJECT="your-project-id"
+    export GOOGLE_CLOUD_LOCATION="global"
+    ```
+
+    You can use `DEEPAGENTS_CODE_GOOGLE_CLOUD_PROJECT` and `DEEPAGENTS_CODE_GOOGLE_CLOUD_LOCATION` to scope these values to Deep Agents Code.
+
+4. Select a Claude model with the `google_anthropic_vertex` provider:
+
+    <CodeGroup>
+        ```txt In session
+        /model google_anthropic_vertex:claude-sonnet-4-6
+        ```
+
+        ```bash Shell
+        dcode --model google_anthropic_vertex:claude-sonnet-4-6
+        ```
+    </CodeGroup>
+
+Use `google_vertexai` for Google models. Claude models use Anthropic's Messages API and must use `google_anthropic_vertex` instead.
 
 ### Model routers and proxies
 

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -75,6 +75,53 @@ Using a provider not listed here? See [Arbitrary providers](/oss/deepagents/code
 | OpenRouter | [`langchain-openrouter`](/oss/integrations/chat/openrouter) | `OPENROUTER_API_KEY` | ✅ |
 | LiteLLM | [`langchain-litellm`](/oss/integrations/chat/litellm) | Per-provider (see [docs](https://docs.litellm.ai/)) | ❌ |
 
+<Accordion title="Configure Anthropic models on Vertex AI" icon="brand-google">
+    The `google_anthropic_vertex` provider runs Claude through Anthropic's Messages API on Vertex AI. It uses Google Cloud Application Default Credentials (ADC) instead of an Anthropic API key.
+
+    To use the provider:
+
+    1. Install the Vertex AI extra:
+
+        <CodeGroup>
+            ```txt In session
+            /install vertex
+            ```
+
+            ```bash Shell
+            dcode --install vertex
+            ```
+        </CodeGroup>
+
+    2. [Enable a Claude model in your Google Cloud project](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude), then configure ADC:
+
+        ```bash
+        gcloud auth application-default login
+        ```
+
+    3. Set your Google Cloud project and location:
+
+        ```bash
+        export GOOGLE_CLOUD_PROJECT="your-project-id"
+        export GOOGLE_CLOUD_LOCATION="global"
+        ```
+
+        You can use `DEEPAGENTS_CODE_GOOGLE_CLOUD_PROJECT` and `DEEPAGENTS_CODE_GOOGLE_CLOUD_LOCATION` to scope these values to Deep Agents Code.
+
+    4. Select a Claude model with the `google_anthropic_vertex` provider:
+
+        <CodeGroup>
+            ```txt In session
+            /model google_anthropic_vertex:claude-sonnet-4-6
+            ```
+
+            ```bash Shell
+            dcode --model google_anthropic_vertex:claude-sonnet-4-6
+            ```
+        </CodeGroup>
+
+    Use `google_vertexai` for Google models. Claude models use Anthropic's Messages API and must use `google_anthropic_vertex` instead.
+</Accordion>
+
 <Tip>
     You can scope any credential to Deep Agents Code by adding a `DEEPAGENTS_CODE_` prefix. For example, `DEEPAGENTS_CODE_OPENAI_API_KEY` takes priority over `OPENAI_API_KEY` within Deep Agents Code without affecting other tools. See [`DEEPAGENTS_CODE_` prefix](/oss/deepagents/code/configuration#deepagents_code_-prefix) for details.
 </Tip>
@@ -114,53 +161,6 @@ Your sign-in persists across sessions. To check your status or sign out, run `/a
 <Note>
     Some provider-specific account types or key scopes may not work for API access. If a provider appears configured in `/auth` but requests still fail, verify that the account plan and API-key permissions match the provider's API requirements.
 </Note>
-
-### Use Anthropic models on Vertex AI
-
-The `google_anthropic_vertex` provider runs Claude through Anthropic's Messages API on Vertex AI. It uses Google Cloud Application Default Credentials (ADC) instead of an Anthropic API key.
-
-To use the provider:
-
-1. Install the Vertex AI extra:
-
-    <CodeGroup>
-        ```txt In session
-        /install vertex
-        ```
-
-        ```bash Shell
-        dcode --install vertex
-        ```
-    </CodeGroup>
-
-2. [Enable a Claude model in your Google Cloud project](https://cloud.google.com/vertex-ai/generative-ai/docs/partner-models/use-claude), then configure ADC:
-
-    ```bash
-    gcloud auth application-default login
-    ```
-
-3. Set your Google Cloud project and location:
-
-    ```bash
-    export GOOGLE_CLOUD_PROJECT="your-project-id"
-    export GOOGLE_CLOUD_LOCATION="global"
-    ```
-
-    You can use `DEEPAGENTS_CODE_GOOGLE_CLOUD_PROJECT` and `DEEPAGENTS_CODE_GOOGLE_CLOUD_LOCATION` to scope these values to Deep Agents Code.
-
-4. Select a Claude model with the `google_anthropic_vertex` provider:
-
-    <CodeGroup>
-        ```txt In session
-        /model google_anthropic_vertex:claude-sonnet-4-6
-        ```
-
-        ```bash Shell
-        dcode --model google_anthropic_vertex:claude-sonnet-4-6
-        ```
-    </CodeGroup>
-
-Use `google_vertexai` for Google models. Claude models use Anthropic's Messages API and must use `google_anthropic_vertex` instead.
 
 ### Model routers and proxies
 


### PR DESCRIPTION
## Description
Document the built-in `google_anthropic_vertex` provider so Deep Agents Code users can configure ADC, project/location settings, the `vertex` extra, and the correct model spec. This also distinguishes Anthropic's Messages API transport from Google's Vertex provider.

## Test Plan
- [x] Run Vale and codespell on the updated provider guide

Related implementation: https://github.com/langchain-ai/deepagents/pull/5760

Made by [Open SWE](https://openswe.vercel.app/agents/979e343f-42ad-580d-ab0a-69827de47d40)