### PR TITLE
Updated assistant-ui.mdx

### DIFF
--- a/src/oss/langchain/frontend/integrations/assistant-ui.mdx
+++ b/src/oss/langchain/frontend/integrations/assistant-ui.mdx
@@ -137,9 +137,9 @@ export function toThreadMessages(messages: BaseMessage[]): ThreadMessageLike[] {
 }
 ```
 
-## Customising the thread UI
+## Customizing the thread UI
 
-`<Thread />` ships a complete default thread UI including message list, composer, and scroll management. Customise individual parts by overriding component slots:
+`<Thread />` ships a complete default thread UI including message list, composer, and scroll management. Customize individual parts by overriding component slots:
 
 ```tsx
 import { Thread, ThreadMessages, Composer } from "@assistant-ui/react";


### PR DESCRIPTION
Changed “Customise” and “Customising” to their American English equivalents to maintain consistency with the documentation’s language standards.

## Overview
Changed “Customise” and “Customising” to their American English equivalents to maintain consistency with LangChain's documentation language standards.

## Type of change

**Type:** Fix typo

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

## Additional notes
This is a documentation-only terminology change. No code examples, internal links, or navigation were modified.
