### PR TITLE
  docs: fix typo in Elasticsearch retriever guide

### DIFF
--- a/src/oss/python/integrations/retrievers/elasticsearch_retriever.mdx
+++ b/src/oss/python/integrations/retrievers/elasticsearch_retriever.mdx
@@ -302,7 +302,7 @@ fuzzy_retriever = ElasticsearchRetriever.from_es_params(
     url=es_url,
 )
 
-fuzzy_retriever.invoke("fox")  # note the character tolernace
+fuzzy_retriever.invoke("fox")  # note the character tolerance
 ```
 
 ```python


### PR DESCRIPTION
  Fixes a typo: "tolernace" → "tolerance" in the fuzzy matching code comment.