### PR TITLE
[deepagents]: contractions in new deepagents/code/* pages violate style guide

### DIFF
--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -73,9 +73,9 @@ session_cost_threshold_usd = 25
 Some LLM providers automatically cache the conversation prefix between turns, so a follow-up sent while the cache is warm re-processes only new tokens. That cache expires after a provider-specific idle window. Deep Agents Code currently detects this for Anthropic and OpenAI models: when an interactive chat message would be sent to a thread whose cache has likely expired (or whose model or cache settings changed since the last turn), it estimates the re-warm cost and, if it reaches a threshold, asks before sending:
 
 - **Send anyway**: send this turn; the warning still appears on future cold-cache turns.
-- **Send and don't warn again this session**: mute the warning until the app restarts.
+- **Send and do not warn again this session**: mute the warning until the app restarts.
 - **Send and never warn again**: persistently suppress the warning. Re-enable it from the `/notifications` settings screen.
-- **Don't send (keep draft)**: restore the message to the chat input so you can `/clear` first.
+- **Do not send (keep draft)**: restore the message to the chat input so you can `/clear` first.
 
 Set the minimum estimated extra cost (cold versus warm cache) that triggers the warning, in USD. The default is `0.50`; set it to `0` to disable:
 
@@ -199,9 +199,9 @@ temperature = 0.7
 Providers have the following configuration options:
 
 <ResponseField name="models" type="string[]" post={["optional"]}>
-    A list of model names to show in the interactive `/model` switcher for the provider defined as `<name>`. For providers that already ship with model profiles, any names you add here appear in addition to bundled ones (useful for newly released models that haven't been added to the package yet). For [arbitrary providers](#arbitrary-providers), this list is the only source of models in the switcher.
+    A list of model names to show in the interactive `/model` switcher for the provider defined as `<name>`. For providers that already ship with model profiles, any names you add here appear in addition to bundled ones (useful for newly released models that have not been added to the package yet). For [arbitrary providers](#arbitrary-providers), this list is the only source of models in the switcher.
 
-    Models listed here **bypass** any applied profile-based [filtering criteria](/oss/deepagents/code/providers#which-models-appear-in-the-switcher), always appearing in the switcher. This makes it the recommended way to surface models that are excluded because their profile lacks `tool_calling` support or doesn't exist yet.
+    Models listed here **bypass** any applied profile-based [filtering criteria](/oss/deepagents/code/providers#which-models-appear-in-the-switcher), always appearing in the switcher. This makes it the recommended way to surface models that are excluded because their profile lacks `tool_calling` support or does not exist yet.
 
     This key is optional. You can always pass any model name directly to `/model` or `--model` regardless of whether it appears in the switcher; the provider validates the name at request time.
 </ResponseField>
@@ -253,7 +253,7 @@ Providers have the following configuration options:
 </ResponseField>
 
 <ResponseField name="enabled" type="boolean" default="true" post={["optional"]}>
-    Whether this provider appears in the `/model` selector. Set to `false` to hide a provider that was auto-discovered from an installed package (e.g., a transitive dependency you don't want cluttering the model switcher). You can still use a disabled provider directly via `/model provider:model` or `--model`.
+    Whether this provider appears in the `/model` selector. Set to `false` to hide a provider that was auto-discovered from an installed package (e.g., a transitive dependency you do not want cluttering the model switcher). You can still use a disabled provider directly via `/model provider:model` or `--model`.
 </ResponseField>
 
 ## Model constructor params
@@ -397,7 +397,7 @@ Profile overrides are merged into the model's profile after creation. Any featur
 
 ## Adding models to the interactive switcher
 
-Some providers (e.g. `langchain-ollama`) don't bundle model profile data (see [Provider reference](/oss/deepagents/code/providers#provider-reference) for full listing). When this is the case, the interactive `/model` switcher won't list models for that provider. You can fill in the gap by defining a `models` list in your config file for the provider:
+Some providers (e.g. `langchain-ollama`) do not bundle model profile data (see [Provider reference](/oss/deepagents/code/providers#provider-reference) for full listing). When this is the case, the interactive `/model` switcher will not list models for that provider. You can fill in the gap by defining a `models` list in your config file for the provider:
 
 ```toml
 [models.providers.ollama]
@@ -492,7 +492,7 @@ temperature = 0
 With this config, switch to the model with `/model xyz:abc-xyz-1` or `--model xyz:abc-xyz-1`.
 
 <Note>
-    Deep Agents Code requires **tool calling** support. If your custom model supports tool calling but Deep Agents Code doesn't know about it, declare it in the provider profile:
+    Deep Agents Code requires **tool calling** support. If your custom model supports tool calling but Deep Agents Code does not know about it, declare it in the provider profile:
 
     ```toml
     [models.providers.xyz.profile]

--- a/src/oss/deepagents/code/configuration.mdx
+++ b/src/oss/deepagents/code/configuration.mdx
@@ -336,7 +336,7 @@ Disabling update checks also prevents automatic update installs at startup.
 
 You can still check for and install updates manually at any time with the `/update` slash command, which runs an on-demand check and reports success or failure inline.
 
-After an upgrade, Deep Agents Code shows a "what's new" banner on the next launch with a link to the changelog.
+After an upgrade, Deep Agents Code shows a "what is new" banner on the next launch with a link to the changelog.
 
 At session exit, if a newer version was detected during the session, an update banner is displayed as a reminder.
 

--- a/src/oss/deepagents/code/credentials.mdx
+++ b/src/oss/deepagents/code/credentials.mdx
@@ -85,7 +85,7 @@ dcode auth path
 
 ## Environment variables (CI and headless)
 
-For non-interactive runs, CI/CD pipelines, or anywhere a TUI isn't available, export the provider's env var in your shell:
+For non-interactive runs, CI/CD pipelines, or anywhere a TUI is not available, export the provider's env var in your shell:
 
 ```bash
 export ANTHROPIC_API_KEY="sk-ant-..."

--- a/src/oss/deepagents/code/mcp-tools.mdx
+++ b/src/oss/deepagents/code/mcp-tools.mdx
@@ -388,7 +388,7 @@ The list uses the same trust-gated configuration as the login flow. It reports s
 What happens depends on the server's host:
 
 - **Spec-compliant servers** (the default): Deep Agents Code performs Dynamic Client Registration, opens an Authorization Code + PKCE flow in your browser, and asks you to paste the redirected URL back into the terminal.
-- **Slack** (`slack.com`, `*.slack.com`): same paste-back flow, but with Slack's public client preseeded. You're prompted for an optional team ID (e.g., `T01234567`) so the app installs into the right workspace.
+- **Slack** (`slack.com`, `*.slack.com`): same paste-back flow, but with Slack's public client preseeded. You are prompted for an optional team ID (e.g., `T01234567`) so the app installs into the right workspace.
 - **GitHub** (`api.githubcopilot.com`): RFC 8628 Device Authorization Grant. Deep Agents Code prints a verification URL and a user code; you enter the code in your browser and Deep Agents Code polls for completion.
 
 By default, `dcode mcp login` reads the same auto-discovered configs Deep Agents Code uses at runtime (subject to project-level trust gating). Pass `--mcp-config <path>` to use a specific file:
@@ -409,10 +409,10 @@ Tokens are written to:
 ~/.deepagents/.state/mcp-tokens/<server>-<sha256-16(url)>.json
 ```
 
-The `<sha256-16(url)>` segment is the first 16 hex characters of the SHA-256 of the server URL. The directory is locked to mode `0700` and each token file is mode `0600`. Files include the OAuth access token, refresh token, and the dynamically registered client info, all in a schema-versioned payload that's written atomically (write-to-temp + `rename`).
+The `<sha256-16(url)>` segment is the first 16 hex characters of the SHA-256 of the server URL. The directory is locked to mode `0700` and each token file is mode `0600`. Files include the OAuth access token, refresh token, and the dynamically registered client info, all in a schema-versioned payload that is written atomically (write-to-temp + `rename`).
 
 <Note>
-    Hashing the URL into the filename means the same server name pointing at different URLs (for example, dev vs. prod) gets independent token files and can't trample each other.
+    Hashing the URL into the filename means the same server name pointing at different URLs (for example, dev vs. prod) gets independent token files and cannot trample each other.
 </Note>
 
 ### Re-authentication
@@ -505,7 +505,7 @@ Connected MCP servers and their tools are automatically listed in the agent's sy
         npx -y @modelcontextprotocol/server-filesystem /tmp
         ```
 
-        Common causes: the package isn't installed, `npx` isn't on `PATH`, or required environment variables are missing.
+        Common causes: the package is not installed, `npx` is not on `PATH`, or required environment variables are missing.
     </Accordion>
 
     <Accordion title="Connection refused (SSE/HTTP)">
@@ -513,15 +513,15 @@ Connected MCP servers and their tools are automatically listed in the agent's sy
     </Accordion>
 
     <Accordion title="Tools not appearing">
-        Deep Agents Code prints the number of tools loaded at startup (e.g., `✓ Loaded 3 MCP tools`). If you see `0`, the server started successfully but didn't advertise any tools—check the server's own logs or documentation.
+        Deep Agents Code prints the number of tools loaded at startup (e.g., `✓ Loaded 3 MCP tools`). If you see `0`, the server started successfully but did not advertise any tools—check the server's own logs or documentation.
     </Accordion>
 
     <Accordion title="Server shows `unauthenticated` in /mcp">
-        Either you haven't run `dcode mcp login <server>` yet, or the persisted refresh token expired or was revoked server-side. Run the login command again — your session keeps running and the server will re-attach once tokens are refreshed.
+        Either you have not run `dcode mcp login <server>` yet, or the persisted refresh token expired or was revoked server-side. Run the login command again — your session keeps running and the server will re-attach once tokens are refreshed.
     </Accordion>
 
     <Accordion title="`Invalid MCP config at ...`">
-        A pre-flight validation rejected `--mcp-config` (or an auto-discovered `.mcp.json`). Common causes: an unsupported server name (must match `[A-Za-z0-9_-]+`), `auth: oauth` on a stdio server, both `command` and `url` set on the same entry, or a header value that isn't a string. Fix the highlighted reason and relaunch — Deep Agents Code no longer dumps a multi-page subprocess trace for config errors.
+        A pre-flight validation rejected `--mcp-config` (or an auto-discovered `.mcp.json`). Common causes: an unsupported server name (must match `[A-Za-z0-9_-]+`), `auth: oauth` on a stdio server, both `command` and `url` set on the same entry, or a header value that is not a string. Fix the highlighted reason and relaunch — Deep Agents Code no longer dumps a multi-page subprocess trace for config errors.
     </Accordion>
 
     <Accordion title="`${VAR}` references fail">

--- a/src/oss/deepagents/code/memory-and-skills.mdx
+++ b/src/oss/deepagents/code/memory-and-skills.mdx
@@ -85,7 +85,7 @@ Use a global `AGENTS.md` (`~/.deepagents/agent/AGENTS.md`) for:
 - General tone and communication style
 - Universal coding preferences (formatting, type hints, etc.)
 - Tool usage patterns that apply everywhere
-- Workflows and methodologies that don't change per-project
+- Workflows and methodologies that do not change per-project
 
 Use a project `AGENTS.md` (`.deepagents/AGENTS.md` in project root) for:
 

--- a/src/oss/deepagents/code/providers.mdx
+++ b/src/oss/deepagents/code/providers.mdx
@@ -39,7 +39,7 @@ Deep Agents Code integrates automatically with the [following model providers](#
 
     `/auth` shows a list of available providers and stores credentials for reuse across sessions.
 
-    For non-interactive runs, CI/CD, or anywhere a TUI isn't available, store the same key from the shell with [`dcode auth set`](/oss/deepagents/code/credentials#manage-credentials-from-the-shell-dcode-auth) or set the provider's environment variable instead. See [Provider credentials](/oss/deepagents/code/credentials) for the full key resolution order, the [`DEEPAGENTS_CODE_` prefix](/oss/deepagents/code/configuration#deepagents_code_-prefix) for scoping a key to Deep Agents Code, and the [Provider reference](#provider-reference) for each provider's environment variable.
+    For non-interactive runs, CI/CD, or anywhere a TUI is not available, store the same key from the shell with [`dcode auth set`](/oss/deepagents/code/credentials#manage-credentials-from-the-shell-dcode-auth) or set the provider's environment variable instead. See [Provider credentials](/oss/deepagents/code/credentials) for the full key resolution order, the [`DEEPAGENTS_CODE_` prefix](/oss/deepagents/code/configuration#deepagents_code_-prefix) for scoping a key to Deep Agents Code, and the [Provider reference](#provider-reference) for each provider's environment variable.
 
     To configure model parameters, see [Model parameters](#model-parameters).
 
@@ -140,7 +140,7 @@ The `openai_codex` provider lets you use OpenAI's Codex models with your paid **
     </Step>
 
     <Step title="Authorize in your browser">
-        Deep Agents Code opens your browser to the ChatGPT sign-in page. If it can't open a browser (for example, over SSH), it also shows the sign-in URL on screen so you can copy it to a browser on another device.
+        Deep Agents Code opens your browser to the ChatGPT sign-in page. If it cannot open a browser (for example, over SSH), it also shows the sign-in URL on screen so you can copy it to a browser on another device.
     </Step>
 
     <Step title="Select a Codex model">
@@ -438,7 +438,7 @@ For retry counts, prefer `--max-retries` or the top-level [`[retries]` config](/
 </Tip>
 
 <Note>
-    Don't put credentials (`api_key`) in `params`—use [`api_key_env`](/oss/deepagents/code/config-file#provider-configuration) to point at an environment variable instead.
+    Do not put credentials (`api_key`) in `params`—use [`api_key_env`](/oss/deepagents/code/config-file#provider-configuration) to point at an environment variable instead.
 </Note>
 
 To override fields on the model's runtime *profile* (`max_input_tokens`, `tool_calling`, capability flags)—distinct from constructor params—see [Profile overrides](/oss/deepagents/code/config-file#profile-overrides-advanced).

--- a/src/oss/deepagents/code/remote-sandboxes.mdx
+++ b/src/oss/deepagents/code/remote-sandboxes.mdx
@@ -247,7 +247,7 @@ export E2B_API_KEY="..."
 dcode --sandbox e2b
 ```
 
-If you pass a `--sandbox` name that isn't installed or declared, Deep Agents Code lists the available providers and explains how to install or configure the missing one.
+If you pass a `--sandbox` name that is not installed or declared, Deep Agents Code lists the available providers and explains how to install or configure the missing one.
 
 <Accordion title="Publishing a sandbox provider" icon="package">
     To distribute a provider so users can run `dcode --sandbox <name>` after installing your package, implement a `SandboxProvider` subclass and register it under the `deepagents_code.sandbox_providers` entry-point group.
@@ -292,7 +292,7 @@ If you pass a `--sandbox` name that isn't installed or declared, Deep Agents Cod
 
 ### Config-declared providers
 
-For an in-house or local provider you don't want to package, declare it under `[sandboxes.providers]` in `~/.deepagents/config.toml`. This parallels [arbitrary model providers](/oss/deepagents/code/config-file#arbitrary-providers) and uses the same `class_path` trust model.
+For an in-house or local provider you do not want to package, declare it under `[sandboxes.providers]` in `~/.deepagents/config.toml`. This parallels [arbitrary model providers](/oss/deepagents/code/config-file#arbitrary-providers) and uses the same `class_path` trust model.
 
 ```toml
 [sandboxes]


### PR DESCRIPTION
The docs style guide (AGENTS.md) states contractions are not allowed.
Seven recently added pages in src/oss/deepagents/code/ contain 22
contractions in total:

- config-file.mdx: 7 (don't, doesn't, it's, etc.)
- mcp-tools.mdx: 7
- providers.mdx: 3
- remote-sandboxes.mdx: 2
- configuration.mdx: 1
- credentials.mdx: 1
- memory-and-skills.mdx: 1

All pages were added in the last few days. Fix: replace each contraction
with its expanded form ("do not", "does not", "it is", etc.).
7 files, 22 lines changed, pipeline build passes. Fix ready.