### PR TITLE
fix: add programmatic docs page to navigation

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -652,6 +652,7 @@
                         "group": "Additional resources",
                         "icon": "list",
                         "pages": [
+                          "use-these-docs",
                           "oss/python/langchain/academy",
                           "oss/python/langgraph/case-studies",
                           "oss/python/langchain/get-help"
@@ -1252,6 +1253,7 @@
                         "group": "Additional resources",
                         "icon": "list",
                         "pages": [
+                          "use-these-docs",
                           "oss/javascript/langgraph/case-studies",
                           "oss/javascript/langchain/get-help"
                         ]


### PR DESCRIPTION
## Description
Adds the programmatic docs page to Learn → Additional resources for both Python and TypeScript, giving the shared page valid navigation context and preserving discoverability of MCP setup instructions.

## Test Plan
- [x] Validate `src/docs.json` as JSON
- [x] Run broken-link validation

Made by [Open SWE](https://openswe.vercel.app/agents/0b6107f6-7866-5e45-ab82-53d5ebaf0979)