### PR TITLE
docs: add production IAM role setup

### DIFF
--- a/src/langsmith/data-export-destinations.mdx
+++ b/src/langsmith/data-export-destinations.mdx
@@ -467,9 +467,34 @@ Before switching, ensure the new authentication configuration has write access t
 
 Provide `aws_role_arn` in the PATCH body. This clears any previously stored credentials.
 
+```bash
+curl --request PATCH \
+  --url 'https://api.smith.langchain.com/api/v1/bulk-exports/destinations/{destination_id}' \
+  --header 'Content-Type: application/json' \
+  --header 'X-API-Key: YOUR_API_KEY' \
+  --header 'X-Tenant-Id: YOUR_WORKSPACE_ID' \
+  --data '{
+    "aws_role_arn": "arn:aws:iam::123456789012:role/LangSmithBulkExportRole"
+  }'
+```
+
 ### Switch from AWS IAM role to static credentials
 
 Provide a `credentials` object in the PATCH body. This clears the stored role ARN.
+
+```bash
+curl --request PATCH \
+  --url 'https://api.smith.langchain.com/api/v1/bulk-exports/destinations/{destination_id}' \
+  --header 'Content-Type: application/json' \
+  --header 'X-API-Key: YOUR_API_KEY' \
+  --header 'X-Tenant-Id: YOUR_WORKSPACE_ID' \
+  --data '{
+    "credentials": {
+      "access_key_id": "YOUR_NEW_ACCESS_KEY_ID",
+      "secret_access_key": "YOUR_NEW_SECRET_ACCESS_KEY"
+    }
+  }'
+```
 
 ### Behavior during the switch
 

--- a/src/langsmith/data-export-destinations.mdx
+++ b/src/langsmith/data-export-destinations.mdx
@@ -413,38 +413,7 @@ To switch to AWS IAM role assumption, provide `aws_role_arn` in the PATCH body. 
 
 Before switching, ensure the new authentication configuration has write access to the destination bucket. LangSmith validates the configuration with a test write before saving it.
 
-### Switch from static credentials to AWS IAM role
-
-Provide `aws_role_arn` in the PATCH body. This clears any previously stored credentials.
-
-```bash
-curl --request PATCH \
-  --url 'https://api.smith.langchain.com/api/v1/bulk-exports/destinations/{destination_id}' \
-  --header 'Content-Type: application/json' \
-  --header 'X-API-Key: YOUR_API_KEY' \
-  --header 'X-Tenant-Id: YOUR_WORKSPACE_ID' \
-  --data '{
-    "aws_role_arn": "arn:aws:iam::123456789012:role/LangSmithBulkExportRole"
-  }'
-```
-
-### Switch from AWS IAM role to static credentials
-
-Provide a `credentials` object in the PATCH body. This clears the stored role ARN.
-
-```bash
-curl --request PATCH \
-  --url 'https://api.smith.langchain.com/api/v1/bulk-exports/destinations/{destination_id}' \
-  --header 'Content-Type: application/json' \
-  --header 'X-API-Key: YOUR_API_KEY' \
-  --header 'X-Tenant-Id: YOUR_WORKSPACE_ID' \
-  --data '{
-    "credentials": {
-      "access_key_id": "YOUR_NEW_ACCESS_KEY_ID",
-      "secret_access_key": "YOUR_NEW_SECRET_ACCESS_KEY"
-    }
-  }'
-```
+Pass `aws_role_arn` instead of `credentials` to use IAM role assumption.
 
 ### Behavior during the switch
 

--- a/src/langsmith/data-export-destinations.mdx
+++ b/src/langsmith/data-export-destinations.mdx
@@ -324,43 +324,13 @@ Pass `aws_role_arn` instead of `credentials` to use IAM role assumption.
 IAM role assumption is available only on GCP-hosted LangSmith SaaS. It is not available on AWS-hosted SaaS or self-hosted deployments.
 </Note>
 
-### Select your LangSmith region
+### Create the AWS role
 
