### PR TITLE
docs(engine): document Linear integration

### DIFF
--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -218,40 +218,54 @@ For either outcome, you can optionally provide a reason, which feeds back into E
 
 You can reopen a closed issue at any time. Click **Reopen** to clear any fix in progress and stop watching the issue if it was being watched. Engine also reopens an issue automatically when it detects the same problem recurring in a later trace.
 
-## Create issues in Linear
+## Track Engine issues in Linear
 
-Connect Engine to Linear to create a Linear ticket for each Engine issue and keep the two issues linked. The integration is available in LangSmith Cloud. It is not available in self-hosted deployments.
+Connect Engine to Linear to bring issues detected from your production traces into your team's existing planning and triage workflow. Teammates can manage the work in Linear and follow the link back to LangSmith to review the diagnosis and supporting traces.
 
-### Connect Engine to Linear
+<Note>The Linear integration is available in LangSmith Cloud.</Note>
+
+### Set up the Linear integration
 
 <Steps>
   <Step title="Open Linear settings">
     Open the **Engine** tab for a tracing project, click the **Engine Settings** <Icon icon="settings"/> icon, and scroll to **Linear**.
   </Step>
-  <Step title="Connect your Linear account">
-    Click **Connect** and authorize LangSmith in Linear. Engine requests read and write access so it can create tickets and read their current workflow state. If the account is already connected but its authorization has expired, click **Reconnect**.
+  <Step title="Connect Linear">
+    Click **Connect**, sign in to Linear, and authorize LangSmith.
   </Step>
-  <Step title="Choose a destination">
-    Select a **Linear team**. This field is required. You can also select an optional **Linear project**; only projects accessible to the selected team are shown.
+  <Step title="Choose where to create issues">
+    Select the **Linear team** that should receive Engine issues, then optionally choose a **Linear project**.
   </Step>
-  <Step title="Enable Linear">
-    Click **Enable Linear**. New Engine issues are queued for creation in the selected team and project.
+  <Step title="Turn on the integration">
+    Click **Enable Linear**.
   </Step>
 </Steps>
 
-Changing the team or project affects new Linear tickets. Engine does not move or update tickets that it has already created. Disabling the integration also leaves existing Linear tickets untouched.
+New Engine issues are now created in the selected Linear team and, if chosen, project. Each Linear issue includes the Engine issue's title, description, priority, category, tags, and a link back to LangSmith.
 
-### Create a Linear ticket
+### Send an existing issue to Linear
 
-When Linear is enabled, Engine creates a ticket asynchronously for each new issue. To create a ticket for an issue that already exists, open the issue and click **Create in Linear**. The issue shows **Linear creation pending** while the background request is in progress. After creation, the Engine issue displays the Linear identifier and links to the ticket.
+To create a Linear issue for an Engine issue that was detected before you enabled the integration:
 
-The ticket includes the Engine issue's title and description, followed by its severity, category, tags, and a link back to the issue in LangSmith. Engine converts the issue severity to Linear's priority when it creates the ticket.
+1. Open the issue in Engine.
+2. Click **Create in Linear** next to the issue title.
+3. After the Linear issue is created, click its identifier in Engine to open it in Linear.
 
-### Keep Engine context current
+### Work with linked issues
 
-After a ticket is linked, Engine reads its current Linear workflow state and displays it with the Linear identifier in the issue detail view. Engine also recognizes GitHub pull request URLs attached to the Linear ticket and can use matching pull requests to update the Engine issue.
+Engine displays the Linear issue's current workflow status next to its identifier. Changes in Linear affect the Engine issue as follows:
 
-When you complete the Linear ticket, Engine marks the linked issue as resolved. When you cancel the Linear ticket, Engine marks the linked issue as incorrectly flagged. These updates are applied when Engine refreshes the Linear context; edits made in Linear are not overwritten by Engine.
+- Completing the Linear issue marks the Engine issue as resolved.
+- Canceling the Linear issue marks the Engine issue as incorrectly flagged.
+- Attaching a GitHub pull request from Engine's connected code repository links that pull request to the Engine issue.
+
+Engine does not overwrite changes you make to the Linear issue after it is created.
+
+### Change or turn off the integration
+
+Return to **Engine Settings > Linear** to choose a different team or project. The new destination applies to issues created after you save the change; existing Linear issues stay in their original location.
+
+Click **Disable** to stop creating Linear issues. Issues already created in Linear remain available there.
 
 ## List issues via the CLI
 
