### PR TITLE
docs(langchain): add lead-in sentence before full-example accordion

### DIFF
--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -1147,6 +1147,8 @@ Along the way you will explore the following concepts:
         ```
         :::
 
+        Here's everything together in a runnable script:
+
         <Expandable title="Full example code">
 
         :::python

--- a/src/oss/langchain/quickstart.mdx
+++ b/src/oss/langchain/quickstart.mdx
@@ -1147,7 +1147,7 @@ Along the way you will explore the following concepts:
         ```
         :::
 
-        Here's everything together in a runnable script:
+        The following expander has everything together in a runnable script:
 
         <Expandable title="Full example code">
 


### PR DESCRIPTION
## Overview

Add lead-in text above the 'Full example' accordion: "Here's everything together in a runnable script." Without this, the full example is easy to miss.

Note that 3 other pages already use this convention:

`multi-agent/handoffs-customer-support.mdx`
`multi-agent/router-knowledge-base.mdx`
`multi-agent/subagents-personal-assistant.mdx`

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: N/A
- Feature PR: N/A

## Checklist

- [x] I have read the contributing guidelines, including the language policy
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used root relative paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed — N/A, no nav change

## Additional notes

`make lint_prose` passes on the changed file.
Written with AI agent (Claude Code) assistance, at the requester's direction.

