### PR TITLE
docs(langchain): Add a tip callout to use .env as the persistent alternative to export

### DIFF
--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -65,84 +65,130 @@ Install the following packages to follow along:
 
 Get an API key from [any supported model provider](/oss/integrations/providers/overview) (for example, Google Gemini or OpenAI).
 
-Set the API keys, for example:
+Set the API keys in your shell or in a `.env` file, for example:
 
 <Tabs>
   <Tab title="OpenAI">
+    <CodeGroup>
+    ```bash Shell
+    export OPENAI_API_KEY="your-api-key"
+    ```
 
-```bash
-export OPENAI_API_KEY="your-api-key"
-```
-
+    ```bash .env
+    OPENAI_API_KEY=your-api-key
+    ```
+    </CodeGroup>
   </Tab>
   <Tab title="Google Gemini">
+    <CodeGroup>
+    ```bash Shell
+    export GOOGLE_API_KEY="your-api-key"
+    ```
 
-```bash
-export GOOGLE_API_KEY="your-api-key"
-```
-
+    ```bash .env
+    GOOGLE_API_KEY=your-api-key
+    ```
+    </CodeGroup>
   </Tab>
   <Tab title="Claude (Anthropic)">
+    <CodeGroup>
+    ```bash Shell
+    export ANTHROPIC_API_KEY="your-api-key"
+    ```
 
-```bash
-export ANTHROPIC_API_KEY="your-api-key"
-```
-
+    ```bash .env
+    ANTHROPIC_API_KEY=your-api-key
+    ```
+    </CodeGroup>
   </Tab>
   <Tab title="OpenRouter">
+    <CodeGroup>
+    ```bash Shell
+    export OPENROUTER_API_KEY="your-api-key"
+    ```
 
-```bash
-export OPENROUTER_API_KEY="your-api-key"
-```
-
+    ```bash .env
+    OPENROUTER_API_KEY=your-api-key
+    ```
+    </CodeGroup>
   </Tab>
   <Tab title="Fireworks">
+    <CodeGroup>
+    ```bash Shell
+    export FIREWORKS_API_KEY="your-api-key"
+    ```
 
-```bash
-export FIREWORKS_API_KEY="your-api-key"
-```
-
+    ```bash .env
+    FIREWORKS_API_KEY=your-api-key
+    ```
+    </CodeGroup>
   </Tab>
   <Tab title="Baseten">
+    <CodeGroup>
+    ```bash Shell
+    export BASETEN_API_KEY="your-api-key"
+    ```
 
-```bash
-export BASETEN_API_KEY="your-api-key"
-```
-
+    ```bash .env
+    BASETEN_API_KEY=your-api-key
+    ```
+    </CodeGroup>
   </Tab>
   <Tab title="Ollama">
+    <CodeGroup>
+    ```bash Shell
+    # Local: Ollama must be running (https://ollama.com)
+    # Cloud: Set your Ollama API key for hosted inference
+    export OLLAMA_API_KEY="your-api-key"
+    ```
 
-```bash
-# Local: Ollama must be running (https://ollama.com)
-# Cloud: Set your Ollama API key for hosted inference
-export OLLAMA_API_KEY="your-api-key"
-```
-
+    ```bash .env
+    # Local: Ollama must be running (https://ollama.com)
+    # Cloud: Set your Ollama API key for hosted inference
+    OLLAMA_API_KEY=your-api-key
+    ```
+    </CodeGroup>
   </Tab>
   <Tab title="Azure">
+    <CodeGroup>
+    ```bash Shell
+    export AZURE_OPENAI_API_KEY="your-api-key"
+    export AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com"
+    export AZURE_OPENAI_DEPLOYMENT_NAME="your-deployment"
+    ```
 
-```bash
-export AZURE_OPENAI_API_KEY="your-api-key"
-export AZURE_OPENAI_ENDPOINT="https://your-resource.openai.azure.com"
-export AZURE_OPENAI_DEPLOYMENT_NAME="your-deployment"
-```
-
+    ```bash .env
+    AZURE_OPENAI_API_KEY=your-api-key
+    AZURE_OPENAI_ENDPOINT=https://your-resource.openai.azure.com
+    AZURE_OPENAI_DEPLOYMENT_NAME=your-deployment
+    ```
+    </CodeGroup>
   </Tab>
   <Tab title="AWS Bedrock">
+    <CodeGroup>
+    ```bash Shell
+    export AWS_ACCESS_KEY_ID="your-access-key"
+    export AWS_SECRET_ACCESS_KEY="your-secret-key"
+    export AWS_REGION="us-east-1"
+    ```
 
-```bash
-export AWS_ACCESS_KEY_ID="your-access-key"
-export AWS_SECRET_ACCESS_KEY="your-secret-key"
-export AWS_REGION="us-east-1"
-```
-
+    ```bash .env
+    AWS_ACCESS_KEY_ID=your-access-key
+    AWS_SECRET_ACCESS_KEY=your-secret-key
+    AWS_REGION=us-east-1
+    ```
+    </CodeGroup>
   </Tab>
   <Tab title="HuggingFace">
+    <CodeGroup>
+    ```bash Shell
+    export HUGGINGFACEHUB_API_TOKEN="hf_..."
+    ```
 
-```bash
-export HUGGINGFACEHUB_API_TOKEN="hf_..."
-```
-
+    ```bash .env
+    HUGGINGFACEHUB_API_TOKEN=hf_...
+    ```
+    </CodeGroup>
   </Tab>
   <Tab title="Other">
     See the full list of supported [chat model integrations](/oss/integrations/chat).
@@ -150,13 +196,11 @@ export HUGGINGFACEHUB_API_TOKEN="hf_..."
 </Tabs>
 
 :::python
-<Tip>
-    **Persisting keys across sessions**
+To load a `.env` file, use [`python-dotenv`](https://pypi.org/project/python-dotenv/) (`load_dotenv()`).
+:::
 
-    To persist the above key across terminal sessions, use a `.env` file.
-
-    For more detail, see: [Manage API keys](/oss/langchain/test/integration-testing#manage-api-keys)
-</Tip>
+:::js
+To load a `.env` file, use [`dotenv`](https://www.npmjs.com/package/dotenv) (`import "dotenv/config"`).
 :::
 
 <Tip>

--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -149,6 +149,16 @@ export HUGGINGFACEHUB_API_TOKEN="hf_..."
   </Tab>
 </Tabs>
 
+:::python
+<Tip>
+    **Persisting keys across sessions**
+
+    To persist the above key across terminal sessions, use a `.env` file.
+
+    For more detail, see: [Manage API keys](/oss/langchain/test/integration-testing#manage-api-keys)
+</Tip>
+:::
+
 <Tip>
     **Using LangSmith Gateway**
 


### PR DESCRIPTION
## Overview

Add a short tip about using .env, and link to the existing "Manage API keys" section for more detail. (Using .env enables the API key to persist across future terminal sessions.)

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: N/A
- Feature PR: N/A

## Checklist

- [x] I have read the contributing guidelines, including the language policy
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used root relative paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed — N/A, no nav change

## Additional notes

`make lint_prose` passes on the changed file.
Written with AI agent (Claude Code) assistance, at the requester's direction.

