### PR TITLE
docs: clarify retry parameter purpose

### DIFF
--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -265,7 +265,7 @@ max_retries = 0
 
 The global `[retries].max_retries` value applies to all supported providers. A provider-specific table, such as `[retries.fireworks]`, overrides the global value for that provider. Values must be integers greater than or equal to `0`.
 
-For an arbitrary provider, set `param` to its retry-count constructor argument so Deep Agents Code can disable the provider's retry loop and use the configured retry budget:
+For an arbitrary provider, set `param` to the name of its retry-count constructor argument. Deep Agents Code uses `param` only to disable the provider SDK's retry loop, which leaves the model-node middleware as the sole owner of the configured retry budget:
 
 ```toml
 [retries]
@@ -276,7 +276,7 @@ param = "retries"
 max_retries = 4
 ```
 
-`param` must be a valid Python identifier string, such as `"max_retries"` or `"retries"`.
+`param` must be a valid Python identifier string, such as `"max_retries"` or `"retries"`. It does not set the retry budget. Set the budget with `max_retries` in this section or with `--max-retries`.
 
 The retry-budget precedence order is:
 


### PR DESCRIPTION
Clarifies that `[retries.<provider>].param` only identifies the provider SDK retry argument so Deep Agents Code can disable SDK-level retries. The model-node middleware remains the sole owner of the retry budget, which is configured separately with `max_retries` or `--max-retries`.

Verification: `make lint_prose FILES="src/oss/deepagents/code/config-file.mdx" NO_COLOR=1`

Made by [Open SWE](https://openswe.vercel.app/agents/888802e2-eda3-5e94-9be5-677fd00df654)