### PR TITLE
chore: Update constraints for API version 0.15.0

### DIFF
--- a/src/langsmith/setup-app-requirements-txt.mdx
+++ b/src/langsmith/setup-app-requirements-txt.mdx
@@ -46,7 +46,7 @@ The dependencies below will be included in the image, you can also use them in y
 
 ```
 langgraph>=0.4.10,<2
-langgraph-sdk>=0.3.5
+langgraph-sdk>=0.4.4
 langgraph-checkpoint>=3.0.1,<5
 langchain-core>=0.3.66
 langsmith>=0.7.31
@@ -54,7 +54,7 @@ orjson>=3.9.7
 httpx>=0.25.0
 tenacity>=8.0.0
 uvicorn>=0.26.0
-sse-starlette>=2.1.3,<3.4.0
+sse-starlette>=2.1.3,<4.0.0
 uvloop>=0.18.0
 httptools>=0.5.0
 jsonschema-rs>=0.20.0

--- a/src/langsmith/setup-pyproject.mdx
+++ b/src/langsmith/setup-pyproject.mdx
@@ -45,7 +45,7 @@ The dependencies below will be included in the image, you can also use them in y
 
 ```
 langgraph>=0.4.10,<2
-langgraph-sdk>=0.3.5
+langgraph-sdk>=0.4.4
 langgraph-checkpoint>=3.0.1,<5
 langchain-core>=0.3.66
 langsmith>=0.7.31
@@ -53,7 +53,7 @@ orjson>=3.9.7
 httpx>=0.25.0
 tenacity>=8.0.0
 uvicorn>=0.26.0
-sse-starlette>=2.1.3,<3.4.0
+sse-starlette>=2.1.3,<4.0.0
 uvloop>=0.18.0
 httptools>=0.5.0
 jsonschema-rs>=0.20.0


### PR DESCRIPTION
This PR updates the dependency constraints in the setup docs to match `api/constraints.txt`. Merge when convenient.

**Changes detected as of API version 0.15.0**

This update was automatically generated by the sync workflow in the langgraph-api repository.