### PR TITLE
docs: backfill Deep Agents Code configuration

### DIFF
--- a/src/oss/deepagents/code/cli-reference.mdx
+++ b/src/oss/deepagents/code/cli-reference.mdx
@@ -331,7 +331,7 @@ Run OAuth login for MCP servers marked `auth: "oauth"` with `dcode mcp login <se
 | `--no-mcp`             | Disable all MCP tool loading                                |
 | `--trust-project-mcp`  | Trust project-level MCP servers without prompting for the current run. Explicit denies still apply. |
 | `--interpreter`        | Enable the JS interpreter (`js_eval`) middleware on the main agent when it has been disabled in config. `js_eval` is enabled by default. |
-| `--interpreter-tools VALUE` | PTC allowlist for `js_eval`: `safe`, `all`, or a comma-separated list of tool names. Default: no PTC (pure REPL) |
+| `--interpreter-tools VALUE` | PTC allowlist for `js_eval`: `safe`, `all`, or a comma-separated list of tool names. Default: `safe` (read-only `read_file`/`glob`/`grep` preset). See [JS interpreter](/oss/deepagents/code/config-file#js-interpreter) |
 | `--profile-override JSON` | Override model profile fields as a JSON string (e.g., `'{"max_input_tokens": 4096}'`). Merged on top of config file profile overrides |
 | `--acp`                | Run as an ACP server over stdio instead of launching the interactive UI |
 | `--update`             | Check for and install updates, then exit                    |

--- a/src/oss/deepagents/code/cli-reference.mdx
+++ b/src/oss/deepagents/code/cli-reference.mdx
@@ -300,7 +300,7 @@ Run OAuth login for MCP servers marked `auth: "oauth"` with `dcode mcp login <se
 | `-a`, `--agent NAME`   | Use named agent with separate memory. Overrides `[agents].recent` and `[agents].default` in `config.toml`. Default: `agent` (or the most recently used agent if `[agents].recent` is set) |
 | `-M`, `--model MODEL`  | Use a specific model (`provider:model`)                    |
 | `--model-params JSON`  | Extra kwargs to pass to the model as a JSON string (e.g., `'{"temperature": 0.7}'`) |
