### PR TITLE
docs: refresh the agent navigation map, and pin Vale once

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -26,8 +26,8 @@ docs/
 │   ├── index.mdx               # Home page
 │   ├── style.css               # Custom CSS
 │   ├── langsmith/              # LangSmith product docs
-│   │   └── fleet/              #   LangSmith Fleet
-│   ├── oss/                    # Open source docs (LangChain, LangGraph, Deep Agents)
+│   │   └── fleet/              #   Fleet (nav label: "No-code agents")
+│   ├── oss/                    # Open source docs (LangChain, LangGraph, Deep Agents, OpenWiki)
 │   ├── snippets/               # Reusable MDX snippets
 │   ├── images/                 # Documentation images
 │   └── fonts/                  # Font files
@@ -37,7 +37,7 @@ docs/
 └── tests/                      # Pipeline tests
 ```
 
-For the navigation map (every product, tab, and group), see `AGENTS.md`. Navigation is defined in `src/docs.json`, and new pages must be added to the correct product, tab, and group.
+For the navigation map (every product, menu item, tab, and group), see `AGENTS.md`. Navigation is defined in `src/docs.json` as 2 products: `AGENT DEVELOPMENT LIFECYCLE` (Home, Build, Test, Deploy, Monitor) and `PRODUCTS AND SETUP` (LangSmith setup, LLM Gateway, No-code agents, Engine, Deep Agents Code). Nav names do not match source directory names, so consult `AGENTS.md` before placing a new page.
 
 ## Quick reference
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -26,8 +26,8 @@ docs/
 │   ├── index.mdx               # Home page
 │   ├── style.css               # Custom CSS
 │   ├── langsmith/              # LangSmith product docs
-│   │   └── fleet/              #   LangSmith Fleet
-│   ├── oss/                    # Open source docs (LangChain, LangGraph, Deep Agents)
+│   │   └── fleet/              #   Fleet (nav label: "No-code agents")
+│   ├── oss/                    # Open source docs (LangChain, LangGraph, Deep Agents, OpenWiki)
 │   ├── snippets/               # Reusable MDX snippets
 │   ├── images/                 # Documentation images
 │   └── fonts/                  # Font files
@@ -37,7 +37,7 @@ docs/
 └── tests/                      # Pipeline tests
 ```
 
-For the navigation map (every product, tab, and group), see `AGENTS.md`. Navigation is defined in `src/docs.json`, and new pages must be added to the correct product, tab, and group.
+For the navigation map (every product, menu item, tab, and group), see `AGENTS.md`. Navigation is defined in `src/docs.json` as 2 products: `AGENT DEVELOPMENT LIFECYCLE` (Home, Build, Test, Deploy, Monitor) and `PRODUCTS AND SETUP` (LangSmith setup, LLM Gateway, No-code agents, Engine, Deep Agents Code). Nav names do not match source directory names, so consult `AGENTS.md` before placing a new page.
 
 ## Quick reference
 

--- a/.github/workflows/check-agents-sync.yml
+++ b/.github/workflows/check-agents-sync.yml
@@ -8,7 +8,7 @@ name: "🔄 Check CLAUDE.md / AGENTS.md Sync"
 
 on:
   push:
-    branches: [master]
+    branches: [main]
     paths:
       - "CLAUDE.md"
       - "AGENTS.md"

--- a/.github/workflows/lint-prose.yml
+++ b/.github/workflows/lint-prose.yml
@@ -38,11 +38,11 @@ jobs:
             echo "EOF" >> $GITHUB_OUTPUT
           fi
 
+      # Installs the version pinned in .mise.toml so CI and local runs use the
+      # same engine. Bump the pin there, not here.
       - name: Install Vale
         if: steps.changed-files.outputs.count != '0'
-        run: |
-          VALE_VERSION="3.17.1"
-          curl -sL "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" | sudo tar xz -C /usr/local/bin vale
+        run: bash scripts/install-vale.sh .bin/vale
 
       - name: Lint prose
         if: steps.changed-files.outputs.count != '0'

--- a/.mise.toml
+++ b/.mise.toml
@@ -17,7 +17,9 @@ uv = "0.9.26"
 prek = "latest"
 
 # Prose linter used by the lint-prose CI workflow.
-vale = "3.12.0"
+# CANONICAL PIN. The Makefile, scripts/install-vale.sh, and the
+# lint-prose workflow all read this value, so bump it here only.
+vale = "3.17.1"
 
 # Mintlify CLI used by the broken-links Makefile targets.
 "npm:mint" = "latest"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -496,6 +496,8 @@ Always run `make lint_prose` (Vale) before handing off or committing doc changes
 
 Scope to changed files for speed: `make lint_prose FILES="src/path/to/file.mdx"` (or pass space-separated paths). Run with no `FILES` arg to lint all of `src/`.
 
+The Vale version is pinned once, in `.mise.toml`. The `Makefile`, `scripts/install-vale.sh`, and the `lint-prose` workflow all read it from there, so local runs use the same engine as CI. Bump it only in `.mise.toml`. Do not hardcode a version in any of the three call sites.
+
 Also run `make broken-links` when adding or renaming links, pages, or nav entries.
 
 ## Changelog / Release notes

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,10 +48,13 @@ docs/
 │   ├── index.mdx               # Home page
 │   ├── style.css               # Custom CSS
 │   ├── langsmith/              # LangSmith product docs
+│   │   └── fleet/              #   Fleet (nav label: "No-code agents")
 │   ├── oss/                    # Open source docs
 │   │   ├── langchain/          #   LangChain framework
 │   │   ├── langgraph/          #   LangGraph framework
 │   │   ├── deepagents/         #   Deep Agents
+│   │   │   └── code/           #     Deep Agents Code (unversioned, no language split)
+│   │   ├── openwiki/           #   OpenWiki (unversioned, no language split)
 │   │   ├── python/             #   Python-specific (integrations, migrations, releases)
 │   │   ├── javascript/         #   TypeScript-specific (integrations, migrations, releases)
 │   │   ├── integrations/       #   Shared integration content
