### PR TITLE
fix: redirect un-prefixed Managed Deep Agents URLs [closes DOC-1563]

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -2668,8 +2668,80 @@
       "destination": "/langsmith/python/managed-deep-agents-channels"
     },
     {
-      "source": "/langsmith/managed-deep-agents-:path*",
-      "destination": "/langsmith/python/managed-deep-agents-:path*"
+      "source": "/langsmith/managed-deep-agents-agent-definition",
+      "destination": "/langsmith/python/managed-deep-agents-agent-definition"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-channels",
+      "destination": "/langsmith/python/managed-deep-agents-channels"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-channels-slack",
+      "destination": "/langsmith/python/managed-deep-agents-channels-slack"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-cli",
+      "destination": "/langsmith/python/managed-deep-agents-cli"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-deploy",
+      "destination": "/langsmith/python/managed-deep-agents-deploy"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-evals",
+      "destination": "/langsmith/python/managed-deep-agents-evals"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-identity",
+      "destination": "/langsmith/python/managed-deep-agents-identity"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-instructions",
+      "destination": "/langsmith/python/managed-deep-agents-instructions"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-local-development",
+      "destination": "/langsmith/python/managed-deep-agents-local-development"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-mcp-connectors",
+      "destination": "/langsmith/python/managed-deep-agents-mcp-connectors"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-memory",
+      "destination": "/langsmith/python/managed-deep-agents-memory"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-middleware",
+      "destination": "/langsmith/python/managed-deep-agents-middleware"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-project-structure",
+      "destination": "/langsmith/python/managed-deep-agents-project-structure"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-quickstart",
+      "destination": "/langsmith/python/managed-deep-agents-quickstart"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-sandboxes",
+      "destination": "/langsmith/python/managed-deep-agents-sandboxes"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-schedules",
+      "destination": "/langsmith/python/managed-deep-agents-schedules"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-skills",
+      "destination": "/langsmith/python/managed-deep-agents-skills"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-tools",
+      "destination": "/langsmith/python/managed-deep-agents-tools"
+    },
+    {
+      "source": "/langsmith/managed-deep-agents-tutorial",
+      "destination": "/langsmith/python/managed-deep-agents-tutorial"
     },
     {
       "source": "/langsmith/polly",


### PR DESCRIPTION
## Description

Every Managed Deep Agents page is language-split, so it publishes only at `/langsmith/python/...` and `/langsmith/javascript/...`. The un-prefixed URLs (still indexed by Google) were meant to be covered by the `"/langsmith/managed-deep-agents-:path*"` catch-all, but that mid-segment wildcard never matches in Mintlify, so `/langsmith/managed-deep-agents-identity`, `-tools`, `-cli`, and 16 others returned 404 while explicitly-listed sources like `-overview` correctly 308'd. This replaces the dead wildcard with explicit redirects for all 19 remaining pages.

## Test Plan

- [ ] After deploy, confirm `/langsmith/managed-deep-agents-identity` and `/langsmith/managed-deep-agents-tools` 308 to their `/langsmith/python/...` equivalents.

Made by [Open SWE](https://openswe.vercel.app/agents/d650b23a-442d-5027-b93c-9c8d89a0dad8)