-Your role trust policy must allow all three subject IDs for your LangSmith region:
+Create an AWS IAM role with a trust policy that permits web identity federation from the three subject IDs for your region. Grant the role access to your export bucket. Select your LangSmith region to use the corresponding subject IDs. Each Terraform example uses the minimum required `s3:PutObject` permission:
 
 <CodeGroup>
 
 ```hcl US
-[
-  "110136955440523778103",
-  "116331607438151298187",
-  "115251468294701876731",
-]
-```
-
-```hcl EU
-[
-  "110207823358662523645",
-  "115689110758588220909",
-  "109691164801275818274",
-]
-```
-
-```hcl APAC
-[
-  "105923862603785245337",
-  "114288557158507552617",
-  "116622461022404604716",
-]
-```
-
-</CodeGroup>
-
-### Create the AWS role
-
-Create an AWS IAM role with a trust policy that permits web identity federation from the three subject IDs for your region. Grant the role access to your export bucket. This Terraform example uses the minimum required `s3:PutObject` permission:
-
-```hcl
 resource "aws_iam_role" "langsmith_bulk_export" {
   name                 = "langsmith-bulk-export"
   max_session_duration = 43200
@@ -375,9 +345,9 @@ resource "aws_iam_role" "langsmith_bulk_export" {
         StringEquals = {
           "accounts.google.com:oaud" = "langsmith-bulk-export"
           "accounts.google.com:sub" = [
-            "LANGSMITH_API_SERVER_SUBJECT_ID",
-            "LANGSMITH_SAQ_WORKER_SUBJECT_ID",
-            "LANGSMITH_ASYNQ_WORKER_SUBJECT_ID",
+            "110136955440523778103",
+            "116331607438151298187",
+            "115251468294701876731",
           ]
         }
       }
@@ -398,7 +368,85 @@ resource "aws_iam_role" "langsmith_bulk_export" {
 }
 ```
 
