### PR TITLE
docs(deepagents): skills paths are source dirs, not skill dirs

### DIFF
--- a/src/code-samples/deepagents/skills-dynamic-lists.ts
+++ b/src/code-samples/deepagents/skills-dynamic-lists.ts
@@ -2,17 +2,9 @@
 import { createDeepAgent } from "deepagents";
 
 const SKILLS_BY_ROLE: Record<string, string[]> = {
-  engineering: [
-    "/skills/code-review/",
-    "/skills/testing/",
-    "/skills/deployment/",
-  ],
-  data: [
-    "/skills/sql-analysis/",
-    "/skills/visualization/",
-    "/skills/data-pipeline/",
-  ],
-  support: ["/skills/ticket-triage/", "/skills/runbook/"],
+  engineering: ["/skills/shared/", "/skills/engineering/"],
+  data: ["/skills/shared/", "/skills/data/"],
+  support: ["/skills/shared/", "/skills/support/"],
 };
 
 function createAgentForUser(userRole: string) {

--- a/src/code-samples/deepagents/skills.py
+++ b/src/code-samples/deepagents/skills.py
@@ -30,9 +30,9 @@ agent = create_deep_agent(
 from deepagents import create_deep_agent
 
 SKILLS_BY_ROLE = {
-    "engineering": ["/skills/code-review/", "/skills/testing/", "/skills/deployment/"],
-    "data": ["/skills/sql-analysis/", "/skills/visualization/", "/skills/data-pipeline/"],
-    "support": ["/skills/ticket-triage/", "/skills/runbook/"],
+    "engineering": ["/skills/shared/", "/skills/engineering/"],
+    "data": ["/skills/shared/", "/skills/data/"],
+    "support": ["/skills/shared/", "/skills/support/"],
 }
 
 

--- a/src/oss/deepagents/skills.mdx
+++ b/src/oss/deepagents/skills.mdx
@@ -133,6 +133,8 @@ This example uses `FilesystemBackend` to load skills from disk. For other storag
 <ParamField body="skills" type="list[str]" optional>
     List of skill source paths.
 
+    Each path is a directory that *contains* skill directories, not a skill directory itself. Discovery lists the source path, keeps its subdirectories, and looks for `SKILL.md` in each one. Pointing a source directly at a skill directory loads nothing and reports no error, because the `SKILL.md` sits at the source path rather than one level below it.
+
     Paths must be specified using forward slashes and are relative to the backend's root.
 
     - If omitted, no skills are loaded.
@@ -615,11 +617,13 @@ Use [LangSmith](https://smith.langchain.com) traces to debug skill discovery, `r
 
 1. **Check the skill path.** Paths must use forward slashes and be relative to the backend root. With `FilesystemBackend`, the path is relative to `root_dir`. With `StateBackend`, pass skill files in `invoke(files={...})` using `create_file_data()`.
 
-2. **Validate `SKILL.md` [frontmatter](#frontmatter-fields).** The [`name`](#frontmatter-fields) must match the parent directory name and follow the [Agent Skills specification](https://agentskills.io/specification). Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check formatting.
+2. **Check the path level.** Each entry in `skills` is a source directory that contains skill directories. Passing the skill directories themselves (`["/skills/code-review/", "/skills/testing/"]` instead of `["/skills/"]`) discovers nothing and raises no error, because the source directory exists and only its subdirectories are searched for `SKILL.md`. The system prompt shows `No skills available yet.` in that case.
 
-3. **Check file size.** Deep Agents skips `SKILL.md` files over 10 MB during discovery.
+3. **Validate `SKILL.md` [frontmatter](#frontmatter-fields).** The [`name`](#frontmatter-fields) must match the parent directory name and follow the [Agent Skills specification](https://agentskills.io/specification). Use the [`skills-ref` validation tool](https://github.com/agentskills/agentskills/tree/main/skills-ref) to check formatting.
 
-4. **Check layered sources.** When the same skill name appears in multiple sources, the [last source wins](#usage). An older or empty skill from a later path can override the one you expect.
+4. **Check file size.** Deep Agents skips `SKILL.md` files over 10 MB during discovery.
+
+5. **Check layered sources.** When the same skill name appears in multiple sources, the [last source wins](#usage). An older or empty skill from a later path can override the one you expect.
 
 ### Supporting files not found
 

--- a/src/snippets/code-samples/skills-dynamic-lists-js.mdx
+++ b/src/snippets/code-samples/skills-dynamic-lists-js.mdx
@@ -2,17 +2,9 @@
 import { createDeepAgent } from "deepagents";
 
 const SKILLS_BY_ROLE: Record<string, string[]> = {
-  engineering: [
-    "/skills/code-review/",
-    "/skills/testing/",
-    "/skills/deployment/",
-  ],
-  data: [
-    "/skills/sql-analysis/",
-    "/skills/visualization/",
-    "/skills/data-pipeline/",
-  ],
-  support: ["/skills/ticket-triage/", "/skills/runbook/"],
+  engineering: ["/skills/shared/", "/skills/engineering/"],
+  data: ["/skills/shared/", "/skills/data/"],
+  support: ["/skills/shared/", "/skills/support/"],
 };
 
 function createAgentForUser(userRole: string) {

--- a/src/snippets/code-samples/skills-dynamic-lists-py.mdx
+++ b/src/snippets/code-samples/skills-dynamic-lists-py.mdx
@@ -2,9 +2,9 @@
 from deepagents import create_deep_agent
 
 SKILLS_BY_ROLE = {
-    "engineering": ["/skills/code-review/", "/skills/testing/", "/skills/deployment/"],
-    "data": ["/skills/sql-analysis/", "/skills/visualization/", "/skills/data-pipeline/"],
-    "support": ["/skills/ticket-triage/", "/skills/runbook/"],
+    "engineering": ["/skills/shared/", "/skills/engineering/"],
+    "data": ["/skills/shared/", "/skills/data/"],
+    "support": ["/skills/shared/", "/skills/support/"],
 }
 
 


### PR DESCRIPTION
## Overview

The "Load skills at runtime" sample on `/oss/deepagents/skills` passes individual skill directories in `skills`, which discovers no skills at all.

`SkillsMiddleware` treats every entry in `skills` as a *source* directory: it lists the path, keeps only the subdirectories, and looks for `SKILL.md` one level down (`_discover_skills_from_source` in `deepagents/middleware/skills.py`). A source pointing at `/skills/code-review/` therefore finds that skill's `references/`, `scripts/`, and `assets/` as candidate skills, none of which contain a `SKILL.md`, and loads nothing.

It fails silently. The source directory exists, `ls` succeeds, `source_error` stays `None`, and nothing is logged. The only symptom is `(No skills available yet. You can create skills in ...)` in the system prompt.

The rest of the page is already correct — "Pass the path to your top-level skills directory in the `skills` argument", and every other sample uses `/skills/`. The runtime-loading sample is the odd one out, and it's the one people copy when building per-user skill sets, which is exactly when a skills tree is laid out one-directory-per-skill and the mistake looks right.

Changes:

- `skills-dynamic-lists` (Python + TS) passes source directories (`/skills/shared/`, `/skills/engineering/`) instead of skill directories. Role names kept so the per-role layering still reads as the point of the sample.
- The `skills` `ParamField` states that each entry is a directory that *contains* skill directories.
- New bullet under "Skills missing at startup" for the wrong-path-level case, since none of the existing four bullets covers a failure that produces no error.
- `src/snippets/code-samples/skills-dynamic-lists-{py,js}.mdx` regenerated with `make code-snippets`, not hand-edited.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs

- GitHub issue: none — happy to open one and wait for approval if you'd rather have the discussion there first.
- Feature PR: n/a

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes

Validation, honestly:

- Reproduced the bug against `deepagents` 0.2.x with a real `FilesystemBackend` behind a `CompositeBackend`: per-skill source paths give `No skills available yet.`; the parent directory lists every skill with its description.
- `make code-snippets` is clean — the two generated mirrors in this PR are the only diff, so samples and snippets are in sync.
- Ran the changed Python snippet from `src/code-samples-generated/` and confirmed both branches construct (`create_agent_for_user("engineering")` and the unknown-role fallback).
- `make test-code-samples FILES="src/code-samples/deepagents/skills.py"` fails before reaching the assertions, on the unrelated `skills-subagents-py` block which needs `GOOGLE_API_KEY`. Same failure on `main`, so it isn't from this change, but I couldn't get a green full-file run.
- I did not run `docs dev` — no Mintlify setup locally. The prose edits are plain text plus one existing-anchor link, so rendering risk is low, but I haven't looked at the built page.
- No navigation change needed; no new pages or anchors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
