### PR TITLE
docs(abac): clarify abac policies can attach to built-in workspace roles

### DIFF
--- a/src/langsmith/abac.mdx
+++ b/src/langsmith/abac.mdx
@@ -158,7 +158,7 @@ In an **allow** policy, `_if_exists` variants grant access to resources that eit
 
 The `role_ids` array specifies which workspace roles the policy applies to. When a user with that role accesses a resource, the policy conditions are evaluated.
 
-Policies can be attached to roles when creating the policy, or attached later via the API.
+Policies can be attached to [workspace roles](/langsmith/rbac#workspace-roles) (built-in or [custom](/langsmith/rbac#custom-roles)) when creating the policy, or attached later via the API.
 
 ## Managing access policies
 


### PR DESCRIPTION
## Summary

We now allow ABAC policies to be attached to built-in workspace roles in addition to custom roles.

Updates wording to call out this ability explicitly.

## AI disclosure

Drafted with Claude Code. Reviewed by me before opening.
