### PR TITLE
docs(deepagents): fix broken JS cross-references for ToolErrorMiddleware

### DIFF
--- a/src/oss/deepagents/fault-tolerance.mdx
+++ b/src/oss/deepagents/fault-tolerance.mdx
@@ -12,7 +12,7 @@ Different errors need different handling strategies:
 | Error type | Who fixes it | Strategy | Middleware or feature |
 |------------|--------------|----------|----------------------|
 | Transient errors (network issues, rate limits) | System (automatic) | Retry with exponential backoff | @[ModelRetryMiddleware], @[ToolRetryMiddleware] |
-| LLM-recoverable errors (tool failures, parsing issues) | LLM | Convert to error `ToolMessage` and let the model adjust | @[ToolErrorMiddleware] |
+| LLM-recoverable errors (tool failures, parsing issues) | LLM | Convert to error `ToolMessage` and let the model adjust | `ToolErrorMiddleware` (Python only) |
 | User-fixable errors (missing information, unclear instructions) | Human | Pause with `interrupt()` | [Human-in-the-loop](/oss/deepagents/human-in-the-loop) |
 | Provider outage | System (automatic) | Fall back to an alternative model | @[ModelFallbackMiddleware] |
 | Excessive calls (runaway loops) | System (automatic) | Cap model and tool calls per run | @[ModelCallLimitMiddleware], @[ToolCallLimitMiddleware] |
