### PR TITLE
docs(aimlapi): correct integration pages to match the langchain-aimlapi package

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -69,7 +69,7 @@ python:
     tool_calling: false
     structured_output: false
     multimodal: false
-  - name: ChatAIMLAPI
+  - name: ChatAimlapi
     pypi: langchain-aimlapi
     docs_url: https://docs.aimlapi.com/
     stream: true
@@ -1354,7 +1354,7 @@ python:
   - name: Modelscope
     pypi: langchain-modelscope-integration
     docs_url: https://www.modelscope.cn/docs/sdk/pipelines
-  - name: AIMlAPIEmbeddings
+  - name: AimlapiEmbeddings
     pypi: langchain-aimlapi
     docs_url: https://docs.aimlapi.com/
   - name: PredictionGuardEmbeddings

--- a/src/oss/python/integrations/llms/aimlapi.mdx
+++ b/src/oss/python/integrations/llms/aimlapi.mdx
@@ -20,13 +20,13 @@ This page helps you get started with AI/ML API text completion models.
 
 | Class | Package | Local | Serializable | JS support | Downloads | Version |
 | :--- | :--- | :---: | :---: | :---: | :---: | :---: |
-| `AIMLAPILLM` | `langchain-aimlapi` | ❌ | beta | ❌ | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain-aimlapi?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-aimlapi?style=flat-square&label=%20) |
+| `AimlapiLLM` | `langchain-aimlapi` | ❌ | beta | ❌ | ![PyPI - Downloads](https://img.shields.io/pypi/dm/langchain-aimlapi?style=flat-square&label=%20) | ![PyPI - Version](https://img.shields.io/pypi/v/langchain-aimlapi?style=flat-square&label=%20) |
 
 ### Model features
 
 | [Tool calling](/oss/langchain/tools) | [Structured output](/oss/langchain/structured-output) | [Image input](/oss/langchain/messages#multimodal) | Audio input | Video input | [Token-level streaming](/oss/langchain/streaming/) | Native async | [Token usage](/oss/langchain/models#token-usage) | [Logprobs](/oss/langchain/models#log-probabilities) |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ |
 
 ## Setup
 
@@ -64,12 +64,12 @@ pip install -qU langchain-aimlapi
 Now we can instantiate our model object and generate text completions:
 
 ```python
-from langchain_aimlapi import AIMLAPILLM
+from langchain_aimlapi import AimlapiLLM
 
-llm = AIMLAPILLM(
-    model="gpt-3.5-turbo-instruct",
+llm = AimlapiLLM(
+    model="openai/gpt-5-5",
     temperature=0.5,
-    max_tokens=256,
+    max_tokens=1024,
 )
 ```
 
@@ -82,20 +82,6 @@ print(response)
 
 ```text
 Bubble sort is a simple sorting algorithm that repeatedly steps through a list, compares adjacent items, and swaps them when they are out of order. The process repeats until the entire list is sorted. While easy to understand and implement, bubble sort is inefficient on large datasets because it has quadratic time complexity.
-```
-
-## Streaming invocation
-
-You can also stream responses token-by-token:
-
-```python
-llm = AIMLAPILLM(
-    model="gpt-3.5-turbo-instruct",
-)
-
-stream = llm.stream_events("List top 5 programming languages in 2025 with reasons.", version="v3")
-for token in stream.text:
-    print(token, end="", flush=True)
 ```
 
 ---

--- a/src/oss/python/integrations/providers/aimlapi.mdx
+++ b/src/oss/python/integrations/providers/aimlapi.mdx
@@ -27,15 +27,15 @@ os.environ["AIMLAPI_API_KEY"] = "aimlapi_..."
 See a [usage example](https://docs.aimlapi.com/).
 
 ```python
-from langchain_aimlapi import ChatAIMLAPI
+from langchain_aimlapi import ChatAimlapi
 ```
 
 ## LLMs
 
-See a [usage example](/oss/integrations/llms/aimlapi).
+See a [usage example](/oss/python/integrations/llms/aimlapi).
 
 ```python
-from langchain_aimlapi import AIMLAPILLM
+from langchain_aimlapi import AimlapiLLM
 ```
 
 ## Embedding models
@@ -43,5 +43,5 @@ from langchain_aimlapi import AIMLAPILLM
 See a [usage example](https://docs.aimlapi.com/).
 
 ```python
-from langchain_aimlapi import AIMLAPIEmbeddings
+from langchain_aimlapi import AimlapiEmbeddings
 ```


### PR DESCRIPTION
Hi! I'm Hugo from aimlapi.com — an AI aggregator that gives access to 1000+ models in one API, trusted by 400k+ users.

We'd love to be available as a verified provider option inside LangChain — so we went ahead and did all the technical work on our side.

To build our partnership, we offer a 50/50 revenue share on all traffic from this integration. (P.S.: tracking starts as soon as this release goes live, so no earnings will be lost during setup)

My contacts: hugo@aimlapi.com (email / Slack), Telegram: @hug0the

## Overview

The AI/ML API integration pages (added in #599) drifted from what the `langchain-aimlapi` package actually exports, so every import shown in the docs currently fails with `ImportError`:

- `providers/aimlapi.mdx` imported `ChatAIMLAPI`, `AIMLAPILLM`, and `AIMLAPIEmbeddings`; the package exports `ChatAimlapi`, `AimlapiLLM`, and `AimlapiEmbeddings`. The LLM "usage example" link pointed at a path that 404s.
- `llms/aimlapi.mdx` claimed tool calling / structured output / multimodal / token-level streaming and showed a `stream_events` example; `AimlapiLLM` is a plain `LLM` subclass (sync + native async only). The example model `gpt-3.5-turbo-instruct` is no longer served, so it is replaced with `openai/gpt-5-5`.
- `scripts/data/integration_external_docs.yaml` rows were named `ChatAIMLAPI` and `AIMlAPIEmbeddings` (typo); renamed to the classes the package exports.

No new hosted pages are added: chat and embeddings stay as external YAML listing rows per the current integration submission process.

## Type of change

**Type:** Update existing documentation / Fix typo/bug/link/formatting

## Related issues/PRs

- GitHub issue: N/A — follow-up to #599 (original AI/ML API docs) and #4865 (integrations curation)
- Feature PR: https://github.com/aimlapi/langchain-aimlapi (the `langchain-aimlapi` package; class names and behavior here match the 0.1.2 release on PyPI)

## Checklist

- [x] I have read the [contributing guidelines](https://docs.langchain.com/oss/python/contributing/overview), including the language policy
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used root relative paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed (not needed: no pages added or removed)

## Additional notes

Class names were verified against `langchain-aimlapi==0.1.2` as published on PyPI, and `openai/gpt-5-5` against the live AI/ML API model catalog. This PR was prepared with AI agent assistance (Claude) and then reviewed by a maintainer of the `langchain-aimlapi` package before submission.