### PR TITLE
docs: document Deep Agents Code 0.1.65 features

### DIFF
--- a/src/oss/deepagents/code/cli-reference.mdx
+++ b/src/oss/deepagents/code/cli-reference.mdx
@@ -66,22 +66,18 @@ You can also pin a default from the interactive `/model` switcher (`Ctrl+S`) or 
 
 ### Choose a summarization model
 
-<Note>
-    Summarization model selection requires `deepagents-code>=0.1.65`.
-</Note>
-
 Use a separate model for automatic context compaction, `/offload`, and `/compact` without changing the main agent model:
 
 ```bash
 # Set the summarization model for this launch
-dcode --summarization-model openai:gpt-5.5
+dcode --summarization-model openai:gpt-5.6-sol
 ```
 
 In an interactive session, run `/summarization-model` to open the model picker, pass a model spec to switch directly, or pass `clear` to reuse the main agent model:
 
 ```text
 /summarization-model
-/summarization-model openai:gpt-5.5
+/summarization-model openai:gpt-5.6-sol
 /summarization-model clear
 ```
 
@@ -119,10 +115,6 @@ Add `--package` to install an arbitrary provider package via `uv --with` (see [A
 
 ### Remove an optional extra
 
-<Note>
-    Optional extra removal requires `deepagents-code>=0.1.65`.
-</Note>
-
 Remove one installed extra while preserving the rest of the Deep Agents Code installation:
 
 <CodeGroup>
@@ -136,7 +128,7 @@ Remove one installed extra while preserving the rest of the Deep Agents Code ins
     ```
 </CodeGroup>
 
-Removal rebuilds a uv tool installation without the selected extra while preserving the interpreter, release channel, other extras, and packages installed with `--package`. The command has no effect when the extra is already absent. It refuses to remove base dependencies, an extra that is still supplied by a composite extra, or extras from unsupported installation methods.
+Removal rebuilds a uv tool installation without the selected extra while preserving the interpreter, release channel, other extras, and packages installed with `--package`.
 
 ## Agents and sessions
 
@@ -181,10 +173,6 @@ Use `-q`/`--quiet` to emit only the agent's response on stdout (for piping into 
 dcode -n "Generate a .gitignore for Python" -q > .gitignore
 dcode -n "List dependencies" -q --no-stream | sort
 ```
-
-<Note>
-    Provider-visible reasoning requires `deepagents-code>=0.1.65`.
-</Note>
 
 Add `--show-reasoning` to display provider-visible reasoning. In an interactive session, reasoning streams into a separate row that collapses when the phase ends; press `Ctrl+O` to reopen it. In non-interactive mode, reasoning goes to stderr so the final answer on stdout remains pipeable. This setting is off by default and applies for the full session. See [Show provider-visible reasoning](/oss/deepagents/code/config-file#show-provider-visible-reasoning) for persistent configuration.
 

--- a/src/oss/deepagents/code/cli-reference.mdx
+++ b/src/oss/deepagents/code/cli-reference.mdx
@@ -64,6 +64,29 @@ dcode --clear-default-model
 
 You can also pin a default from the interactive `/model` switcher (`Ctrl+S`) or set `[models].default` in `config.toml`. See [Set a default model](/oss/deepagents/code/providers#set-a-default-model).
 
+### Choose a summarization model
+
+<Note>
+    Summarization model selection requires `deepagents-code>=0.1.65`.
+</Note>
+
+Use a separate model for automatic context compaction, `/offload`, and `/compact` without changing the main agent model:
+
+```bash
+# Set the summarization model for this launch
+dcode --summarization-model openai:gpt-5.5
+```
+
+In an interactive session, run `/summarization-model` to open the model picker, pass a model spec to switch directly, or pass `clear` to reuse the main agent model:
+
+```text
+/summarization-model
+/summarization-model openai:gpt-5.5
+/summarization-model clear
+```
+
+The summarization model resolves from `--summarization-model`, then `[models].summarization_default` in `config.toml`, then the main agent model. See [Set a summarization model](/oss/deepagents/code/config-file#set-a-summarization-model).
+
 ### Model parameters and profile overrides
 
 Pass extra constructor kwargs to the model with `--model-params` as a JSON string. These apply for the current session only and override `config.toml` provider params:
@@ -93,6 +116,27 @@ dcode --install ollama
 ```
 
 Add `--package` to install an arbitrary provider package via `uv --with` (see [Arbitrary providers](/oss/deepagents/code/config-file#arbitrary-providers)), and `--yes` to skip confirmation prompts. To preinstall extras during the initial CLI install, set `DEEPAGENTS_CODE_EXTRAS` (for example, `DEEPAGENTS_CODE_EXTRAS="groq,fireworks"`).
+
+### Remove an optional extra
+
+<Note>
+    Optional extra removal requires `deepagents-code>=0.1.65`.
+</Note>
+
+Remove one installed extra while preserving the rest of the Deep Agents Code installation:
+
+<CodeGroup>
+    ```bash Shell
+    dcode uninstall groq
+    dcode --uninstall groq
+    ```
+
+    ```text In session
+    /uninstall groq
+    ```
+</CodeGroup>
+
+Removal rebuilds a uv tool installation without the selected extra while preserving the interpreter, release channel, other extras, and packages installed with `--package`. The command has no effect when the extra is already absent. It refuses to remove base dependencies, an extra that is still supplied by a composite extra, or extras from unsupported installation methods.
 
 ## Agents and sessions
 
@@ -137,6 +181,12 @@ Use `-q`/`--quiet` to emit only the agent's response on stdout (for piping into 
 dcode -n "Generate a .gitignore for Python" -q > .gitignore
 dcode -n "List dependencies" -q --no-stream | sort
 ```
+
+<Note>
+    Provider-visible reasoning requires `deepagents-code>=0.1.65`.
+</Note>
+
+Add `--show-reasoning` to display provider-visible reasoning. In an interactive session, reasoning streams into a separate row that collapses when the phase ends; press `Ctrl+O` to reopen it. In non-interactive mode, reasoning goes to stderr so the final answer on stdout remains pipeable. This setting is off by default and applies for the full session. See [Show provider-visible reasoning](/oss/deepagents/code/config-file#show-provider-visible-reasoning) for persistent configuration.
 
 Cap agent runs in CI with `--max-turns` or `--timeout`. Both exit with code 124 when the budget is exceeded. Requires `-n` or piped stdin:
 
@@ -396,6 +446,7 @@ Run OAuth login for an MCP server marked `auth: "oauth"` with `dcode mcp login <
 |------------------------|-------------------------------------------------------------|
 | `-a`, `--agent NAME`   | Use named agent with separate memory. Overrides `[agents].recent` and `[agents].default` in `config.toml`. Default: `agent` (or the most recently used agent if `[agents].recent` is set) |
 | `-M`, `--model MODEL`  | Use a specific model (`provider:model`)                    |
+| `--summarization-model MODEL` | Model used for context-compaction summaries. Overrides `[models].summarization_default`; defaults to the main agent model |
 | `--model-params JSON`  | Extra kwargs to pass to the model as a JSON string (e.g., `'{"temperature": 0.7}'`) |
 | `--max-retries N`      | Override retries after a transient model error. Default: `5`; set to `0` to disable retries |
 | `--default-model [MODEL]` | Set the [default model](/oss/deepagents/code/providers#set-a-default-model) (omit `MODEL` to view the current default) |
@@ -413,6 +464,7 @@ Run OAuth login for an MCP server marked `auth: "oauth"` with `dcode mcp login <
 | `--timeout SECONDS`    | Hard wall-clock timeout for non-interactive mode. Exits with code 124 when exceeded. Requires `-n` or piped stdin. See [Non-interactive mode and piping](#non-interactive-mode-and-piping) |
 | `-q`, `--quiet`        | Clean output for piping—only the agent's response goes to stdout. Requires `-n` or piped stdin |
 | `--no-stream`          | Buffer the full response and write to stdout at once instead of streaming. Requires `-n` or piped stdin |
+| `--show-reasoning`     | Show provider-visible reasoning in the interactive transcript or on stderr in non-interactive mode. Off by default |
 | `--stdin`              | Read input from stdin explicitly instead of auto-detection. Errors clearly when stdin is unavailable or is a TTY |
 | `-y`, `--auto-approve` | Enable classifier-backed [Auto](/oss/deepagents/code/approval-modes) mode. Requires an interactive local session; toggle with `Shift+Tab` during an interactive session |
 | `--auto-classifier-model MODEL` | Model used by the [Auto classifier](/oss/deepagents/code/approval-modes#select-a-classifier-model) to review gated tool calls (`provider:model` format). Overrides `DEEPAGENTS_CODE_AUTO_CLASSIFIER_MODEL` and `[models].auto_classifier` in `config.toml`. Interactive TUI sessions only |
@@ -434,6 +486,7 @@ Run OAuth login for an MCP server marked `auth: "oauth"` with `dcode mcp login <
 | `--update`             | Check for and install updates, then exit                    |
 | `--auto-update`        | Toggle automatic updates on or off, then exit               |
 | `--install NAME`       | Install an optional extra (e.g., `quickjs`, `daytona`, `fireworks`), then exit. Add `--package` to treat `NAME` as a custom provider package installed via `uv --with` rather than an extra (see [arbitrary providers](/oss/deepagents/code/config-file#arbitrary-providers)), and `--yes` to skip confirmation prompts |
+| `--uninstall NAME`     | Remove an installed optional extra and exit. Alias for `dcode uninstall NAME` |
 | `-v`, `--version`      | Display version                                             |
 | `-h`, `--help`         | Show help                                                   |
 
@@ -485,6 +538,7 @@ Pair `dcode doctor` with `dcode config show` when you need both a high-level hea
 | `dcode agents list`             | List all agents (alias: `ls`)          |
 | `dcode agents reset --agent NAME` | Clear agent memory and reset to default. Supports `--dry-run` |
 | `dcode agents reset --agent NAME --target SOURCE` | Copy memory from another agent |
+| `dcode uninstall NAME`         | Remove one installed optional extra while preserving the rest of the tool environment |
 | `dcode update`                  | Check for and install Deep Agents Code updates |
 | `dcode doctor`                  | Run diagnostics without launching a session. See [Run diagnostics](#run-diagnostics-dcode-doctor) |
 | `dcode skills list [--project]`           | List all skills (alias: `ls`) |

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -31,15 +31,11 @@ auto_classifier = "openai:gpt-5.6-luna"  # optional: cheaper model for Auto appr
 
 ## Set a summarization model
 
-<Note>
-    Summarization model selection requires `deepagents-code>=0.1.65`.
-</Note>
-
 Set a dedicated model for automatic context compaction, `/offload`, and `/compact`:
 
 ```toml title="~/.deepagents/config.toml"
 [models]
-summarization_default = "openai:gpt-5.5"
+summarization_default = "openai:gpt-5.6-sol"
 ```
 
 The summarization model resolves in this order:
@@ -99,10 +95,6 @@ trusted_cache_endpoints = ["smith.langchain.com"]
 Entries are hostnames matched exactly — trusting `example.com` does not trust `gw.example.com`. One entry covers every provider routed through that endpoint. Cross-format routes through the LangSmith gateway (for example, an OpenAI-format request routed to an Anthropic model) stay silent even when trusted, because translation rewrites the cache settings the estimate assumes.
 
 ## Show provider-visible reasoning
-
-<Note>
-    Provider-visible reasoning requires `deepagents-code>=0.1.65`.
-</Note>
 
 Provider-visible reasoning is hidden by default. To show it in the interactive transcript and non-interactive output, set:
 

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -6,8 +6,9 @@ description: Configure model providers, defaults, retries, and gateways in confi
 
 `~/.deepagents/config.toml` lets you customize model providers, set defaults, and pass extra parameters to model constructors. For environment variables and inspection commands, see [Configuration](/oss/deepagents/code/configuration). This page covers:
 
-- **Defaults**: pin a [default model](#default-and-recent-model) or [agent](#default-and-recent-agent), or [restrict usable models](#allowed-models) with an allowlist.
+- **Defaults**: pin a [default model](#default-and-recent-model), [summarization model](#set-a-summarization-model), or [agent](#default-and-recent-agent), or [restrict usable models](#allowed-models) with an allowlist.
 - **Warnings**: [session cost](#session-cost-warning) and [cold prompt-cache](#cold-prompt-cache-warning) thresholds, and [trusted gateway endpoints](#trust-a-gateway-endpoint-for-cache-policies).
+- **Display**: [provider-visible reasoning](#show-provider-visible-reasoning) and diff line numbers.
 - **Interpreter**: the [`[interpreter]` settings](#js-interpreter) for the built-in QuickJS REPL.
 - **Tracing**: [client-side secret redaction](#redact-langsmith-trace-secrets) for LangSmith traces.
 - **Provider setup**: the [`[models.providers.<name>]` table](#provider-configuration), [constructor params](#model-constructor-params), [retries](#retries), [profile overrides](#profile-overrides-advanced), and [adding models to the `/model` switcher](#adding-models-to-the-interactive-switcher).
@@ -27,6 +28,27 @@ auto_classifier = "openai:gpt-5.6-luna"  # optional: cheaper model for Auto appr
 `[models].default` always takes priority over `[models].recent`. The `/model` command only writes to `[models].recent`, so your configured default is never overwritten by mid-session switches. To remove the default, use `/model --default --clear` or delete the `default` key from the config file.
 
 `[models].auto_classifier` sets the model used by the [Auto approval classifier](/oss/deepagents/code/approval-modes#select-a-classifier-model) to review gated tool calls. When unset, the classifier inherits the main agent model. You can override this at runtime with `--auto-classifier-model` or `/auto model`. See [Select a classifier model](/oss/deepagents/code/approval-modes#select-a-classifier-model) for full precedence and security notes.
+
+## Set a summarization model
+
+<Note>
+    Summarization model selection requires `deepagents-code>=0.1.65`.
+</Note>
+
+Set a dedicated model for automatic context compaction, `/offload`, and `/compact`:
+
+```toml title="~/.deepagents/config.toml"
+[models]
+summarization_default = "openai:gpt-5.5"
+```
+
+The summarization model resolves in this order:
+
+1. `--summarization-model` for the current launch.
+2. `[models].summarization_default`.
+3. The main agent model.
+
+In an interactive session, run `/summarization-model` to open the model picker, `/summarization-model <provider:model>` to switch directly, or `/summarization-model clear` to follow the main agent model again. Changing the summarization model does not change the main agent model.
 
 ## Default and recent agent
 
@@ -75,6 +97,27 @@ trusted_cache_endpoints = ["smith.langchain.com"]
 ```
 
 Entries are hostnames matched exactly — trusting `example.com` does not trust `gw.example.com`. One entry covers every provider routed through that endpoint. Cross-format routes through the LangSmith gateway (for example, an OpenAI-format request routed to an Anthropic model) stay silent even when trusted, because translation rewrites the cache settings the estimate assumes.
+
+## Show provider-visible reasoning
+
+<Note>
+    Provider-visible reasoning requires `deepagents-code>=0.1.65`.
+</Note>
+
+Provider-visible reasoning is hidden by default. To show it in the interactive transcript and non-interactive output, set:
+
+```toml title="~/.deepagents/config.toml"
+[ui]
+show_reasoning = true
+```
+
+In an interactive session, reasoning streams into a separate row that collapses when the phase ends. Click the row or press `Ctrl+O` to reopen it. In non-interactive mode, reasoning goes to stderr so the final answer on stdout remains pipeable.
+
+Set `DEEPAGENTS_CODE_SHOW_REASONING=1` to override `config.toml`, or pass `--show-reasoning` to enable the setting for one launch. The launch flag takes precedence over the environment variable, which takes precedence over `config.toml`.
+
+<Note>
+    Deep Agents Code displays only reasoning content that the model provider exposes. Redacted or opaque reasoning remains hidden.
+</Note>
 
 ## Diff line numbers
 

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -715,6 +715,10 @@ All Deep Agents Code-specific environment variables use the `DEEPAGENTS_CODE_` p
     Comma-separated shell commands to allow (or `recommended` / `all`).
 </ResponseField>
 
+<ResponseField name="DEEPAGENTS_CODE_SHOW_REASONING" type="string" default="false" post={["optional"]}>
+    Show provider-visible reasoning in the interactive transcript and on stderr in non-interactive mode. Overrides `[ui].show_reasoning`; `--show-reasoning` takes precedence for a single launch. See [Show provider-visible reasoning](/oss/deepagents/code/config-file#show-provider-visible-reasoning).
+</ResponseField>
+
 <ResponseField name="DEEPAGENTS_CODE_SHOW_USAGE_STATS" type="string" default="true" post={["optional"]}>
     Show session usage statistics when a session ends. Set to a falsy value (or empty) to hide them. Overrides `[ui].show_usage_stats`. See [Session usage stats](#session-usage-stats).
 </ResponseField>


### PR DESCRIPTION
## Overview

Documents the user-facing Deep Agents Code 0.1.65 features from the release in [langchain-ai/deepagents#5929](https://github.com/langchain-ai/deepagents/pull/5929):

- Select a dedicated summarization model through the CLI, model picker, or `config.toml`.
- Show provider-visible reasoning in interactive and non-interactive sessions.
- Remove optional extras without uninstalling Deep Agents Code.

The extension feature from the same release is covered separately by [langchain-ai/docs#5737](https://github.com/langchain-ai/docs/pull/5737).

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Feature PR: [langchain-ai/deepagents#5929](https://github.com/langchain-ai/deepagents/pull/5929)
- Feature PR: [langchain-ai/deepagents#5875](https://github.com/langchain-ai/deepagents/pull/5875)
- Feature PR: [langchain-ai/deepagents#5884](https://github.com/langchain-ai/deepagents/pull/5884)
- Feature PR: [langchain-ai/deepagents#5887](https://github.com/langchain-ai/deepagents/pull/5887)
- Feature PR: [langchain-ai/deepagents#5932](https://github.com/langchain-ai/deepagents/pull/5932)

## Checklist

- [x] I have read the contributing guidelines, including the language policy
- [x] I have tested the changed pages with Vale and an anchor-aware link check
- [x] All code examples have been checked against the released CLI and configuration source
- [x] I have used root-relative paths for internal links
- [x] Navigation does not need an update because no pages were added

## Additional notes

Validation:

- `make lint_prose FILES="src/oss/deepagents/code/cli-reference.mdx src/oss/deepagents/code/config-file.mdx src/oss/deepagents/code/configuration.mdx"`
- `make broken-links-with-anchors`

Made by [Open SWE](https://openswe.vercel.app/agents/7a14b173-a659-5276-acb0-92672c3b6d33)