@@ -68,7 +68,7 @@ const agent = createAgent({
 
   <Tab title="LLM-recoverable" icon="brain">
 
-  Use @[ToolErrorMiddleware] to catch tool exceptions and convert them into error `ToolMessage`s so the LLM can see what went wrong and try again:
+  Use `ToolErrorMiddleware` to catch tool exceptions and convert them into error `ToolMessage`s so the LLM can see what went wrong and try again:
 
 :::python
 <Note>
@@ -212,7 +212,7 @@ const agent = createAgent({
 
   <Tab title="Unexpected" icon="alert-triangle">
 
-  Let them bubble up for debugging. Do not catch what you cannot handle. @[ToolErrorMiddleware] only surfaces exceptions you explicitly return content for; everything else propagates unchanged:
+  Let them bubble up for debugging. Do not catch what you cannot handle. `ToolErrorMiddleware` only surfaces exceptions you explicitly return content for; everything else propagates unchanged:
 
 :::python
 ```python
@@ -395,7 +395,7 @@ See @[ModelFallbackMiddleware] for the full configuration.
 
 ## Error handling
 
-When a tool raises an exception during execution, the agent run halts by default. Use @[ToolErrorMiddleware] to catch specific exceptions and convert them into error ToolMessages that the model can see and recover from, instead of crashing the run.
+When a tool raises an exception during execution, the agent run halts by default. Use `ToolErrorMiddleware` to catch specific exceptions and convert them into error ToolMessages that the model can see and recover from, instead of crashing the run.
 
 :::python
 <Note>
@@ -420,4 +420,8 @@ agent = create_deep_agent(
 ```
 
 For the full configuration options and usage patterns, including async handlers and composing with retry middleware, see [Prebuilt middleware](/oss/langchain/middleware/built-in#tool-error).
+:::
+
+:::js
+`ToolErrorMiddleware` is not yet available in the JavaScript SDK.
 :::

--- a/src/oss/deepagents/fault-tolerance.mdx
+++ b/src/oss/deepagents/fault-tolerance.mdx
@@ -12,8 +12,9 @@ Different errors need different handling strategies:
 | Error type | Who fixes it | Strategy | Middleware or feature |
 |------------|--------------|----------|----------------------|
 | Transient errors (network issues, rate limits) | System (automatic) | Retry with exponential backoff | @[ModelRetryMiddleware], @[ToolRetryMiddleware] |
-| LLM-recoverable errors (tool failures, parsing issues) | LLM | Convert to error `ToolMessage` and let the model adjust | `ToolErrorMiddleware` (Python only) |
-| User-fixable errors (missing information, unclear instructions) | Human | Pause with `interrupt()` | [Human-in-the-loop](/oss/deepagents/human-in-the-loop) |
+:::python
+| LLM-recoverable errors (tool failures, parsing issues) | LLM | Convert to error `ToolMessage` and let the model adjust | @[ToolErrorMiddleware] |
+::: | User-fixable errors (missing information, unclear instructions) | Human | Pause with `interrupt()` | [Human-in-the-loop](/oss/deepagents/human-in-the-loop) |
 | Provider outage | System (automatic) | Fall back to an alternative model | @[ModelFallbackMiddleware] |
 | Excessive calls (runaway loops) | System (automatic) | Cap model and tool calls per run | @[ModelCallLimitMiddleware], @[ToolCallLimitMiddleware] |
 | Unexpected errors | Developer | Let them bubble up | No middleware; let the exception propagate |
@@ -66,14 +67,14 @@ const agent = createAgent({
 
   </Tab>
 
+:::python
   <Tab title="LLM-recoverable" icon="brain">
 
-  Use `ToolErrorMiddleware` to catch tool exceptions and convert them into error `ToolMessage`s so the LLM can see what went wrong and try again:
+  Use @[ToolErrorMiddleware] to catch tool exceptions and convert them into error `ToolMessage`s so the LLM can see what went wrong and try again:
 
-:::python
-<Note>
-`ToolErrorMiddleware` requires `langchain>=1.3.14`.
-</Note>
+  <Note>
+  `ToolErrorMiddleware` requires `langchain>=1.3.14`.
+  </Note>
 
 ```python
 from langchain.agents import create_agent
@@ -92,13 +93,9 @@ agent = create_agent(
     middleware=[ToolErrorMiddleware(on_error)],
 )
 ```
-:::
-
-:::js
-This middleware is not yet available in the JavaScript SDK.
-:::
 
   </Tab>
+:::
 
   <Tab title="User-fixable" icon="user">
 
@@ -212,9 +209,9 @@ const agent = createAgent({
 
   <Tab title="Unexpected" icon="alert-triangle">
 
-  Let them bubble up for debugging. Do not catch what you cannot handle. `ToolErrorMiddleware` only surfaces exceptions you explicitly return content for; everything else propagates unchanged:
-
 :::python
+  Let them bubble up for debugging. Do not catch what you cannot handle. @[ToolErrorMiddleware] only surfaces exceptions you explicitly return content for; everything else propagates unchanged:
+
 ```python
 def on_error(exc: Exception, request: ToolCallRequest) -> str | None:
     if isinstance(exc, (ValueError, KeyError)):
@@ -225,7 +222,7 @@ def on_error(exc: Exception, request: ToolCallRequest) -> str | None:
 :::
 
 :::js
-This pattern applies to custom middleware in the JavaScript SDK as well.
+  Let them bubble up for debugging. Do not catch what you cannot handle. This pattern applies to custom middleware in the JavaScript SDK as well.
 :::
 
   </Tab>
@@ -395,9 +392,9 @@ See @[ModelFallbackMiddleware] for the full configuration.
 
 ## Error handling
 
-When a tool raises an exception during execution, the agent run halts by default. Use `ToolErrorMiddleware` to catch specific exceptions and convert them into error ToolMessages that the model can see and recover from, instead of crashing the run.
-
 :::python
+When a tool raises an exception during execution, the agent run halts by default. Use @[ToolErrorMiddleware] to catch specific exceptions and convert them into error ToolMessages that the model can see and recover from, instead of crashing the run.
+
 <Note>
 `ToolErrorMiddleware` requires `langchain>=1.3.14`.
 </Note>
@@ -423,5 +420,5 @@ For the full configuration options and usage patterns, including async handlers 
 :::
 
 :::js
-`ToolErrorMiddleware` is not yet available in the JavaScript SDK.
+When a tool raises an exception during execution, the agent run halts by default. `ToolErrorMiddleware` is not yet available in the JavaScript SDK.
 :::


### PR DESCRIPTION
Fixes #5539

ToolErrorMiddleware is Python-only — the JS SDK does not yet have an equivalent.
Four mentions of @[ToolErrorMiddleware] outside :::python-gated blocks were being
rendered on the JS variant of the page too, producing a cross-reference link to a
symbol that doesn't exist in the JS API reference.

Changes:
- Table row and shared tab/section intros now use a plain `ToolErrorMiddleware`
  code span instead of the @[...] auto-link syntax
- Added a missing :::js note to the `## Error handling` section, mirroring the
  existing pattern used earlier in the same file (lines 97-99)