### PR TITLE
[langsmith]: contractions in abac.mdx and alerts.mdx violate style guide

### DIFF
--- a/src/langsmith/abac.mdx
+++ b/src/langsmith/abac.mdx
@@ -53,7 +53,7 @@ Roles and resource tags can be managed via the UI or API. ABAC policies are conf
 
 ## Access policy structure
 
-An access policy defines conditions under which access is granted or denied. Here's the structure:
+An access policy defines conditions under which access is granted or denied. Here is the structure:
 
 ```json
 {
@@ -111,7 +111,7 @@ Each condition group specifies:
 | `fleet_integration` | `mcp-servers:read`, `mcp-servers:invoke`. See [Fleet tool access control](/langsmith/fleet/access-and-oversight#tool-access-control). |
 
 <Note>
-Runs don't have their own tags. Run permissions (`runs:read`, `runs:create`, `runs:share`, `runs:delete`) are evaluated against the parent project's tags.
+Runs do not have their own tags. Run permissions (`runs:read`, `runs:create`, `runs:share`, `runs:delete`) are evaluated against the parent project's tags.
 </Note>
 
 <Note>
@@ -135,7 +135,7 @@ Each condition in the `conditions` array specifies:
 | `equals_ignore_case` | Exact match (case insensitive) |
 | `not_equals_ignore_case` | Values differ (case insensitive) |
 | `matches` | Glob pattern matching with `*` and `?` wildcards |
-| `not_matches` | Match when value doesn't match glob pattern |
+| `not_matches` | Match when value does not match glob pattern |
 
 ##### `_if_exists` variants
 
@@ -148,10 +148,10 @@ Each operator has an `_if_exists` variant that matches by default when the tag k
 | `equals_ignore_case_if_exists` | Exact match (case insensitive), or if tag key absent |
 | `not_equals_ignore_case_if_exists` | Values differ (case insensitive), or if tag key absent |
 | `matches_if_exists` | Glob pattern match, or if tag key absent |
-| `not_matches_if_exists` | Match when value doesn't match glob pattern, or if tag key absent |
+| `not_matches_if_exists` | Match when value does not match glob pattern, or if tag key absent |
 
 <Tip>
-In an **allow** policy, `_if_exists` variants grant access to resources that either match the condition or don't have the specified tag key. In a **deny** policy, they block resources that either match the condition or don't have the tag key.
+In an **allow** policy, `_if_exists` variants grant access to resources that either match the condition or do not have the specified tag key. In a **deny** policy, they block resources that either match the condition or do not have the tag key.
 </Tip>
 
 ### Roles
@@ -290,7 +290,7 @@ Grant access only if both conditions are met - dataset is for training AND belon
 
 ### 5. Client data plus resources without a `Client` tag using `_if_exists`
 
-Consultants don't have RBAC `datasets:read` permission, but this policy grants them access to datasets tagged `Client=Acme-Corp`, as well as datasets that don't have a `Client` tag at all. Datasets tagged with a different client (e.g., `Client=Other-Corp`) remain blocked:
+Consultants do not have RBAC `datasets:read` permission, but this policy grants them access to datasets tagged `Client=Acme-Corp`, as well as datasets that do not have a `Client` tag at all. Datasets tagged with a different client (e.g., `Client=Other-Corp`) remain blocked:
 
 ```json
 {

--- a/src/langsmith/alerts.mdx
+++ b/src/langsmith/alerts.mdx
@@ -78,7 +78,7 @@ You can preview alert behavior over a historical time window to understand how m
 
     **Prerequisites**
 
-    - A Slack workspace connected to your LangSmith organization. If you haven't connected one yet, LangSmith will prompt you to do so inline when you configure this notification type.
+    - A Slack workspace connected to your LangSmith organization. If you have not connected one yet, LangSmith will prompt you to do so inline when you configure this notification type.
 
     ### 1. Configure the Slack notification
 
@@ -151,7 +151,7 @@ You can preview alert behavior over a historical time window to understand how m
 
     ### Troubleshooting
 
-    If incidents aren't being created in PagerDuty:
+    If incidents are not being created in PagerDuty:
 
     - Verify the Integration Key is entered correctly in LangSmith
     - Ensure the PagerDuty service is active and not in maintenance mode
@@ -172,7 +172,7 @@ You can preview alert behavior over a historical time window to understand how m
     - An active Dynatrace environment (SaaS or Managed).
     - A Dynatrace API access token with the `events.ingest` scope.
 
-    If you're working from a custom [deployment](/langsmith/self-hosted) of LangSmith, make sure there are no firewall settings blocking egress traffic from LangSmith services.
+    If you are working from a custom [deployment](/langsmith/self-hosted) of LangSmith, make sure there are no firewall settings blocking egress traffic from LangSmith services.
 
     ### 1. Create an API token in Dynatrace
 
@@ -206,7 +206,7 @@ You can preview alert behavior over a historical time window to understand how m
 
     ### Troubleshooting
 
-    If events aren't appearing in Dynatrace:
+    If events are not appearing in Dynatrace:
 
     - Verify the API token has the `events.ingest` scope and is not expired.
     - Ensure the environment URL is correct and includes your environment ID.
@@ -283,7 +283,7 @@ You can preview alert behavior over a historical time window to understand how m
 
     ### Troubleshooting
 
-    If webhook notifications aren't being delivered:
+    If webhook notifications are not being delivered:
 
     - Verify the webhook URL is correct and accessible
     - Ensure any authentication headers are properly formatted
@@ -328,7 +328,7 @@ You can preview alert behavior over a historical time window to understand how m
       2. Scroll down to **Bot Token Scopes** under **Scopes** and click **Add an OAuth Scope**.
       3. Add the following scopes:
          - `chat:write` (Send messages as the app).
-         - `chat:write.public` (Send messages to channels the app isn't in).
+         - `chat:write.public` (Send messages to channels the app is not in).
          - `channels:read` (View basic channel information).
 
       **Step 3: Install the app to your workspace**


### PR DESCRIPTION
The docs style guide (AGENTS.md) states: "Use contractions ('do not' not 'don't',
'cannot' not 'can't', 'it is' not 'it's')". Two recently added pages have 12
contractions that violate this rule:

**abac.mdx** (6 contractions):
- "don't" → "do not" (×4)
- "doesn't" → "does not" (×1)
- "Here's" → "Here is" (×1)

**alerts.mdx** (6 contractions):
- "aren't" → "are not" (×3)
- "you're" → "you are" (×1)
- "haven't" → "have not" (×1)
- "isn't" → "is not" (×1)

These are new pages added in the last few days. Pipeline build passes
with the fix applied. Fix ready.