-| `--max-retries N`      | Override the max retries for transient model errors |
+| `--max-retries N`      | Override retries after a transient model error. Default: `5`; set to `0` to disable retries |
 | `--default-model [MODEL]` | Set the [default model](/oss/deepagents/code/providers#set-a-default-model) (omit `MODEL` to view the current default) |
 | `--clear-default-model` | Clear the [default model](/oss/deepagents/code/providers#set-a-default-model) |
 | `-r`, `--resume [ID]`  | Resume a session: `-r` for most recent, `-r <ID>` for a specific thread |
@@ -311,7 +311,7 @@ Run OAuth login for MCP servers marked `auth: "oauth"` with `dcode mcp login <se
 | `--rubric-model MODEL` | Model the rubric grader uses. Defaults to the main agent model. Requires `-n` or piped stdin |
 | `--rubric-max-iterations N` | Grader iterations per rubric attempt before stopping. Requires `-n` or piped stdin |
 | `-n`, `--non-interactive TEXT` | Run a single task non-interactively and exit. Shell is disabled unless `--shell-allow-list` is set |
-| `--recursion-limit N`  | LangGraph graph step budget (max node invocations per turn). Valid range: `25`–`100000`. Out-of-range or non-integer values log a warning and fall back to the default (`2000`). Overrides `DEEPAGENTS_CODE_RECURSION_LIMIT` and `[runtime].recursion_limit` in `config.toml` |
+| `--recursion-limit N`  | LangGraph graph step budget (max node invocations per turn). Accepts integers greater than or equal to `1`. Overrides the environment and user config, but administrator-owned managed configuration takes precedence. When unset, the LangGraph server default applies |
 | `--max-turns N`        | Cap agentic turns in non-interactive mode. Exits with code 124 when exceeded. Requires `-n` or piped stdin. See [Non-interactive mode and piping](#non-interactive-mode-and-piping) |
 | `--timeout SECONDS`    | Hard wall-clock timeout for non-interactive mode. Exits with code 124 when exceeded. Requires `-n` or piped stdin. See [Non-interactive mode and piping](#non-interactive-mode-and-piping) |
 | `-q`, `--quiet`        | Clean output for piping—only the agent's response goes to stdout. Requires `-n` or piped stdin |

--- a/src/oss/deepagents/code/cli-reference.mdx
+++ b/src/oss/deepagents/code/cli-reference.mdx
@@ -311,7 +311,7 @@ Run OAuth login for MCP servers marked `auth: "oauth"` with `dcode mcp login <se
 | `--rubric-model MODEL` | Model the rubric grader uses. Defaults to the main agent model. Requires `-n` or piped stdin |
 | `--rubric-max-iterations N` | Grader iterations per rubric attempt before stopping. Requires `-n` or piped stdin |
 | `-n`, `--non-interactive TEXT` | Run a single task non-interactively and exit. Shell is disabled unless `--shell-allow-list` is set |
-| `--recursion-limit N`  | LangGraph graph step budget (max node invocations per turn). Accepts integers greater than or equal to `1`. Overrides the environment and user config, but administrator-owned managed configuration takes precedence. When unset, the LangGraph server default applies |
+| `--recursion-limit N`  | Set the LangGraph graph step budget (maximum node invocations per turn). When unset, the LangGraph server default applies |
 | `--max-turns N`        | Cap agentic turns in non-interactive mode. Exits with code 124 when exceeded. Requires `-n` or piped stdin. See [Non-interactive mode and piping](#non-interactive-mode-and-piping) |
 | `--timeout SECONDS`    | Hard wall-clock timeout for non-interactive mode. Exits with code 124 when exceeded. Requires `-n` or piped stdin. See [Non-interactive mode and piping](#non-interactive-mode-and-piping) |
 | `-q`, `--quiet`        | Clean output for piping—only the agent's response goes to stdout. Requires `-n` or piped stdin |

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -89,8 +89,6 @@ Run `/line-numbers` in a session to toggle the preference and save it to `config
 
 ## Allowed models
 
-Requires `deepagents-code>=0.1.61`.
-
 Restrict `dcode` to an approved set of models with the `[models].allowed` list:
 
 ```toml title="~/.deepagents/config.toml"

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -109,7 +109,7 @@ A `provider:*` wildcard names no model itself, so default resolution expands it 
 
 ## Redact LangSmith trace secrets
 
-With LangSmith tracing enabled, Deep Agents Code redacts detected secrets from agent-trace inputs and outputs before upload. This is enabled by default (since `deepagents-code>=0.1.62`); earlier versions send traces without client-side redaction unless opted in.
+With LangSmith tracing enabled, Deep Agents Code redacts detected secrets from agent-trace inputs and outputs before upload. This is enabled by default.
 
 To disable redaction:
 

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -6,8 +6,10 @@ description: Configure model providers, defaults, retries, and gateways in confi
 
 `~/.deepagents/config.toml` lets you customize model providers, set defaults, and pass extra parameters to model constructors. For environment variables and inspection commands, see [Configuration](/oss/deepagents/code/configuration). This page covers:
 
-- **Defaults**: pin a [default model](#default-and-recent-model) or [agent](#default-and-recent-agent).
+- **Defaults**: pin a [default model](#default-and-recent-model) or [agent](#default-and-recent-agent), or [restrict usable models](#allowed-models) with an allowlist.
 - **Warnings**: [session cost](#session-cost-warning) and [cold prompt-cache](#cold-prompt-cache-warning) thresholds, and [trusted gateway endpoints](#trust-a-gateway-endpoint-for-cache-policies).
+- **Interpreter**: the [`[interpreter]` settings](#js-interpreter) for the built-in QuickJS REPL.
+- **Tracing**: [client-side secret redaction](#redact-langsmith-trace-secrets) for LangSmith traces (on by default).
 - **Provider setup**: the [`[models.providers.<name>]` table](#provider-configuration), [constructor params](#model-constructor-params), [retries](#retries), [profile overrides](#profile-overrides-advanced), and [adding models to the `/model` switcher](#adding-models-to-the-interactive-switcher).
 - **Auto mode**: the [auto classifier timeout](#auto-classifier-timeout).
 - **Custom endpoints and providers**: [custom base URLs](#custom-base-url), [OpenAI- or Anthropic-compatible APIs](#compatible-apis), and [arbitrary providers](#arbitrary-providers).
@@ -85,26 +87,44 @@ show_diff_line_numbers = false
 
 Run `/line-numbers` in a session to toggle the preference and save it to `config.toml`. The change applies to new diffs; already rendered diffs do not change.
 
+## Allowed models
+
+Requires `deepagents-code>=0.1.61`.
+
+Restrict `dcode` to an approved set of models with the `[models].allowed` list:
+
+```toml title="~/.deepagents/config.toml"
+[models]
+allowed = ["anthropic:claude-sonnet-4-5", "openai:*"]
+```
+
+Entries are exact `provider:model` specs or `provider:*` wildcards that admit a provider's whole lineup. Write bare Bedrock model IDs as `bedrock:<id>`. When the list is set, every model the app tries to use is checked against it: the launch default, `--model`, `/model` selections, saved defaults, and subagent model declarations. Blocked entries are hidden from the `/model` switcher; a blocked selection is rejected with an error that lists the allowed entries. A malformed list fails closed (denies everything) with an error naming the defect, so a typo cannot silently disable the guardrail.
+
+When the key is unset, all models are allowed. An explicit empty list allows none:
+
+```toml
+[models]
+allowed = []   # no model may be used
+```
+
+A `provider:*` wildcard names no model itself, so default resolution expands it to the provider's discovered models (the bundled profile lineup merged with any configured `models` list). A wildcard for a provider with no discovered or configured models fails closed instead of prompting for credentials.
+
 ## Redact LangSmith trace secrets
 
-With LangSmith tracing enabled, Deep Agents Code sends agent-trace inputs and outputs without client-side secret redaction by default.
+With LangSmith tracing enabled, Deep Agents Code redacts detected secrets from agent-trace inputs and outputs before upload. This is enabled by default (since `deepagents-code>=0.1.62`); earlier versions send traces without client-side redaction unless opted in.
 
-<Warning>
-    Without redaction, secrets may be uploaded to LangSmith as part of agent traces.
-</Warning>
-
-To redact detected secrets before upload:
+To disable redaction:
 
 <Tabs>
     <Tab title="Config file">
         ```toml title="~/.deepagents/config.toml"
         [tracing]
-        langsmith_redact = true
+        langsmith_redact = false
         ```
     </Tab>
     <Tab title="Environment variable">
         ```bash
-        export DEEPAGENTS_CODE_LANGSMITH_REDACT=true
+        export DEEPAGENTS_CODE_LANGSMITH_REDACT=false
         ```
     </Tab>
 </Tabs>
@@ -511,6 +531,54 @@ DEEPAGENTS_CODE_OPENAI_BASE_URL=https://api.openai.com/v1
 On a machine provisioned with a model gateway (for example, the LangSmith gateway), the gateway typically exports a gateway key and the matching endpoint variable (`OPENAI_BASE_URL`, `ANTHROPIC_BASE_URL`, or `GOOGLE_GEMINI_BASE_URL`) together. Deep Agents Code uses that pair by default, so no configuration is needed.
 
 To use your own key instead, store it with `/auth` (leave the base URL blank for the provider default, or set it explicitly), or set the `DEEPAGENTS_CODE_` prefixed key and endpoint. Both override the gateway pair without leaving a mismatched endpoint behind.
+
+## JS interpreter
+
+The `[interpreter]` section tunes the built-in JavaScript interpreter (the `js_eval` tool), which runs agent-written code in a QuickJS sandbox. These keys are `config.toml`-only; see [Command line options](/oss/deepagents/code/cli-reference#command-line-options) for the `--interpreter` and `--interpreter-tools` flag equivalents.
+
+```toml title="~/.deepagents/config.toml"
+[interpreter]
+enable_interpreter = true       # default
+timeout_seconds = 5.0           # default
+memory_limit_mb = 64            # default
+max_ptc_calls = 256             # default
+max_result_chars = 4000         # default
+ptc = "safe"                    # default: "safe"
+ptc_acknowledge_unsafe = false  # default
+```
+
+<ResponseField name="enable_interpreter" type="boolean" default="true" post={["optional"]}>
+    Wire the QuickJS REPL middleware (`js_eval`) into the main agent (local sessions only). Set to `false` to disable the interpreter entirely; re-enable for a session with `--interpreter`.
+</ResponseField>
+
+<ResponseField name="timeout_seconds" type="number" default="5.0" post={["optional"]}>
+    Per-call wall-clock timeout for the QuickJS REPL.
+</ResponseField>
+
+<ResponseField name="memory_limit_mb" type="integer" default="64" post={["optional"]}>
+    QuickJS heap memory cap in MB, shared across a session.
+</ResponseField>
+
+<ResponseField name="max_ptc_calls" type="integer" default="256" post={["optional"]}>
+    Maximum `tools.*` host-bridge invocations per `js_eval` call.
+</ResponseField>
+
+<ResponseField name="max_result_chars" type="integer" default="4000" post={["optional"]}>
+    Cap in characters on the `js_eval` result and captured stdout before truncation.
+</ResponseField>
+
+<ResponseField name="ptc" type="string | boolean | string[]" default='"safe"' post={["optional"]}>
+    [Programmatic tool calling](/oss/deepagents/interpreters#programmatic-tool-calling-ptc) allowlist for `js_eval`. Accepted values:
+
+    - `"safe"` (default): the read-only preset `read_file`, `glob`, `grep`. These tools are not approval-gated outside the REPL, so exposing them introduces no approval bypass. Network tools, subagent dispatch, shell execution, and file writes are deliberately excluded.
+    - `"all"`: every host tool. Requires `ptc_acknowledge_unsafe = true` unless approvals are globally disabled, because PTC calls bypass approval prompts.
+    - A list of tool names, e.g. `["safe", "web_search"]` — the `"safe"` entry expands to the preset. `"all"` is not allowed inside a list.
+    - `false` or `[]`: no tool access from the REPL (pure interpreter). `true` is rejected — use `"safe"`, `"all"`, or an explicit list.
+</ResponseField>
+
+<ResponseField name="ptc_acknowledge_unsafe" type="boolean" default="false" post={["optional"]}>
+    Acknowledge that `ptc = "all"` exposes every tool to PTC calls that bypass approval prompts. Required for `ptc = "all"` unless running with approvals disabled.
+</ResponseField>
 
 ## Agent runtime limits
 

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -96,7 +96,7 @@ Restrict `dcode` to an approved set of models with the `[models].allowed` list:
 allowed = ["anthropic:claude-fable-5", "openai:*"]
 ```
 
-Entries are exact `provider:model` specs or `provider:*` wildcards that admit a provider's whole lineup. When the list is set, blocked models are hidden from the `/model` switcher and rejected if selected elsewhere. Invalid entries fail closed.
+Entries are exact `provider:model` specs or `provider:*` wildcards that admit a provider's whole lineup. When the list is set, blocked models are hidden from the `/model` switcher and rejected if selected elsewhere.
 
 When the key is unset, all models are allowed. An explicit empty list allows none:
 
@@ -265,7 +265,7 @@ max_retries = 0
 
 The global `[retries].max_retries` value applies to all supported providers. A provider-specific table, such as `[retries.fireworks]`, overrides the global value for that provider. Values must be integers greater than or equal to `0`.
 
-Deep Agents Code disables the provider SDK retry loop when it knows the provider's retry-count constructor argument. This prevents provider retries from multiplying model-node attempts. Some integrations use an argument other than `max_retries`. For an arbitrary provider, or to override the registered argument for a known provider, set `param` in the provider-specific retries table:
+For an arbitrary provider, set `param` to its retry-count constructor argument so Deep Agents Code can disable the provider's retry loop and use the configured retry budget:
 
 ```toml
 [retries]
@@ -276,7 +276,7 @@ param = "retries"
 max_retries = 4
 ```
 
-`param` must be a valid Python identifier string, such as `"max_retries"` or `"retries"`. For an unknown provider without `param`, Deep Agents Code keeps the provider's own retry loop active and logs a warning that its attempts can multiply the model-node retries.
+`param` must be a valid Python identifier string, such as `"max_retries"` or `"retries"`.
 
 The retry-budget precedence order is:
 

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -9,7 +9,7 @@ description: Configure model providers, defaults, retries, and gateways in confi
 - **Defaults**: pin a [default model](#default-and-recent-model) or [agent](#default-and-recent-agent), or [restrict usable models](#allowed-models) with an allowlist.
 - **Warnings**: [session cost](#session-cost-warning) and [cold prompt-cache](#cold-prompt-cache-warning) thresholds, and [trusted gateway endpoints](#trust-a-gateway-endpoint-for-cache-policies).
 - **Interpreter**: the [`[interpreter]` settings](#js-interpreter) for the built-in QuickJS REPL.
-- **Tracing**: [client-side secret redaction](#redact-langsmith-trace-secrets) for LangSmith traces (on by default).
+- **Tracing**: [client-side secret redaction](#redact-langsmith-trace-secrets) for LangSmith traces.
 - **Provider setup**: the [`[models.providers.<name>]` table](#provider-configuration), [constructor params](#model-constructor-params), [retries](#retries), [profile overrides](#profile-overrides-advanced), and [adding models to the `/model` switcher](#adding-models-to-the-interactive-switcher).
 - **Auto mode**: the [auto classifier timeout](#auto-classifier-timeout).
 - **Custom endpoints and providers**: [custom base URLs](#custom-base-url), [OpenAI- or Anthropic-compatible APIs](#compatible-apis), and [arbitrary providers](#arbitrary-providers).
@@ -96,7 +96,7 @@ Restrict `dcode` to an approved set of models with the `[models].allowed` list:
 allowed = ["anthropic:claude-sonnet-4-5", "openai:*"]
 ```
 
-Entries are exact `provider:model` specs or `provider:*` wildcards that admit a provider's whole lineup. Write bare Bedrock model IDs as `bedrock:<id>`. When the list is set, every model the app tries to use is checked against it: the launch default, `--model`, `/model` selections, saved defaults, and subagent model declarations. Blocked entries are hidden from the `/model` switcher; a blocked selection is rejected with an error that lists the allowed entries. A malformed list fails closed (denies everything) with an error naming the defect, so a typo cannot silently disable the guardrail.
+Entries are exact `provider:model` specs or `provider:*` wildcards that admit a provider's whole lineup. When the list is set, blocked models are hidden from the `/model` switcher and rejected if selected elsewhere. Invalid entries fail closed so a typo cannot silently disable the restriction.
 
 When the key is unset, all models are allowed. An explicit empty list allows none:
 
@@ -105,7 +105,11 @@ When the key is unset, all models are allowed. An explicit empty list allows non
 allowed = []   # no model may be used
 ```
 
-A `provider:*` wildcard names no model itself, so default resolution expands it to the provider's discovered models (the bundled profile lineup merged with any configured `models` list). A wildcard for a provider with no discovered or configured models fails closed instead of prompting for credentials.
+Wildcards include models discovered from the bundled provider profile or your configured `models` list. If no models are available for that provider, the wildcard allows none.
+
+<Accordion title="Allow Amazon Bedrock models">
+    Write bare Bedrock model IDs as `bedrock:<id>`.
+</Accordion>
 
 ## Redact LangSmith trace secrets
 
@@ -532,7 +536,7 @@ To use your own key instead, store it with `/auth` (leave the base URL blank for
 
 ## JS interpreter
 
-The `[interpreter]` section tunes the built-in JavaScript interpreter (the `js_eval` tool), which runs agent-written code in a QuickJS sandbox. These keys are `config.toml`-only; see [Command line options](/oss/deepagents/code/cli-reference#command-line-options) for the `--interpreter` and `--interpreter-tools` flag equivalents.
+The `[interpreter]` section tunes the built-in JavaScript interpreter (the `js_eval` tool), which runs agent-written code in a QuickJS sandbox. These keys apply only to config files; see [Command line options](/oss/deepagents/code/cli-reference#command-line-options) for the `--interpreter` and `--interpreter-tools` flag equivalents.
 
 ```toml title="~/.deepagents/config.toml"
 [interpreter]

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -250,7 +250,7 @@ The merge is shallow: any key present in the model sub-table replaces the same k
 
 ## Retries
 
-Configure retry counts for transient model provider errors with the top-level `[retries]` section. Deep Agents Code passes these values through to provider integrations that accept retry-count constructor kwargs. If you omit this section, the provider SDK default applies.
+Deep Agents Code retries transient model errors at the model node. The default is five retries after the first request. Set the top-level `[retries]` value to change the budget, or set it to `0` to disable retries:
 
 ```toml
 [retries]
@@ -265,7 +265,7 @@ max_retries = 0
 
 The global `[retries].max_retries` value applies to all supported providers. A provider-specific table, such as `[retries.fireworks]`, overrides the global value for that provider. Values must be integers greater than or equal to `0`.
 
-Most supported providers receive the retry count as `max_retries`. Some integrations use a different constructor kwarg. For an arbitrary provider, or to override the registered kwarg for a known provider, set `param` in the provider-specific retries table:
+Deep Agents Code disables the provider SDK retry loop when it knows the provider's retry-count constructor argument. This prevents provider retries from multiplying model-node attempts. Some integrations use an argument other than `max_retries`. For an arbitrary provider, or to override the registered argument for a known provider, set `param` in the provider-specific retries table:
 
 ```toml
 [retries]
@@ -276,16 +276,14 @@ param = "retries"
 max_retries = 4
 ```
 
-`param` must be a valid Python identifier string, such as `"max_retries"` or `"retries"`. Deep Agents Code ignores unknown providers that do not set `param`, because passing the wrong retry kwarg can break model creation.
+`param` must be a valid Python identifier string, such as `"max_retries"` or `"retries"`. For an unknown provider without `param`, Deep Agents Code keeps the provider's own retry loop active and logs a warning that its attempts can multiply the model-node retries.
 
-`[retries]` is lower precedence than constructor parameters. The complete precedence order is:
+The retry-budget precedence order is:
 
-1. `--max-retries N`, applied under the provider's resolved retry kwarg
-2. `--model-params` with the provider's retry kwarg, such as `'{"max_retries": N}'` or `'{"retries": N}'`
-3. `[models.providers.<provider>.params]` with the provider's retry kwarg
-4. `[retries.<provider>].max_retries`
-5. `[retries].max_retries`
-6. Provider SDK default
+1. `--max-retries N`
+2. `[retries.<provider>].max_retries`
+3. `[retries].max_retries`
+4. Deep Agents Code default (`5`)
 
 ## Startup approval mode
 
@@ -593,19 +591,20 @@ The LangGraph graph step budget is the maximum number of node invocations the `d
 
 ```toml title="~/.deepagents/config.toml"
 [runtime]
-recursion_limit = 2000
+recursion_limit = 5000
 ```
 
-The default is `2000`. Valid values are integers from `25` to `100000` (inclusive). Values outside this range or non-integer values log a warning and fall back to the default.
+Deep Agents Code does not set a default. When no source sets a valid value, the LangGraph server default applies. Values from managed configuration, the environment, and `config.toml` must be integers from `25` to `100000` (inclusive). Invalid values log a warning and resolution continues to the next source. The `--recursion-limit` flag accepts any integer greater than or equal to `1`.
 
 Precedence (highest to lowest):
 
-1. `--recursion-limit` CLI flag
-2. `DEEPAGENTS_CODE_RECURSION_LIMIT` environment variable
-3. `[runtime].recursion_limit` in `config.toml`
-4. Built-in default (`2000`)
+1. Administrator-owned `managed_config.toml`
+2. `--recursion-limit` CLI flag
+3. `DEEPAGENTS_CODE_RECURSION_LIMIT` environment variable
+4. `[runtime].recursion_limit` in `config.toml`
+5. LangGraph server default
 
-Use `dcode config get runtime.recursion_limit` to see the effective value and its source.
+Use `dcode config get runtime.recursion_limit` to see the effective Deep Agents Code value and its source. An unset result leaves the limit to the LangGraph server.
 
 <Tabs>
     <Tab title="CLI flag">

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -93,10 +93,10 @@ Restrict `dcode` to an approved set of models with the `[models].allowed` list:
 
 ```toml title="~/.deepagents/config.toml"
 [models]
-allowed = ["anthropic:claude-sonnet-4-5", "openai:*"]
+allowed = ["anthropic:claude-fable-5", "openai:*"]
 ```
 
-Entries are exact `provider:model` specs or `provider:*` wildcards that admit a provider's whole lineup. When the list is set, blocked models are hidden from the `/model` switcher and rejected if selected elsewhere. Invalid entries fail closed so a typo cannot silently disable the restriction.
+Entries are exact `provider:model` specs or `provider:*` wildcards that admit a provider's whole lineup. When the list is set, blocked models are hidden from the `/model` switcher and rejected if selected elsewhere. Invalid entries fail closed.
 
 When the key is unset, all models are allowed. An explicit empty list allows none:
 
@@ -108,7 +108,12 @@ allowed = []   # no model may be used
 Wildcards include models discovered from the bundled provider profile or your configured `models` list. If no models are available for that provider, the wildcard allows none.
 
 <Accordion title="Allow Amazon Bedrock models">
-    Write bare Bedrock model IDs as `bedrock:<id>`.
+    Write Bedrock model IDs as `bedrock:<id>`, including the version colon in the ID:
+
+    ```toml title="~/.deepagents/config.toml"
+    [models]
+    allowed = ["bedrock:anthropic.claude-3-5-sonnet-20241022-v2:0"]
+    ```
 </Accordion>
 
 ## Redact LangSmith trace secrets

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -373,7 +373,7 @@ The environment variable takes precedence over the config file. With a `DEEPAGEN
 
 ## Compact on resume
 
-Resuming a thread restores its full context, so the next turn pays for it. Since `deepagents-code>=0.1.53`, when a resumed thread's context exceeds a threshold, Deep Agents Code offers to compact it before your next message; declining is free and `/compact` (or `/offload`) remains available. The default threshold is 400,000 tokens; set it to `0` to disable the offer:
+Resuming a thread restores its full context, so the next turn pays for it. When a resumed thread's context exceeds a threshold, Deep Agents Code offers to compact it before your next message; declining is free and `/compact` (or `/offload`) remains available. The default threshold is 400,000 tokens; set it to `0` to disable the offer:
 
 ```toml title="~/.deepagents/config.toml"
 [threads]

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -499,7 +499,7 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_LANGSMITH_REDACT" type="string" default="true" post={["optional"]}>
-    Toggle client-side secret redaction for Deep Agents Code's LangSmith agent-trace inputs and outputs. Enabled by default since `deepagents-code>=0.1.62` (disabled by default in earlier versions). Accepts `1`, `true`, `yes`, or `on` to enable redaction and `0`, `false`, `no`, or `off` to disable it, case-insensitively. When redaction is enabled, tracing is disabled for that run if redaction cannot be configured. See [Configure LangSmith trace redaction](/oss/deepagents/code/config-file#redact-langsmith-trace-secrets).
+    Toggle client-side secret redaction for Deep Agents Code's LangSmith agent-trace inputs and outputs. Enabled by default. Accepts `1`, `true`, `yes`, or `on` to enable redaction and `0`, `false`, `no`, or `off` to disable it, case-insensitively. When redaction is enabled, tracing is disabled for that run if redaction cannot be configured. See [Configure LangSmith trace redaction](/oss/deepagents/code/config-file#redact-langsmith-trace-secrets).
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS" type="string" post={["optional"]}>

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -333,7 +333,7 @@ The environment variable takes precedence; setting it to an empty value also dis
 
 ### Collapse large pastes
 
-Large pastes into the chat input are collapsed into compact placeholders (default on; configurable since `deepagents-code>=0.1.32`). To keep the full pasted text visible:
+Large pastes into the chat input are collapsed into compact placeholders (default on). To keep the full pasted text visible:
 
 <Tabs>
     <Tab title="Config file">

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -507,7 +507,7 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_MEMORY_AUTO_SAVE" type="string" default="true" post={["optional"]}>
-    Let the agent proactively save learnings to memory. Set to a falsy value (or empty) to keep loading memory while stopping unprompted auto-saving; explicit saves still work. Overrides `[memory].auto_save`. See [Automatic memory](/oss/deepagents/code/memory-and-skills#automatic-memory). Requires `deepagents-code>=0.1.38`.
+    Let the agent proactively save learnings to memory. Set to a falsy value (or empty) to keep loading memory while stopping unprompted auto-saving; explicit saves still work. Overrides `[memory].auto_save`. See [Automatic memory](/oss/deepagents/code/memory-and-skills#automatic-memory).
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_NO_UPDATE_CHECK" type="string" post={["optional"]}>

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -267,7 +267,7 @@ When enabled (default), Deep Agents Code checks PyPI for a newer version at sess
 
 ### Pricing catalog auto-update
 
-Since `deepagents-code>=0.1.52`, Deep Agents Code refreshes its model pricing catalog from upstream hourly in the background so cost estimates stay current. To opt out:
+Deep Agents Code refreshes its model pricing catalog from upstream hourly in the background so cost estimates stay current. To opt out:
 
 <Tabs>
     <Tab title="Config file">

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -73,7 +73,7 @@ For provider keys specifically, see [Provider credentials](/oss/deepagents/code/
 
 At startup, Deep Agents Code reads the nearest project `.env`, found by searching the directory you launch from and walking up through its parents (the first `.env` found wins), then `~/.deepagents/.env` as a global fallback for all projects. A project `.env` wins over the global one, and neither overrides a value already set in your shell. Running `/reload` re-reads both `.env` files so you can change keys without restarting, with shell values still taking precedence.
 
-To skip the project `.env` entirely (the global `~/.deepagents/.env` still loads), set `startup.read_project_dotenv`, available since `deepagents-code>=0.1.60`:
+To skip the project `.env` entirely (the global `~/.deepagents/.env` still loads), set `startup.read_project_dotenv`.
 
 <Tabs>
     <Tab title="Config file">

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -351,7 +351,7 @@ Large pastes into the chat input are collapsed into compact placeholders (defaul
 
 ## Conversation history retention
 
-Offloading a thread with `/offload` writes a markdown archive under `~/.deepagents/conversation_history/`. Since `deepagents-code>=0.1.61`, a best-effort startup sweep deletes archives older than 30 days. The sweep only touches regular `.md` files directly inside the archive directory, never blocks startup, and logs and swallows filesystem errors.
+Offloading a thread with `/offload` writes a markdown archive under `~/.deepagents/conversation_history/`. A best-effort startup sweep deletes archives older than 30 days. The sweep only touches regular `.md` files directly inside the archive directory, never blocks startup, and logs and swallows filesystem errors.
 
 Change the retention window, or disable cleanup with `0`:
 

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -71,7 +71,37 @@ For provider keys specifically, see [Provider credentials](/oss/deepagents/code/
 
 ### Loading order and precedence
 
-At startup, Deep Agents Code reads the nearest project `.env`, found by searching the directory you launch from and walking up through its parents (the first `.env` found wins), then `~/.deepagents/.env` as a global fallback for all projects. A project `.env` wins over the global one, and neither overrides a value already set in your shell. Running `/reload` re-reads both `.env` files so you can change keys without restarting, with shell values still taking precedence. This applies to every variable Deep Agents Code reads (for example, `TAVILY_API_KEY` or the `DEEPAGENTS_CODE_*` settings), except `DEEPAGENTS_CODE_DANGEROUSLY_ENABLE_PROJECT_MCP_SERVERS` and `DEEPAGENTS_CODE_DISABLED_PROJECT_MCP_SERVERS`. Deep Agents Code ignores these project MCP trust settings in a project `.env` so a repository cannot approve its own servers. Set them in your shell or the global `~/.deepagents/.env` instead.
+At startup, Deep Agents Code reads the nearest project `.env`, found by searching the directory you launch from and walking up through its parents (the first `.env` found wins), then `~/.deepagents/.env` as a global fallback for all projects. A project `.env` wins over the global one, and neither overrides a value already set in your shell. Running `/reload` re-reads both `.env` files so you can change keys without restarting, with shell values still taking precedence.
+
+To skip the project `.env` entirely (the global `~/.deepagents/.env` still loads), set `startup.read_project_dotenv`, available since `deepagents-code>=0.1.60`:
+
+<Tabs>
+    <Tab title="Config file">
+        ```toml title="~/.deepagents/config.toml"
+        [startup]
+        read_project_dotenv = false
+        ```
+    </Tab>
+    <Tab title="Environment variable">
+        ```bash
+        export DEEPAGENTS_CODE_READ_PROJECT_DOTENV=0
+        ```
+    </Tab>
+</Tabs>
+
+The setting resolves from managed config, the environment variable, and the user `config.toml`. All of those are read before any project `.env` is applied, so a project `.env` cannot turn the toggle off (or back on) for itself.
+
+The loading rules above apply to every variable Deep Agents Code reads (for example, `TAVILY_API_KEY` or the `DEEPAGENTS_CODE_*` settings), except the following keys, which a `.env` file may never set. Deep Agents Code ignores these so that loading configuration cannot turn into code execution in child processes (`dcode` runs `git` and shells during startup, before any approval prompt):
+
+- Profile and trust roots: `DEEPAGENTS_HOME`, `DEEPAGENTS_HOME_IS_DEFAULT`, `DEEPAGENTS_CODE_READ_PROJECT_DOTENV`, `DEEPAGENTS_INHERITED_PYTHONPATH`
+- Dynamic-linker preload/audit: `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, `LD_AUDIT`, `LD_LIBRARY_PATH`, `LD_PRELOAD`
+- Interpreter startup/path: `NODE_OPTIONS`, `PATH`, `PYTHONEXECUTABLE`, `PYTHONHOME`, `PYTHONPATH`, `PYTHONSTARTUP`
+- Shell startup hooks: `BASH_ENV`, `ENV`, `BASHOPTS`, `SHELLOPTS`, `CDPATH`, `GLOBIGNORE`
+- Credential-prompt hijack: `GIT_ASKPASS`, `SSH_ASKPASS`
+- Git config/exec injection: `GIT_DIR`, `GIT_WORK_TREE`, `GIT_OBJECT_DIRECTORY`, `GIT_EXEC_PATH`, `GIT_EDITOR`, `GIT_PAGER`, `GIT_SSH`, `GIT_SSH_COMMAND`, plus the prefix families `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_*`, `GIT_CONFIG_VALUE_*`, `GIT_CONFIG_PARAMETERS`, `GIT_CONFIG_SYSTEM`, and `GIT_CONFIG_GLOBAL` (blocked since `deepagents-code>=0.1.60`)
+- Windows process variables: `COMSPEC`, `SYSTEMROOT`, `WINDIR`
+
+A project `.env` is additionally barred from setting `DEEPAGENTS_CODE_DANGEROUSLY_ENABLE_PROJECT_MCP_SERVERS` and `DEEPAGENTS_CODE_DISABLED_PROJECT_MCP_SERVERS` (so a repository cannot approve or deny its own MCP servers), `DEEPAGENTS_CODE_AUTO_CLASSIFIER_MODEL` and `DEEPAGENTS_CODE_AUTO_CLASSIFIER_TIMEOUT` (so a repository cannot weaken the Auto approval reviewer), and `TERM_PROGRAM`. Set any of these in your shell or the global `~/.deepagents/.env` instead.
 
 <Warning>
     Running `dcode` inside an untrusted project directory exposes you to project-controlled files. A malicious `.env`, `Makefile`, or build script in that directory can influence the agent's process environment and what it runs. Treat any directory you would not run arbitrary scripts in as untrusted, and use a [remote sandbox](/oss/deepagents/code/remote-sandboxes) for untrusted repositories.
@@ -116,6 +146,27 @@ export DEEPAGENTS_CODE_EXTRA_SKILLS_DIRS="~/shared-skills:/opt/team-skills"
 ```
 
 When the environment variable is set, it takes precedence over the config file value. Changes take effect on `/reload`.
+
+## Profile location (`DEEPAGENTS_HOME`)
+
+Requires `deepagents-code>=0.1.62`.
+
+`DEEPAGENTS_HOME` selects the directory Deep Agents Code uses as its user profile — everything normally stored under `~/.deepagents/` moves under the configured path. This includes `config.toml`, the global `.env`, `~/.deepagents/.mcp.json` and `hooks.json`, per-agent directories (`AGENTS.md`, `skills/`, `memories/`, `agents/`), plugins, and `.state/` (sessions, input history, credentials, and locks). When unset, the profile defaults to `~/.deepagents`.
+
+Valid forms are an absolute path or a path beginning with `~/`:
+
+```bash
+export DEEPAGENTS_HOME="~/profiles/work"        # resolved against your home directory
+export DEEPAGENTS_HOME="/opt/dcode-profiles/work"  # absolute; works even with no resolvable home
+```
+
+Relative paths and `~user` forms are rejected. The resolved path must also not be the filesystem root, the home directory itself, an existing non-directory, an unreadable or unsearchable directory, or a symlink with a missing target — these fail at launch with an error.
+
+<Warning>
+    `DEEPAGENTS_HOME` is a trust boundary: it selects which `config.toml`, `.env`, and `.mcp.json` Deep Agents Code treats as user-trusted. It must be set in the inherited shell environment (for example, `export DEEPAGENTS_HOME=...` before launching). It is captured at launch, before dotenv loading, and no `.env` file may set or change it — a project-controlled `.env` could otherwise relocate the trust root to files it controls. Child processes inherit the resolved path.
+</Warning>
+
+The alias `~/.agents/skills/` (shared across AI CLI tools) is resolved from the launch home directory, not from `DEEPAGENTS_HOME`. See [Data locations](#data-locations) for the full directory tree.
 
 ## Themes
 
@@ -212,9 +263,27 @@ To opt out of automatic updates:
     </Tab>
 </Tabs>
 
-The environment variable takes precedence over the config file.
+The environment variable takes precedence over the config file. Setting the environment variable to an empty value disables the feature.
 
 When enabled (default), Deep Agents Code checks PyPI for a newer version at session start and automatically upgrades. When disabled, Deep Agents Code shows an update hint with the appropriate install command instead.
+
+### Pricing catalog auto-update
+
+Since `deepagents-code>=0.1.52`, Deep Agents Code refreshes its model pricing catalog from upstream hourly in the background so cost estimates stay current. To opt out:
+
+<Tabs>
+    <Tab title="Config file">
+        ```toml
+        [update]
+        prices_auto_update = false
+        ```
+    </Tab>
+    <Tab title="Environment variable">
+        ```bash
+        export DEEPAGENTS_CODE_PRICES_AUTO_UPDATE=0
+        ```
+    </Tab>
+</Tabs>
 
 To suppress automatic update checks entirely:
 
@@ -239,6 +308,79 @@ You can still check for and install updates manually at any time with the `/upda
 After an upgrade, Deep Agents Code shows a "what's new" banner on the next launch with a link to the changelog.
 
 At session exit, if a newer version was detected during the session, an update banner is displayed as a reminder.
+
+## Display options
+
+These `[ui]` keys tune what the terminal UI shows.
+
+### Session usage stats
+
+Deep Agents Code shows session usage statistics when a session ends (default on; configurable since `deepagents-code>=0.1.59`):
+
+<Tabs>
+    <Tab title="Config file">
+        ```toml
+        [ui]
+        show_usage_stats = false
+        ```
+    </Tab>
+    <Tab title="Environment variable">
+        ```bash
+        export DEEPAGENTS_CODE_SHOW_USAGE_STATS=0
+        ```
+    </Tab>
+</Tabs>
+
+The environment variable takes precedence; setting it to an empty value also disables the stats.
+
+### Collapse large pastes
+
+Large pastes into the chat input are collapsed into compact placeholders (default on; configurable since `deepagents-code>=0.1.32`). To keep the full pasted text visible:
+
+<Tabs>
+    <Tab title="Config file">
+        ```toml
+        [ui]
+        collapse_pastes = false
+        ```
+    </Tab>
+    <Tab title="Environment variable">
+        ```bash
+        export DEEPAGENTS_CODE_COLLAPSE_PASTES=0
+        ```
+    </Tab>
+</Tabs>
+
+## Conversation history retention
+
+Offloading a thread with `/offload` writes a markdown archive under `~/.deepagents/conversation_history/`. Since `deepagents-code>=0.1.61`, a best-effort startup sweep deletes archives older than 30 days. The sweep only touches regular `.md` files directly inside the archive directory, never blocks startup, and logs and swallows filesystem errors.
+
+Change the retention window, or disable cleanup with `0`:
+
+<Tabs>
+    <Tab title="Config file">
+        ```toml title="~/.deepagents/config.toml"
+        [history]
+        retention_days = 90   # 0 disables the sweep
+        ```
+    </Tab>
+    <Tab title="Environment variable">
+        ```bash
+        export DEEPAGENTS_CODE_HISTORY_RETENTION_DAYS=90
+        ```
+    </Tab>
+</Tabs>
+
+The environment variable takes precedence over the config file. With a `DEEPAGENTS_HOME` profile, archives live under `$DEEPAGENTS_HOME/conversation_history/`.
+
+## Compact on resume
+
+Resuming a thread restores its full context, so the next turn pays for it. Since `deepagents-code>=0.1.53`, when a resumed thread's context exceeds a threshold, Deep Agents Code offers to compact it before your next message; declining is free and `/compact` (or `/offload`) remains available. The default threshold is 400,000 tokens; set it to `0` to disable the offer:
+
+```toml title="~/.deepagents/config.toml"
+[threads]
+compact_on_resume_threshold = 200000
+```
 
 ## Uninstall
 
@@ -311,7 +453,7 @@ To route every user's model traffic through a managed gateway (provisioning a ga
 All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` prefix. See [`DEEPAGENTS_CODE_` prefix](#deepagents_code_-prefix) for how the prefix also works as an override for third-party credentials.
 
 <ResponseField name="DEEPAGENTS_CODE_AUTO_UPDATE" type="string" post={["optional"]}>
-    Toggle automatic Deep Agents Code updates. Enabled by default; set to `0`, `false`, `no`, or `off` to opt out.
+    Toggle automatic Deep Agents Code updates. Enabled by default; set to `0`, `false`, `no`, or `off` (or an empty value) to opt out.
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_AUTO_CLASSIFIER_TIMEOUT" type="integer" post={["optional"]}>
@@ -342,28 +484,52 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
     Comma-separated project MCP server names to pre-approve by name for any project. This is a process-wide escape hatch: A different project, command change, or URL change under the same server name still matches. When set, this variable replaces saved approvals for the process. Prefer saved approvals from the project MCP prompt when possible.
 </ResponseField>
 
+<ResponseField name="DEEPAGENTS_CODE_COLLAPSE_PASTES" type="string" default="true" post={["optional"]}>
+    Collapse large chat-input pastes into compact placeholders. Set to a falsy value (or empty) to keep full pasted text visible. Overrides `[ui].collapse_pastes`. See [Collapse large pastes](#collapse-large-pastes).
+</ResponseField>
+
 <ResponseField name="DEEPAGENTS_CODE_EXTRA_SKILLS_DIRS" type="string" post={["optional"]}>
     Colon-separated paths added to the [skill containment allowlist](#skill-directory-allowlist).
+</ResponseField>
+
+<ResponseField name="DEEPAGENTS_CODE_HISTORY_RETENTION_DAYS" type="integer" default="30" post={["optional"]}>
+    Days an offloaded conversation-history archive is kept before the startup sweep deletes it; `0` disables cleanup. Overrides `[history].retention_days`. See [Conversation history retention](#conversation-history-retention). Requires `deepagents-code>=0.1.61`.
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_LANGSMITH_PROJECT" type="string" post={["optional"]}>
     Override the LangSmith project name for Deep Agents Code's own agent traces. Shell commands still run with the user's original `LANGSMITH_PROJECT`, so app, test, or script traces can appear in a separate project. See [Trace with LangSmith](/oss/deepagents/code/quickstart#trace-with-langsmith).
 </ResponseField>
 
-<ResponseField name="DEEPAGENTS_CODE_LANGSMITH_REDACT" type="string" default="false" post={["optional"]}>
-    Toggle client-side secret redaction for Deep Agents Code's LangSmith agent-trace inputs and outputs. Accepts `1`, `true`, `yes`, or `on` to enable redaction and `0`, `false`, `no`, or `off` to disable it, case-insensitively. When redaction is enabled, tracing is disabled for that run if redaction cannot be configured. See [Configure LangSmith trace redaction](/oss/deepagents/code/config-file#redact-langsmith-trace-secrets).
+<ResponseField name="DEEPAGENTS_CODE_LANGSMITH_REDACT" type="string" default="true" post={["optional"]}>
+    Toggle client-side secret redaction for Deep Agents Code's LangSmith agent-trace inputs and outputs. Enabled by default since `deepagents-code>=0.1.62` (disabled by default in earlier versions). Accepts `1`, `true`, `yes`, or `on` to enable redaction and `0`, `false`, `no`, or `off` to disable it, case-insensitively. When redaction is enabled, tracing is disabled for that run if redaction cannot be configured. See [Configure LangSmith trace redaction](/oss/deepagents/code/config-file#redact-langsmith-trace-secrets).
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_LANGSMITH_REPLICA_PROJECTS" type="string" post={["optional"]}>
     A second LangSmith project to *also* write agent traces to. When set and tracing is active, each agent run is dual-written to the primary project (from `DEEPAGENTS_CODE_LANGSMITH_PROJECT`, or `deepagents-code` by default) and this project. Off by default. See [Trace with LangSmith](/oss/deepagents/code/quickstart#trace-with-langsmith).
 </ResponseField>
 
+<ResponseField name="DEEPAGENTS_CODE_MEMORY_AUTO_SAVE" type="string" default="true" post={["optional"]}>
+    Let the agent proactively save learnings to memory. Set to a falsy value (or empty) to keep loading memory while stopping unprompted auto-saving; explicit saves still work. Overrides `[memory].auto_save`. See [Automatic memory](/oss/deepagents/code/memory-and-skills#automatic-memory). Requires `deepagents-code>=0.1.38`.
+</ResponseField>
+
 <ResponseField name="DEEPAGENTS_CODE_NO_UPDATE_CHECK" type="string" post={["optional"]}>
     Disable automatic update checking when set. This also prevents automatic update installs at startup.
 </ResponseField>
 
+<ResponseField name="DEEPAGENTS_HOME" type="string" post={["optional"]}>
+    Select the user profile and trust root instead of the default `~/.deepagents`. Accepts an absolute path or a path beginning with `~/`; `~user` forms and relative paths are rejected. Must be set in the inherited shell environment — no `.env` file may set it. See [Profile location](#profile-location-deepagents_home). Requires `deepagents-code>=0.1.62`.
+</ResponseField>
+
 <ResponseField name="DEEPAGENTS_CODE_ONBOARDING" type="string" post={["optional"]}>
     Override the first-run onboarding flow. Set to a truthy value to force it open on every startup; set to a falsy value to suppress it entirely (useful for CI and provisioned machines). Leave unset for the default first-run behavior.
+</ResponseField>
+
+<ResponseField name="DEEPAGENTS_CODE_PRICES_AUTO_UPDATE" type="string" default="true" post={["optional"]}>
+    Refresh the model pricing catalog from upstream hourly in the background. Set to a falsy value (or empty) to opt out. Overrides `[update].prices_auto_update`. See [Pricing catalog auto-update](#pricing-catalog-auto-update).
+</ResponseField>
+
+<ResponseField name="DEEPAGENTS_CODE_READ_PROJECT_DOTENV" type="string" default="true" post={["optional"]}>
+    Load the project `.env` (found walking up from the working directory) into the process environment. Set to a falsy value to skip an untrusted repository's file; the global `~/.deepagents/.env` still loads. Overrides `[startup].read_project_dotenv`. See [Loading order and precedence](#loading-order-and-precedence). Requires `deepagents-code>=0.1.60`.
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_RECURSION_LIMIT" type="integer" post={["optional"]}>
@@ -372,6 +538,10 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
 
 <ResponseField name="DEEPAGENTS_CODE_SHELL_ALLOW_LIST" type="string" post={["optional"]}>
     Comma-separated shell commands to allow (or `recommended` / `all`).
+</ResponseField>
+
+<ResponseField name="DEEPAGENTS_CODE_SHOW_USAGE_STATS" type="string" default="true" post={["optional"]}>
+    Show session usage statistics when a session ends. Set to a falsy value (or empty) to hide them. Overrides `[ui].show_usage_stats`. See [Session usage stats](#session-usage-stats).
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_USER_ID" type="string" post={["optional"]}>
@@ -427,7 +597,7 @@ Output:
 
 Deep Agents Code stores data in two directory hierarchies:
 
-- **`~/.deepagents/`** — Deep Agents-specific data (agent memory, skills, sessions)
+- **`~/.deepagents/`** — Deep Agents-specific data (agent memory, skills, sessions). Relocatable with [`DEEPAGENTS_HOME`](#profile-location-deepagents_home); the paths below are then rooted at that directory instead.
 - **`~/.agents/`** — Tool-agnostic data (skills shared across AI CLI tools)
 
 ### Directory structure

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -491,7 +491,7 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_HISTORY_RETENTION_DAYS" type="integer" default="30" post={["optional"]}>
-    Days an offloaded conversation-history archive is kept before the startup sweep deletes it; `0` disables cleanup. Overrides `[history].retention_days`. See [Conversation history retention](#conversation-history-retention). Requires `deepagents-code>=0.1.61`.
+    Days an offloaded conversation-history archive is kept before the startup sweep deletes it; `0` disables cleanup. Overrides `[history].retention_days`. See [Conversation history retention](#conversation-history-retention).
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_LANGSMITH_PROJECT" type="string" post={["optional"]}>

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -149,8 +149,6 @@ When the environment variable is set, it takes precedence over the config file v
 
 ## Profile location (`DEEPAGENTS_HOME`)
 
-Requires `deepagents-code>=0.1.62`.
-
 `DEEPAGENTS_HOME` selects the directory Deep Agents Code uses as its user profile — everything normally stored under `~/.deepagents/` moves under the configured path. This includes `config.toml`, the global `.env`, `~/.deepagents/.mcp.json` and `hooks.json`, per-agent directories (`AGENTS.md`, `skills/`, `memories/`, `agents/`), plugins, and `.state/` (sessions, input history, credentials, and locks). When unset, the profile defaults to `~/.deepagents`.
 
 Valid forms are an absolute path or a path beginning with `~/`:

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -313,7 +313,7 @@ These `[ui]` keys tune what the terminal UI shows.
 
 ### Session usage stats
 
-Deep Agents Code shows session usage statistics when a session ends (default on; configurable since `deepagents-code>=0.1.59`):
+Deep Agents Code shows session usage statistics when a session ends (default on):
 
 <Tabs>
     <Tab title="Config file">

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -529,7 +529,7 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_READ_PROJECT_DOTENV" type="string" default="true" post={["optional"]}>
-    Load the project `.env` (found walking up from the working directory) into the process environment. Set to a falsy value to skip an untrusted repository's file; the global `~/.deepagents/.env` still loads. Overrides `[startup].read_project_dotenv`. See [Loading order and precedence](#loading-order-and-precedence). Requires `deepagents-code>=0.1.60`.
+    Load the project `.env` (found walking up from the working directory) into the process environment. Set to a falsy value to skip an untrusted repository's file; the global `~/.deepagents/.env` still loads. Overrides `[startup].read_project_dotenv`. See [Loading order and precedence](#loading-order-and-precedence).
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_RECURSION_LIMIT" type="integer" post={["optional"]}>

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -515,7 +515,7 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_HOME" type="string" post={["optional"]}>
-    Select the user profile and trust root instead of the default `~/.deepagents`. Accepts an absolute path or a path beginning with `~/`; `~user` forms and relative paths are rejected. Must be set in the inherited shell environment — no `.env` file may set it. See [Profile location](#profile-location-deepagents_home). Requires `deepagents-code>=0.1.62`.
+    Select the user profile and trust root instead of the default `~/.deepagents`. Accepts an absolute path or a path beginning with `~/`; `~user` forms and relative paths are rejected. Must be set in the inherited shell environment — no `.env` file may set it. See [Profile location](#profile-location-deepagents_home).
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_ONBOARDING" type="string" post={["optional"]}>

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -98,7 +98,7 @@ The loading rules above apply to every variable Deep Agents Code reads (for exam
 - Interpreter startup/path: `NODE_OPTIONS`, `PATH`, `PYTHONEXECUTABLE`, `PYTHONHOME`, `PYTHONPATH`, `PYTHONSTARTUP`
 - Shell startup hooks: `BASH_ENV`, `ENV`, `BASHOPTS`, `SHELLOPTS`, `CDPATH`, `GLOBIGNORE`
 - Credential-prompt hijack: `GIT_ASKPASS`, `SSH_ASKPASS`
-- Git config/exec injection: `GIT_DIR`, `GIT_WORK_TREE`, `GIT_OBJECT_DIRECTORY`, `GIT_EXEC_PATH`, `GIT_EDITOR`, `GIT_PAGER`, `GIT_SSH`, `GIT_SSH_COMMAND`, plus the prefix families `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_*`, `GIT_CONFIG_VALUE_*`, `GIT_CONFIG_PARAMETERS`, `GIT_CONFIG_SYSTEM`, and `GIT_CONFIG_GLOBAL` (blocked since `deepagents-code>=0.1.60`)
+- Git config/exec injection: `GIT_DIR`, `GIT_WORK_TREE`, `GIT_OBJECT_DIRECTORY`, `GIT_EXEC_PATH`, `GIT_EDITOR`, `GIT_PAGER`, `GIT_SSH`, `GIT_SSH_COMMAND`, plus the prefix families `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_*`, `GIT_CONFIG_VALUE_*`, `GIT_CONFIG_PARAMETERS`, `GIT_CONFIG_SYSTEM`, and `GIT_CONFIG_GLOBAL`
 - Windows process variables: `COMSPEC`, `SYSTEMROOT`, `WINDIR`
 
 A project `.env` is additionally barred from setting `DEEPAGENTS_CODE_DANGEROUSLY_ENABLE_PROJECT_MCP_SERVERS` and `DEEPAGENTS_CODE_DISABLED_PROJECT_MCP_SERVERS` (so a repository cannot approve or deny its own MCP servers), `DEEPAGENTS_CODE_AUTO_CLASSIFIER_MODEL` and `DEEPAGENTS_CODE_AUTO_CLASSIFIER_TIMEOUT` (so a repository cannot weaken the Auto approval reviewer), and `TERM_PROGRAM`. Set any of these in your shell or the global `~/.deepagents/.env` instead.

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -439,6 +439,28 @@ langsmith_redact = true
 
 Only administrators should have permission to edit this file. Deep Agents Code treats it as read-only. Users can still save preferences to `config.toml`, but administrator settings remain in effect until they are removed from `managed_config.toml`.
 
+### Restrict model use
+
+Set `[models].allowed` to exact, case-sensitive `provider:model` specifications, or use `provider:*` to allow all discoverable models from one provider. The allowlist applies to launch defaults, `--model`, `/model`, saved defaults, Auto classifiers, rubric graders, and explicit local subagent models.
+
+```toml title="managed_config.toml"
+[models]
+allowed = [
+    "acme:production",
+    "openai:*",
+]
+default = "acme:production"
+auto_classifier = "openai:gpt-5.5"
+```
+
+If you omit `allowed`, users can select any model. An empty list blocks all models. If a user's list is invalid, Deep Agents Code blocks all models. If the administrator's list is invalid, Deep Agents Code blocks startup, reload, and other commands that use configuration. The administrator's list replaces the user's list rather than combining with it. The managed `default`, `recent`, and `auto_classifier` values must also appear in the administrator's allowlist.
+
+Adding a model under `[models.providers.<name>].models` makes it available for selection but does not allow it automatically. Add the exact model or a provider wildcard to the allowlist. A wildcard covers only the models available for that provider. If no models are available, Deep Agents Code cannot choose a default. When Deep Agents Code can identify the provider for a bare model name entered in the interface, it converts the name to `provider:model` before checking the allowlist. For Amazon Bedrock models, use `bedrock:<id>` because the model ID itself contains a version colon.
+
+<Warning>
+    `[sandboxes].default` selects the backend when a user launches with `--sandbox`. It does not force sandboxing. A launch without `--sandbox` runs on the host and reports that it did not use the managed backend.
+</Warning>
+
 ### Load policy remotely
 
 You can store the policy on a central server while keeping its location in the local `managed_config.toml`:
@@ -469,28 +491,6 @@ Deep Agents Code does not save the remote policy or any authentication details t
 
 <Warning>
     `SSL_CERT_FILE` and `SSL_CERT_DIR` can change which certificate authorities Python trusts. When you use a remote policy, make sure users cannot change these environment variables for the Deep Agents Code process.
-</Warning>
-
-### Restrict model use
-
-Set `[models].allowed` to exact, case-sensitive `provider:model` specifications, or use `provider:*` to allow all discoverable models from one provider. The allowlist applies to launch defaults, `--model`, `/model`, saved defaults, Auto classifiers, rubric graders, and explicit local subagent models.
-
-```toml title="managed_config.toml"
-[models]
-allowed = [
-    "acme:production",
-    "openai:*",
-]
-default = "acme:production"
-auto_classifier = "openai:gpt-5.5"
-```
-
-If you omit `allowed`, users can select any model. An empty list blocks all models. If a user's list is invalid, Deep Agents Code blocks all models. If the administrator's list is invalid, Deep Agents Code blocks startup, reload, and other commands that use configuration. The administrator's list replaces the user's list rather than combining with it. The managed `default`, `recent`, and `auto_classifier` values must also appear in the administrator's allowlist.
-
-Adding a model under `[models.providers.<name>].models` makes it available for selection but does not allow it automatically. Add the exact model or a provider wildcard to the allowlist. A wildcard covers only the models available for that provider. If no models are available, Deep Agents Code cannot choose a default. When Deep Agents Code can identify the provider for a bare model name entered in the interface, it converts the name to `provider:model` before checking the allowlist. For Amazon Bedrock models, use `bedrock:<id>` because the model ID itself contains a version colon.
-
-<Warning>
-    `[sandboxes].default` selects the backend when a user launches with `--sandbox`. It does not force sandboxing. A launch without `--sandbox` runs on the host and reports that it did not use the managed backend.
 </Warning>
 
 ### Validate a managed policy

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -4,7 +4,7 @@ sidebarTitle: Configuration
 description: Configure Deep Agents Code with config files, administrator settings, environment variables, hooks, and CLI flags
 ---
 
-Deep Agents Code stores user configuration under `~/.deepagents/` and in project-level dotfiles. Administrators can enforce settings from a fixed system path with [`managed_config.toml`](#managed-configuration). For the full directory tree, session storage, and skill paths, see [Data locations](/oss/deepagents/code/configuration#data-locations).
+Deep Agents Code stores user configuration in its profile directory, which defaults to `~/.deepagents/`, and in project-level dotfiles. Administrators can enforce settings from a fixed system path with [`managed_config.toml`](#managed-configuration). For the full directory tree, session storage, and skill paths, see [Data locations](/oss/deepagents/code/configuration#data-locations).
 
 The main config files are:
 <CardGroup cols={2}>

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -356,6 +356,26 @@ Large pastes into the chat input are collapsed into compact placeholders (defaul
     </Tab>
 </Tabs>
 
+## Automatic memory
+
+Deep Agents Code automatically saves learnings to memory. To keep loading memory while stopping automatic saves:
+
+<Tabs>
+    <Tab title="Config file">
+        ```toml title="~/.deepagents/config.toml"
+        [memory]
+        auto_save = false
+        ```
+    </Tab>
+    <Tab title="Environment variable">
+        ```bash
+        export DEEPAGENTS_CODE_MEMORY_AUTO_SAVE=0
+        ```
+    </Tab>
+</Tabs>
+
+You can still save memories explicitly with `/remember`. The environment variable takes precedence over the config file.
+
 ## Conversation history retention
 
 Offloading a thread with `/offload` writes a markdown archive under `~/.deepagents/conversation_history/`. A best-effort startup sweep deletes archives older than 30 days. The sweep only touches regular `.md` files directly inside the archive directory, never blocks startup, and logs and swallows filesystem errors.

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -58,7 +58,7 @@ The `dcode config` commands show the settings Deep Agents Code uses and where ea
 Add `--verbose` to `dcode config` or `dcode config get` to show descriptions, defaults, and where each setting can be defined. Combine `--verbose` with `--json` to include accepted types and other reference details. All three commands accept `--json` for machine-readable output. For the full list of commands, see [CLI reference](/oss/deepagents/code/cli-reference).
 
 <Warning>
-    Provider credentials and other secrets are reported as configured / not configured only. Their values are never printed by `config` or `config get`, so the output is safe to paste into a bug report.
+    Provider credentials and other secrets are reported as configured / not configured only. Their values are never printed by `config` or `config get`.
 </Warning>
 
 ## Environment variables
@@ -74,7 +74,7 @@ For provider keys specifically, see [Provider credentials](/oss/deepagents/code/
 
 ### Loading order and precedence
 
-At startup, Deep Agents Code reads the nearest project `.env`, found by searching the directory you launch from and walking up through its parents (the first `.env` found wins), then `~/.deepagents/.env` as a global fallback for all projects. A project `.env` wins over the global one, and neither overrides a value already set in your shell. Running `/reload` re-reads both `.env` files so you can change keys without restarting, with shell values still taking precedence.
+At startup, Deep Agents Code reads the nearest project `.env`, found by searching the directory you launch from and walking up through its parents (the first `.env` found wins), then `~/.deepagents/.env` as a global fallback for all projects. A project `.env` wins over the global one, and neither overrides a value already set in your shell.
 
 To skip the project `.env` entirely (the global `~/.deepagents/.env` still loads), set `startup.read_project_dotenv`.
 
@@ -94,17 +94,21 @@ To skip the project `.env` entirely (the global `~/.deepagents/.env` still loads
 
 The setting resolves from managed config, the environment variable, and the user `config.toml`. All of those are read before any project `.env` is applied, so a project `.env` cannot turn the toggle off (or back on) for itself.
 
-The loading rules above apply to every variable Deep Agents Code reads (for example, `TAVILY_API_KEY` or the `DEEPAGENTS_CODE_*` settings), except the following keys, which a `.env` file may never set. Deep Agents Code ignores these so that loading configuration cannot turn into code execution in child processes (`dcode` runs `git` and shells during startup, before any approval prompt):
+Deep Agents Code ignores environment variables that could alter executable lookup, interpreter or shell startup, Git behavior, or trust settings when they come from dotenv files.
 
-- Profile and trust roots: `DEEPAGENTS_HOME`, `DEEPAGENTS_HOME_IS_DEFAULT`, `DEEPAGENTS_CODE_READ_PROJECT_DOTENV`, `DEEPAGENTS_INHERITED_PYTHONPATH`
-- Dynamic-linker preload/audit: `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, `LD_AUDIT`, `LD_LIBRARY_PATH`, `LD_PRELOAD`
-- Interpreter startup/path: `NODE_OPTIONS`, `PATH`, `PYTHONEXECUTABLE`, `PYTHONHOME`, `PYTHONPATH`, `PYTHONSTARTUP`
-- Shell startup hooks: `BASH_ENV`, `ENV`, `BASHOPTS`, `SHELLOPTS`, `CDPATH`, `GLOBIGNORE`
-- Credential-prompt hijack: `GIT_ASKPASS`, `SSH_ASKPASS`
-- Git config/exec injection: `GIT_DIR`, `GIT_WORK_TREE`, `GIT_OBJECT_DIRECTORY`, `GIT_EXEC_PATH`, `GIT_EDITOR`, `GIT_PAGER`, `GIT_SSH`, `GIT_SSH_COMMAND`, plus the prefix families `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_*`, `GIT_CONFIG_VALUE_*`, `GIT_CONFIG_PARAMETERS`, `GIT_CONFIG_SYSTEM`, and `GIT_CONFIG_GLOBAL`
-- Windows process variables: `COMSPEC`, `SYSTEMROOT`, `WINDIR`
+<Accordion title="View environment variables blocked in dotenv files">
+    The following keys cannot be set in either project or global dotenv files:
 
-A project `.env` is additionally barred from setting `DEEPAGENTS_CODE_DANGEROUSLY_ENABLE_PROJECT_MCP_SERVERS` and `DEEPAGENTS_CODE_DISABLED_PROJECT_MCP_SERVERS` (so a repository cannot approve or deny its own MCP servers), `DEEPAGENTS_CODE_AUTO_CLASSIFIER_MODEL` and `DEEPAGENTS_CODE_AUTO_CLASSIFIER_TIMEOUT` (so a repository cannot weaken the Auto approval reviewer), and `TERM_PROGRAM`. Set any of these in your shell or the global `~/.deepagents/.env` instead.
+    - Profile and trust roots: `DEEPAGENTS_HOME`, `DEEPAGENTS_HOME_IS_DEFAULT`, `DEEPAGENTS_CODE_READ_PROJECT_DOTENV`, `DEEPAGENTS_INHERITED_PYTHONPATH`
+    - Dynamic-linker preload/audit: `DYLD_INSERT_LIBRARIES`, `DYLD_LIBRARY_PATH`, `LD_AUDIT`, `LD_LIBRARY_PATH`, `LD_PRELOAD`
+    - Interpreter startup/path: `NODE_OPTIONS`, `PATH`, `PYTHONEXECUTABLE`, `PYTHONHOME`, `PYTHONPATH`, `PYTHONSTARTUP`
+    - Shell startup hooks: `BASH_ENV`, `ENV`, `BASHOPTS`, `SHELLOPTS`, `CDPATH`, `GLOBIGNORE`
+    - Credential-prompt hijack: `GIT_ASKPASS`, `SSH_ASKPASS`
+    - Git config/exec injection: `GIT_DIR`, `GIT_WORK_TREE`, `GIT_OBJECT_DIRECTORY`, `GIT_EXEC_PATH`, `GIT_EDITOR`, `GIT_PAGER`, `GIT_SSH`, `GIT_SSH_COMMAND`, plus the prefix families `GIT_CONFIG_COUNT`, `GIT_CONFIG_KEY_*`, `GIT_CONFIG_VALUE_*`, `GIT_CONFIG_PARAMETERS`, `GIT_CONFIG_SYSTEM`, and `GIT_CONFIG_GLOBAL`
+    - Windows process variables: `COMSPEC`, `SYSTEMROOT`, `WINDIR`
+
+    A project `.env` also cannot set `DEEPAGENTS_CODE_DANGEROUSLY_ENABLE_PROJECT_MCP_SERVERS`, `DEEPAGENTS_CODE_DISABLED_PROJECT_MCP_SERVERS`, `DEEPAGENTS_CODE_AUTO_CLASSIFIER_MODEL`, `DEEPAGENTS_CODE_AUTO_CLASSIFIER_TIMEOUT`, or `TERM_PROGRAM`. Set these in your shell or the global `~/.deepagents/.env` instead.
+</Accordion>
 
 <Warning>
     Running `dcode` inside an untrusted project directory exposes you to project-controlled files. A malicious `.env`, `Makefile`, or build script in that directory can influence the agent's process environment and what it runs. Treat any directory you would not run arbitrary scripts in as untrusted, and use a [remote sandbox](/oss/deepagents/code/remote-sandboxes) for untrusted repositories.

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -37,7 +37,7 @@ Deep Agents Code merges settings from several sources. Which source wins depends
 4. `~/.deepagents/config.toml`
 5. Built-in default
 
-Use `dcode config show` or `dcode config get <key>` to see the effective value and source. See [Inspect configuration](#inspect-configuration).
+Use `dcode config` or `dcode config get <key>` to see the effective value and source. See [Inspect configuration](#inspect-configuration).
 
 **Provider API keys** use a separate order. See [Key resolution order](/oss/deepagents/code/credentials#key-resolution-order).
 
@@ -51,15 +51,14 @@ The `dcode config` command group reports what configuration is in effect and whe
 
 | Command | Description |
 |---------|-------------|
-| `dcode config show` | Resolve every option against managed policy, the live environment, and `config.toml`, printing the effective value and which source provided it |
-| `dcode config list` (alias `ls`) | List every available option with its type, default, and where it can be set, without resolving values |
-| `dcode config get <key>` | Show the effective value and source for a single option, e.g. `dcode config get interpreter.memory_limit_mb` |
+| `dcode config` | Resolve every option against managed policy, the live environment, and `config.toml`, printing the effective value and source |
+| `dcode config get <key>` | Show the effective value and source for one option, for example, `dcode config get interpreter.memory_limit_mb` |
 | `dcode config path` | Show the on-disk config file locations (`managed_config.toml`, `config.toml`, project and global `.env`, `hooks.json`, and managed state files) and whether each exists |
 
-All four commands accept `--json` for machine-readable output. For the full list of management subcommands, see [CLI reference](/oss/deepagents/code/cli-reference).
+Add `--verbose` to `dcode config` or `dcode config get` to show option descriptions, defaults, and where each option can be set. Combine `--verbose` with `--json` to include accepted types and other catalog metadata. All three commands accept `--json` for machine-readable output. For the full list of management subcommands, see [CLI reference](/oss/deepagents/code/cli-reference).
 
 <Warning>
-    Provider credentials and other secrets are reported as configured / not configured only—their values are never printed by `config show` or `config get`, so the output is safe to paste into a bug report.
+    Provider credentials and other secrets are reported as configured / not configured only. Their values are never printed by `config` or `config get`, so the output is safe to paste into a bug report.
 </Warning>
 
 ## Environment variables
@@ -400,6 +399,10 @@ rm -rf ~/.deepagents
 
 ## Managed configuration
 
+<Note>
+    Managed configuration requires `deepagents-code>=0.1.59`. Model allowlists require `deepagents-code>=0.1.61`.
+</Note>
+
 Managed configuration lets an administrator enforce Deep Agents Code settings across a fleet. Deep Agents Code reads an administrator-owned `managed_config.toml` before user environment variables and `~/.deepagents/config.toml`, so users cannot override a managed value from those sources.
 
 ### Locate the managed config file
@@ -412,13 +415,13 @@ Deep Agents Code reads managed policy from a fixed path for each operating syste
 | Linux | `/etc/dcode/managed_config.toml` |
 | Windows | `<ProgramData>\dcode\managed_config.toml` |
 
-On Windows, Deep Agents Code reads the ProgramData location from the system registry, not the `%ProgramData%` environment variable. Process environment variables cannot redirect any managed config path. A missing file means that no managed policy is configured.
+On Windows, Deep Agents Code reads the ProgramData location from the system registry, not the `%ProgramData%` environment variable. Process environment variables cannot redirect any managed config path. When the registry lookup succeeds, a missing file means that no managed policy is configured. When the lookup fails, Deep Agents Code checks `C:\ProgramData\dcode\managed_config.toml`; if that fallback file is also missing, the policy state is indeterminate and commands that use configuration fail closed.
 
 ### Create a managed policy
 
-Use the same TOML sections and keys as `~/.deepagents/config.toml`. Run `dcode config list` to see the available options, their accepted types, and whether they support a config file value.
+Use the same TOML sections and keys as `~/.deepagents/config.toml`. Run `dcode config --verbose --json` to see the available options, their accepted types, and whether they support a config file value.
 
-For example, the following policy pins Manual approval mode, removes YOLO from the `Shift+Tab` mode cycle, limits shell auto-approval, disables the JavaScript interpreter, and enables client-side LangSmith secret redaction:
+For example, the following policy pins Manual approval mode, removes YOLO from the `Shift+Tab` mode cycle, limits shell auto-approval, restricts model use, disables the JavaScript interpreter, and enables client-side LangSmith secret redaction:
 
 ```toml title="managed_config.toml"
 [startup]
@@ -428,6 +431,9 @@ yolo_switcher = false
 [shell]
 allow_list = ["git", "make"]
 
+[models]
+allowed = ["acme:production", "openai:*"]
+
 [interpreter]
 enable_interpreter = false
 
@@ -436,6 +442,24 @@ langsmith_redact = true
 ```
 
 Deploy the file with write access restricted to administrators. Deep Agents Code treats managed policy as read-only. A user can still save a preference to `config.toml`, but the managed value remains effective until the administrator removes it.
+
+### Restrict model use
+
+Set `[models].allowed` to exact, case-sensitive `provider:model` specifications, or use `provider:*` to allow all discoverable models from one provider. The allowlist applies to launch defaults, `--model`, `/model`, saved defaults, Auto classifiers, rubric graders, and explicit local subagent models.
+
+```toml title="managed_config.toml"
+[models]
+allowed = [
+    "acme:production",
+    "openai:*",
+]
+default = "acme:production"
+auto_classifier = "openai:gpt-5.5"
+```
+
+A missing `allowed` key leaves model selection unrestricted. An empty list denies all model use. A malformed user list fails closed as deny-all; a malformed managed list invalidates the policy and blocks startup, reload, and commands that use configuration. A managed list replaces, rather than combines with, the user's list. Any managed `default`, `recent`, or `auto_classifier` value must also match the managed allowlist, or Deep Agents Code rejects the policy.
+
+Models added under `[models.providers.<name>].models` become discoverable but are not automatically allowed. Add an exact entry or a provider wildcard to the allowlist. A wildcard allows only models discovered or configured for that provider; if there are none, default resolution fails closed. Bare model names entered through supported user interfaces are resolved to `provider:model` before matching when Deep Agents Code can infer the provider. Use `bedrock:<id>` for Amazon Bedrock models because a bare Bedrock ID contains a version colon.
 
 <Warning>
     `[sandboxes].default` selects the backend when a user launches with `--sandbox`. It does not force sandboxing. A launch without `--sandbox` runs on the host and reports that it did not use the managed backend.
@@ -447,12 +471,12 @@ Use the configuration and diagnostic commands after deploying or changing policy
 
 ```bash
 dcode config path
-dcode config show
+dcode config
 dcode config get startup.mode
 dcode doctor
 ```
 
-`dcode config path` reports the managed file path and health. `dcode config show` and `dcode config get` label values from the file as `managed config`. `dcode doctor` reports parse errors, rejected values, and the keys that need correction.
+`dcode config path` reports the managed file path and health. `dcode config` and `dcode config get` label values from the file as `managed config`. `dcode doctor` reports parse errors, rejected values, and the keys that need correction.
 
 ### Handle invalid policy
 
@@ -463,6 +487,7 @@ A rejected value for one of the following policy-enforced keys also stops startu
 - `interpreter.enable_interpreter`
 - `interpreter.ptc`
 - `interpreter.ptc_acknowledge_unsafe`
+- `models.allowed`
 - `models.auto_classifier`
 - `runtime.recursion_limit`
 - `sandboxes.default`
@@ -663,12 +688,12 @@ Output:
   ├ Data directory: /Users/naomi/.deepagents (exists)
   └ Config file: /Users/naomi/.deepagents/config.toml (exists)
 
-  Tip: Run `dcode config show` or `dcode config get <key>` to drill into config details.
+  Tip: Run `dcode config` or `dcode config get <key>` to drill into config details.
        Run `dcode --version` (or `dcode -v`) for dependency versions.
 ```
 
 <Tip>
-    Pair `dcode doctor` with `dcode config show` when you need both a high-level health check and the exact source of a specific setting.
+    Pair `dcode doctor` with `dcode config` when you need both a high-level health check and the exact source of a specific setting.
 </Tip>
 
 ## Data locations

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -1,7 +1,7 @@
 ---
 title: Configuration
 sidebarTitle: Configuration
-description: Configure Deep Agents Code with config files, managed policy, environment variables, hooks, and CLI flags
+description: Configure Deep Agents Code with config files, administrator settings, environment variables, hooks, and CLI flags
 ---
 
 Deep Agents Code stores user configuration under `~/.deepagents/` and in project-level dotfiles. Administrators can enforce settings from a fixed system path with [`managed_config.toml`](#managed-configuration). For the full directory tree, session storage, and skill paths, see [Data locations](/oss/deepagents/code/configuration#data-locations).
@@ -12,7 +12,7 @@ The main config files are:
         Edit `config.toml` for model defaults, provider settings, themes, and update settings.
     </Card>
     <Card title="Managed configuration" icon="shield-lock" href="#managed-configuration">
-        Enforce fleet-wide settings with administrator-owned `managed_config.toml`.
+        Set administrator-controlled settings for every user with `managed_config.toml`.
     </Card>
     <Card title="Environment variables" icon="variable" href="/oss/deepagents/code/configuration#environment-variables">
         Set global API keys and secrets in `~/.deepagents/.env` or shell exports.
@@ -27,9 +27,9 @@ The main config files are:
 
 ## How settings resolve
 
-Deep Agents Code merges settings from several sources. Which source wins depends on the setting type.
+Deep Agents Code reads settings from several places. The order depends on the setting type.
 
-**General options** (interpreter limits, update settings, themes, and other `config.toml` keys) resolve in this order:
+**General options** (interpreter limits, update settings, themes, and other `config.toml` keys) use the first available value in this order:
 
 1. Administrator-owned `managed_config.toml`
 2. `DEEPAGENTS_CODE_`-prefixed environment variable
@@ -37,7 +37,7 @@ Deep Agents Code merges settings from several sources. Which source wins depends
 4. `~/.deepagents/config.toml`
 5. Built-in default
 
-Use `dcode config` or `dcode config get <key>` to see the effective value and source. See [Inspect configuration](#inspect-configuration).
+Use `dcode config` or `dcode config get <key>` to see the current value and where it comes from. See [Inspect configuration](#inspect-configuration).
 
 **Provider API keys** use a separate order. See [Key resolution order](/oss/deepagents/code/credentials#key-resolution-order).
 
@@ -47,15 +47,15 @@ Use `dcode config` or `dcode config get <key>` to see the effective value and so
 
 ## Inspect configuration
 
-The `dcode config` command group reports what configuration is in effect and where each value comes from, without starting a session. This is useful for confirming that managed policy, an environment variable, or a `config.toml` setting is being picked up, and for sharing a redacted snapshot in a bug report.
+The `dcode config` commands show the settings Deep Agents Code uses and where each value comes from, without starting a session. Use them to confirm that an administrator setting, environment variable, or `config.toml` setting is active, or to create a redacted report for troubleshooting.
 
 | Command | Description |
 |---------|-------------|
-| `dcode config` | Resolve every option against managed policy, the live environment, and `config.toml`, printing the effective value and source |
-| `dcode config get <key>` | Show the effective value and source for one option, for example, `dcode config get interpreter.memory_limit_mb` |
-| `dcode config path` | Show the on-disk config file locations (`managed_config.toml`, `config.toml`, project and global `.env`, `hooks.json`, and managed state files) and whether each exists |
+| `dcode config` | Show every setting, its current value, and where that value comes from |
+| `dcode config get <key>` | Show the current value and source for one setting, for example, `dcode config get interpreter.memory_limit_mb` |
+| `dcode config path` | Show the file locations for `managed_config.toml`, `config.toml`, project and global `.env` files, `hooks.json`, and managed state, including whether each file exists |
 
-Add `--verbose` to `dcode config` or `dcode config get` to show option descriptions, defaults, and where each option can be set. Combine `--verbose` with `--json` to include accepted types and other catalog metadata. All three commands accept `--json` for machine-readable output. For the full list of management subcommands, see [CLI reference](/oss/deepagents/code/cli-reference).
+Add `--verbose` to `dcode config` or `dcode config get` to show descriptions, defaults, and where each setting can be defined. Combine `--verbose` with `--json` to include accepted types and other reference details. All three commands accept `--json` for machine-readable output. For the full list of commands, see [CLI reference](/oss/deepagents/code/cli-reference).
 
 <Warning>
     Provider credentials and other secrets are reported as configured / not configured only. Their values are never printed by `config` or `config get`, so the output is safe to paste into a bug report.
@@ -399,11 +399,11 @@ rm -rf ~/.deepagents
 
 ## Managed configuration
 
-Managed configuration lets an administrator enforce Deep Agents Code settings across a fleet. Deep Agents Code reads an administrator-owned `managed_config.toml` before user environment variables and `~/.deepagents/config.toml`, so users cannot override a managed value from those sources.
+Managed configuration lets administrators control Deep Agents Code settings across a fleet. Deep Agents Code checks the administrator-owned `managed_config.toml` before user environment variables and `~/.deepagents/config.toml`, so users cannot override settings defined there.
 
 ### Locate the managed config file
 
-Deep Agents Code reads managed policy from a fixed path for each operating system:
+Deep Agents Code looks for `managed_config.toml` in a fixed location on each operating system:
 
 | Operating system | Path |
 |------------------|------|
@@ -411,11 +411,11 @@ Deep Agents Code reads managed policy from a fixed path for each operating syste
 | Linux | `/etc/dcode/managed_config.toml` |
 | Windows | `<ProgramData>\dcode\managed_config.toml` |
 
-On Windows, Deep Agents Code reads the ProgramData location from the system registry, not the `%ProgramData%` environment variable. Process environment variables cannot redirect any managed config path. When the registry lookup succeeds, a missing file means that no managed policy is configured. When the lookup fails, Deep Agents Code checks `C:\ProgramData\dcode\managed_config.toml`; if that fallback file is also missing, the policy state is indeterminate and commands that use configuration fail closed.
+On Windows, Deep Agents Code finds ProgramData through the system registry, not the `%ProgramData%` environment variable. Environment variables cannot change the managed config location. If the registry is unavailable, Deep Agents Code checks `C:\ProgramData\dcode\managed_config.toml`. If that file is also missing, Deep Agents Code cannot determine whether an administrator configured a policy, so commands that use configuration stop instead of running without it.
 
 ### Create a managed policy
 
-Use the same TOML sections and keys as `~/.deepagents/config.toml`. Run `dcode config --verbose --json` to see the available options, their accepted types, and whether they support a config file value.
+Use the same TOML sections and keys as `~/.deepagents/config.toml`. Run `dcode config --verbose --json` to see the available settings, their accepted types, and whether they can be set in a config file.
 
 For example, the following policy pins Manual approval mode, removes YOLO from the `Shift+Tab` mode cycle, limits shell auto-approval, restricts model use, disables the JavaScript interpreter, and enables client-side LangSmith secret redaction:
 
@@ -437,27 +437,38 @@ enable_interpreter = false
 langsmith_redact = true
 ```
 
-Deploy the file with write access restricted to administrators. Deep Agents Code treats managed policy as read-only. A user can still save a preference to `config.toml`, but the managed value remains effective until the administrator removes it.
+Only administrators should have permission to edit this file. Deep Agents Code treats it as read-only. Users can still save preferences to `config.toml`, but administrator settings remain in effect until they are removed from `managed_config.toml`.
 
-### Load policy from HTTPS
+### Load policy remotely
 
-To host policy centrally, use the fixed local `managed_config.toml` as an administrator-owned descriptor:
+You can store the policy on a central server while keeping its location in the local `managed_config.toml`:
 
 ```toml title="managed_config.toml"
 [managed_config]
 source = "https://config.example.com/dcode-policy.toml"
 ```
 
-In descriptor mode, the local file must contain only `[managed_config].source`. The downloaded TOML document supplies the complete managed policy. Deep Agents Code does not merge it with local policy keys, and the remote document cannot declare another `[managed_config]` source.
+When you configure a remote policy, the local file can contain only the `[managed_config].source` setting. Put the complete policy in the remote TOML file. Deep Agents Code does not combine remote and local policy settings, and the remote file cannot point to another source.
 
-The source must be an absolute HTTPS URL of at most 2,048 ASCII characters. URLs with credentials, query strings, fragments, whitespace, or control characters are rejected. The fetch uses Python's default TLS trust store, bypasses environment proxies, refuses redirects and compressed responses, and applies a five-second end-to-end timeout and a 1 MiB response limit.
+The URL must meet these requirements:
 
-The server must return HTTP 200 with a complete response delimited by a matching `Content-Length` value or chunked transfer encoding. If the response includes `Content-Type`, it must be `application/toml`, `text/plain`, or `application/octet-stream`. A missing `Content-Type` is accepted. The response must contain a non-empty UTF-8 TOML policy.
+- Use HTTPS.
+- Use no more than 2,048 ASCII characters.
+- Do not include credentials, a query string, a fragment, whitespace, or control characters.
 
-Deep Agents Code does not store a disk cache or authentication material for the remote source.
+Deep Agents Code downloads the policy using Python's default trusted certificate authorities. It ignores proxy environment variables, does not follow redirects, rejects compressed responses, stops the request after five seconds, and accepts up to 1 MiB.
+
+The server must return:
+
+- HTTP status `200`.
+- A complete response that uses either `Content-Length` or chunked transfer encoding.
+- A non-empty UTF-8 TOML file.
+- One of the following `Content-Type` values, if provided: `application/toml`, `text/plain`, or `application/octet-stream`.
+
+Deep Agents Code does not save the remote policy or any authentication details to disk.
 
 <Warning>
-    The TLS trust store is not pinned. `SSL_CERT_FILE` and `SSL_CERT_DIR` can change the certificate authorities used for the request, so run Deep Agents Code in an environment controlled by the administrator when relying on remote managed policy.
+    `SSL_CERT_FILE` and `SSL_CERT_DIR` can change which certificate authorities Python trusts. When you use a remote policy, make sure users cannot change these environment variables for the Deep Agents Code process.
 </Warning>
 
 ### Restrict model use
@@ -474,9 +485,9 @@ default = "acme:production"
 auto_classifier = "openai:gpt-5.5"
 ```
 
-A missing `allowed` key leaves model selection unrestricted. An empty list denies all model use. A malformed user list fails closed as deny-all; a malformed managed list invalidates the policy and blocks startup, reload, and commands that use configuration. A managed list replaces, rather than combines with, the user's list. Any managed `default`, `recent`, or `auto_classifier` value must also match the managed allowlist, or Deep Agents Code rejects the policy.
+If you omit `allowed`, users can select any model. An empty list blocks all models. If a user's list is invalid, Deep Agents Code blocks all models. If the administrator's list is invalid, Deep Agents Code blocks startup, reload, and other commands that use configuration. The administrator's list replaces the user's list rather than combining with it. The managed `default`, `recent`, and `auto_classifier` values must also appear in the administrator's allowlist.
 
-Models added under `[models.providers.<name>].models` become discoverable but are not automatically allowed. Add an exact entry or a provider wildcard to the allowlist. A wildcard allows only models discovered or configured for that provider; if there are none, default resolution fails closed. Bare model names entered through supported user interfaces are resolved to `provider:model` before matching when Deep Agents Code can infer the provider. Use `bedrock:<id>` for Amazon Bedrock models because a bare Bedrock ID contains a version colon.
+Adding a model under `[models.providers.<name>].models` makes it available for selection but does not allow it automatically. Add the exact model or a provider wildcard to the allowlist. A wildcard covers only the models available for that provider. If no models are available, Deep Agents Code cannot choose a default. When Deep Agents Code can identify the provider for a bare model name entered in the interface, it converts the name to `provider:model` before checking the allowlist. For Amazon Bedrock models, use `bedrock:<id>` because the model ID itself contains a version colon.
 
 <Warning>
     `[sandboxes].default` selects the backend when a user launches with `--sandbox`. It does not force sandboxing. A launch without `--sandbox` runs on the host and reports that it did not use the managed backend.
@@ -493,15 +504,15 @@ dcode config get startup.mode
 dcode doctor
 ```
 
-`dcode config path` reports the managed file path and health. `dcode config` and `dcode config get` label values from the file as `managed config`. `dcode doctor` reports parse errors, rejected values, and the keys that need correction. For remote policy, `dcode doctor` shows the local descriptor and remote URL. If a refresh fails, it also reports whether the session is still enforcing the last enforceable policy.
+`dcode config path` shows the managed file location and whether Deep Agents Code can read it. `dcode config` and `dcode config get` label settings from the file as `managed config`. `dcode doctor` lists parsing errors, invalid values, and the settings that need correction. For a remote policy, it also shows the local file and remote URL. If an update fails, it confirms whether the session continues to use the previous valid policy.
 
-### Handle invalid policy
+### Fix an invalid policy
 
-Deep Agents Code fails closed when a managed file cannot be read or parsed, when a remote policy cannot be fetched completely, or when its policy is unsafe to apply. Commands that use configuration exit with code `78`; `dcode config`, `dcode doctor`, `dcode auth path`, and help screens remain available for troubleshooting.
+Deep Agents Code stops rather than run without required administrator settings when it cannot read or parse the managed file, cannot download the complete remote policy, or cannot safely apply the policy. Commands that use configuration exit with code `78`. You can still run `dcode config`, `dcode doctor`, `dcode auth path`, and help commands to troubleshoot the problem.
 
-A failed refresh does not replace policy that the current process already enforced. Deep Agents Code keeps the last enforceable generation and reports the failed refresh. A new process without an enforceable generation cannot start with an unavailable or invalid remote policy.
+If an update fails during a running session, Deep Agents Code continues to use the previous valid policy and reports the failure. A new process cannot start until it can load a valid policy.
 
-A rejected value for one of the following policy-enforced keys also stops startup because falling through to a user value could grant a privilege or remove a boundary:
+An invalid value for any of the following settings also stops startup because using a user value instead could remove a required restriction:
 
 - `interpreter.enable_interpreter`
 - `interpreter.ptc`
@@ -516,7 +527,7 @@ A rejected value for one of the following policy-enforced keys also stops startu
 - `startup.yolo_switcher`
 - `tracing.langsmith_redact`
 
-A known configuration section declared with the wrong TOML shape also stops startup. For other options, Deep Agents Code ignores an invalid managed value, uses the next valid lower-precedence source, and reports the rejected key through `dcode config` and `dcode doctor`.
+A known configuration section also stops startup if it has the wrong TOML structure. For other settings, Deep Agents Code ignores an invalid administrator value, uses the next valid source, and lists the ignored setting in `dcode config` and `dcode doctor`.
 
 ## Managed deployments
 
@@ -566,7 +577,7 @@ curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_VERSION="0.1.16" bash
     Path to the uv binary. Auto-detected if unset.
 </ResponseField>
 
-Auto-update is enabled by default for managed installs. To manage update behavior fleet-wide, set `[update] auto_update = false` or `[update] check = false` in [`managed_config.toml`](#managed-configuration). For an unmanaged installation, use `DEEPAGENTS_CODE_AUTO_UPDATE=0`, `DEEPAGENTS_CODE_NO_UPDATE_CHECK=1`, or the corresponding keys in `~/.deepagents/config.toml`.
+Auto-update is enabled by default for managed installations. To control updates for every user, set `[update] auto_update = false` or `[update] check = false` in [`managed_config.toml`](#managed-configuration). For other installations, use `DEEPAGENTS_CODE_AUTO_UPDATE=0`, `DEEPAGENTS_CODE_NO_UPDATE_CHECK=1`, or the corresponding settings in `~/.deepagents/config.toml`.
 
 To route every user's model traffic through a managed gateway (provisioning a gateway key and base URL fleet-wide), see [Managed gateways](/oss/deepagents/code/config-file#managed-gateways).
 
@@ -712,7 +723,7 @@ Output:
 ```
 
 <Tip>
-    Pair `dcode doctor` with `dcode config` when you need both a high-level health check and the exact source of a specific setting.
+    Pair `dcode doctor` with `dcode config` to check overall health and see where a specific setting comes from.
 </Tip>
 
 ## Data locations

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -690,7 +690,7 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_RECURSION_LIMIT" type="integer" post={["optional"]}>
-    LangGraph graph step budget, which is the maximum number of node invocations the `dcode` agent graph may execute per turn. Valid range: `25`–`100000`. Out-of-range or non-integer values log a warning and fall back to the default (`2000`). Overridden by `--recursion-limit` at the CLI. See [Agent runtime limits](/oss/deepagents/code/config-file#agent-runtime-limits).
+    LangGraph graph step budget, which is the maximum number of node invocations the `dcode` agent graph may execute per turn. Valid range: `25`–`100000`. Invalid values log a warning and resolution continues to the next source. The `--recursion-limit` CLI flag takes precedence unless administrator-owned managed configuration sets the value. When no source sets a valid value, Deep Agents Code leaves the limit to the LangGraph server. See [Agent runtime limits](/oss/deepagents/code/config-file#agent-runtime-limits).
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_SHELL_ALLOW_LIST" type="string" post={["optional"]}>

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -399,7 +399,7 @@ rm -rf ~/.deepagents
 
 ## Managed configuration
 
-Managed configuration lets administrators control Deep Agents Code settings across a fleet. Deep Agents Code checks the administrator-owned `managed_config.toml` before user environment variables and `~/.deepagents/config.toml`, so users cannot override settings defined there.
+Managed configuration lets administrators control Deep Agents Code settings across a fleet. Deep Agents Code checks the administrator-owned `managed_config.toml` before user environment variables and config, so users cannot override settings defined there.
 
 ### Locate the managed config file
 

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -47,7 +47,7 @@ Use `dcode config` or `dcode config get <key>` to see the current value and wher
 
 ## Inspect configuration
 
-The `dcode config` commands show the settings Deep Agents Code uses and where each value comes from, without starting a session. Use them to confirm that an administrator setting, environment variable, or `config.toml` setting is active, or to create a redacted report for troubleshooting.
+The `dcode config` commands show the settings Deep Agents Code uses and where each value comes from, without starting a session. Use them to confirm that an administrator setting, environment variable, or `config.toml` setting is active.
 
 | Command | Description |
 |---------|-------------|

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -439,6 +439,27 @@ langsmith_redact = true
 
 Deploy the file with write access restricted to administrators. Deep Agents Code treats managed policy as read-only. A user can still save a preference to `config.toml`, but the managed value remains effective until the administrator removes it.
 
+### Load policy from HTTPS
+
+To host policy centrally, use the fixed local `managed_config.toml` as an administrator-owned descriptor:
+
+```toml title="managed_config.toml"
+[managed_config]
+source = "https://config.example.com/dcode-policy.toml"
+```
+
+In descriptor mode, the local file must contain only `[managed_config].source`. The downloaded TOML document supplies the complete managed policy. Deep Agents Code does not merge it with local policy keys, and the remote document cannot declare another `[managed_config]` source.
+
+The source must be an absolute HTTPS URL of at most 2,048 ASCII characters. URLs with credentials, query strings, fragments, whitespace, or control characters are rejected. The fetch uses Python's default TLS trust store, bypasses environment proxies, refuses redirects and compressed responses, and applies a five-second end-to-end timeout and a 1 MiB response limit.
+
+The server must return HTTP 200 with a complete response delimited by a matching `Content-Length` value or chunked transfer encoding. If the response includes `Content-Type`, it must be `application/toml`, `text/plain`, or `application/octet-stream`. A missing `Content-Type` is accepted. The response must contain a non-empty UTF-8 TOML policy.
+
+Deep Agents Code does not store a disk cache or authentication material for the remote source.
+
+<Warning>
+    The TLS trust store is not pinned. `SSL_CERT_FILE` and `SSL_CERT_DIR` can change the certificate authorities used for the request, so run Deep Agents Code in an environment controlled by the administrator when relying on remote managed policy.
+</Warning>
+
 ### Restrict model use
 
 Set `[models].allowed` to exact, case-sensitive `provider:model` specifications, or use `provider:*` to allow all discoverable models from one provider. The allowlist applies to launch defaults, `--model`, `/model`, saved defaults, Auto classifiers, rubric graders, and explicit local subagent models.
@@ -472,11 +493,13 @@ dcode config get startup.mode
 dcode doctor
 ```
 
-`dcode config path` reports the managed file path and health. `dcode config` and `dcode config get` label values from the file as `managed config`. `dcode doctor` reports parse errors, rejected values, and the keys that need correction.
+`dcode config path` reports the managed file path and health. `dcode config` and `dcode config get` label values from the file as `managed config`. `dcode doctor` reports parse errors, rejected values, and the keys that need correction. For remote policy, `dcode doctor` shows the local descriptor and remote URL. If a refresh fails, it also reports whether the session is still enforcing the last enforceable policy.
 
 ### Handle invalid policy
 
-Deep Agents Code fails closed when a managed file cannot be read or parsed, or when its policy is unsafe to apply. Commands that use configuration exit with code `78`; `dcode config`, `dcode doctor`, `dcode auth path`, and help screens remain available for troubleshooting.
+Deep Agents Code fails closed when a managed file cannot be read or parsed, when a remote policy cannot be fetched completely, or when its policy is unsafe to apply. Commands that use configuration exit with code `78`; `dcode config`, `dcode doctor`, `dcode auth path`, and help screens remain available for troubleshooting.
+
+A failed refresh does not replace policy that the current process already enforced. Deep Agents Code keeps the last enforceable generation and reports the failed refresh. A new process without an enforceable generation cannot start with an unavailable or invalid remote policy.
 
 A rejected value for one of the following policy-enforced keys also stops startup because falling through to a user value could grant a privilege or remove a boundary:
 

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -399,10 +399,6 @@ rm -rf ~/.deepagents
 
 ## Managed configuration
 
-<Note>
-    Managed configuration requires `deepagents-code>=0.1.59`. Model allowlists require `deepagents-code>=0.1.61`.
-</Note>
-
 Managed configuration lets an administrator enforce Deep Agents Code settings across a fleet. Deep Agents Code reads an administrator-owned `managed_config.toml` before user environment variables and `~/.deepagents/config.toml`, so users cannot override a managed value from those sources.
 
 ### Locate the managed config file

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -1,15 +1,18 @@
 ---
 title: Configuration
 sidebarTitle: Configuration
-description: Configure Deep Agents Code with config.toml, environment variables, hooks, and CLI flags
+description: Configure Deep Agents Code with config files, managed policy, environment variables, hooks, and CLI flags
 ---
 
-Deep Agents Code stores configuration under `~/.deepagents/` and in project-level dotfiles. For the full directory tree, session storage, and skill paths, see [Data locations](/oss/deepagents/code/configuration#data-locations).
+Deep Agents Code stores user configuration under `~/.deepagents/` and in project-level dotfiles. Administrators can enforce settings from a fixed system path with [`managed_config.toml`](#managed-configuration). For the full directory tree, session storage, and skill paths, see [Data locations](/oss/deepagents/code/configuration#data-locations).
 
 The main config files are:
 <CardGroup cols={2}>
     <Card title="Config file" icon="file-code" href="/oss/deepagents/code/config-file">
         Edit `config.toml` for model defaults, provider settings, themes, and update settings.
+    </Card>
+    <Card title="Managed configuration" icon="shield-lock" href="#managed-configuration">
+        Enforce fleet-wide settings with administrator-owned `managed_config.toml`.
     </Card>
     <Card title="Environment variables" icon="variable" href="/oss/deepagents/code/configuration#environment-variables">
         Set global API keys and secrets in `~/.deepagents/.env` or shell exports.
@@ -28,10 +31,11 @@ Deep Agents Code merges settings from several sources. Which source wins depends
 
 **General options** (interpreter limits, update settings, themes, and other `config.toml` keys) resolve in this order:
 
-1. `DEEPAGENTS_CODE_`-prefixed environment variable
-2. Canonical environment variable (when applicable)
-3. `~/.deepagents/config.toml`
-4. Built-in default
+1. Administrator-owned `managed_config.toml`
+2. `DEEPAGENTS_CODE_`-prefixed environment variable
+3. Canonical environment variable (when applicable)
+4. `~/.deepagents/config.toml`
+5. Built-in default
 
 Use `dcode config show` or `dcode config get <key>` to see the effective value and source. See [Inspect configuration](#inspect-configuration).
 
@@ -43,14 +47,14 @@ Use `dcode config show` or `dcode config get <key>` to see the effective value a
 
 ## Inspect configuration
 
-The `dcode config` command group reports what configuration is in effect and where each value comes from, without starting a session. This is useful for confirming that an environment variable or `config.toml` setting is being picked up, and for sharing a redacted snapshot in a bug report.
+The `dcode config` command group reports what configuration is in effect and where each value comes from, without starting a session. This is useful for confirming that managed policy, an environment variable, or a `config.toml` setting is being picked up, and for sharing a redacted snapshot in a bug report.
 
 | Command | Description |
 |---------|-------------|
-| `dcode config show` | Resolve every option against the live environment and `config.toml`, printing the effective value and which source provided it |
+| `dcode config show` | Resolve every option against managed policy, the live environment, and `config.toml`, printing the effective value and which source provided it |
 | `dcode config list` (alias `ls`) | List every available option with its type, default, and where it can be set, without resolving values |
 | `dcode config get <key>` | Show the effective value and source for a single option, e.g. `dcode config get interpreter.memory_limit_mb` |
-| `dcode config path` | Show the on-disk config file locations (`config.toml`, project and global `.env`, `hooks.json`, and managed state files) and whether each exists |
+| `dcode config path` | Show the on-disk config file locations (`managed_config.toml`, `config.toml`, project and global `.env`, `hooks.json`, and managed state files) and whether each exists |
 
 All four commands accept `--json` for machine-readable output. For the full list of management subcommands, see [CLI reference](/oss/deepagents/code/cli-reference).
 
@@ -394,6 +398,86 @@ The uninstall command does not remove user configuration or session data. Deep A
 rm -rf ~/.deepagents
 ```
 
+## Managed configuration
+
+Managed configuration lets an administrator enforce Deep Agents Code settings across a fleet. Deep Agents Code reads an administrator-owned `managed_config.toml` before user environment variables and `~/.deepagents/config.toml`, so users cannot override a managed value from those sources.
+
+<Note>
+    Managed configuration requires `deepagents-code>=0.1.59`.
+</Note>
+
+### Locate the managed config file
+
+Deep Agents Code reads managed policy from a fixed path for each operating system:
+
+| Operating system | Path |
+|------------------|------|
+| macOS | `/Library/Application Support/dcode/managed_config.toml` |
+| Linux | `/etc/dcode/managed_config.toml` |
+| Windows | `<ProgramData>\dcode\managed_config.toml` |
+
+On Windows, Deep Agents Code reads the ProgramData location from the system registry, not the `%ProgramData%` environment variable. Process environment variables cannot redirect any managed config path. A missing file means that no managed policy is configured.
+
+### Create a managed policy
+
+Use the same TOML sections and keys as `~/.deepagents/config.toml`. Run `dcode config list` to see the available options, their accepted types, and whether they support a config file value.
+
+For example, the following policy pins Manual approval mode, removes YOLO from the `Shift+Tab` mode cycle, limits shell auto-approval, disables the JavaScript interpreter, and enables client-side LangSmith secret redaction:
+
+```toml title="managed_config.toml"
+[startup]
+mode = "manual"
+yolo_switcher = false
+
+[shell]
+allow_list = ["git", "make"]
+
+[interpreter]
+enable_interpreter = false
+
+[tracing]
+langsmith_redact = true
+```
+
+Deploy the file with write access restricted to administrators. Deep Agents Code treats managed policy as read-only. A user can still save a preference to `config.toml`, but the managed value remains effective until the administrator removes it.
+
+<Warning>
+    `[sandboxes].default` selects the backend when a user launches with `--sandbox`. It does not force sandboxing. A launch without `--sandbox` runs on the host and reports that it did not use the managed backend.
+</Warning>
+
+### Validate a managed policy
+
+Use the configuration and diagnostic commands after deploying or changing policy:
+
+```bash
+dcode config path
+dcode config show
+dcode config get startup.mode
+dcode doctor
+```
+
+`dcode config path` reports the managed file path and health. `dcode config show` and `dcode config get` label values from the file as `managed config`. `dcode doctor` reports parse errors, rejected values, and the keys that need correction.
+
+### Handle invalid policy
+
+Deep Agents Code fails closed when a managed file cannot be read or parsed, or when its policy is unsafe to apply. Commands that use configuration exit with code `78`; `dcode config`, `dcode doctor`, `dcode auth path`, and help screens remain available for troubleshooting.
+
+A rejected value for one of the following policy-enforced keys also stops startup because falling through to a user value could grant a privilege or remove a boundary:
+
+- `interpreter.enable_interpreter`
+- `interpreter.ptc`
+- `interpreter.ptc_acknowledge_unsafe`
+- `models.auto_classifier`
+- `runtime.recursion_limit`
+- `sandboxes.default`
+- `shell.allow_list`
+- `skills.extra_allowed_dirs`
+- `startup.mode`
+- `startup.yolo_switcher`
+- `tracing.langsmith_redact`
+
+A known configuration section declared with the wrong TOML shape also stops startup. For other options, Deep Agents Code ignores an invalid managed value, uses the next valid lower-precedence source, and reports the rejected key through `dcode config` and `dcode doctor`.
+
 ## Managed deployments
 
 The [install script](https://github.com/langchain-ai/deepagents/blob/main/libs/code/scripts/install.sh) supports running as root, targeting macOS MDM tools (Kandji, Jamf, etc.) that execute scripts in a minimal root environment.
@@ -442,7 +526,7 @@ curl -LsSf https://langch.in/dcode | DEEPAGENTS_CODE_VERSION="0.1.16" bash
     Path to the uv binary. Auto-detected if unset.
 </ResponseField>
 
-Auto-update is enabled by default for managed installs. To opt out, set `DEEPAGENTS_CODE_AUTO_UPDATE=0` in the user's shell profile or deploy a `config.toml` with `[update] auto_update = false` to `~/.deepagents/config.toml`. To suppress automatic updates and update checks entirely, set `DEEPAGENTS_CODE_NO_UPDATE_CHECK=1` or deploy `[update] check = false`.
+Auto-update is enabled by default for managed installs. To manage update behavior fleet-wide, set `[update] auto_update = false` or `[update] check = false` in [`managed_config.toml`](#managed-configuration). For an unmanaged installation, use `DEEPAGENTS_CODE_AUTO_UPDATE=0`, `DEEPAGENTS_CODE_NO_UPDATE_CHECK=1`, or the corresponding keys in `~/.deepagents/config.toml`.
 
 To route every user's model traffic through a managed gateway (provisioning a gateway key and base URL fleet-wide), see [Managed gateways](/oss/deepagents/code/config-file#managed-gateways).
 

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -27,7 +27,7 @@ The main config files are:
 
 ## How settings resolve
 
-Deep Agents Code reads settings from several places. The order depends on the setting type.
+Deep Agents Code uses tiered configuration. The precedence order depends on the setting type.
 
 **General options** (interpreter limits, update settings, themes, and other `config.toml` keys) use the first available value in this order:
 
@@ -358,7 +358,7 @@ Large pastes into the chat input are collapsed into compact placeholders (defaul
 
 ## Automatic memory
 
-Deep Agents Code automatically saves learnings to memory. To keep loading memory while stopping automatic saves:
+Deep Agents Code automatically saves learnings to memory. To keep loading memory while stopping automatic saves, change the [automatic memory setting](/oss/deepagents/code/memory-and-skills#automatic-memory):
 
 <Tabs>
     <Tab title="Config file">
@@ -378,7 +378,7 @@ You can still save memories explicitly with `/remember`. The environment variabl
 
 ## Conversation history retention
 
-Offloading a thread with `/offload` writes a markdown archive under `~/.deepagents/conversation_history/`. A best-effort startup sweep deletes archives older than 30 days. The sweep only touches regular `.md` files directly inside the archive directory, never blocks startup, and logs and swallows filesystem errors.
+Offloading a thread with `/offload` writes a markdown archive under `~/.deepagents/conversation_history/`. A startup sweep deletes archives older than 30 days. The sweep only touches regular `.md` files directly inside the archive directory, never blocks startup, and logs and swallows filesystem errors.
 
 Change the retention window, or disable cleanup with `0`:
 
@@ -479,7 +479,7 @@ auto_classifier = "openai:gpt-5.5"
 
 If you omit `allowed`, users can select any model. An empty list blocks all models. If a user's list is invalid, Deep Agents Code blocks all models. If the administrator's list is invalid, Deep Agents Code blocks startup, reload, and other commands that use configuration. The administrator's list replaces the user's list rather than combining with it. The managed `default`, `recent`, and `auto_classifier` values must also appear in the administrator's allowlist.
 
-Adding a model under `[models.providers.<name>].models` makes it available for selection but does not allow it automatically. Add the exact model or a provider wildcard to the allowlist. A wildcard covers only the models available for that provider. If no models are available, Deep Agents Code cannot choose a default. When Deep Agents Code can identify the provider for a bare model name entered in the interface, it converts the name to `provider:model` before checking the allowlist. For Amazon Bedrock models, use `bedrock:<id>` because the model ID itself contains a version colon.
+Adding a model under `[models.providers.<name>].models` makes it available for selection but does not allow it automatically. Add the exact model or a provider wildcard to the allowlist. A wildcard covers only the models available for that provider. If no models are available, Deep Agents Code cannot choose a default. When Deep Agents Code can identify the provider for a bare model name entered in the interface, it converts the name to `provider:model` before checking the allowlist.
 
 <Warning>
     `[sandboxes].default` selects the backend when a user launches with `--sandbox`. It does not force sandboxing. A launch without `--sandbox` runs on the host and reports that it did not use the managed backend.
@@ -496,26 +496,15 @@ source = "https://config.example.com/dcode-policy.toml"
 
 When you configure a remote policy, the local file can contain only the `[managed_config].source` setting. Put the complete policy in the remote TOML file. Deep Agents Code does not combine remote and local policy settings, and the remote file cannot point to another source.
 
-The URL must meet these requirements:
+<Accordion title="View remote policy requirements">
+    The URL must use HTTPS, contain no credentials or query parameters, and be no more than 2,048 ASCII characters. Deep Agents Code does not follow redirects, use proxy environment variables, or save the remote policy to disk.
 
-- Use HTTPS.
-- Use no more than 2,048 ASCII characters.
-- Do not include credentials, a query string, a fragment, whitespace, or control characters.
+    The server must return a non-empty UTF-8 TOML file with HTTP status `200`, no compression, and a maximum size of 1 MiB. Requests time out after five seconds.
 
-Deep Agents Code downloads the policy using Python's default trusted certificate authorities. It ignores proxy environment variables, does not follow redirects, rejects compressed responses, stops the request after five seconds, and accepts up to 1 MiB.
-
-The server must return:
-
-- HTTP status `200`.
-- A complete response that uses either `Content-Length` or chunked transfer encoding.
-- A non-empty UTF-8 TOML file.
-- One of the following `Content-Type` values, if provided: `application/toml`, `text/plain`, or `application/octet-stream`.
-
-Deep Agents Code does not save the remote policy or any authentication details to disk.
-
-<Warning>
-    `SSL_CERT_FILE` and `SSL_CERT_DIR` can change which certificate authorities Python trusts. When you use a remote policy, make sure users cannot change these environment variables for the Deep Agents Code process.
-</Warning>
+    <Warning>
+        `SSL_CERT_FILE` and `SSL_CERT_DIR` can change which certificate authorities Python trusts. Make sure users cannot change these variables for the Deep Agents Code process.
+    </Warning>
+</Accordion>
 
 ### Validate a managed policy
 
@@ -536,22 +525,24 @@ Deep Agents Code stops rather than run without required administrator settings w
 
 If an update fails during a running session, Deep Agents Code continues to use the previous valid policy and reports the failure. A new process cannot start until it can load a valid policy.
 
-An invalid value for any of the following settings also stops startup because using a user value instead could remove a required restriction:
+<Accordion title="View settings that fail closed">
+    An invalid value for any of the following settings stops startup because falling back to a user value could remove a required restriction:
 
-- `interpreter.enable_interpreter`
-- `interpreter.ptc`
-- `interpreter.ptc_acknowledge_unsafe`
-- `models.allowed`
-- `models.auto_classifier`
-- `runtime.recursion_limit`
-- `sandboxes.default`
-- `shell.allow_list`
-- `skills.extra_allowed_dirs`
-- `startup.mode`
-- `startup.yolo_switcher`
-- `tracing.langsmith_redact`
+    - `interpreter.enable_interpreter`
+    - `interpreter.ptc`
+    - `interpreter.ptc_acknowledge_unsafe`
+    - `models.allowed`
+    - `models.auto_classifier`
+    - `runtime.recursion_limit`
+    - `sandboxes.default`
+    - `shell.allow_list`
+    - `skills.extra_allowed_dirs`
+    - `startup.mode`
+    - `startup.yolo_switcher`
+    - `tracing.langsmith_redact`
 
-A known configuration section also stops startup if it has the wrong TOML structure. For other settings, Deep Agents Code ignores an invalid administrator value, uses the next valid source, and lists the ignored setting in `dcode config` and `dcode doctor`.
+    A known configuration section also stops startup if it has the wrong TOML structure. For other settings, Deep Agents Code ignores an invalid administrator value, uses the next valid source, and lists the ignored setting in `dcode config` and `dcode doctor`.
+</Accordion>
 
 ## Managed deployments
 
@@ -690,7 +681,7 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_RECURSION_LIMIT" type="integer" post={["optional"]}>
-    LangGraph graph step budget, which is the maximum number of node invocations the `dcode` agent graph may execute per turn. Valid range: `25`–`100000`. Invalid values log a warning and resolution continues to the next source. The `--recursion-limit` CLI flag takes precedence unless administrator-owned managed configuration sets the value. When no source sets a valid value, Deep Agents Code leaves the limit to the LangGraph server. See [Agent runtime limits](/oss/deepagents/code/config-file#agent-runtime-limits).
+    LangGraph graph step budget, which is the maximum number of node invocations the `dcode` agent graph may execute per turn. Valid range: `25`–`100000`. Invalid values log a warning and resolution continues to the next source. When unset, the LangGraph server default applies. See [Agent runtime limits](/oss/deepagents/code/config-file#agent-runtime-limits).
 </ResponseField>
 
 <ResponseField name="DEEPAGENTS_CODE_SHELL_ALLOW_LIST" type="string" post={["optional"]}>

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -402,10 +402,6 @@ rm -rf ~/.deepagents
 
 Managed configuration lets an administrator enforce Deep Agents Code settings across a fleet. Deep Agents Code reads an administrator-owned `managed_config.toml` before user environment variables and `~/.deepagents/config.toml`, so users cannot override a managed value from those sources.
 
-<Note>
-    Managed configuration requires `deepagents-code>=0.1.59`.
-</Note>
-
 ### Locate the managed config file
 
 Deep Agents Code reads managed policy from a fixed path for each operating system:

--- a/src/oss/deepagents/code/memory-and-skills.mdx
+++ b/src/oss/deepagents/code/memory-and-skills.mdx
@@ -28,7 +28,7 @@ As you use the agent, it automatically stores information in `~/.deepagents/<age
 2. **Response**: Checks memory when uncertain during execution
 3. **Learning**: Automatically saves new information for future sessions
 
-Since `deepagents-code>=0.1.38`, you can keep loading memory while stopping the agent from *automatically* writing learnings back to its `AGENTS.md` sources:
+You can keep loading memory while stopping the agent from *automatically* writing learnings back to its `AGENTS.md` sources:
 
 <Tabs>
     <Tab title="Config file">

--- a/src/oss/deepagents/code/memory-and-skills.mdx
+++ b/src/oss/deepagents/code/memory-and-skills.mdx
@@ -28,6 +28,24 @@ As you use the agent, it automatically stores information in `~/.deepagents/<age
 2. **Response**: Checks memory when uncertain during execution
 3. **Learning**: Automatically saves new information for future sessions
 
+Since `deepagents-code>=0.1.38`, you can keep loading memory while stopping the agent from *automatically* writing learnings back to its `AGENTS.md` sources:
+
+<Tabs>
+    <Tab title="Config file">
+        ```toml title="~/.deepagents/config.toml"
+        [memory]
+        auto_save = false
+        ```
+    </Tab>
+    <Tab title="Environment variable">
+        ```bash
+        export DEEPAGENTS_CODE_MEMORY_AUTO_SAVE=0
+        ```
+    </Tab>
+</Tabs>
+
+With `auto_save` off, memory is still read into context and explicit saves (such as `/remember`) still work—only unprompted auto-saving stops.
+
 The agent organizes its memories by topic with descriptive filenames:
 
 ```

--- a/src/oss/deepagents/code/memory-and-skills.mdx
+++ b/src/oss/deepagents/code/memory-and-skills.mdx
@@ -28,23 +28,7 @@ As you use the agent, it automatically stores information in `~/.deepagents/<age
 2. **Response**: Checks memory when uncertain during execution
 3. **Learning**: Automatically saves new information for future sessions
 
-You can keep loading memory while stopping the agent from *automatically* writing learnings back to its `AGENTS.md` sources:
-
-<Tabs>
-    <Tab title="Config file">
-        ```toml title="~/.deepagents/config.toml"
-        [memory]
-        auto_save = false
-        ```
-    </Tab>
-    <Tab title="Environment variable">
-        ```bash
-        export DEEPAGENTS_CODE_MEMORY_AUTO_SAVE=0
-        ```
-    </Tab>
-</Tabs>
-
-With `auto_save` off, memory is still read into context and explicit saves (such as `/remember`) still work—only unprompted auto-saving stops.
+To keep loading memory while stopping automatic saves, see [Automatic memory](/oss/deepagents/code/configuration#automatic-memory).
 
 The agent organizes its memories by topic with descriptive filenames:
 


### PR DESCRIPTION
Shared Deep Agents Code config docs were stale or missing for several shipped releases. This backfills them, verified against `libs/code/deepagents_code/config_manifest.py` on `langchain-ai/deepagents` main.

- `[models].allowed` allowlist syntax and fail-closed semantics (0.1.61, #5649); `startup.read_project_dotenv` plus the exact dotenv-denied key set (0.1.60, #5726 #5723); `DEEPAGENTS_HOME` forms and trust boundary (0.1.62, #5773); LangSmith redaction now default-on (0.1.62, #5816); `history.retention_days` (0.1.61, #5751); `memory.auto_save` (0.1.38, #4700); `show_usage_stats`, `collapse_pastes`, `compact_on_resume_threshold`, `prices_auto_update`; complete `[interpreter]` reference.
- Fixes the stale `--interpreter-tools` default in `cli-reference.mdx` (`safe`, not "no PTC") and the inverted `langsmith_redact` default.
- Refreshes retry documentation for the model-node retry middleware (default `5`, `0` disables) and updates recursion-limit precedence, bounds, and LangGraph server fallback to match current `main`.
- Verification: scoped `make lint_prose` (0 errors) and `make broken-links` (clean). No new pages or nav changes; approval/goals/command/MCP pages untouched.

## Stack

This is stack 1/4 and targets `main`. It also supersedes #5626.

Made by [Open SWE](https://openswe.vercel.app/agents/71ca157c-3fc4-5555-853e-259b564414f2)