-Replace the subject ID placeholders with the values from the selected region. Add the optional permissions from [AWS S3 permissions](#aws-s3-permissions) if you want LangSmith to clean up test files, verify file sizes, or abort multipart uploads.
+```hcl EU
+resource "aws_iam_role" "langsmith_bulk_export" {
+  name                 = "langsmith-bulk-export"
+  max_session_duration = 43200
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = "accounts.google.com" }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "accounts.google.com:oaud" = "langsmith-bulk-export"
+          "accounts.google.com:sub" = [
+            "110207823358662523645",
+            "115689110758588220909",
+            "109691164801275818274",
+          ]
+        }
+      }
+    }]
+  })
+
+  inline_policy {
+    name = "langsmith-bulk-export-s3"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [{
+        Effect   = "Allow"
+        Action   = "s3:PutObject"
+        Resource = "arn:aws:s3:::YOUR_BUCKET_NAME/*"
+      }]
+    })
+  }
+}
+```
+
+```hcl APAC
+resource "aws_iam_role" "langsmith_bulk_export" {
+  name                 = "langsmith-bulk-export"
+  max_session_duration = 43200
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = "accounts.google.com" }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "accounts.google.com:oaud" = "langsmith-bulk-export"
+          "accounts.google.com:sub" = [
+            "105923862603785245337",
+            "114288557158507552617",
+            "116622461022404604716",
+          ]
+        }
+      }
+    }]
+  })
+
+  inline_policy {
+    name = "langsmith-bulk-export-s3"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [{
+        Effect   = "Allow"
+        Action   = "s3:PutObject"
+        Resource = "arn:aws:s3:::YOUR_BUCKET_NAME/*"
+      }]
+    })
+  }
+}
+```
+
+</CodeGroup>
+
+Add the optional permissions from [AWS S3 permissions](#aws-s3-permissions) if you want LangSmith to clean up test files, verify file sizes, or abort multipart uploads.
 
 ## Switch authentication mode
 

--- a/src/langsmith/data-export-destinations.mdx
+++ b/src/langsmith/data-export-destinations.mdx
@@ -446,7 +446,7 @@ resource "aws_iam_role" "langsmith_bulk_export" {
 
 </CodeGroup>
 
-Add the optional permissions from [AWS S3 permissions](#aws-s3-permissions) if you want LangSmith to clean up test files, verify file sizes, or abort multipart uploads.
+See [AWS S3 permissions](#aws-s3-permissions) for optional permissions.
 
 ## Switch authentication mode
 

--- a/src/langsmith/data-export-destinations.mdx
+++ b/src/langsmith/data-export-destinations.mdx
@@ -398,30 +398,6 @@ resource "aws_iam_role" "langsmith_bulk_export" {
 
 Replace the subject ID placeholders with the values from the selected region. Add the optional permissions from [AWS S3 permissions](#aws-s3-permissions) if you want LangSmith to clean up test files, verify file sizes, or abort multipart uploads.
 
-### Create a destination with the role
-
-After you create the AWS role, pass its ARN as `aws_role_arn` instead of providing `credentials`:
-
-```bash
-curl --request POST \
-  --url 'https://api.smith.langchain.com/api/v1/bulk-exports/destinations' \
-  --header 'Content-Type: application/json' \
-  --header 'X-API-Key: YOUR_API_KEY' \
-  --header 'X-Tenant-Id: YOUR_WORKSPACE_ID' \
-  --data '{
-    "destination_type": "s3",
-    "display_name": "My AWS S3 Destination",
-    "config": {
-      "bucket_name": "YOUR_BUCKET_NAME",
-      "prefix": "data_exports",
-      "region": "YOUR_AWS_REGION"
-    },
-    "aws_role_arn": "arn:aws:iam::YOUR_AWS_ACCOUNT_ID:role/langsmith-bulk-export"
-  }'
-```
-
-LangSmith validates the role with a test write before saving the destination. The request fails with `400` if the trust policy or S3 permissions are insufficient.
-
 ## Switch authentication mode
 
 Switch an existing destination between static credentials and [AWS IAM role assumption](#authenticate-with-an-aws-iam-role) without recreating it. Use `PATCH /api/v1/bulk-exports/destinations/{destination_id}`.

--- a/src/langsmith/data-export-destinations.mdx
+++ b/src/langsmith/data-export-destinations.mdx
@@ -318,6 +318,8 @@ Returns the updated destination object. Credential values are never returned—o
 
 AWS IAM role assumption lets GCP-hosted LangSmith SaaS export to S3 without storing static AWS credentials. Configure an AWS role that trusts the LangSmith service accounts for your production region, then provide its ARN when you create or update a destination.
 
+Pass `aws_role_arn` instead of `credentials` to use IAM role assumption.
+
 <Note>
 IAM role assumption is available only on GCP-hosted LangSmith SaaS. It is not available on AWS-hosted SaaS or self-hosted deployments.
 </Note>
@@ -413,7 +415,13 @@ To switch to AWS IAM role assumption, provide `aws_role_arn` in the PATCH body. 
 
 Before switching, ensure the new authentication configuration has write access to the destination bucket. LangSmith validates the configuration with a test write before saving it.
 
-Pass `aws_role_arn` instead of `credentials` to use IAM role assumption.
+### Switch from static credentials to AWS IAM role
+
+Provide `aws_role_arn` in the PATCH body. This clears any previously stored credentials.
+
+### Switch from AWS IAM role to static credentials
+
+Provide a `credentials` object in the PATCH body. This clears the stored role ARN.
 
 ### Behavior during the switch
 

--- a/src/langsmith/data-export-destinations.mdx
+++ b/src/langsmith/data-export-destinations.mdx
@@ -314,11 +314,119 @@ Returns the updated destination object. Credential values are never returned—o
 1. Keep old credentials active until all in-flight bulk export runs finish (up to the [maximum run duration](/langsmith/data-export-monitor#automatic-retry-behavior)).
 1. Revoke old credentials once no runs are using them.
 
+## Authenticate with an AWS IAM role
+
+AWS IAM role assumption lets GCP-hosted LangSmith SaaS export to S3 without storing static AWS credentials. Configure an AWS role that trusts the LangSmith service accounts for your production region, then provide its ARN when you create or update a destination.
+
+<Note>
+IAM role assumption is available only on GCP-hosted LangSmith SaaS. It is not available on AWS-hosted SaaS or self-hosted deployments.
+</Note>
+
+### Select your LangSmith region
+
+Your role trust policy must allow all three service-account subject IDs for your LangSmith region. The API server validates the destination, the SAQ worker runs exports, and the asynq worker supports future export execution.
+
+<Tabs>
+<Tab title="US">
+
+| LangSmith service | `accounts.google.com:sub` |
+|---|---|
+| API server | `110136955440523778103` |
+| SAQ worker | `116331607438151298187` |
+| Asynq worker | `115251468294701876731` |
+
+</Tab>
+<Tab title="EU">
+
+| LangSmith service | `accounts.google.com:sub` |
+|---|---|
+| API server | `110207823358662523645` |
+| SAQ worker | `115689110758588220909` |
+| Asynq worker | `109691164801275818274` |
+
+</Tab>
+<Tab title="APAC">
+
+| LangSmith service | `accounts.google.com:sub` |
+|---|---|
+| API server | `105923862603785245337` |
+| SAQ worker | `114288557158507552617` |
+| Asynq worker | `116622461022404604716` |
+
+</Tab>
+</Tabs>
+
+### Create the AWS role
+
+Create an AWS IAM role with a trust policy that permits web identity federation from the three subject IDs for your region. Grant the role access to your export bucket. This Terraform example uses the minimum required `s3:PutObject` permission:
+
+```hcl
+resource "aws_iam_role" "langsmith_bulk_export" {
+  name                 = "langsmith-bulk-export"
+  max_session_duration = 43200
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [{
+      Effect    = "Allow"
+      Principal = { Federated = "accounts.google.com" }
+      Action    = "sts:AssumeRoleWithWebIdentity"
+      Condition = {
+        StringEquals = {
+          "accounts.google.com:oaud" = "langsmith-bulk-export"
+          "accounts.google.com:sub" = [
+            "LANGSMITH_API_SERVER_SUBJECT_ID",
+            "LANGSMITH_SAQ_WORKER_SUBJECT_ID",
+            "LANGSMITH_ASYNQ_WORKER_SUBJECT_ID",
+          ]
+        }
+      }
+    }]
+  })
+
+  inline_policy {
+    name = "langsmith-bulk-export-s3"
+    policy = jsonencode({
+      Version = "2012-10-17"
+      Statement = [{
+        Effect   = "Allow"
+        Action   = "s3:PutObject"
+        Resource = "arn:aws:s3:::YOUR_BUCKET_NAME/*"
+      }]
+    })
+  }
+}
+```
+
+Replace the three subject ID placeholders with the values from the selected region tab. Add the optional permissions from [AWS S3 permissions](#aws-s3-permissions) if you want LangSmith to clean up test files, verify file sizes, or abort multipart uploads.
+
+### Create a destination with the role
+
+After you create the AWS role, pass its ARN as `aws_role_arn` instead of providing `credentials`:
+
+```bash
+curl --request POST \
+  --url 'https://api.smith.langchain.com/api/v1/bulk-exports/destinations' \
+  --header 'Content-Type: application/json' \
+  --header 'X-API-Key: YOUR_API_KEY' \
+  --header 'X-Tenant-Id: YOUR_WORKSPACE_ID' \
+  --data '{
+    "destination_type": "s3",
+    "display_name": "My AWS S3 Destination",
+    "config": {
+      "bucket_name": "YOUR_BUCKET_NAME",
+      "prefix": "data_exports",
+      "region": "YOUR_AWS_REGION"
+    },
+    "aws_role_arn": "arn:aws:iam::YOUR_AWS_ACCOUNT_ID:role/langsmith-bulk-export"
+  }'
+```
+
+LangSmith validates the role with a test write before saving the destination. The request fails with `400` if the trust policy or S3 permissions are insufficient.
+
 ## Switch authentication mode
 
-<Note>**`aws_role_arn` is available only on GCP SaaS deployments.**</Note>
-
-Switch an existing destination between static credentials and AWS IAM role assumption without recreating it. Use `PATCH /api/v1/bulk-exports/destinations/{destination_id}`.
+Switch an existing destination between static credentials and [AWS IAM role assumption](#authenticate-with-an-aws-iam-role) without recreating it. Use `PATCH /api/v1/bulk-exports/destinations/{destination_id}`.
 
 [**Required permission**](/langsmith/organization-workspace-operations#bulk-exports): `bulk-exports:manage`.
 

--- a/src/langsmith/data-export-destinations.mdx
+++ b/src/langsmith/data-export-destinations.mdx
@@ -324,37 +324,35 @@ IAM role assumption is available only on GCP-hosted LangSmith SaaS. It is not av
 
 ### Select your LangSmith region
 
-Your role trust policy must allow all three service-account subject IDs for your LangSmith region. The API server validates the destination, the SAQ worker runs exports, and the asynq worker supports future export execution.
+Your role trust policy must allow all three subject IDs for your LangSmith region:
 
-<Tabs>
-<Tab title="US">
+<CodeGroup>
 
-| LangSmith service | `accounts.google.com:sub` |
-|---|---|
-| API server | `110136955440523778103` |
-| SAQ worker | `116331607438151298187` |
-| Asynq worker | `115251468294701876731` |
+```hcl US
+[
+  "110136955440523778103",
+  "116331607438151298187",
+  "115251468294701876731",
+]
+```
 
-</Tab>
-<Tab title="EU">
+```hcl EU
+[
+  "110207823358662523645",
+  "115689110758588220909",
+  "109691164801275818274",
+]
+```
 
-| LangSmith service | `accounts.google.com:sub` |
-|---|---|
-| API server | `110207823358662523645` |
-| SAQ worker | `115689110758588220909` |
-| Asynq worker | `109691164801275818274` |
+```hcl APAC
+[
+  "105923862603785245337",
+  "114288557158507552617",
+  "116622461022404604716",
+]
+```
 
-</Tab>
-<Tab title="APAC">
-
-| LangSmith service | `accounts.google.com:sub` |
-|---|---|
-| API server | `105923862603785245337` |
-| SAQ worker | `114288557158507552617` |
-| Asynq worker | `116622461022404604716` |
-
-</Tab>
-</Tabs>
+</CodeGroup>
 
 ### Create the AWS role
 
@@ -398,7 +396,7 @@ resource "aws_iam_role" "langsmith_bulk_export" {
 }
 ```
 
-Replace the three subject ID placeholders with the values from the selected region tab. Add the optional permissions from [AWS S3 permissions](#aws-s3-permissions) if you want LangSmith to clean up test files, verify file sizes, or abort multipart uploads.
+Replace the subject ID placeholders with the values from the selected region. Add the optional permissions from [AWS S3 permissions](#aws-s3-permissions) if you want LangSmith to clean up test files, verify file sizes, or abort multipart uploads.
 
 ### Create a destination with the role
 


### PR DESCRIPTION
## Overview

Document production AWS IAM role setup for GCP-hosted LangSmith bulk exports, with a code-sample-style region selector for the required US, EU, and APAC subject IDs.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue:
- Feature PR: https://github.com/langchain-ai/langchainplus/pull/25202

- Linear issue:
- Slack thread:

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes

- `make build` passes.
- Vale prose lint passes for the changed page.
- Navigation did not require changes because this updates an existing page.

Made by [Open SWE](https://openswe.vercel.app/agents/5008df6b-1031-542a-91b5-a71a3e623843)
