### PR TITLE
Replace shut-down gemini-2.0-flash-exp in OpenTelemetry ADK example

### DIFF
--- a/src/langsmith/trace-with-opentelemetry.mdx
+++ b/src/langsmith/trace-with-opentelemetry.mdx
@@ -641,7 +641,7 @@ async def main():
     agent = LlmAgent(
         name="travel_assistant",
         tools=[get_flight_info, get_hotel_recommendations],
-        model="gemini-2.0-flash-exp",
+        model="gemini-2.5-flash-lite",
         instruction="You are a helpful travel assistant that can help with flights and hotels.",
     )
 


### PR DESCRIPTION
## Overview

The "Add an attachment to a trace" example uses `model="gemini-2.0-flash-exp"`, which
doesn't work anymore. Google shut down the Gemini 2.0 Flash models, and the experimental
variants went even earlier, so the snippet just errors out if you copy it.

Changed it to `gemini-2.5-flash-lite`, which is what the other ADK example on this page
already uses. It supports image input too, which this example needs for the receipt
attachment.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs

- GitHub issue:
- Feature PR:

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

Skipped `docs dev` since this is a one-line string change inside a code block, nothing to
render. I haven't run the example itself either (no Google API key handy), but
`gemini-2.0-flash` shows up under "Previous models (Shut down)" on
https://ai.google.dev/gemini-api/docs/models and there's no `-exp` variant listed at all.

Happy to switch to a different model if you'd rather point people elsewhere.
