### PR TITLE
docs: list Microsandbox sandbox integration

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -991,6 +991,9 @@ python:
   - name: NonoSandbox
     pypi: langchain-nono
     docs_url: https://github.com/always-further/langchain-nono
+  - name: MicrosandboxSandbox
+    pypi: langchain-microsandbox
+    docs_url: https://github.com/kenwoodjw/langchain-microsandbox
   retrievers:
   - name: Self Querying with SAP HANA Cloud Vector Engine
     pypi: langchain-hana


### PR DESCRIPTION
## Overview

List `MicrosandboxSandbox` as an external Python sandbox integration. The independently published `langchain-microsandbox` package provides a Deep Agents `BaseSandbox` adapter backed by Microsandbox microVMs.

This follows the listing-only path requested for new sandbox integrations and lets the post-merge refresh job add it to the sandbox download table.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Related issue: https://github.com/langchain-ai/deepagents/issues/5534
- Package: https://pypi.org/project/langchain-microsandbox/
- Repository: https://github.com/kenwoodjw/langchain-microsandbox

## Checklist

- [x] I have read the contributing guidelines, including the language policy
- [ ] I have tested my changes locally using `docs dev` (metadata-only change)
- [x] All code examples have been tested and work correctly (no code examples added)
- [x] I have used root relative paths for internal links (no internal links added)
- [x] I have updated navigation in `src/docs.json` if needed (no page added)

## Additional notes

- Validated all external documentation URLs with `refresh_integration_downloads.py --check-docs-urls`.
- Ran the targeted integration-download test suite: 22 tests passed.
- The primary review point is the mapping between `MicrosandboxSandbox`, the `langchain-microsandbox` PyPI package, and its repository URL.
- This contribution was prepared with OpenAI Codex. The package, exported class, PyPI release, repository, and documentation URL were verified by the contributor.
