### PR TITLE
Updated 'Customisation' to 'Custimization' in overview.mdx

### DIFF
--- a/src/oss/langchain/frontend/integrations/overview.mdx
+++ b/src/oss/langchain/frontend/integrations/overview.mdx
@@ -30,7 +30,7 @@ Each library fits a slightly different integration model. The choice depends on 
 | --- | --- | --- | --- | --- |
 | **Best for** | Full chat runtime plus structured generative UI | Chat with rich message types | Full-featured chat with minimal setup | Generated dashboards and reports |
 | **UI style** | CopilotKit chat shell + custom message renderers | Composable shadcn/ui components | Headless slots + default theme | Prebuilt component library with declarative DSL |
-| **Customisation** | Custom backend endpoint, agent context, and renderers | Edit source files directly | Override component slots | Theme via CSS custom properties |
+| **Customization** | Custom backend endpoint, agent context, and renderers | Edit source files directly | Override component slots | Theme via CSS custom properties |
 | **Streaming UX** | Runtime-managed chat stream with structured assistant payloads | Component-level progressive render | Built-in thread management | Hoisting — shell appears immediately, data fills in |
 | **Tool calls** | Via CopilotKit runtime and custom renderers | `Tool` / `ToolHeader` / `ToolOutput` | Custom via message slots | Inline in the generated UI |
 | **Agent format** | Structured assistant responses plus optional Markdown | Any `stream.messages` | Any `stream.messages` | Agent outputs openui-lang text |


### PR DESCRIPTION
Changed “Customisation” to “Customization” to align with American English standards and maintain consistency with terminology used throughout the LangChain documentation.

## Overview
Updated the spelling of “Customisation” to “Customization” to follow American English conventions and maintain consistent terminology across the LangChain documentation.

## Type of change

**Type:** Fix typo

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes
This is a documentation-only terminology change. No code examples, internal links, or navigation were modified.
