### PR TITLE
docs: document encryption key rotation

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -1695,7 +1695,13 @@
                     "group": "Server customization",
                     "pages": [
                       "langsmith/caching",
-                      "langsmith/encryption",
+                      {
+                        "group": "Encryption at rest",
+                        "root": "langsmith/encryption",
+                        "pages": [
+                          "langsmith/custom-encryption"
+                        ]
+                      },
                       "langsmith/graph-rebuild",
                       {
                         "group": "Replace built-in backends",

--- a/src/langsmith/custom-encryption.mdx
+++ b/src/langsmith/custom-encryption.mdx
@@ -5,10 +5,6 @@ sidebarTitle: Custom encryption
 
 Custom encryption lets Agent Server use your encryption handlers for per-tenant keys and external key management systems. Use [built-in AES encryption](/langsmith/encryption) unless you need these capabilities.
 
-<Note>
-Features documented on this page require Agent Server version 0.14.0 or later and Python SDK version `langgraph-sdk>=0.4.3`.
-</Note>
-
 <Warning>
 Agent Server versions 0.5.34–0.6.21 included a pre-release version of custom encryption. Data encrypted with these versions will be corrupted when upgrading to 0.6.22+. Do not use custom encryption on these versions.
 </Warning>
@@ -68,11 +64,11 @@ encryption = Encryption()
 async def get_encryption_context(user: BaseUser, ctx: EncryptionContext) -> dict:
     return {
         **ctx.metadata,
-        "tenant_id": user["tenant_id"],
+        "tenant_id": user.identity,
     }
 ```
 
-This handler runs once per request after authentication. The returned dictionary becomes `ctx.metadata` for every encryption operation in the request and is stored in plaintext so Agent Server can restore it during decryption.
+This handler runs once per request after authentication. The returned dictionary becomes `ctx.metadata` for every encryption operation in the request and is stored in plaintext so Agent Server can restore it during decryption. Include only non-secret identifiers and routing metadata, never keys, tokens, or credentials.
 
 ### Defining your encryption module
 
@@ -83,9 +79,7 @@ Blob handlers encrypt checkpoint data—the serialized state from graph executio
 ```python
 import os
 from cryptography.fernet import Fernet
-from langgraph_sdk import Encryption, EncryptionContext
-
-encryption = Encryption()
+from langgraph_sdk import EncryptionContext
 
 # In production, fetch from a secrets manager
 TENANT_KEYS = {
@@ -121,9 +115,7 @@ JSON handlers encrypt structured data like thread metadata, assistant context, a
 import json
 import os
 from cryptography.fernet import Fernet
-from langgraph_sdk import Encryption, EncryptionContext
-
-encryption = Encryption()
+from langgraph_sdk import EncryptionContext
 
 TENANT_KEYS = {
     "tenant-a": Fernet(os.environ["TENANT_A_KEY"]),
@@ -194,33 +186,72 @@ async def decrypt_json(ctx: EncryptionContext, data: dict) -> dict:
 **Performance consideration:** Per-key encryption means one encryption call per field. If your encryption involves round-trips to an external service (e.g., KMS), this can significantly impact latency. Consider caching data keys locally or using envelope encryption where you encrypt a local data key with KMS and use it for multiple fields.
 </Note>
 
-User-defined fields for authorization (e.g., `tenant_id`, `owner`) should generally be left **unencrypted**, as should fields used for search and filtering. Additionally, **some system-managed fields will never be encrypted**:
+Fields used by authorization filters (e.g., `tenant_id`, `owner`) must remain unchanged and **unencrypted**, as must fields used for search and filtering. Agent Server rejects writes if a custom encryptor changes an authorization-filter field. Additionally, **some system-managed fields will never be encrypted**:
 
 - Resource identifiers (`thread_id`, `run_id`, `assistant_id`, `graph_id`, `checkpoint_id`, `task_id`)
-- Most fields beginning with `langgraph_` (except for `langgraph_auth_user`)
+- Named LangGraph system fields (`langgraph_version`, `langgraph_api_version`, `langgraph_plan`, `langgraph_host`, `langgraph_api_url`, `langgraph_request_id`, `langgraph_auth_user`, `langgraph_auth_user_id`, `langgraph_auth_permissions`)
 - Required checkpoint metadata (`source`, `step`, `parents`, `run_attempt`)
-- Internal fields used for scheduling and orchestration (`__after_seconds__`, `__request_start_time_ms__`, most fields beginning with `__pregel`)
+- Named internal fields used for scheduling and orchestration, including `__after_seconds__` and `__request_start_time_ms__`
 - Run-level execution limits (`max_concurrency`, `recursion_limit`) specified in a run's `config`
 - Thread TTL updates (`ttl`) specified in a run's `config.configurable`
 
 
 #### What gets encrypted
 
-**JSON handlers** (`@encryption.encrypt.json` / `@encryption.decrypt.json`) are applied recursively to the following fields:
+**JSON handlers** (`@encryption.encrypt.json` / `@encryption.decrypt.json`) are applied recursively to fields including:
 - `thread.metadata`, `thread.values`
 - `assistant.metadata`, `assistant.context`
 - `run.metadata`, `run.kwargs`
 - `cron.metadata`, `cron.payload`
 - `store.value`
 
-[Some fields are excluded from encryption.](#what-gets-encrypted) Unless otherwise noted, these exclusions apply at every level of a nested JSON object, not just the root level.
+[Some fields are excluded from encryption.](#json-encryption-considerations) Unless otherwise noted, these exclusions apply at every level of a nested JSON object, not just the root level.
 
 **Blob handlers** (`@encryption.encrypt.blob` / `@encryption.decrypt.blob`) are applied to checkpoint blobs (graph execution state).
 
 
 ### Rotate custom encryption keys lazily
 
+<Note>
+Lazy re-encryption requires Agent Server version 0.14.0 or later and Python SDK version `langgraph-sdk>=0.4.3`.
+</Note>
+
 Return `DecryptResult` from a blob or JSON decrypt handler when the handler decrypts data with an old key. Its `plaintext` value is returned to the caller, and its `replacement` value is new ciphertext for Agent Server to persist.
+
+For example, replace the blob decrypt handler above with one that tries the current tenant key first, then returns replacement ciphertext when a legacy key succeeds:
+
+```python
+import os
+
+from cryptography.fernet import Fernet, InvalidToken
+from langgraph_sdk import DecryptResult, EncryptionContext
+
+LEGACY_TENANT_KEYS = {
+    "tenant-a": [Fernet(os.environ["TENANT_A_LEGACY_KEY"])],
+    "tenant-b": [Fernet(os.environ["TENANT_B_LEGACY_KEY"])],
+}
+
+
+@encryption.decrypt.blob
+async def decrypt_blob(
+    ctx: EncryptionContext, data: bytes
+) -> bytes | DecryptResult[bytes]:
+    current_key = _get_fernet(ctx)
+    try:
+        return current_key.decrypt(data)
+    except InvalidToken:
+        tenant_id = ctx.metadata["tenant_id"]
+        for legacy_key in LEGACY_TENANT_KEYS.get(tenant_id, []):
+            try:
+                plaintext = legacy_key.decrypt(data)
+                return DecryptResult(
+                    plaintext=plaintext,
+                    replacement=current_key.encrypt(plaintext),
+                )
+            except InvalidToken:
+                continue
+        raise
+```
 
 JSON decrypt handlers can return `DecryptResult[dict]` in the same way. The replacement must have the same shape as a normal result from the corresponding encrypt handler.
 
@@ -350,7 +381,7 @@ The `encryption_context` is cryptographically bound to the ciphertext via KMS—
 
 #### Key rotation
 
-KMS handles master key rotation automatically. When you enable automatic rotation on your KMS key, old encrypted data keys can still be decrypted while new operations use the rotated key material. No re-encryption of existing data is required.
+KMS rotates backing material for the same key ID automatically. Old encrypted data keys remain decryptable, so existing data does not need re-encryption.
 
 ## Related
 

--- a/src/langsmith/custom-encryption.mdx
+++ b/src/langsmith/custom-encryption.mdx
@@ -213,7 +213,7 @@ Fields used by authorization filters (e.g., `tenant_id`, `owner`) must remain un
 ### Rotate custom encryption keys lazily
 
 <Note>
-Lazy re-encryption requires Agent Server version 0.14.0 or later and Python SDK version `langgraph-sdk>=0.4.3`.
+Lazy re-encryption requires Agent Server version 0.14.0 or later, Python SDK version `langgraph-sdk>=0.4.3`, the PostgreSQL checkpointer, `PREFER_GRPC_CHECKPOINTER=true`, and `LANGGRAPH_STORE_BACKEND=grpc`.
 </Note>
 
 Return `DecryptResult` from a blob or JSON decrypt handler when the handler decrypts data with an old key. Its `plaintext` value is returned to the caller, and its `replacement` value is new ciphertext for Agent Server to persist.

--- a/src/langsmith/custom-encryption.mdx
+++ b/src/langsmith/custom-encryption.mdx
@@ -256,6 +256,24 @@ Agent Server writes the replacement with a compare-and-swap operation, so it doe
 Lazy re-encryption only updates data as it is read. Keep old keys available while unread data may still require them.
 </Warning>
 
+### Monitor lazy re-encryption
+
+Agent Server emits the following INFO-tier [internal metrics](/langsmith/self-hosted-agent-server-metrics#internal-metrics) for replacement writebacks:
+
+| Metric | Meaning |
+|--------|---------|
+| `lg_api_reencrypt_writeback_succeeded_counter` | The replacement ciphertext was stored. |
+| `lg_api_reencrypt_writeback_cas_skipped_counter` | A concurrent update changed the stored value before writeback. Agent Server left the newer value unchanged. |
+| `lg_api_reencrypt_writeback_failed_counter` | Agent Server could not write the replacement. The read still succeeded. |
+
+Each metric includes `reencryption_table` and `reencryption_column` attributes. Use them to find surfaces that still read old ciphertext and to isolate writeback failures.
+
+CAS skips produce warning logs with `Re-encryption writeback skipped due to concurrent update`. Failures produce error logs with `Re-encryption writeback failed`. Both include the table and column. Successful writebacks do not produce logs.
+
+For Prometheus, set `EXPOSE_INTERNAL_METRICS_PROMETHEUS=true` and scrape the Agent Server `/metrics` endpoint. Internal metrics are also available through the documented Datadog export.
+
+These counters measure writeback outcomes, not the amount of old ciphertext remaining. A period without new writebacks does not prove that every record has been read and rotated. Keep old keys available until your retention policy or a separate exhaustive migration confirms that no unread data requires them.
+
 ### Envelope encryption with AWS Encryption SDK
 
 For production deployments on AWS, use the [AWS Encryption SDK](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/python.html) with AWS KMS, or an equivalent within your cloud provider. This approach:

--- a/src/langsmith/custom-encryption.mdx
+++ b/src/langsmith/custom-encryption.mdx
@@ -1,0 +1,365 @@
+---
+title: Configure custom encryption at rest
+sidebarTitle: Custom encryption
+---
+
+Custom encryption lets Agent Server use your encryption handlers for per-tenant keys and external key management systems. Use [built-in AES encryption](/langsmith/encryption) unless you need these capabilities.
+
+<Note>
+Features documented on this page require Agent Server version 0.14.0 or later and Python SDK version `langgraph-sdk>=0.4.3`.
+</Note>
+
+<Warning>
+Agent Server versions 0.5.34–0.6.21 included a pre-release version of custom encryption. Data encrypted with these versions will be corrupted when upgrading to 0.6.22+. Do not use custom encryption on these versions.
+</Warning>
+
+<Warning>
+Only use custom encryption if built-in AES encryption does not meet your needs. Custom encryption requires you to implement and maintain encryption handlers, and adds operational complexity. If you only need a static key, key rotation, or optional selective field encryption, use [built-in AES encryption](/langsmith/encryption) instead.
+</Warning>
+
+Use custom encryption when you need:
+
+- **Per-tenant key isolation**—different encryption keys for different customers
+- **KMS integration**—AWS KMS, Google Cloud KMS, or HashiCorp Vault for key management, rotation, and audit logging
+
+## Configure custom encryption
+
+### How it works
+
+1. [Configure](#configuration) the encryption module path in `langgraph.json`
+2. [Define your encryption module](#defining-your-encryption-module) with handlers for blob and JSON encryption
+3. [Pass encryption context](#passing-encryption-context) (like tenant ID) via the `X-Encryption-Context` header
+4. LangGraph calls your handlers before storing and after retrieving data
+
+For production deployments with key rotation and audit logging, see [Envelope encryption with AWS Encryption SDK](#envelope-encryption-with-aws-encryption-sdk).
+
+### Configuration
+
+Add your encryption module to `langgraph.json`:
+
+```json
+{
+  "dependencies": ["."],
+  "graphs": {
+    "agent": "./agent.py:graph"
+  },
+  "encryption": {
+    "path": "./encryption.py:encryption"
+  }
+}
+```
+
+<Note>
+If you're migrating from basic encryption, keep `LANGGRAPH_AES_KEY` configured. Custom encryption handles new writes while existing AES-encrypted data remains readable.
+</Note>
+
+### Defining your encryption module
+
+#### Blob encryption (checkpoints)
+
+Blob handlers encrypt checkpoint data—the serialized state from graph execution. Here's a simplified example using per-tenant keys with [Fernet](https://cryptography.io/en/latest/fernet/) (a symmetric encryption scheme from the `cryptography` library):
+
+```python
+import os
+from cryptography.fernet import Fernet
+from langgraph_sdk import Encryption, EncryptionContext
+
+encryption = Encryption()
+
+# In production, fetch from a secrets manager
+TENANT_KEYS = {
+    "tenant-a": Fernet(os.environ["TENANT_A_KEY"]),
+    "tenant-b": Fernet(os.environ["TENANT_B_KEY"]),
+}
+
+
+def _get_fernet(ctx: EncryptionContext) -> Fernet:
+    tenant_id = ctx.metadata.get("tenant_id")
+    if not tenant_id or tenant_id not in TENANT_KEYS:
+        raise ValueError(f"Unknown tenant: {tenant_id}")
+    return TENANT_KEYS[tenant_id]
+
+
+@encryption.encrypt.blob
+async def encrypt_blob(ctx: EncryptionContext, data: bytes) -> bytes:
+    return _get_fernet(ctx).encrypt(data)
+
+
+@encryption.decrypt.blob
+async def decrypt_blob(ctx: EncryptionContext, data: bytes) -> bytes:
+    return _get_fernet(ctx).decrypt(data)
+```
+
+The `ctx.metadata` dict comes from the `X-Encryption-Context` header and is stored in plaintext alongside encrypted data, so the correct key is used on decryption.
+
+#### JSON encryption (metadata)
+
+JSON handlers encrypt structured data like thread metadata, assistant context, and run kwargs. Unlike blob encryption, you choose which fields to encrypt—keeping some unencrypted for search and filtering.
+
+```python
+import json
+import os
+from cryptography.fernet import Fernet
+from langgraph_sdk import Encryption, EncryptionContext
+
+encryption = Encryption()
+
+TENANT_KEYS = {
+    "tenant-a": Fernet(os.environ["TENANT_A_KEY"]),
+    "tenant-b": Fernet(os.environ["TENANT_B_KEY"]),
+}
+
+SKIP_FIELDS = {
+    "tenant_id", "owner",
+    "run_id", "thread_id", "graph_id", "assistant_id", "user_id", "checkpoint_id",
+    "source", "step", "parents", "run_attempt",
+    "langgraph_version", "langgraph_api_version", "langgraph_plan", "langgraph_host",
+    "langgraph_api_url", "langgraph_request_id", "langgraph_auth_user",
+    "langgraph_auth_user_id", "langgraph_auth_permissions",
+}
+ENCRYPTED_PREFIX = "encrypted:"
+
+
+def _get_fernet(ctx: EncryptionContext) -> Fernet:
+    tenant_id = ctx.metadata.get("tenant_id")
+    if not tenant_id or tenant_id not in TENANT_KEYS:
+        raise ValueError(f"Unknown tenant: {tenant_id}")
+    return TENANT_KEYS[tenant_id]
+
+
+@encryption.encrypt.json
+async def encrypt_json(ctx: EncryptionContext, data: dict) -> dict:
+    fernet = _get_fernet(ctx)
+    result = {}
+    for k, v in data.items():
+        if k in SKIP_FIELDS or v is None:
+            result[k] = v
+        else:
+            value_json = json.dumps(v)
+            encrypted = fernet.encrypt(value_json.encode()).decode()
+            result[k] = ENCRYPTED_PREFIX + encrypted
+    return result
+
+
+@encryption.decrypt.json
+async def decrypt_json(ctx: EncryptionContext, data: dict) -> dict:
+    fernet = _get_fernet(ctx)
+    result = {}
+    for k, v in data.items():
+        if isinstance(v, str) and v.startswith(ENCRYPTED_PREFIX):
+            encrypted_value = v[len(ENCRYPTED_PREFIX):]
+            decrypted = fernet.decrypt(encrypted_value.encode()).decode()
+            result[k] = json.loads(decrypted)
+        else:
+            result[k] = v
+    return result
+```
+
+#### JSON encryption considerations
+
+<Warning>
+**Encrypted fields cannot be searched or filtered.** Design your metadata schema so that fields you need to query remain unencrypted.
+</Warning>
+
+<Warning>
+**JSON encryptors must preserve key structure.** SQL JSONB merge operations work at the key level. Encryptors that change keys—whether by consolidating fields (e.g., moving sensitive data into `__encrypted__`) or by encrypting key names themselves—cause data loss during merges. Use per-key encryption: transform values in-place while preserving keys.
+</Warning>
+
+<Note>
+**Migration consideration:** Use a recognizable prefix or format in encrypted values so your decryptor can detect and skip unencrypted data. This allows you to encrypt additional fields in the future without re-encrypting existing records. The example above uses this pattern.
+</Note>
+
+<Note>
+**Performance consideration:** Per-key encryption means one encryption call per field. If your encryption involves round-trips to an external service (e.g., KMS), this can significantly impact latency. Consider caching data keys locally or using envelope encryption where you encrypt a local data key with KMS and use it for multiple fields.
+</Note>
+
+User-defined fields for authorization (e.g., `tenant_id`, `owner`) should generally be left **unencrypted**, as should fields used for search and filtering. Additionally, **some system-managed fields will never be encrypted**:
+
+- Resource identifiers (`thread_id`, `run_id`, `assistant_id`, `graph_id`, `checkpoint_id`, `task_id`)
+- Most fields beginning with `langgraph_` (except for `langgraph_auth_user`)
+- Required checkpoint metadata (`source`, `step`, `parents`, `run_attempt`)
+- Internal fields used for scheduling and orchestration (`__after_seconds__`, `__request_start_time_ms__`, most fields beginning with `__pregel`)
+- Run-level execution limits (`max_concurrency`, `recursion_limit`) specified in a run's `config`
+- Thread TTL updates (`ttl`) specified in a run's `config.configurable`
+
+
+#### What gets encrypted
+
+**JSON handlers** (`@encryption.encrypt.json` / `@encryption.decrypt.json`) are applied recursively to the following fields:
+- `thread.metadata`, `thread.values`
+- `assistant.metadata`, `assistant.context`
+- `run.metadata`, `run.kwargs`
+- `cron.metadata`, `cron.payload`
+- `store.value`
+
+[Some fields are excluded from encryption.](#what-gets-encrypted) Unless otherwise noted, these exclusions apply at every level of a nested JSON object, not just the root level.
+
+**Blob handlers** (`@encryption.encrypt.blob` / `@encryption.decrypt.blob`) are applied to checkpoint blobs (graph execution state).
+
+
+#### Deriving context from authentication
+
+Instead of passing `X-Encryption-Context` explicitly, derive encryption context from the authenticated user:
+
+```python
+from langgraph_sdk import Encryption, EncryptionContext
+from starlette.authentication import BaseUser
+
+encryption = Encryption()
+
+@encryption.context
+async def get_encryption_context(user: BaseUser, ctx: EncryptionContext) -> dict:
+    return {
+        **ctx.metadata,
+        "tenant_id": user["tenant_id"],
+    }
+```
+
+This handler runs once per request after authentication. The returned dict becomes `ctx.metadata` for all encryption operations in that request.
+
+### Passing encryption context
+
+Pass encryption context via the `X-Encryption-Context` header. The context is arbitrary data that you define—you control the schema and can include any fields your encryption logic needs (e.g., `tenant_id`, `key_version`). The context is available in your handlers as `ctx.metadata` and is stored in plaintext for use during decryption.
+
+```python
+import base64
+import json
+from langgraph_sdk import get_client
+
+encryption_context = base64.b64encode(
+    json.dumps({"tenant_id": "tenant-a"}).encode()
+).decode()
+
+client = get_client(url="http://localhost:2024")
+
+result = await client.runs.wait(
+    thread_id=None,
+    assistant_id="agent",
+    input={"messages": [{"role": "user", "content": "Hello"}]},
+    headers={"X-Encryption-Context": encryption_context},
+)
+```
+
+<Note>
+The encryption context is stored in plaintext. On decryption, it's automatically restored—callers don't need to pass the header when reading.
+</Note>
+
+### Rotate custom encryption keys lazily
+
+Return `DecryptResult` from a blob or JSON decrypt handler when the handler decrypts data with an old key. Its `plaintext` value is returned to the caller, and its `replacement` value is new ciphertext for Agent Server to persist.
+
+JSON decrypt handlers can return `DecryptResult[dict]` in the same way. The replacement must have the same shape as a normal result from the corresponding encrypt handler.
+
+Agent Server writes the replacement with a compare-and-swap operation, so it does not overwrite a concurrent update. Re-encryption is best effort: a read still succeeds if the stored value changes before writeback or if writeback fails.
+
+<Warning>
+Lazy re-encryption only updates data as it is read. Keep old keys available while unread data may still require them.
+</Warning>
+
+### Envelope encryption with AWS Encryption SDK
+
+For production deployments on AWS, use the [AWS Encryption SDK](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/python.html) with AWS KMS, or an equivalent within your cloud provider. This approach:
+
+- Handles envelope encryption automatically (no manual key packing)
+- Provides key rotation and audit logging
+- Binds ciphertext to encryption context (tenant isolation)
+- Caches data keys locally to avoid repeated KMS calls, latency and rate limits
+
+#### Complete example
+
+```python
+import base64
+import json
+import os
+
+import aws_encryption_sdk
+from aws_encryption_sdk import (
+    CachingCryptoMaterialsManager,
+    CommitmentPolicy,
+    LocalCryptoMaterialsCache,
+    StrictAwsKmsMasterKeyProvider,
+)
+from langgraph_sdk import Encryption, EncryptionContext
+
+encryption = Encryption()
+
+# The SDK uses envelope encryption: one KMS API call generates a data key,
+# then encrypts/decrypts locally. The cache reuses data keys across operations.
+client = aws_encryption_sdk.EncryptionSDKClient(
+    commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
+)
+key_provider = StrictAwsKmsMasterKeyProvider(key_ids=[os.environ["KMS_KEY_ARN"]])
+cache = LocalCryptoMaterialsCache(capacity=100)
+cmm = CachingCryptoMaterialsManager(
+    master_key_provider=key_provider,
+    cache=cache,
+    max_age=300.0,
+    max_messages_encrypted=100,
+)
+
+SKIP_FIELDS = {
+    "tenant_id", "owner",
+    "run_id", "thread_id", "graph_id", "assistant_id", "user_id", "checkpoint_id",
+    "source", "step", "parents", "run_attempt",
+    "langgraph_version", "langgraph_api_version", "langgraph_plan", "langgraph_host",
+    "langgraph_api_url", "langgraph_request_id", "langgraph_auth_user",
+    "langgraph_auth_user_id", "langgraph_auth_permissions",
+}
+ENCRYPTED_PREFIX = "encrypted:"
+
+
+@encryption.encrypt.blob
+async def encrypt_blob(ctx: EncryptionContext, data: bytes) -> bytes:
+    ciphertext, _ = client.encrypt(
+        source=data,
+        materials_manager=cmm,
+        encryption_context={"tenant_id": ctx.metadata["tenant_id"]},
+    )
+    return ciphertext
+
+
+@encryption.decrypt.blob
+async def decrypt_blob(ctx: EncryptionContext, data: bytes) -> bytes:
+    plaintext, _ = client.decrypt(source=data, key_provider=key_provider)
+    return plaintext
+
+
+@encryption.encrypt.json
+async def encrypt_json(ctx: EncryptionContext, data: dict) -> dict:
+    tenant_id = ctx.metadata["tenant_id"]
+    result = {}
+    for k, v in data.items():
+        if k in SKIP_FIELDS or v is None:
+            result[k] = v
+        else:
+            ciphertext, _ = client.encrypt(
+                source=json.dumps(v).encode(),
+                materials_manager=cmm,
+                encryption_context={"tenant_id": tenant_id},
+            )
+            result[k] = ENCRYPTED_PREFIX + base64.b64encode(ciphertext).decode()
+    return result
+
+
+@encryption.decrypt.json
+async def decrypt_json(ctx: EncryptionContext, data: dict) -> dict:
+    result = {}
+    for k, v in data.items():
+        if isinstance(v, str) and v.startswith(ENCRYPTED_PREFIX):
+            ciphertext = base64.b64decode(v[len(ENCRYPTED_PREFIX):])
+            plaintext, _ = client.decrypt(source=ciphertext, key_provider=key_provider)
+            result[k] = json.loads(plaintext.decode())
+        else:
+            result[k] = v
+    return result
+```
+
+The `encryption_context` is cryptographically bound to the ciphertext via KMS—decryption fails if the context doesn't match. The context is embedded in the ciphertext, so decrypt handlers don't need to reference `ctx.metadata`.
+
+#### Key rotation
+
+KMS handles master key rotation automatically. When you enable automatic rotation on your KMS key, old encrypted data keys can still be decrypted while new operations use the rotated key material. No re-encryption of existing data is required.
+
+## Related
+
+- [Custom authentication](/langsmith/custom-auth)

--- a/src/langsmith/custom-encryption.mdx
+++ b/src/langsmith/custom-encryption.mdx
@@ -27,9 +27,9 @@ Use custom encryption when you need:
 ### How it works
 
 1. [Configure](#configuration) the encryption module path in `langgraph.json`
-2. [Define your encryption module](#defining-your-encryption-module) with handlers for blob and JSON encryption
-3. [Pass encryption context](#passing-encryption-context) (like tenant ID) via the `X-Encryption-Context` header
-4. LangGraph calls your handlers before storing and after retrieving data
+2. [Define an encryption context handler](#define-encryption-context) that derives values such as a tenant ID from the authenticated user
+3. [Define your encryption module](#defining-your-encryption-module) with handlers for blob and JSON encryption
+4. Agent Server calls your handlers before storing and after retrieving data
 
 For production deployments with key rotation and audit logging, see [Envelope encryption with AWS Encryption SDK](#envelope-encryption-with-aws-encryption-sdk).
 
@@ -52,6 +52,27 @@ Add your encryption module to `langgraph.json`:
 <Note>
 If you're migrating from basic encryption, keep `LANGGRAPH_AES_KEY` configured. Custom encryption handles new writes while existing AES-encrypted data remains readable.
 </Note>
+
+### Define encryption context
+
+Use `@encryption.context` to derive encryption context from the authenticated user:
+
+```python
+from langgraph_sdk import Encryption, EncryptionContext
+from starlette.authentication import BaseUser
+
+encryption = Encryption()
+
+
+@encryption.context
+async def get_encryption_context(user: BaseUser, ctx: EncryptionContext) -> dict:
+    return {
+        **ctx.metadata,
+        "tenant_id": user["tenant_id"],
+    }
+```
+
+This handler runs once per request after authentication. The returned dictionary becomes `ctx.metadata` for every encryption operation in the request and is stored in plaintext so Agent Server can restore it during decryption.
 
 ### Defining your encryption module
 
@@ -90,7 +111,7 @@ async def decrypt_blob(ctx: EncryptionContext, data: bytes) -> bytes:
     return _get_fernet(ctx).decrypt(data)
 ```
 
-The `ctx.metadata` dict comes from the `X-Encryption-Context` header and is stored in plaintext alongside encrypted data, so the correct key is used on decryption.
+The `ctx.metadata` dictionary comes from the context handler, so each encryption handler can select the correct key.
 
 #### JSON encryption (metadata)
 
@@ -196,53 +217,6 @@ User-defined fields for authorization (e.g., `tenant_id`, `owner`) should genera
 
 **Blob handlers** (`@encryption.encrypt.blob` / `@encryption.decrypt.blob`) are applied to checkpoint blobs (graph execution state).
 
-
-#### Deriving context from authentication
-
-Instead of passing `X-Encryption-Context` explicitly, derive encryption context from the authenticated user:
-
-```python
-from langgraph_sdk import Encryption, EncryptionContext
-from starlette.authentication import BaseUser
-
-encryption = Encryption()
-
-@encryption.context
-async def get_encryption_context(user: BaseUser, ctx: EncryptionContext) -> dict:
-    return {
-        **ctx.metadata,
-        "tenant_id": user["tenant_id"],
-    }
-```
-
-This handler runs once per request after authentication. The returned dict becomes `ctx.metadata` for all encryption operations in that request.
-
-### Passing encryption context
-
-Pass encryption context via the `X-Encryption-Context` header. The context is arbitrary data that you define—you control the schema and can include any fields your encryption logic needs (e.g., `tenant_id`, `key_version`). The context is available in your handlers as `ctx.metadata` and is stored in plaintext for use during decryption.
-
-```python
-import base64
-import json
-from langgraph_sdk import get_client
-
-encryption_context = base64.b64encode(
-    json.dumps({"tenant_id": "tenant-a"}).encode()
-).decode()
-
-client = get_client(url="http://localhost:2024")
-
-result = await client.runs.wait(
-    thread_id=None,
-    assistant_id="agent",
-    input={"messages": [{"role": "user", "content": "Hello"}]},
-    headers={"X-Encryption-Context": encryption_context},
-)
-```
-
-<Note>
-The encryption context is stored in plaintext. On decryption, it's automatically restored—callers don't need to pass the header when reading.
-</Note>
 
 ### Rotate custom encryption keys lazily
 

--- a/src/langsmith/encryption.mdx
+++ b/src/langsmith/encryption.mdx
@@ -5,10 +5,6 @@ sidebarTitle: Encryption at rest
 
 Agent Server supports built-in AES encryption at rest for checkpoint data and metadata. Use this option unless you need [custom encryption handlers](/langsmith/custom-encryption) for per-tenant keys or an external key management system.
 
-<Note>
-Features documented on this page require Agent Server version 0.14.0 or later and Python SDK version `langgraph-sdk>=0.4.3`.
-</Note>
-
 ## Configure AES encryption
 
 Set `LANGGRAPH_AES_KEY` to encrypt checkpoint blobs automatically:
@@ -43,6 +39,10 @@ Encrypted fields cannot be searched or filtered.
 System fields cannot be encrypted: `langgraph_version`, `langgraph_api_version`, `langgraph_plan`, `langgraph_host`, `langgraph_api_url`, `langgraph_request_id`, `langgraph_auth_user_id`, and `langgraph_auth_permissions`.
 
 ## Rotate AES keys
+
+<Note>
+AES key rotation requires Agent Server version 0.14.0 or later.
+</Note>
 
 Agent Server encrypts new data with `LANGGRAPH_AES_KEY`. When it reads data encrypted with a configured old key, it returns the plaintext and lazily re-encrypts the stored value with the current key.
 

--- a/src/langsmith/encryption.mdx
+++ b/src/langsmith/encryption.mdx
@@ -3,18 +3,15 @@ title: Add encryption at rest
 sidebarTitle: Encryption at rest
 ---
 
-Agent Server supports encryption at rest for checkpoint data and metadata. You can choose between basic encryption with a single key or custom encryption for advanced use cases.
+Agent Server supports built-in AES encryption at rest for checkpoint data and metadata. Use this option unless you need [custom encryption handlers](/langsmith/custom-encryption) for per-tenant keys or an external key management system.
 
-## Choosing an encryption method
+<Note>
+Features documented on this page require Agent Server version 0.14.0 or later and Python SDK version `langgraph-sdk>=0.4.3`.
+</Note>
 
-| Method | What's encrypted | Use case |
-|--------|------------------|----------|
-| **Basic encryption** | Checkpoint blobs, optionally JSON fields | Single static key, automatic AES encryption, selective field encryption |
-| **Custom encryption** | Checkpoints, threads, runs, assistants, crons and stores | Per-tenant keys, KMS integration |
+## Configure AES encryption
 
-## Basic encryption
-
-For simple encryption with a single static key, set the `LANGGRAPH_AES_KEY` environment variable. LangGraph will automatically encrypt checkpoint blobs using AES.
+Set `LANGGRAPH_AES_KEY` to encrypt checkpoint blobs automatically:
 
 1. Add `pycryptodome` to your dependencies in `langgraph.json`:
    ```json
@@ -26,11 +23,11 @@ For simple encryption with a single static key, set the `LANGGRAPH_AES_KEY` envi
    }
    ```
 
-2. Set the `LANGGRAPH_AES_KEY` environment variable to a 16, 24, or 32-byte key (for AES-128, AES-192, or AES-256 respectively).
+2. Set `LANGGRAPH_AES_KEY` to a 16, 24, or 32-byte key for AES-128, AES-192, or AES-256, respectively.
 
-### Encrypting JSON fields
+### Encrypt JSON fields
 
-To also encrypt specific JSON fields, set `LANGGRAPH_AES_JSON_KEYS` to a comma-separated list of keys to encrypt:
+Set `LANGGRAPH_AES_JSON_KEYS` to a comma-separated list of JSON keys to encrypt:
 
 ```bash
 export LANGGRAPH_AES_KEY="your-16-24-or-32-byte-key"
@@ -45,349 +42,34 @@ Encrypted fields cannot be searched or filtered.
 
 System fields cannot be encrypted: `langgraph_version`, `langgraph_api_version`, `langgraph_plan`, `langgraph_host`, `langgraph_api_url`, `langgraph_request_id`, `langgraph_auth_user_id`, and `langgraph_auth_permissions`.
 
-## Custom encryption
+## Rotate AES keys
 
-<Note>
-Requires Agent Server version 0.6.22+ and Python SDK version `langgraph-sdk>=0.3.1`.
-</Note>
+Agent Server encrypts new data with `LANGGRAPH_AES_KEY`. When it reads data encrypted with a configured old key, it returns the plaintext and lazily re-encrypts the stored value with the current key.
+
+To rotate a key:
+
+1. Move the current `LANGGRAPH_AES_KEY` value to `LANGGRAPH_AES_LEGACY_KEY`.
+2. Set `LANGGRAPH_AES_KEY` to the new 16, 24, or 32-byte key.
+3. Keep both keys configured until all required data has been read and re-encrypted.
+
+```bash
+export LANGGRAPH_AES_KEY="your-new-16-24-or-32-byte-key"
+export LANGGRAPH_AES_LEGACY_KEY="your-old-16-24-or-32-byte-key"
+```
+
+`LANGGRAPH_AES_LEGACY_KEY` decrypts ciphertext created before Agent Server 0.14.0, which does not contain a key identifier. For ciphertext created by Agent Server 0.14.0 or later, set `LANGGRAPH_AES_FALLBACK_KEYS` to a comma-separated list of old keys:
+
+```bash
+export LANGGRAPH_AES_KEY="your-current-16-24-or-32-byte-key"
+export LANGGRAPH_AES_FALLBACK_KEYS="first-old-key,second-old-key"
+```
 
 <Warning>
-Agent Server versions 0.5.34–0.6.21 included a pre-release version of custom encryption. Data encrypted with these versions will be corrupted when upgrading to 0.6.22+. Do not use custom encryption on these versions.
+Lazy re-encryption only updates data as it is read. Keep old keys configured while unread data may still require them.
 </Warning>
 
-<Warning>
-Only use custom encryption if basic encryption doesn't meet your needs. Custom encryption requires you to implement and maintain encryption handlers, and adds operational complexity. If you only need a single static key with optional selective field encryption, use [basic encryption](#basic-encryption) instead.
-</Warning>
-
-Use custom encryption when you need:
-
-- **Per-tenant key isolation** — different encryption keys for different customers
-- **KMS integration** — AWS KMS, Google Cloud KMS, or HashiCorp Vault for key management, rotation, and audit logging
-
-### How it works
-
-1. [Configure](#configuration) the encryption module path in `langgraph.json`
-2. [Define your encryption module](#defining-your-encryption-module) with handlers for blob and JSON encryption
-3. [Pass encryption context](#passing-encryption-context) (like tenant ID) via the `X-Encryption-Context` header
-4. LangGraph calls your handlers before storing and after retrieving data
-
-For production deployments with key rotation and audit logging, see [Envelope encryption with AWS Encryption SDK](#envelope-encryption-with-aws-encryption-sdk).
-
-### Configuration
-
-Add your encryption module to `langgraph.json`:
-
-```json
-{
-  "dependencies": ["."],
-  "graphs": {
-    "agent": "./agent.py:graph"
-  },
-  "encryption": {
-    "path": "./encryption.py:encryption"
-  }
-}
-```
-
-<Note>
-If you're migrating from basic encryption, keep `LANGGRAPH_AES_KEY` configured. Custom encryption handles new writes while existing AES-encrypted data remains readable.
-</Note>
-
-### Defining your encryption module
-
-#### Blob encryption (checkpoints)
-
-Blob handlers encrypt checkpoint data—the serialized state from graph execution. Here's a simplified example using per-tenant keys with [Fernet](https://cryptography.io/en/latest/fernet/) (a symmetric encryption scheme from the `cryptography` library):
-
-```python
-import os
-from cryptography.fernet import Fernet
-from langgraph_sdk import Encryption, EncryptionContext
-
-encryption = Encryption()
-
-# In production, fetch from a secrets manager
-TENANT_KEYS = {
-    "tenant-a": Fernet(os.environ["TENANT_A_KEY"]),
-    "tenant-b": Fernet(os.environ["TENANT_B_KEY"]),
-}
-
-
-def _get_fernet(ctx: EncryptionContext) -> Fernet:
-    tenant_id = ctx.metadata.get("tenant_id")
-    if not tenant_id or tenant_id not in TENANT_KEYS:
-        raise ValueError(f"Unknown tenant: {tenant_id}")
-    return TENANT_KEYS[tenant_id]
-
-
-@encryption.encrypt.blob
-async def encrypt_blob(ctx: EncryptionContext, data: bytes) -> bytes:
-    return _get_fernet(ctx).encrypt(data)
-
-
-@encryption.decrypt.blob
-async def decrypt_blob(ctx: EncryptionContext, data: bytes) -> bytes:
-    return _get_fernet(ctx).decrypt(data)
-```
-
-The `ctx.metadata` dict comes from the `X-Encryption-Context` header and is stored in plaintext alongside encrypted data, so the correct key is used on decryption.
-
-#### JSON encryption (metadata)
-
-JSON handlers encrypt structured data like thread metadata, assistant context, and run kwargs. Unlike blob encryption, you choose which fields to encrypt—keeping some unencrypted for search and filtering.
-
-```python
-import json
-import os
-from cryptography.fernet import Fernet
-from langgraph_sdk import Encryption, EncryptionContext
-
-encryption = Encryption()
-
-TENANT_KEYS = {
-    "tenant-a": Fernet(os.environ["TENANT_A_KEY"]),
-    "tenant-b": Fernet(os.environ["TENANT_B_KEY"]),
-}
-
-SKIP_FIELDS = {
-    "tenant_id", "owner",
-    "run_id", "thread_id", "graph_id", "assistant_id", "user_id", "checkpoint_id",
-    "source", "step", "parents", "run_attempt",
-    "langgraph_version", "langgraph_api_version", "langgraph_plan", "langgraph_host",
-    "langgraph_api_url", "langgraph_request_id", "langgraph_auth_user",
-    "langgraph_auth_user_id", "langgraph_auth_permissions",
-}
-ENCRYPTED_PREFIX = "encrypted:"
-
-
-def _get_fernet(ctx: EncryptionContext) -> Fernet:
-    tenant_id = ctx.metadata.get("tenant_id")
-    if not tenant_id or tenant_id not in TENANT_KEYS:
-        raise ValueError(f"Unknown tenant: {tenant_id}")
-    return TENANT_KEYS[tenant_id]
-
-
-@encryption.encrypt.json
-async def encrypt_json(ctx: EncryptionContext, data: dict) -> dict:
-    fernet = _get_fernet(ctx)
-    result = {}
-    for k, v in data.items():
-        if k in SKIP_FIELDS or v is None:
-            result[k] = v
-        else:
-            value_json = json.dumps(v)
-            encrypted = fernet.encrypt(value_json.encode()).decode()
-            result[k] = ENCRYPTED_PREFIX + encrypted
-    return result
-
-
-@encryption.decrypt.json
-async def decrypt_json(ctx: EncryptionContext, data: dict) -> dict:
-    fernet = _get_fernet(ctx)
-    result = {}
-    for k, v in data.items():
-        if isinstance(v, str) and v.startswith(ENCRYPTED_PREFIX):
-            encrypted_value = v[len(ENCRYPTED_PREFIX):]
-            decrypted = fernet.decrypt(encrypted_value.encode()).decode()
-            result[k] = json.loads(decrypted)
-        else:
-            result[k] = v
-    return result
-```
-
-#### JSON encryption considerations
-
-<Warning>
-**Encrypted fields cannot be searched or filtered.** Design your metadata schema so that fields you need to query remain unencrypted.
-</Warning>
-
-<Warning>
-**JSON encryptors must preserve key structure.** SQL JSONB merge operations work at the key level. Encryptors that change keys—whether by consolidating fields (e.g., moving sensitive data into `__encrypted__`) or by encrypting key names themselves—cause data loss during merges. Use per-key encryption: transform values in-place while preserving keys.
-</Warning>
-
-<Note>
-**Migration consideration:** Use a recognizable prefix or format in encrypted values so your decryptor can detect and skip unencrypted data. This allows you to encrypt additional fields in the future without re-encrypting existing records. The example above uses this pattern.
-</Note>
-
-<Note>
-**Performance consideration:** Per-key encryption means one encryption call per field. If your encryption involves round-trips to an external service (e.g., KMS), this can significantly impact latency. Consider caching data keys locally or using envelope encryption where you encrypt a local data key with KMS and use it for multiple fields.
-</Note>
-
-User-defined fields for authorization (e.g., `tenant_id`, `owner`) should generally be left **unencrypted**, as should fields used for search and filtering. Additionally, **some system-managed fields will never be encrypted**:
-
-- Resource identifiers (`thread_id`, `run_id`, `assistant_id`, `graph_id`, `checkpoint_id`, `task_id`)
-- Most fields beginning with `langgraph_` (except for `langgraph_auth_user`)
-- Required checkpoint metadata (`source`, `step`, `parents`, `run_attempt`)
-- Internal fields used for scheduling and orchestration (`__after_seconds__`, `__request_start_time_ms__`, most fields beginning with `__pregel`)
-- Run-level execution limits (`max_concurrency`, `recursion_limit`) specified in a run's `config`
-- Thread TTL updates (`ttl`) specified in a run's `config.configurable`
-
-
-#### What gets encrypted
-
-**JSON handlers** (`@encryption.encrypt.json` / `@encryption.decrypt.json`) are applied recursively to the following fields:
-- `thread.metadata`, `thread.values`
-- `assistant.metadata`, `assistant.context`
-- `run.metadata`, `run.kwargs`
-- `cron.metadata`, `cron.payload`
-- `store.value`
-
-[Some fields are excluded from encryption.](#what-gets-encrypted) Unless otherwise noted, these exclusions apply at every level of a nested JSON object, not just the root level.
-
-**Blob handlers** (`@encryption.encrypt.blob` / `@encryption.decrypt.blob`) are applied to checkpoint blobs (graph execution state).
-
-
-#### Deriving context from authentication
-
-Instead of passing `X-Encryption-Context` explicitly, derive encryption context from the authenticated user:
-
-```python
-from langgraph_sdk import Encryption, EncryptionContext
-from starlette.authentication import BaseUser
-
-encryption = Encryption()
-
-@encryption.context
-async def get_encryption_context(user: BaseUser, ctx: EncryptionContext) -> dict:
-    return {
-        **ctx.metadata,
-        "tenant_id": user["tenant_id"],
-    }
-```
-
-This handler runs once per request after authentication. The returned dict becomes `ctx.metadata` for all encryption operations in that request.
-
-### Passing encryption context
-
-Pass encryption context via the `X-Encryption-Context` header. The context is arbitrary data that you define—you control the schema and can include any fields your encryption logic needs (e.g., `tenant_id`, `key_version`). The context is available in your handlers as `ctx.metadata` and is stored in plaintext for use during decryption.
-
-```python
-import base64
-import json
-from langgraph_sdk import get_client
-
-encryption_context = base64.b64encode(
-    json.dumps({"tenant_id": "tenant-a"}).encode()
-).decode()
-
-client = get_client(url="http://localhost:2024")
-
-result = await client.runs.wait(
-    thread_id=None,
-    assistant_id="agent",
-    input={"messages": [{"role": "user", "content": "Hello"}]},
-    headers={"X-Encryption-Context": encryption_context},
-)
-```
-
-<Note>
-The encryption context is stored in plaintext. On decryption, it's automatically restored—callers don't need to pass the header when reading.
-</Note>
-
-### Envelope encryption with AWS Encryption SDK
-
-For production deployments on AWS, use the [AWS Encryption SDK](https://docs.aws.amazon.com/encryption-sdk/latest/developer-guide/python.html) with AWS KMS, or an equivalent within your cloud provider. This approach:
-
-- Handles envelope encryption automatically (no manual key packing)
-- Provides key rotation and audit logging
-- Binds ciphertext to encryption context (tenant isolation)
-- Caches data keys locally to avoid repeated KMS calls, latency and rate limits
-
-#### Complete example
-
-```python
-import base64
-import json
-import os
-
-import aws_encryption_sdk
-from aws_encryption_sdk import (
-    CachingCryptoMaterialsManager,
-    CommitmentPolicy,
-    LocalCryptoMaterialsCache,
-    StrictAwsKmsMasterKeyProvider,
-)
-from langgraph_sdk import Encryption, EncryptionContext
-
-encryption = Encryption()
-
-# The SDK uses envelope encryption: one KMS API call generates a data key,
-# then encrypts/decrypts locally. The cache reuses data keys across operations.
-client = aws_encryption_sdk.EncryptionSDKClient(
-    commitment_policy=CommitmentPolicy.REQUIRE_ENCRYPT_REQUIRE_DECRYPT
-)
-key_provider = StrictAwsKmsMasterKeyProvider(key_ids=[os.environ["KMS_KEY_ARN"]])
-cache = LocalCryptoMaterialsCache(capacity=100)
-cmm = CachingCryptoMaterialsManager(
-    master_key_provider=key_provider,
-    cache=cache,
-    max_age=300.0,
-    max_messages_encrypted=100,
-)
-
-SKIP_FIELDS = {
-    "tenant_id", "owner",
-    "run_id", "thread_id", "graph_id", "assistant_id", "user_id", "checkpoint_id",
-    "source", "step", "parents", "run_attempt",
-    "langgraph_version", "langgraph_api_version", "langgraph_plan", "langgraph_host",
-    "langgraph_api_url", "langgraph_request_id", "langgraph_auth_user",
-    "langgraph_auth_user_id", "langgraph_auth_permissions",
-}
-ENCRYPTED_PREFIX = "encrypted:"
-
-
-@encryption.encrypt.blob
-async def encrypt_blob(ctx: EncryptionContext, data: bytes) -> bytes:
-    ciphertext, _ = client.encrypt(
-        source=data,
-        materials_manager=cmm,
-        encryption_context={"tenant_id": ctx.metadata["tenant_id"]},
-    )
-    return ciphertext
-
-
-@encryption.decrypt.blob
-async def decrypt_blob(ctx: EncryptionContext, data: bytes) -> bytes:
-    plaintext, _ = client.decrypt(source=data, key_provider=key_provider)
-    return plaintext
-
-
-@encryption.encrypt.json
-async def encrypt_json(ctx: EncryptionContext, data: dict) -> dict:
-    tenant_id = ctx.metadata["tenant_id"]
-    result = {}
-    for k, v in data.items():
-        if k in SKIP_FIELDS or v is None:
-            result[k] = v
-        else:
-            ciphertext, _ = client.encrypt(
-                source=json.dumps(v).encode(),
-                materials_manager=cmm,
-                encryption_context={"tenant_id": tenant_id},
-            )
-            result[k] = ENCRYPTED_PREFIX + base64.b64encode(ciphertext).decode()
-    return result
-
-
-@encryption.decrypt.json
-async def decrypt_json(ctx: EncryptionContext, data: dict) -> dict:
-    result = {}
-    for k, v in data.items():
-        if isinstance(v, str) and v.startswith(ENCRYPTED_PREFIX):
-            ciphertext = base64.b64decode(v[len(ENCRYPTED_PREFIX):])
-            plaintext, _ = client.decrypt(source=ciphertext, key_provider=key_provider)
-            result[k] = json.loads(plaintext.decode())
-        else:
-            result[k] = v
-    return result
-```
-
-The `encryption_context` is cryptographically bound to the ciphertext via KMS—decryption fails if the context doesn't match. The context is embedded in the ciphertext, so decrypt handlers don't need to reference `ctx.metadata`.
-
-#### Key rotation
-
-KMS handles master key rotation automatically. When you enable automatic rotation on your KMS key, old encrypted data keys can still be decrypted while new operations use the rotated key material. No re-encryption of existing data is required.
+AES key rotation requires the PostgreSQL checkpointer, `PREFER_GRPC_CHECKPOINTER=true`, and `LANGGRAPH_STORE_BACKEND=grpc`.
 
 ## Related
 
-- [Custom authentication](/langsmith/custom-auth)
+- [Configure custom encryption](/langsmith/custom-encryption)

--- a/src/langsmith/self-hosted-agent-server-metrics.mdx
+++ b/src/langsmith/self-hosted-agent-server-metrics.mdx
@@ -88,6 +88,16 @@ These metrics have `lsd_web_metric=true`. They appear on the Prometheus `/metric
 
 These metrics have `lsd_web_metric=false`. By default they are exported to Datadog when `LSD_DD_API_KEY` is set. Set `EXPOSE_INTERNAL_METRICS_PROMETHEUS=true` to include them on the Prometheus `/metrics` scrape. Internal metrics at or below `METRIC_MAX_EMITTING_TIER` are recorded; higher-tier metrics are omitted.
 
+### Re-encryption
+
+| Name | Type | Tier | Description |
+|------|------|------|-------------|
+| `lg_api_reencrypt_writeback_succeeded_counter` | Counter | INFO | Lazy re-encryption replacement writebacks that succeeded. |
+| `lg_api_reencrypt_writeback_cas_skipped_counter` | Counter | INFO | Replacement writebacks skipped because a concurrent update changed the stored value. |
+| `lg_api_reencrypt_writeback_failed_counter` | Counter | INFO | Replacement writebacks that failed. Reads still return decrypted data. |
+
+All three metrics include `reencryption_table` and `reencryption_column` attributes. See [Monitor lazy re-encryption](/langsmith/custom-encryption#monitor-lazy-re-encryption) for operational guidance.
+
 ### Run lifecycle
 
 | Name | Type | Tier | Description |


### PR DESCRIPTION
DO NOT MERGE, half the stuff that this documents is not merged or released yet

## Overview

Split built-in AES and custom encryption guidance. Document AES key rotation, custom lazy re-encryption, and version requirements. Nest custom encryption under the base page.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Feature PRs: langchain-ai/langgraph-api#3970, langchain-ai/langgraph-api#3989, langchain-ai/langgraph#8598
- Linear project: https://linear.app/langchain/project/go-checkpointer-custom-encryption-re-encryption-d7f4f0c6366d/overview

## Checklist

- [x] I have read the contributing guidelines, including the language policy
- [ ] I have tested my changes locally using `docs dev`
- [x] Existing code examples are unchanged
- [x] I have used root-relative paths for internal links
- [x] I have updated navigation in `src/docs.json`

## Validation

- Vale: passed
- `src/docs.json`: valid JSON
- Cross-reference check: blocked by `quickjs-rs==0.1.2` build failure fetching `branchseer/oxc`