### PR TITLE
docs(langsmith): drop manual Slack invite step for alert notifications

### DIFF
--- a/src/langsmith/alerts.mdx
+++ b/src/langsmith/alerts.mdx
@@ -84,9 +84,10 @@ You can preview alert behavior over a historical time window to understand how m
 
     1. In the **Notification Settings** section of your alert setup, select **Slack**.
     2. Click the channel selector. If no Slack workspace is linked yet, click **Connect Slack** and complete the OAuth flow to authorize LangSmith.
-    3. Add the `@LangSmith` app to the channel you want to receive notifications in. The app must be a member of the channel — type `/invite @LangSmith` in the channel to add it.
-    4. Select the workspace and channel from the dropdown. Click the refresh icon if the channel does not appear immediately.
-    5. Click **Save** to save the notification configuration.
+    3. Select the workspace and channel from the dropdown. Click the refresh icon if the channel does not appear immediately.
+    4. Click **Save** to save the notification configuration.
+
+    LangSmith automatically joins the public channel you select. To post to a private channel, invite the `@LangSmith` app to that channel in Slack first.
 
     ### 2. Test the integration
 

--- a/src/langsmith/alerts.mdx
+++ b/src/langsmith/alerts.mdx
@@ -83,9 +83,9 @@ You can preview alert behavior over a historical time window to understand how m
     ### 1. Configure the Slack notification
 
     1. In the **Notification Settings** section of your alert setup, select **Slack**.
-    2. Click the channel selector. If no Slack workspace is linked yet, click **Connect Slack** and complete the OAuth flow to authorize LangSmith.
-    3. Select the workspace and channel from the dropdown. Click the refresh icon if the channel does not appear immediately.
-    4. Click **Save** to save the notification configuration.
+    1. Click the channel selector. If no Slack workspace is linked yet, click **Connect Slack** and complete the OAuth flow to authorize LangSmith.
+    1. Select the workspace and channel from the dropdown. Click the refresh icon if the channel does not appear immediately.
+    1. Click **Save** to save the notification configuration.
 
     LangSmith automatically joins the public channel you select. To post to a private channel, invite the `@LangSmith` app to that channel in Slack first.
 


### PR DESCRIPTION
## Overview

The Slack notification setup for alerts told readers to run `/invite @LangSmith` in the target channel before saving. LangSmith now joins a selected public channel on its own, so that step is only needed for private channels, which Slack does not allow apps to join.

This removes the invite step from the numbered procedure and states the current behavior after it, matching the wording already used for Slack destinations on [Engine notifications](https://docs.langchain.com/langsmith/engine#notify-a-slack-channel).

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- GitHub issue:
- Feature PR: langchain-ai/langchainplus#35043

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

Affects one page, `src/langsmith/alerts.mdx`, under **Step 4: Configure notification channel** in the **Slack** tab. No new pages, links, or navigation entries, so `src/docs.json` is unchanged.

`make lint_prose FILES="src/langsmith/alerts.mdx"` passes with 0 errors, 0 warnings, and 0 suggestions. Local `docs dev` was not run: the change is a prose edit with no new components or links.

Drafted with Claude Code.
