### PR TITLE
docs(rbac): add Model price map permissions to workspace operations

### DIFF
--- a/src/langsmith/organization-workspace-operations.mdx
+++ b/src/langsmith/organization-workspace-operations.mdx
@@ -23,7 +23,7 @@ For an overview of LangSmith's RBAC system, role definitions, and permission con
 | **Core management:**<br/>• [Organization settings](#organization-settings): Org info and configuration<br/>• [Workspaces](#workspaces): Workspace management<br/>• [Organization members](#organization-members): Member management<br/>• [Roles and permissions](#roles-and-permissions): Custom roles | **Core resources:**<br/>• [Projects](#projects): Organize traces and runs<br/>• [Runs](#runs): Individual execution traces<br/>• [Datasets](#datasets): Test datasets for evaluation<br/>• [Examples](#examples): Individual dataset examples<br/>• [Experiments](#experiments): Comparative experiments |
 | **Security and authentication:**<br/>• [SSO and authentication](#sso-and-authentication): Single sign-on setup<br/>• [SCIM](#scim): Identity provisioning<br/>• [Access policies](#access-policies): Attribute-based access control | **Monitoring and analysis:**<br/>• [Rules](#rules): Automated run rules<br/>• [Alerts](#alerts): Alert rules for monitoring<br/>• [Feedback](#feedback): Scores and labels on outputs<br/>• [Annotation Queues](#annotation-queues): Human review queues<br/>• [Charts](#charts): Custom visualizations |
 | **Billing and accounts:**<br/>• [Billing and payments](#billing-and-payments): Subscription management<br/>• [API keys](#api-keys): Org-level keys | **Development and configuration:**<br/>• [Prompts](#prompts): Prompt templates (LangChain Hub)<br/>• [Custom apps](#custom-apps): User-authored mini web apps<br/>• [Deployments](#deployments): Deployment configurations<br/>• [MCP Servers](#mcp-servers): Model Context Protocol servers<br/>• [Fleet](#fleet): Fleet admin operations |
-| **Analytics:**<br/>• [Charts and dashboards](#organization-charts-and-dashboards): Org-level visualizations<br/>• [Usage and analytics](#usage-and-analytics): Usage tracking and TTL settings | **Workspace management:**<br/>• [Workspace settings](#workspace-settings-and-management): Members, settings<br/>• [Tags](#tags): Metadata tagging system<br/>• [Bulk Exports](#bulk-exports): Data export operations |
+| **Analytics:**<br/>• [Charts and dashboards](#organization-charts-and-dashboards): Org-level visualizations<br/>• [Usage and analytics](#usage-and-analytics): Usage tracking and TTL settings | **Workspace management:**<br/>• [Model price map](#model-price-map): Per-token model prices<br/>• [Workspace settings](#workspace-settings-and-management): Members, settings<br/>• [Tags](#tags): Metadata tagging system<br/>• [Bulk Exports](#bulk-exports): Data export operations |
 
 **Additional information:**
 
@@ -500,6 +500,21 @@ Custom visualizations and dashboards.
 | View deployment | ✓ | ✓ | ✓ | `deployments:read` |
 | Update deployment | ✓ | ✓ | ✗ | `deployments:update` |
 | Delete deployment | ✓ | ✗ | ✗ | `deployments:delete` |
+
+### Model price map
+
+Per-token model prices used to compute run costs. See [Cost tracking](/langsmith/cost-tracking).
+
+| Operation | Workspace Admin | Workspace Editor | Workspace Viewer | Required Permission |
+|-----------|:---------------:|:--------------:|:----------------:|---------------------|
+| View model prices | ✓ | ✓ | ✓ | `model-price-map:read` |
+| Create a model price entry | ✓ | ✓ | ✗ | `model-price-map:create` |
+| Update a model price entry | ✓ | ✓ | ✗ | `model-price-map:update` |
+| Delete a model price entry | ✓ | ✓ | ✗ | `model-price-map:delete` |
+
+<Note>
+These permissions replace the `runs:read` and `runs:create` checks that previously gated model prices. Built-in roles keep the access they had. Custom roles created after this change need the `model-price-map` permissions granted explicitly; they appear as their own checkboxes in the custom role editor.
+</Note>
 
 ### Workspace settings and management
 


### PR DESCRIPTION
## Overview

Model Price Map now checks granular `model-price-map:{create,read,update,delete}` permissions instead of reusing `runs:read` and `runs:create`. It had no permission coverage in the workspace operations reference at all, so this adds a section rather than correcting a row.

- `organization-workspace-operations.mdx`: new **Model price map** section under Workspace-level operations, plus a Contents entry under Workspace management.

**No built-in role gains or loses access.** The migrations backfill existing roles from their current `runs:read` / `runs:create` grants, so the checkmarks match the previous behavior exactly. The user-visible change is that these are now four separate checkboxes in the custom role editor, and custom roles created after the change need them granted explicitly.



## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Feature PR: langchain-ai/langchainplus#34402 (merged)
- Linear issue: ENT-1497

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev` — not run; this is a table and Contents addition with one root-relative link, leaving verification to the link-check CI
- [x] All code examples have been tested and work correctly (no code examples in this change)
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed (no new page, so no nav change)