@@ -65,60 +68,154 @@ docs/
 │   ├── images/                 # Documentation images
 │   │   ├── brand/              #   Logos, favicons
 │   │   └── providers/          #   Provider icons (dark/ and light/ variants)
+│   ├── code-samples/           # Testable standalone code samples (see make test-code-samples)
 │   └── fonts/                  # TWK Lausanne font files
 ├── pipeline/                   # Python build system & preprocessors
 ├── build/                      # Build output — do not edit
-├── scripts/                    # Helper utilities
+├── scripts/                    # Helper utilities and automation scripts
 └── tests/                      # Pipeline tests
 ```
 
 ## Navigation map
 
-Navigation is defined in `src/docs.json`. The site has 4 products (Home, LangSmith, LangSmith Fleet, Open source). When adding pages, find the correct product/tab/group below, then update the matching section in `docs.json`.
+Navigation is defined in `src/docs.json`. The site has 2 products, each a `menu` of items rather than a flat tab list. When adding pages, find the correct product → menu item → tab → group below, then update the matching section in `docs.json`.
 
-### Home
+Product and menu names in `docs.json` do not match source directory names. Lifecycle stages mix LangSmith and OSS content: the Build menu draws from both `src/oss/` and `src/langsmith/`, and Test, Deploy, and Monitor all draw from `src/langsmith/`. Locate pages by directory, not by product name.
 
-Single page (`src/index.mdx`). No tabs.
+### AGENT DEVELOPMENT LIFECYCLE
 
-### LangSmith (`src/langsmith/`)
+Five menu items: Home, Build, Test, Deploy, Monitor.
 
-7 tabs, all files in `src/langsmith/`:
+#### Home
+
+Single page (`src/index.mdx`).
+
+#### Build
+
+Two language dropdowns (Python, TypeScript) with the same 10 tabs each. Most content is language-versioned from `src/oss/`; two tabs are exceptions.
+
+| Tab | Source | Groups |
+|-----|--------|--------|
+| Overview | `src/build-overview.mdx` | Single page |
+| Deep Agents | `src/oss/deepagents/` | Get started, Deployment (Going to production), Execution environment, Context management, Delegation, Steering, Frontend (Patterns), Protocols |
+| Managed Deep Agents | `src/langsmith/managed-deep-agents*.mdx` | Get started, Agent definition (Channels), Build and deploy |
+| LangChain | `src/oss/langchain/` | Get started, Core components, Middleware, Frontend (Patterns → Generative UI, Integrations), Advanced usage (Multi-agent), Agent development (Test), Production |
+| LangGraph | `src/oss/langgraph/` | Get started, Capabilities, Production, Frontend, LangGraph APIs (Graph API, Functional API) |
+| OpenWiki | `src/oss/openwiki/` | Modes |
+| Integrations | `src/oss/python/integrations/` or `src/oss/javascript/integrations/` | Python: Popular Providers, Integrations by component. TypeScript: Popular Providers (OpenAI, Anthropic, Google, AWS, Microsoft), General integrations, RAG integrations |
+| Learn | `src/oss/` (various) | Tutorials (Deep Agents, LangChain, Multi-agent, LangGraph), Conceptual overviews, Additional resources. TypeScript adds LangChain Academy |
+| Reference | `src/oss/reference/` | Reference, Releases (Releases, Migration guides), Policies — short entry pages linking to reference.langchain.com |
+| Contribute | `src/oss/contributing/` | Contribute (Integrations) |
+
+Two Build tabs are not language-versioned in the usual way:
+
+- **Managed Deep Agents** lives in `src/langsmith/`, not `src/oss/`. Files named `managed-deep-agents*.mdx` emit only language-prefixed routes (`/langsmith/python/...` and `/langsmith/javascript/...`). The unversioned `/langsmith/managed-deep-agents*` URLs redirect to the Python routes via `docs.json`.
+- **OpenWiki** ships one set of pages at `/oss/openwiki/...` with no language split. Conditional fences resolve against the Python branch.
+
+#### Test
+
+Six tabs, all files flat in `src/langsmith/`:
 
 | Tab | Groups |
 |-----|--------|
-| Get started | Account administration (Workspace setup, Users & access control, Billing & usage), Tools, Additional resources |
-| Observability | Tracing setup, Configuration & troubleshooting, Viewing & managing traces, Automations, Feedback & evaluation, Monitoring & alerting, Data type reference |
-| Evaluation | Datasets, Set up evaluations, Analyze experiment results, Annotation & human feedback, Common data types |
-| Prompt engineering | Create and update prompts, Tutorials |
-| Agent deployment | Agent server, Core capabilities, Develop agents, Deployment guides, Studio, Auth & access control, Server customization |
-| Platform setup | Overview, Hybrid, Self-hosted (by cloud provider, Setup guides, Enable features, Configuration, External services, Auth, Observability, Scripts) |
-| Reference | LangSmith Deployment (Agent Server API, Control Plane API), Releases |
+| Get started | No groups |
+| Datasets & Experiments | Datasets (Create a dataset), Run an evaluation, Evaluation techniques (Define evaluation target, Scoring methods, Experiment configuration, Multimodal evaluations), Analyze experiment results, Tutorials, Common data types |
+| Evaluators | Evaluator types (UI, SDK), Frameworks & integrations, Improve evaluators |
+| Annotation Queues | Feedback |
+| Test from Playground | No groups |
+| Test from Studio | No groups |
 
-All LangSmith files are flat in `src/langsmith/` (no per-tab subdirectories except `fleet/` and `images/`).
+#### Deploy
 
-### LangSmith Fleet (`src/langsmith/fleet/`)
+Six tabs, all files flat in `src/langsmith/`:
 
-Flat groups (no tabs):
+| Tab | Groups |
+|-----|--------|
+| Get started | Deployment components, Develop & test, Frameworks and platforms (Full-stack web apps), Reference (Agent Server API, Control Plane API, Related) |
+| Agent Server | Develop your application (Set up dependencies, Persistence), Capabilities (Assistants, Runs, Double-texting), How to build, Auth & access control (Custom auth tutorial), Server customization (Replace built-in backends, Extend the HTTP server, Headers and logging) |
+| Deploy to Cloud | Deployment guide, Reference |
+| Deploy to Self-hosted | Configure, Reference |
+| Prompt & Context Hub | Prompts (Create and manage prompts, Connect to models), Context Hub, Tutorials |
+| Sandboxes | No groups |
 
-- Get started
-- Configure
-- Tools and automation
-- Advanced
-- Additional resources
+The Get started tab's Reference group holds two OpenAPI-generated sections. See [Reference docs](#reference-docs) below.
 
-### Open source (`src/oss/`)
+#### Monitor
 
-2 language dropdowns (Python, TypeScript), each with 7 tabs sharing the same names. Groups listed below are for the Python dropdown; TypeScript groups differ in some tabs (noted with *).
+Five tabs, all files flat in `src/langsmith/`:
 
-| Tab | Directory | Groups |
-|-----|-----------|--------|
-| Deep Agents | `src/oss/deepagents/` | Get started, Deployment, Core capabilities, Frontend, Protocols, Code |
-| LangChain | `src/oss/langchain/` | Get started, Core components, Middleware, Frontend, Advanced usage, Agent development, Production |
-| LangGraph | `src/oss/langgraph/` | Get started, Capabilities, Production, Frontend, LangGraph APIs |
-| Integrations* | `src/oss/python/integrations/` or `src/oss/javascript/integrations/` | Popular Providers, Integrations by component (TS: "General integrations, RAG integrations") |
-| Learn* | `src/oss/` (various) | Tutorials, Conceptual overviews, Additional resources (TS adds: "LangChain Academy") |
-| Reference | `src/oss/reference/` | Reference, Errors, Releases, Policies — short entry pages linking to reference.langchain.com |
-| Contribute | `src/oss/contributing/` | Contribution guides, integration authoring |
+| Tab | Groups |
+|-----|--------|
+| Overview | Single page |
+| Trace | Tracing setup (Integrations → LLM providers, Agent frameworks, Voice AI frameworks, Developer tools; Manual instrumentation), Configuration & troubleshooting (Project & environment settings, Advanced tracing techniques, Data & privacy, Troubleshooting guides) |
+| Debug | Viewing & managing traces, Bulk export trace data, Messages view, Data type reference |
+| Observe | Monitoring & alerting, Online evaluators, Automations |
+| Reference | SmithDB SDK migration, LangSmith REST API |
+
+The Reference tab's LangSmith REST API group is OpenAPI-generated. See [Reference docs](#reference-docs) below.
+
+### PRODUCTS AND SETUP
+
+Five menu items. Only LangSmith setup has tabs; the rest are flat group lists.
+
+#### LangSmith setup
+
+Six tabs, all files flat in `src/langsmith/`:
+
+| Tab | Groups |
+|-----|--------|
+| Overview | Single page |
+| Account | Billing & usage |
+| Cloud | Reference |
+| BYOC | No groups |
+| Self-hosted | Get started by cloud provider, Deploy with Terraform (AWS, GCP, Azure), Setup guides (Manage an installation), Configuration, Connect external services, Platform auth & access control, Self-hosted observability, Hybrid, Scripts, Reference |
+| Govern | Organization (Workspace setup), Users & access control, Tools, Auditing, Data & compliance, Additional resources (FAQ) |
+
+#### Other menu items
+
+| Menu item | Source | Groups |
+|-----------|--------|--------|
+| LLM Gateway | `src/langsmith/llm-gateway*.mdx` | Core capabilities, Administration and governance, Advanced |
+| No-code agents | `src/langsmith/fleet/` | Get started, Configure, Tools and automation, Advanced, Additional resources |
+| Engine | `src/langsmith/engine*.mdx` | No groups |
+| Deep Agents Code | `src/oss/deepagents/code/` | Configuration |
+
+"No-code agents" is the nav label for Fleet. The source directory and URLs still use `fleet`.
+
+"Deep Agents Code" ships one set of pages at `/oss/deepagents/code/...` with no language split, even though it sits under `src/oss/deepagents/`. Conditional fences resolve against the Python branch.
+
+### Source directory summary
+
+Because nav names and directories diverge, use this to go from a file to its place in the nav:
+
+| Source | Appears under |
+|--------|---------------|
+| `src/index.mdx` | Lifecycle → Home |
+| `src/oss/deepagents/` (except `code/`) | Build → Deep Agents |
+| `src/oss/deepagents/code/` | Products and setup → Deep Agents Code |
+| `src/oss/langchain/` | Build → LangChain |
+| `src/oss/langgraph/` | Build → LangGraph |
+| `src/oss/openwiki/` | Build → OpenWiki |
+| `src/oss/{python,javascript}/integrations/` | Build → Integrations |
+| `src/oss/reference/` | Build → Reference |
+| `src/oss/contributing/` | Build → Contribute |
+| `src/langsmith/managed-deep-agents*.mdx` | Build → Managed Deep Agents |
+| `src/langsmith/fleet/` | Products and setup → No-code agents |
+| `src/langsmith/*.mdx` (everything else) | Test, Deploy, Monitor, or LangSmith setup, depending on subject |
+
+### Reference docs
+
+Three OpenAPI-generated sections. Mintlify generates the endpoint pages at deploy time, so they do not exist in the local `build/` output — `make broken-links` filters them as false positives.
+
+| Section | Nav location | Spec source | Generated under |
+|---------|--------------|-------------|-----------------|
+| Agent Server API | Deploy → Get started → Reference | `src/langsmith/agent-server-openapi.json` (committed) | `/langsmith/agent-server-api/` |
+| Control Plane API | Deploy → Get started → Reference | `https://api.host.langchain.com/openapi.json` (fetched at deploy time, no local file) | `/api-reference/` |
+| LangSmith REST API | Monitor → Reference | `src/langsmith/langsmith-platform-openapi.json` (committed) | `/langsmith/smith-api/` |
+
+`src/langsmith/langsmith-platform-openapi.json` is refreshed daily by `.github/workflows/refresh-langsmith-openapi.yml`, which runs `scripts/process_langsmith_openapi.py` and opens or appends to a standing `chore/refresh-langsmith-openapi` PR. Do not edit it by hand.
+
+`src/langsmith/agent-server-openapi.json` is updated by PRs from the `langgraph-api` repository, titled `Update Agent ServerOpenAPI spec for API version X.Y.Z`. Validate either spec with `make check-openapi`.
 
 ## Local development
 
@@ -325,8 +422,8 @@ Reserve "the platform" for LangSmith. LangChain is the open agent engineering ec
 **Add a new LangSmith doc:**
 
 1. Create `src/langsmith/<name>.mdx` with frontmatter
-2. Find the correct tab and group in `src/docs.json` under `navigation.products[1]` (LangSmith)
-3. Add the page path (e.g., `"langsmith/<name>"`) to that group's `pages` array
+2. Decide which lifecycle stage the page belongs to, then find the matching menu item in `src/docs.json`: `navigation.products[0].menu` holds Home, Build, Test, Deploy, and Monitor; `navigation.products[1].menu` holds LangSmith setup, LLM Gateway, No-code agents, Engine, and Deep Agents Code
+3. Add the page path (e.g., `"langsmith/<name>"`) to the correct group's `pages` array
 
 **Add a new integration page (Python):**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -496,6 +496,8 @@ Always run `make lint_prose` (Vale) before handing off or committing doc changes
 
 Scope to changed files for speed: `make lint_prose FILES="src/path/to/file.mdx"` (or pass space-separated paths). Run with no `FILES` arg to lint all of `src/`.
 
+The Vale version is pinned once, in `.mise.toml`. The `Makefile`, `scripts/install-vale.sh`, and the `lint-prose` workflow all read it from there, so local runs use the same engine as CI. Bump it only in `.mise.toml`. Do not hardcode a version in any of the three call sites.
+
 Also run `make broken-links` when adding or renaming links, pages, or nav entries.
 
 ## Changelog / Release notes

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,13 @@ docs/
 │   ├── index.mdx               # Home page
 │   ├── style.css               # Custom CSS
 │   ├── langsmith/              # LangSmith product docs
+│   │   └── fleet/              #   Fleet (nav label: "No-code agents")
 │   ├── oss/                    # Open source docs
 │   │   ├── langchain/          #   LangChain framework
 │   │   ├── langgraph/          #   LangGraph framework
 │   │   ├── deepagents/         #   Deep Agents
+│   │   │   └── code/           #     Deep Agents Code (unversioned, no language split)
+│   │   ├── openwiki/           #   OpenWiki (unversioned, no language split)
 │   │   ├── python/             #   Python-specific (integrations, migrations, releases)
 │   │   ├── javascript/         #   TypeScript-specific (integrations, migrations, releases)
 │   │   ├── integrations/       #   Shared integration content
@@ -65,60 +68,154 @@ docs/
 │   ├── images/                 # Documentation images
 │   │   ├── brand/              #   Logos, favicons
 │   │   └── providers/          #   Provider icons (dark/ and light/ variants)
+│   ├── code-samples/           # Testable standalone code samples (see make test-code-samples)
 │   └── fonts/                  # TWK Lausanne font files
 ├── pipeline/                   # Python build system & preprocessors
 ├── build/                      # Build output — do not edit
-├── scripts/                    # Helper utilities
+├── scripts/                    # Helper utilities and automation scripts
 └── tests/                      # Pipeline tests
 ```
 
 ## Navigation map
 
-Navigation is defined in `src/docs.json`. The site has 4 products (Home, LangSmith, LangSmith Fleet, Open source). When adding pages, find the correct product/tab/group below, then update the matching section in `docs.json`.
+Navigation is defined in `src/docs.json`. The site has 2 products, each a `menu` of items rather than a flat tab list. When adding pages, find the correct product → menu item → tab → group below, then update the matching section in `docs.json`.
 
-### Home
+Product and menu names in `docs.json` do not match source directory names. Lifecycle stages mix LangSmith and OSS content: the Build menu draws from both `src/oss/` and `src/langsmith/`, and Test, Deploy, and Monitor all draw from `src/langsmith/`. Locate pages by directory, not by product name.
 
-Single page (`src/index.mdx`). No tabs.
+### AGENT DEVELOPMENT LIFECYCLE
 
-### LangSmith (`src/langsmith/`)
+Five menu items: Home, Build, Test, Deploy, Monitor.
 
-7 tabs, all files in `src/langsmith/`:
+#### Home
+
+Single page (`src/index.mdx`).
+
+#### Build
+
+Two language dropdowns (Python, TypeScript) with the same 10 tabs each. Most content is language-versioned from `src/oss/`; two tabs are exceptions.
+
+| Tab | Source | Groups |
+|-----|--------|--------|
+| Overview | `src/build-overview.mdx` | Single page |
+| Deep Agents | `src/oss/deepagents/` | Get started, Deployment (Going to production), Execution environment, Context management, Delegation, Steering, Frontend (Patterns), Protocols |
+| Managed Deep Agents | `src/langsmith/managed-deep-agents*.mdx` | Get started, Agent definition (Channels), Build and deploy |
+| LangChain | `src/oss/langchain/` | Get started, Core components, Middleware, Frontend (Patterns → Generative UI, Integrations), Advanced usage (Multi-agent), Agent development (Test), Production |
+| LangGraph | `src/oss/langgraph/` | Get started, Capabilities, Production, Frontend, LangGraph APIs (Graph API, Functional API) |
+| OpenWiki | `src/oss/openwiki/` | Modes |
+| Integrations | `src/oss/python/integrations/` or `src/oss/javascript/integrations/` | Python: Popular Providers, Integrations by component. TypeScript: Popular Providers (OpenAI, Anthropic, Google, AWS, Microsoft), General integrations, RAG integrations |
+| Learn | `src/oss/` (various) | Tutorials (Deep Agents, LangChain, Multi-agent, LangGraph), Conceptual overviews, Additional resources. TypeScript adds LangChain Academy |
+| Reference | `src/oss/reference/` | Reference, Releases (Releases, Migration guides), Policies — short entry pages linking to reference.langchain.com |
+| Contribute | `src/oss/contributing/` | Contribute (Integrations) |
+
+Two Build tabs are not language-versioned in the usual way:
+
+- **Managed Deep Agents** lives in `src/langsmith/`, not `src/oss/`. Files named `managed-deep-agents*.mdx` emit only language-prefixed routes (`/langsmith/python/...` and `/langsmith/javascript/...`). The unversioned `/langsmith/managed-deep-agents*` URLs redirect to the Python routes via `docs.json`.
+- **OpenWiki** ships one set of pages at `/oss/openwiki/...` with no language split. Conditional fences resolve against the Python branch.
+
+#### Test
+
+Six tabs, all files flat in `src/langsmith/`:
 
 | Tab | Groups |
 |-----|--------|
-| Get started | Account administration (Workspace setup, Users & access control, Billing & usage), Tools, Additional resources |
-| Observability | Tracing setup, Configuration & troubleshooting, Viewing & managing traces, Automations, Feedback & evaluation, Monitoring & alerting, Data type reference |
-| Evaluation | Datasets, Set up evaluations, Analyze experiment results, Annotation & human feedback, Common data types |
-| Prompt engineering | Create and update prompts, Tutorials |
-| Agent deployment | Agent server, Core capabilities, Develop agents, Deployment guides, Studio, Auth & access control, Server customization |
-| Platform setup | Overview, Hybrid, Self-hosted (by cloud provider, Setup guides, Enable features, Configuration, External services, Auth, Observability, Scripts) |
-| Reference | LangSmith Deployment (Agent Server API, Control Plane API), Releases |
+| Get started | No groups |
+| Datasets & Experiments | Datasets (Create a dataset), Run an evaluation, Evaluation techniques (Define evaluation target, Scoring methods, Experiment configuration, Multimodal evaluations), Analyze experiment results, Tutorials, Common data types |
+| Evaluators | Evaluator types (UI, SDK), Frameworks & integrations, Improve evaluators |
+| Annotation Queues | Feedback |
+| Test from Playground | No groups |
+| Test from Studio | No groups |
 
-All LangSmith files are flat in `src/langsmith/` (no per-tab subdirectories except `fleet/` and `images/`).
+#### Deploy
 
-### LangSmith Fleet (`src/langsmith/fleet/`)
+Six tabs, all files flat in `src/langsmith/`:
 
-Flat groups (no tabs):
+| Tab | Groups |
+|-----|--------|
+| Get started | Deployment components, Develop & test, Frameworks and platforms (Full-stack web apps), Reference (Agent Server API, Control Plane API, Related) |
+| Agent Server | Develop your application (Set up dependencies, Persistence), Capabilities (Assistants, Runs, Double-texting), How to build, Auth & access control (Custom auth tutorial), Server customization (Replace built-in backends, Extend the HTTP server, Headers and logging) |
+| Deploy to Cloud | Deployment guide, Reference |
+| Deploy to Self-hosted | Configure, Reference |
+| Prompt & Context Hub | Prompts (Create and manage prompts, Connect to models), Context Hub, Tutorials |
+| Sandboxes | No groups |
 
-- Get started
-- Configure
-- Tools and automation
-- Advanced
-- Additional resources
+The Get started tab's Reference group holds two OpenAPI-generated sections. See [Reference docs](#reference-docs) below.
 
-### Open source (`src/oss/`)
+#### Monitor
 
-2 language dropdowns (Python, TypeScript), each with 7 tabs sharing the same names. Groups listed below are for the Python dropdown; TypeScript groups differ in some tabs (noted with *).
+Five tabs, all files flat in `src/langsmith/`:
 
-| Tab | Directory | Groups |
-|-----|-----------|--------|
-| Deep Agents | `src/oss/deepagents/` | Get started, Deployment, Core capabilities, Frontend, Protocols, Code |
-| LangChain | `src/oss/langchain/` | Get started, Core components, Middleware, Frontend, Advanced usage, Agent development, Production |
-| LangGraph | `src/oss/langgraph/` | Get started, Capabilities, Production, Frontend, LangGraph APIs |
-| Integrations* | `src/oss/python/integrations/` or `src/oss/javascript/integrations/` | Popular Providers, Integrations by component (TS: "General integrations, RAG integrations") |
-| Learn* | `src/oss/` (various) | Tutorials, Conceptual overviews, Additional resources (TS adds: "LangChain Academy") |
-| Reference | `src/oss/reference/` | Reference, Errors, Releases, Policies — short entry pages linking to reference.langchain.com |
-| Contribute | `src/oss/contributing/` | Contribution guides, integration authoring |
+| Tab | Groups |
+|-----|--------|
+| Overview | Single page |
+| Trace | Tracing setup (Integrations → LLM providers, Agent frameworks, Voice AI frameworks, Developer tools; Manual instrumentation), Configuration & troubleshooting (Project & environment settings, Advanced tracing techniques, Data & privacy, Troubleshooting guides) |
+| Debug | Viewing & managing traces, Bulk export trace data, Messages view, Data type reference |
+| Observe | Monitoring & alerting, Online evaluators, Automations |
+| Reference | SmithDB SDK migration, LangSmith REST API |
+
+The Reference tab's LangSmith REST API group is OpenAPI-generated. See [Reference docs](#reference-docs) below.
+
+### PRODUCTS AND SETUP
+
+Five menu items. Only LangSmith setup has tabs; the rest are flat group lists.
+
+#### LangSmith setup
+
+Six tabs, all files flat in `src/langsmith/`:
+
+| Tab | Groups |
+|-----|--------|
+| Overview | Single page |
+| Account | Billing & usage |
+| Cloud | Reference |
+| BYOC | No groups |
+| Self-hosted | Get started by cloud provider, Deploy with Terraform (AWS, GCP, Azure), Setup guides (Manage an installation), Configuration, Connect external services, Platform auth & access control, Self-hosted observability, Hybrid, Scripts, Reference |
+| Govern | Organization (Workspace setup), Users & access control, Tools, Auditing, Data & compliance, Additional resources (FAQ) |
+
+#### Other menu items
+
+| Menu item | Source | Groups |
+|-----------|--------|--------|
+| LLM Gateway | `src/langsmith/llm-gateway*.mdx` | Core capabilities, Administration and governance, Advanced |
+| No-code agents | `src/langsmith/fleet/` | Get started, Configure, Tools and automation, Advanced, Additional resources |
+| Engine | `src/langsmith/engine*.mdx` | No groups |
+| Deep Agents Code | `src/oss/deepagents/code/` | Configuration |
+
+"No-code agents" is the nav label for Fleet. The source directory and URLs still use `fleet`.
+
+"Deep Agents Code" ships one set of pages at `/oss/deepagents/code/...` with no language split, even though it sits under `src/oss/deepagents/`. Conditional fences resolve against the Python branch.
+
+### Source directory summary
+
+Because nav names and directories diverge, use this to go from a file to its place in the nav:
+
+| Source | Appears under |
+|--------|---------------|
+| `src/index.mdx` | Lifecycle → Home |
+| `src/oss/deepagents/` (except `code/`) | Build → Deep Agents |
+| `src/oss/deepagents/code/` | Products and setup → Deep Agents Code |
+| `src/oss/langchain/` | Build → LangChain |
+| `src/oss/langgraph/` | Build → LangGraph |
+| `src/oss/openwiki/` | Build → OpenWiki |
+| `src/oss/{python,javascript}/integrations/` | Build → Integrations |
+| `src/oss/reference/` | Build → Reference |
+| `src/oss/contributing/` | Build → Contribute |
+| `src/langsmith/managed-deep-agents*.mdx` | Build → Managed Deep Agents |
+| `src/langsmith/fleet/` | Products and setup → No-code agents |
+| `src/langsmith/*.mdx` (everything else) | Test, Deploy, Monitor, or LangSmith setup, depending on subject |
+
+### Reference docs
+
+Three OpenAPI-generated sections. Mintlify generates the endpoint pages at deploy time, so they do not exist in the local `build/` output — `make broken-links` filters them as false positives.
+
+| Section | Nav location | Spec source | Generated under |
+|---------|--------------|-------------|-----------------|
+| Agent Server API | Deploy → Get started → Reference | `src/langsmith/agent-server-openapi.json` (committed) | `/langsmith/agent-server-api/` |
+| Control Plane API | Deploy → Get started → Reference | `https://api.host.langchain.com/openapi.json` (fetched at deploy time, no local file) | `/api-reference/` |
+| LangSmith REST API | Monitor → Reference | `src/langsmith/langsmith-platform-openapi.json` (committed) | `/langsmith/smith-api/` |
+
+`src/langsmith/langsmith-platform-openapi.json` is refreshed daily by `.github/workflows/refresh-langsmith-openapi.yml`, which runs `scripts/process_langsmith_openapi.py` and opens or appends to a standing `chore/refresh-langsmith-openapi` PR. Do not edit it by hand.
+
+`src/langsmith/agent-server-openapi.json` is updated by PRs from the `langgraph-api` repository, titled `Update Agent ServerOpenAPI spec for API version X.Y.Z`. Validate either spec with `make check-openapi`.
 
 ## Local development
 
@@ -325,8 +422,8 @@ Reserve "the platform" for LangSmith. LangChain is the open agent engineering ec
 **Add a new LangSmith doc:**
 
 1. Create `src/langsmith/<name>.mdx` with frontmatter
-2. Find the correct tab and group in `src/docs.json` under `navigation.products[1]` (LangSmith)
-3. Add the page path (e.g., `"langsmith/<name>"`) to that group's `pages` array
+2. Decide which lifecycle stage the page belongs to, then find the matching menu item in `src/docs.json`: `navigation.products[0].menu` holds Home, Build, Test, Deploy, and Monitor; `navigation.products[1].menu` holds LangSmith setup, LLM Gateway, No-code agents, Engine, and Deep Agents Code
+3. Add the page path (e.g., `"langsmith/<name>"`) to the correct group's `pages` array
 
 **Add a new integration page (Python):**
 

--- a/Makefile
+++ b/Makefile
@@ -60,14 +60,16 @@ lint_md_fix:
 	fi
 
 VALE_BIN ?= .bin/vale
-VALE_VERSION ?= v3.9.6
+# Single source of truth for the Vale pin is .mise.toml. Override on the
+# command line only for a one-off test: make lint_prose VALE_VERSION=3.16.0
+VALE_VERSION ?= $(shell sed -n 's/^[[:space:]]*vale[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' .mise.toml | head -n 1)
 
 install_vale:
 	@bash scripts/install-vale.sh "$(VALE_BIN)" "$(VALE_VERSION)"
 
 lint_prose:
 	@echo "Linting prose with Vale..."
-	@if [ ! -x "$(VALE_BIN)" ]; then bash scripts/install-vale.sh "$(VALE_BIN)" "$(VALE_VERSION)"; fi
+	@bash scripts/install-vale.sh "$(VALE_BIN)" "$(VALE_VERSION)"
 	@if [ -n "$(FILES)" ]; then \
 		"$(VALE_BIN)" --glob='!**/node_modules/**' $(FILES); \
 	else \

--- a/README.md
+++ b/README.md
@@ -147,6 +147,11 @@ These can be used directly using the `Makefile` or via the `docs` CLI tool:
 
 After running `make install`, you can use `make lint_prose` to ensure your writing meets our style guide rules.
 
+`make lint_prose` installs the Vale version pinned in `.mise.toml` to `.bin/vale`, which is the same version the
+`lint-prose` CI workflow uses. Bump the pin in `.mise.toml` only; the `Makefile`, `scripts/install-vale.sh`, and
+the workflow all read it from there. If you already have a different `vale` on your `PATH` (from Homebrew, say),
+the pinned copy in `.bin/` takes precedence, so local results match CI.
+
 ### Codespell
 
 `make lint` runs `uv run codespell src` to check source documentation for common spelling errors.

--- a/scripts/install-vale.sh
+++ b/scripts/install-vale.sh
@@ -1,46 +1,72 @@
 #!/usr/bin/env bash
+# Install a pinned Vale binary to "$1" (default .bin/vale).
+#
+# The version comes from a single source of truth, .mise.toml, so local runs,
+# the prek hooks, and the lint-prose workflow all lint with the same engine.
+# Pass an explicit version as "$2" to override (with or without a leading "v").
+#
+# Note on release naming: the git tag carries a "v" prefix while the asset
+# filename does not, e.g. tag v3.17.1 holds vale_3.17.1_Linux_64-bit.tar.gz.
 set -euo pipefail
 
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 dest_path="${1:-.bin/vale}"
-vale_version="${2:-v3.9.6}"
+requested_version="${2:-}"
 
-if [ -x "$dest_path" ]; then
+# Read the canonical pin from .mise.toml unless one was passed in.
+if [ -z "$requested_version" ]; then
+  mise_toml="$repo_root/.mise.toml"
+  if [ ! -f "$mise_toml" ]; then
+    echo "Cannot resolve the Vale version: $mise_toml is missing." >&2
+    exit 1
+  fi
+  requested_version="$(sed -n 's/^[[:space:]]*vale[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' "$mise_toml" | head -n 1)"
+  if [ -z "$requested_version" ]; then
+    echo "Cannot resolve the Vale version: no 'vale = \"...\"' entry in $mise_toml." >&2
+    exit 1
+  fi
+fi
+
+# Normalize away any leading "v" so the tag and the filename can be built
+# separately below.
+vale_version="${requested_version#v}"
+
+# This value is interpolated into a download URL and a filesystem path, so
+# constrain it to a bare semantic version before going any further.
+if ! printf '%s' "$vale_version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "Refusing to use Vale version '$requested_version': expected a bare semantic version such as 3.17.1." >&2
+  exit 1
+fi
+
+# Report the version of a vale binary, or nothing if it cannot be determined.
+installed_version() {
+  local candidate="$1"
+  [ -x "$candidate" ] || return 0
+  "$candidate" --version 2>/dev/null | grep -Eo '[0-9]+\.[0-9]+\.[0-9]+' | head -n 1 || true
+}
+
+# Already correct at the destination.
+if [ "$(installed_version "$dest_path")" = "$vale_version" ]; then
+  exit 0
+fi
+
+# A matching vale is already on PATH (for example one that mise installed), so
+# reuse it rather than downloading a second copy.
+if path_vale="$(command -v vale 2>/dev/null)" &&
+   [ "$(installed_version "$path_vale")" = "$vale_version" ]; then
+  mkdir -p "$(dirname "$dest_path")"
+  ln -sf "$path_vale" "$dest_path"
   exit 0
 fi
 
 os_name="$(uname -s)"
-
-mkdir -p "$(dirname "$dest_path")"
-
-if [ "$os_name" = "Darwin" ] && command -v brew >/dev/null 2>&1; then
-  brew install vale
-  ln -sf "$(brew --prefix)/bin/vale" "$dest_path"
-  exit 0
-fi
-
-if [ "$os_name" = "Linux" ] && command -v docker >/dev/null 2>&1; then
-  cat > "$dest_path" <<'EOF'
-#!/usr/bin/env bash
-set -euo pipefail
-exec docker run --rm -i \
-  -v "$PWD:/work" \
-  -w /work \
-  jdkato/vale:latest "$@"
-EOF
-  chmod +x "$dest_path"
-  exit 0
-fi
-
 arch_name="$(uname -m)"
+
 case "$os_name" in
   Linux)
     case "$arch_name" in
-      x86_64|amd64)
-        asset_suffix="Linux_64-bit"
-        ;;
-      arm64|aarch64)
-        asset_suffix="Linux_arm64"
-        ;;
+      x86_64|amd64) asset_suffix="Linux_64-bit" ;;
+      arm64|aarch64) asset_suffix="Linux_arm64" ;;
       *)
         echo "Unsupported Linux architecture for Vale: $arch_name" >&2
         exit 1
@@ -48,8 +74,14 @@ case "$os_name" in
     esac
     ;;
   Darwin)
-    echo "Homebrew is required to install Vale on macOS when it is not already present." >&2
-    exit 1
+    case "$arch_name" in
+      x86_64|amd64) asset_suffix="macOS_64-bit" ;;
+      arm64|aarch64) asset_suffix="macOS_arm64" ;;
+      *)
+        echo "Unsupported macOS architecture for Vale: $arch_name" >&2
+        exit 1
+        ;;
+    esac
     ;;
   *)
     echo "Unsupported operating system for Vale installation: $os_name" >&2
@@ -60,14 +92,16 @@ esac
 workdir="$(mktemp -d)"
 trap 'rm -rf "$workdir"' EXIT
 archive="$workdir/vale.tar.gz"
-url="https://github.com/errata-ai/vale/releases/download/${vale_version}/vale_${vale_version}_${asset_suffix}.tar.gz"
+url="https://github.com/errata-ai/vale/releases/download/v${vale_version}/vale_${vale_version}_${asset_suffix}.tar.gz"
 
-curl -fsSL "$url" -o "$archive"
+echo "Installing Vale $vale_version ($asset_suffix) to $dest_path"
+curl -fsSL --max-time 120 --retry 3 "$url" -o "$archive"
 tar -xzf "$archive" -C "$workdir"
 install_bin="$(find "$workdir" -type f -name vale | head -n 1)"
 if [ -z "$install_bin" ]; then
   echo "Downloaded Vale archive did not contain a vale binary." >&2
   exit 1
 fi
+mkdir -p "$(dirname "$dest_path")"
 cp "$install_bin" "$dest_path"
 chmod +x "$dest_path"


### PR DESCRIPTION
## Why

Two independent staleness bugs found while auditing the docs tooling against the internal tech-stack doc.

**1. The agent navigation map was describing a site structure that no longer exists.**

`CLAUDE.md` and `AGENTS.md` claimed the site has 4 products (Home, LangSmith, LangSmith Fleet, Open source) and mapped tabs and groups for each. `src/docs.json` now defines 2 lifecycle-stage products. Every tab name in the old map was wrong, so every coding agent reading these files was being told to file pages into tabs that do not exist.

**2. Vale was pinned in four places with three different versions — and CI was silently using none of them.**

| Location | Version |
|---|---|
| `.github/workflows/lint-prose.yml` | 3.17.1, downloaded to `/usr/local/bin` |
| `.mise.toml` | 3.12.0 |
| `Makefile` | v3.9.6 |
| `scripts/install-vale.sh` | unpinned `brew install vale` on macOS, `jdkato/vale:latest` under Docker |

The drift was worse than the table suggests. `make lint_prose` always invoked `$(VALE_BIN)`, i.e. `.bin/vale`, never whatever was on `PATH`. In a fresh CI checkout `.bin/vale` does not exist, so the Makefile fell through to `install-vale.sh`, which on an ubuntu runner takes the "Linux and docker is available" branch and writes a wrapper around **`jdkato/vale:latest`**.

So the 3.17.1 binary the workflow carefully downloaded was never executed. **CI has been linting prose with an unpinned `:latest` image**, and the pin in the workflow was decorative. Meanwhile a macOS contributor got whatever Homebrew last installed — 3.18.0 on the machine this was found on.

## What changed

### Navigation map

Rewritten from `src/docs.json` and verified against the filesystem and `pipeline/core/builder.py`:

- Both products and all 10 menu items, each tab labelled with its **source directory**. The old map gave no directory mapping for LangSmith at all.
- A source-directory summary table for going from a file to its nav location, because the two diverge: `No-code agents` is `src/langsmith/fleet/`, and the Build menu draws from both `src/oss/` and `src/langsmith/`.
- The three exceptions to the build-twice rule: `src/oss/deepagents/code/` and `src/oss/openwiki/` ship unversioned, while `src/langsmith/managed-deep-agents*.mdx` inverts the pattern by living outside `src/oss/` yet emitting only language-prefixed routes.
- A reference-docs table covering all three OpenAPI specs, noting that two are committed locally and which one is auto-refreshed daily.

Also corrected: the structure tree (missing `oss/openwiki/`, `oss/deepagents/code/`, `src/code-samples/`), the "Adding pages" instruction that pointed at `navigation.products[1]` as LangSmith, and the `LangSmith Fleet` label in the two derived instruction files.

### Vale

`.mise.toml` is now the only pin. The `Makefile`, `scripts/install-vale.sh`, and the workflow all read the version from it, and the workflow installs to `.bin/vale` so the binary the Makefile actually runs is the pinned one.

Staying on **3.17.1** — the version the workflow intended to use. Note this is a real behavior change for CI, which was effectively on `:latest`, so a small number of new violations are possible on the next docs PR. Bumping to 3.18.0 is a separate call.

Two latent bugs in `scripts/install-vale.sh` fixed along the way:

- The release tag carries a `v` prefix but the asset filename does not, and the script interpolated the same string into both. With its own `v3.9.6` default it requested `.../download/v3.9.6/vale_v3.9.6_Linux_64-bit.tar.gz`, which 404s (verified with a live request).
- An existing `.bin/vale` short-circuited the install regardless of version, so a stale binary was never replaced. It now compares `vale --version` against the pin, and reuses a matching binary already on `PATH` instead of downloading a second copy.

The unpinned Homebrew and Docker paths are gone; every platform gets the pinned tarball, macOS on both architectures included. The version reaches a download URL from a config file, so it is validated against a bare-semver pattern first.

### Unrelated one-liner

`check-agents-sync.yml` triggered on pushes to `master`. The default branch is `main`, so the push-side check never ran. The `pull_request` trigger was unaffected, so this was dead config rather than a broken gate.

## Review notes

- **Please sanity-check the navigation map tables** against your own mental model of the nav — that is the part with the most surface area for error. Generated from `docs.json` programmatically, then spot-verified, but a human who knows the IA will catch anything I mismapped.
- **The Vale change is the riskier half.** Since CI was on `:latest`, expect the possibility of new violations on the next docs PR. Happy to bump the pin to 3.18.0 instead if you would rather match what `:latest` was resolving to.
- `CLAUDE.md` and `AGENTS.md` are byte-identical, so `check-agents-sync` passes.
- The nav map deliberately stays out of the four derived instruction files; they point back to `AGENTS.md` so a future restructure only needs the twins updated.

### What I verified, and what I could not

Verified locally on macOS arm64: the Makefile resolves the pin from `.mise.toml`; the installer replaces a stale binary (3.18.0 to 3.17.1); it is idempotent on a second run; an explicit `v`-prefixed override works; malformed version strings are rejected; `make lint_prose` passes on a sample of `src/`.

Not verified: **the Linux/CI download path did not run.** Docker was unavailable locally to simulate it, and this PR changes no `src/**/*.md(x)` file, so `lint-prose` does not trigger here. The Linux asset URLs return 200 and the code path is shared with the macOS one I did exercise, but the first real test will be the next PR that touches a docs page. Worth watching that run.

## AI disclosure

Written with Claude Code (Opus 5). The nav map was generated from `src/docs.json` and each claim checked against the filesystem and `builder.py`; the asset-name 404, the version drift, and the `:latest` fallthrough were all reproduced before being described here.
