### PR TITLE
docs: add HackerNews retrievers to external integrations

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -1058,6 +1058,15 @@ python:
     pypi: langchain-nono
     docs_url: https://github.com/always-further/langchain-nono
   retrievers:
+  - name: HackerNewsSearchRetriever
+    pypi: langchain-hackernews
+    docs_url: https://github.com/urraf/langchain-hackernews#readme
+  - name: HackerNewsFrontPageRetriever
+    pypi: langchain-hackernews
+    docs_url: https://github.com/urraf/langchain-hackernews#readme
+  - name: HackerNewsCommentsRetriever
+    pypi: langchain-hackernews
+    docs_url: https://github.com/urraf/langchain-hackernews#readme
   - name: YouTubeSearchRetriever
     pypi: langchain-youtube
     docs_url: https://github.com/urraf/langchain-youtube#readme


### PR DESCRIPTION
## Overview
<!-- Brief description of what documentation is being added/updated -->

## Type of change

**Type:** [Replace with: New documentation page / Update existing documentation / Fix typo/bug/link/formatting / Remove outdated content / Other]

## Related issues/PRs
<!--
Link to related issues, feature PRs, or discussions (if applicable)

To automatically close an issue when this PR is merged, use closing keywords:
- "closes #123" or "fixes #123" or "resolves #123"

For regular references without auto-closing, just use:
- "#123" or "See issue #123"

Examples:
- closes #456 (will auto-close issue #456 when PR is merged)
- See #789 for context (will reference but not auto-close issue #789)
-->
- GitHub issue:
- Feature PR:

<!-- For LangChain employees, if applicable: -->
- Linear issue:
- Slack thread:

## Checklist
<!-- Put an 'x' in all boxes that apply -->
- [ ] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [ ] I have used **root relative** paths for internal links
- [ ] I have updated navigation in `src/docs.json` if needed

(Internal team members only / optional): Create a preview deployment as necessary using the [Create Preview Branch workflow](https://github.com/langchain-ai/docs/actions/workflows/create-preview-branch.yml)

## Additional notes
<!-- Any other information that would be helpful for reviewers -->
