### PR TITLE
docs(backends): update repo link to MongoDB VFS

### DIFF
--- a/src/oss/integrations/backends/index.mdx
+++ b/src/oss/integrations/backends/index.mdx
@@ -27,6 +27,6 @@ The community maintains these backend integrations. They are contributed on an o
 
 | Backend | Description | Source |
 |---------|-------------|--------|
-| [MongoDB VFS Adapter](https://github.com/mongodb-developer/MongoDB-LangChain-DeepAgents-VFS-Adapter) | Virtual filesystem backend backed by MongoDB Atlas. Persist agent files, including memories, artifacts, and conversation history, in a MongoDB collection. | [`mongodb-developer/MongoDB-LangChain-DeepAgents-VFS-Adapter`](https://github.com/mongodb-developer/MongoDB-LangChain-DeepAgents-VFS-Adapter) |
+| [MongoDB VFS Adapter](https://github.com/langchain-ai/langchain-mongodb/tree/main/libs/langchain-mongodb-deepagents-vfs) | Virtual filesystem backend backed by MongoDB Atlas. Persist agent files, including memories, artifacts, and conversation history, in a MongoDB collection. | [`langchain-mongodb/langchain-mongodb-deepagents-vfs`](https://github.com/langchain-ai/langchain-mongodb/tree/main/libs/langchain-mongodb-deepagents-vfs) |
 
 Have a backend to share? [Open a PR](https://github.com/langchain-ai/docs) to add it here.


### PR DESCRIPTION
## Overview

The codebase for the [MongoDB VFS Adapter](https://github.com/mongodb-developer/MongoDB-LangChain-DeepAgents-VFS-Adapter) has been ported to a different repository. This PR updates the the [Backend Integrations](https://docs.langchain.com/oss/python/integrations/backends/index#community-integrations) section with the correct link.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: n/a
- Feature PR: n/a

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

