### PR TITLE
chore: temporarily remove @katmayb from review routing

### DIFF
--- a/.github/OWNERS
+++ b/.github/OWNERS
@@ -19,7 +19,7 @@
 /.github/OWNERS @lnhsingh
 
 # Default owners for everything in the repo.
-*       @lnhsingh @katmayb @npentrel @fjmorris
+*       @lnhsingh @npentrel @fjmorris
 
 # Any file in the `/src/oss`
 # and any of its subdirectories.
@@ -35,7 +35,7 @@
 
 # Any file in the `/src/langsmith`
 # and any of its subdirectories.
-/src/langsmith/ @katmayb @fjmorris
+/src/langsmith/ @fjmorris @lnhsingh
 
 # Any file in `/src/langsmith/fleet/`
 # (must come after the general /src/langsmith/ rule — last match wins).

--- a/.github/workflows/pr-welcome-comment.yml
+++ b/.github/workflows/pr-welcome-comment.yml
@@ -203,7 +203,7 @@ jobs:
               ];
               let reviewers;
               if (changelogPatterns.some(p => pr.title.includes(p))) {
-                reviewers = ['lnhsingh', 'katmayb'];
+                reviewers = ['lnhsingh'];
               } else {
                 const fromOwners = [...new Set(
                   [...productOwners.values()].flatMap(s => [...s])


### PR DESCRIPTION
This is a **temporary** change while Kathryn is out. Revert it when she is back.

## Why

`@katmayb` was on two review paths. This takes her off both so PRs are not waiting on someone who is away, and adds a backup on LangSmith so that area is not left with a single owner.

## What changed

**`.github/OWNERS`**

| Rule | Before | After |
|------|--------|-------|
| `*` | `@lnhsingh @katmayb @npentrel @fjmorris` | `@lnhsingh @npentrel @fjmorris` |
| `/src/langsmith/` | `@katmayb @fjmorris` | `@fjmorris @lnhsingh` |

**`.github/workflows/pr-welcome-comment.yml`**

The hardcoded reviewer list for changelog bot PRs drops to `["lnhsingh"]`.

## Worth a careful look

- **The workflow line is the part that actually changes behavior.** None of Kathryn's `OWNERS` rules carried an `# auto-request` marker, so those entries only named her in the welcome comment. The hardcoded list in `pr-welcome-comment.yml` was the only place calling `requestReviewers` on her, and it fires on every LangGraph Server and Self-Hosted changelog bot PR.
- **`/src/langsmith/fleet/` is untouched** and was already `@lnhsingh @fjmorris`. Since last match wins, Fleet files never routed to Kathryn, so this change only affects LangSmith files outside `fleet/`.
- Every affected rule still has at least one owner; nothing falls through to an empty rule.

## Testing

- `.github/workflows/pr-welcome-comment.yml` still parses as valid YAML.
- No references to `katmayb` remain anywhere in `.github/` or `src/`.

Drafted with Claude Code; reviewed by me before opening.