### PR TITLE
docs: document AWS support in shared responsibility model

### DIFF
--- a/src/langsmith/shared-responsibility-model.mdx
+++ b/src/langsmith/shared-responsibility-model.mdx
@@ -10,7 +10,7 @@ LangSmith operates as a multi-tenant SaaS solution. Our security model is design
 
 | Domain | LangChain responsibility (provider) | Customer responsibility (user) |
 | :---- | :---- | :---- |
-| **Infrastructure** | We manage the underlying cloud infrastructure (via GCP), including servers, networking, OS patching, and capacity planning. GCP owns the physical data centers. | N/A. You do not provision or maintain compute resources in the SaaS environment. |
+| **Infrastructure** | We manage the underlying cloud infrastructure (via AWS and GCP), including servers, networking, OS patching, and capacity planning. AWS and GCP own the physical data centers. | N/A. You do not provision or maintain compute resources in the SaaS environment. |
 | **Application** | We secure the LangSmith application code, API endpoints, and database clusters, including code scanning and penetration testing. | You are responsible for the security and safety of the AI chains and agents you build using our SDKs. |
 | **Data** | We enforce tenant isolation and encrypt data at rest using AES-256 and in transit using TLS 1.2 or higher. | You control what data is sent to us and must filter sensitive PII via the SDK before it leaves your environment. |
 | **Identity** | We provide the guardrails, including SSO/SCIM, MFA enforcement options, and RBAC frameworks. | You manage your user roster, assign roles (e.g., Admin vs. Viewer), and revoke access for terminated employees. |
@@ -19,7 +19,7 @@ LangSmith operates as a multi-tenant SaaS solution. Our security model is design
 ## LangChain responsibilities (the platform)
 
 - We maintain SOC 2 Type II, GDPR, and HIPAA compliance and undergo annual third-party audits and penetration testing.
-- We manage all underlying infrastructure on Google Cloud Platform (GCP), including network firewalls, DDoS protection via Cloud Armor, and container security.
+- We manage all underlying infrastructure on Amazon Web Services (AWS) and Google Cloud Platform (GCP), including network firewalls, DDoS protection, and container security.
 - We maintain high availability in accordance with our SLA, maintain daily backups, and handle disaster recovery for the LangSmith service.
 - We patch confirmed platform vulnerabilities within strict service level agreements, with critical severity issues remediated in less than 2 weeks and high severity issues within 30 days.
 - We encrypt all customer data at rest using AES-256 and in transit using TLS 1.2 or higher.


### PR DESCRIPTION
## Summary

- Expand the LangSmith shared responsibility model from GCP-only infrastructure language to Amazon Web Services (AWS) and Google Cloud Platform (GCP).
- Replace the GCP-specific Cloud Armor reference with provider-neutral DDoS protection language.

## Why

The shared responsibility model supports both AWS and GCP, so the documentation should not describe the underlying infrastructure as GCP-only.

## Review focus

Please verify that the revised cloud-provider terminology accurately reflects the supported infrastructure.

## Validation

- `make lint_prose FILES="src/langsmith/shared-responsibility-model.mdx"`

AI agent assisted with drafting and validation.
