### PR TITLE
docs: clarify Enterprise deployment callouts [closes DOC-1562]

### DIFF
--- a/src/langsmith/byoc.mdx
+++ b/src/langsmith/byoc.mdx
@@ -5,9 +5,9 @@ description: Deploy LangSmith services and store data in your own cloud environm
 icon: "cloud-cog"
 ---
 
-<Warning>
+<Note>
 BYOC is only available for customers on the [Enterprise plan](https://www.langchain.com/pricing).
-</Warning>
+</Note>
 
 Bring Your Own Cloud (BYOC) lets you deploy LangSmith services and store data in your own cloud environment, while LangChain operates, scales, and upgrades the infrastructure. BYOC suits organizations that require complete sovereignty over their data, but do not want the overhead of provisioning and managing infrastructure.
 

--- a/src/langsmith/platform-setup.mdx
+++ b/src/langsmith/platform-setup.mdx
@@ -31,7 +31,7 @@ icon: "server"
           href="/langsmith/byoc"
           icon="cloud-cog"
         >
-        **(Enterprise)** Full control over your data, while LangChain manages the infrastructure.
+        Full control over your data, while LangChain manages the infrastructure.
         </Card>
 
         <Card
@@ -40,7 +40,7 @@ icon: "server"
           href="/langsmith/self-hosted"
           icon="server"
         >
-        **(Enterprise)** Full control with observability, evaluation, and prompt engineering in your infrastructure.
+        Full control with observability, evaluation, and prompt engineering in your infrastructure.
         </Card>
 
         </CardGroup>

--- a/src/langsmith/self-hosted.mdx
+++ b/src/langsmith/self-hosted.mdx
@@ -4,7 +4,6 @@ sidebarTitle: Overview
 ---
 
 <Note>
-**Important**<br></br>
 Self-hosted LangSmith is an add-on to the Enterprise plan designed for our largest, most security-conscious customers. For more details, refer to [Pricing](https://www.langchain.com/pricing). [Contact our sales team](https://www.langchain.com/contact-sales) if you want to get a license key to trial LangSmith in your environment.
 </Note>
 


### PR DESCRIPTION
## Description
Remove redundant Enterprise labels from the deployment cards and align the BYOC and self-hosted plan notices with the same callout style.

## Test Plan
- [x] Verify Vale reports no prose issues in the three updated pages.

Made by [Open SWE](https://openswe.vercel.app/agents/b59647f6-a903-583b-b6ad-6aff339b9203)