### PR TITLE
docs: document Deep Agents Code prompt clipboard

### DIFF
--- a/src/oss/deepagents/code/quickstart.mdx
+++ b/src/oss/deepagents/code/quickstart.mdx
@@ -136,10 +136,6 @@ The agent uses its built-in tools, skills, and memory to help you with tasks.
 
         Prompt history search lets you find and reuse previously submitted prompts without leaving the chat input. Press `Ctrl+R` to open an inline search of prompts stored on your machine.
 
-        <Note>
-            Prompt history search requires `deepagents-code>=0.1.61`.
-        </Note>
-
         | Shortcut | Action |
         |-|-|
         | Type | Filter submitted prompts |

--- a/src/oss/deepagents/code/quickstart.mdx
+++ b/src/oss/deepagents/code/quickstart.mdx
@@ -69,6 +69,7 @@ The agent uses its built-in tools, skills, and memory to help you with tasks.
         - `/clear`: Clear conversation history and start a new thread.
         - `/force-clear`: Stop active work, clear the chat, and start a new thread.
         - `/copy`: Copy the latest assistant message to the clipboard.
+        - `/prompts`: Search, preview, copy, and reuse previously submitted prompts.
         - `/threads`: Browse and resume previous conversation threads.
         - `/mcp [login <server> | reconnect]`: Show active MCP servers and tools. `login <server>` runs the OAuth flow for a server; `reconnect` loads deferred logins.
         - `/plugins`: Manage [plugins and marketplaces](/oss/deepagents/code/plugins).
@@ -130,6 +131,25 @@ The agent uses its built-in tools, skills, and memory to help you with tasks.
         | `Ctrl+K` | Delete from cursor to end of line |
         | `Ctrl+W` or `Ctrl+Backspace` | Delete word to the left |
         | `Ctrl+Left` / `Ctrl+Right` | Move cursor one word left/right |
+
+        **Search prompt history**
+
+        Prompt history search lets you find and reuse previously submitted prompts without leaving the chat input. Press `Ctrl+R` to open an inline, case-insensitive search of prompts stored on your machine.
+
+        <Note>
+            Prompt history search requires `deepagents-code>=0.1.61`.
+        </Note>
+
+        | Shortcut | Action |
+        |-|-|
+        | Type | Filter submitted prompts |
+        | `Up` / `Down` | Move between matches |
+        | `Tab` / `Shift+Tab` | Move five matches forward or backward |
+        | `Enter` | Insert the selected prompt at the cursor |
+        | `Ctrl+R` | Open the full prompt clipboard from inline search |
+        | `Escape` or `Backspace` on an empty search | Cancel and return to the draft |
+
+        The full prompt clipboard includes a multi-line preview. Press `Ctrl+C` to copy the selected prompt without inserting it, or run `/prompts` to open the full view directly.
 
         <Note>
             **macOS `Cmd+Left` / `Cmd+Right` / `Cmd+Delete`**

--- a/src/oss/deepagents/code/quickstart.mdx
+++ b/src/oss/deepagents/code/quickstart.mdx
@@ -134,7 +134,7 @@ The agent uses its built-in tools, skills, and memory to help you with tasks.
 
         **Search prompt history**
 
-        Prompt history search lets you find and reuse previously submitted prompts without leaving the chat input. Press `Ctrl+R` to open an inline, case-insensitive search of prompts stored on your machine.
+        Prompt history search lets you find and reuse previously submitted prompts without leaving the chat input. Press `Ctrl+R` to open an inline search of prompts stored on your machine.
 
         <Note>
             Prompt history search requires `deepagents-code>=0.1.61`.

--- a/src/oss/deepagents/code/quickstart.mdx
+++ b/src/oss/deepagents/code/quickstart.mdx
@@ -136,8 +136,6 @@ The agent uses its built-in tools, skills, and memory to help you with tasks.
 
         Prompt history search lets you find and reuse previously submitted prompts without leaving the chat input. Press `Ctrl+R` to open an inline search of prompts stored on your machine.
 
-        The full prompt clipboard includes a multi-line preview. Press `Ctrl+C` to copy the selected prompt without inserting it, or run `/prompts` to open the full view directly.
-
         <Note>
             **macOS `Cmd+Left` / `Cmd+Right` / `Cmd+Delete`**
 

--- a/src/oss/deepagents/code/quickstart.mdx
+++ b/src/oss/deepagents/code/quickstart.mdx
@@ -136,15 +136,6 @@ The agent uses its built-in tools, skills, and memory to help you with tasks.
 
         Prompt history search lets you find and reuse previously submitted prompts without leaving the chat input. Press `Ctrl+R` to open an inline search of prompts stored on your machine.
 
-        | Shortcut | Action |
-        |-|-|
-        | Type | Filter submitted prompts |
-        | `Up` / `Down` | Move between matches |
-        | `Tab` / `Shift+Tab` | Move five matches forward or backward |
-        | `Enter` | Insert the selected prompt at the cursor |
-        | `Ctrl+R` | Open the full prompt clipboard from inline search |
-        | `Escape` or `Backspace` on an empty search | Cancel and return to the draft |
-
         The full prompt clipboard includes a multi-line preview. Press `Ctrl+C` to copy the selected prompt without inserting it, or run `/prompts` to open the full view directly.
 
         <Note>


### PR DESCRIPTION
## Description
Documents the prompt clipboard released in `deepagents-code>=0.1.61`, including inline `Ctrl+R` search, full-view navigation, copying, and `/prompts`. This gives users a discoverable reference for the feature introduced by langchain-ai/deepagents#5733.

## Release Note
none

## Test Plan
- [x] Run Vale on the updated quickstart with zero findings

Made by [Open SWE](https://openswe.vercel.app/agents/102b2e1a-c434-599e-866f-7c0755d53491)