### PR TITLE
docs: fix incorrect tool name in parallel tool calls example (JS)

### DIFF
--- a/src/oss/langchain/models.mdx
+++ b/src/oss/langchain/models.mdx
@@ -828,7 +828,7 @@ Below, we show some common ways you can use tool calling.
         console.log(response.tool_calls)
         // [
         //   { name: 'get_weather', args: { location: 'Boston' }, id: 'call_1' },
-        //   { name: 'get_time', args: { location: 'Tokyo' }, id: 'call_2' }
+        //   { name: 'get_weather', args: { location: 'Tokyo' }, id: 'call_2' }
         // ]
 
 


### PR DESCRIPTION
## What
Fixes a copy-paste mistake in the TypeScript "Parallel tool calls" example in `src/oss/langchain/models.mdx`. The second tool call in the sample output was shown as `get_time` instead of `get_weather`.

## Why
The snippet only defines and uses a `get_weather` tool, and the equivalent Python example directly above it correctly shows `get_weather` for both calls. The JS/TS version was inconsistent with it.

## Change
```ts
// Before
{ name: 'get_time', args: { location: 'Tokyo' }, id: 'call_2' }

// After
{ name: 'get_weather', args: { location: 'Tokyo' }, id: 'call_2' }
```

Fixes #2398