### PR TITLE
docs(langchain): state minimum Python version for langchain and deepagents

### DIFF
--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -12,6 +12,8 @@ This quickstart shows you how to create a fully functional AI agent in just a fe
     - Install [LangChain Skills](https://github.com/langchain-ai/langchain-skills) to improve your agent's performance on LangChain ecosystem tasks.
 </Tip>
 
+## Install dependencies
+
 :::python
 <Note>
     **Python 3.11+**
@@ -19,8 +21,6 @@ This quickstart shows you how to create a fully functional AI agent in just a fe
     To run the code in this Quickstart, use Python 3.11 or higher.
 </Note>
 :::
-
-## Install dependencies
 
 Install the following packages to follow along:
 

--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -12,6 +12,14 @@ This quickstart shows you how to create a fully functional AI agent in just a fe
     - Install [LangChain Skills](https://github.com/langchain-ai/langchain-skills) to improve your agent's performance on LangChain ecosystem tasks.
 </Tip>
 
+:::python
+<Note>
+    **Python 3.11+**
+
+    To run the code in this Quickstart, use Python 3.11 or higher.
+</Note>
+:::
+
 ## Install dependencies
 
 Install the following packages to follow along:
@@ -19,17 +27,20 @@ Install the following packages to follow along:
 :::python
 <CodeGroup>
     ```bash uv
+    uv python pin 3.11
     uv init
     uv add langchain
     uv sync
     ```
 
     ```bash pip
+    # Install Python 3.11+ separately if needed.
     pip install -U langchain
     ```
 
     ```bash venv
-    python3 -m venv .venv
+    # Install Python 3.11+ separately if needed.
+    python3.11 -m venv .venv
     source .venv/bin/activate
     # Windows: .venv\Scripts\activate
     pip install -U langchain


### PR DESCRIPTION
## Overview

Add a callout at the top of the Quickstart with the required Python version.

Using a Python version lower than 3.10 causes LangChain to silently resolve to a pre-1.0 release whose API doesn't include `create_agent`.

Since deepagents (used later in the Quickstart) requires 3.11+, mention that version at the start of the tutorial.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: N/A
- Feature PR: N/A

## Checklist

- [x] I have read the contributing guidelines, including the language policy
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used root relative paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed — N/A, no nav change

## Additional notes

Verified against PyPI package metadata for both packages.
Silent-downgrade failure seen firsthand.
`make lint_prose` passes on the changed file.
`uv python pin 3.11` verified empirically (downloads and pins 3.11 live).
`python3.11 -m venv .venv` verified end-to-end (installed Python 3.11 via Homebrew, ran the exact doc commands, confirmed `langchain` installs cleanly).
Written with AI agent (Claude Code) assistance, at the requester's direction.