@@ -303,7 +317,7 @@ Within a tracing project, click the **Engine Settings** <Icon icon="settings"/> 
 - **Engine spend**: View the month-to-date Engine LCU spend for this project. Click **Set limit** to cap monthly spend. New runs pause when the monthly limit is reached.
 - **Focus on specific traces**: Narrow Engine's attention to a subset of runs by run name or metadata. Edits save automatically and take effect on the next scan. See [Focus on specific traces](#focus-on-specific-traces).
 - **Notifications**: Click **Add destination** to add a Slack channel or webhook destination that receives a notification when Engine detects a new issue. Set a minimum priority level per destination to control which issues trigger a notification. See [Get notified about new issues](#get-notified-about-new-issues).
-- **Linear**: Connect a Linear account, choose a team and optional project, and enable ticket creation. See [Create issues in Linear](#create-issues-in-linear).
+- **Linear**: Connect Linear and choose where to create issues. See [Track Engine issues in Linear](#track-engine-issues-in-linear).
 - **Code repository**: Connect or update a GitHub repository so the agent can reference source code when diagnosing issues. Optionally set a **Subfolder** and a **Branch** (defaults to the repository default).
 - **Context repository**: Connect a Context Hub repository so Engine can propose fixes to instructions, docs, and linked skills.
 - **Pause**: Engine scans your traces every 6 hours by default. Click **Pause** to stop scanning without deleting the existing issues, or **Resume** to resume scanning.

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -218,6 +218,41 @@ For either outcome, you can optionally provide a reason, which feeds back into E
 
 You can reopen a closed issue at any time. Click **Reopen** to clear any fix in progress and stop watching the issue if it was being watched. Engine also reopens an issue automatically when it detects the same problem recurring in a later trace.
 
+## Create issues in Linear
+
+Connect Engine to Linear to create a Linear ticket for each Engine issue and keep the two issues linked. The integration is available in LangSmith Cloud. It is not available in self-hosted deployments.
+
+### Connect Engine to Linear
+
+<Steps>
+  <Step title="Open Linear settings">
+    Open the **Engine** tab for a tracing project, click the **Engine Settings** <Icon icon="settings"/> icon, and scroll to **Linear**.
+  </Step>
+  <Step title="Connect your Linear account">
+    Click **Connect** and authorize LangSmith in Linear. Engine requests read and write access so it can create tickets and read their current workflow state. If the account is already connected but its authorization has expired, click **Reconnect**.
+  </Step>
+  <Step title="Choose a destination">
+    Select a **Linear team**. This field is required. You can also select an optional **Linear project**; only projects accessible to the selected team are shown.
+  </Step>
+  <Step title="Enable Linear">
+    Click **Enable Linear**. New Engine issues are queued for creation in the selected team and project.
+  </Step>
+</Steps>
+
+Changing the team or project affects new Linear tickets. Engine does not move or update tickets that it has already created. Disabling the integration also leaves existing Linear tickets untouched.
+
+### Create a Linear ticket
+
+When Linear is enabled, Engine creates a ticket asynchronously for each new issue. To create a ticket for an issue that already exists, open the issue and click **Create in Linear**. The issue shows **Linear creation pending** while the background request is in progress. After creation, the Engine issue displays the Linear identifier and links to the ticket.
+
+The ticket includes the Engine issue's title and description, followed by its severity, category, tags, and a link back to the issue in LangSmith. Engine converts the issue severity to Linear's priority when it creates the ticket.
+
+### Keep Engine context current
+
+After a ticket is linked, Engine reads its current Linear workflow state and displays it with the Linear identifier in the issue detail view. Engine also recognizes GitHub pull request URLs attached to the Linear ticket and can use matching pull requests to update the Engine issue.
+
+When you complete the Linear ticket, Engine marks the linked issue as resolved. When you cancel the Linear ticket, Engine marks the linked issue as incorrectly flagged. These updates are applied when Engine refreshes the Linear context; edits made in Linear are not overwritten by Engine.
+
 ## List issues via the CLI
 
 You can list issues programmatically using the [LangSmith CLI](/langsmith/cli).
@@ -268,6 +303,7 @@ Within a tracing project, click the **Engine Settings** <Icon icon="settings"/> 
 - **Engine spend**: View the month-to-date Engine LCU spend for this project. Click **Set limit** to cap monthly spend. New runs pause when the monthly limit is reached.
 - **Focus on specific traces**: Narrow Engine's attention to a subset of runs by run name or metadata. Edits save automatically and take effect on the next scan. See [Focus on specific traces](#focus-on-specific-traces).
 - **Notifications**: Click **Add destination** to add a Slack channel or webhook destination that receives a notification when Engine detects a new issue. Set a minimum priority level per destination to control which issues trigger a notification. See [Get notified about new issues](#get-notified-about-new-issues).
+- **Linear**: Connect a Linear account, choose a team and optional project, and enable ticket creation. See [Create issues in Linear](#create-issues-in-linear).
 - **Code repository**: Connect or update a GitHub repository so the agent can reference source code when diagnosing issues. Optionally set a **Subfolder** and a **Branch** (defaults to the repository default).
 - **Context repository**: Connect a Context Hub repository so Engine can propose fixes to instructions, docs, and linked skills.
 - **Pause**: Engine scans your traces every 6 hours by default. Click **Pause** to stop scanning without deleting the existing issues, or **Resume** to resume scanning.


### PR DESCRIPTION
## Summary

- Explain how to connect Engine to Linear and choose a team and optional project.
- Show how to send new and existing Engine issues into a team's Linear workflow.
- Explain linked status and pull request behavior, plus how to change or disable the integration.

## Test plan

- [x] `make lint_prose FILES=src/langsmith/engine.mdx`
- [x] `git diff origin/main...HEAD --check`