### PR TITLE
DOC: H5 headings in abac.mdx and microsoft.mdx violate style guide

### DIFF
--- a/src/langsmith/abac.mdx
+++ b/src/langsmith/abac.mdx
@@ -126,7 +126,7 @@ Each condition in the `conditions` array specifies:
 - **`operator`** - The comparison operator
 - **`attribute_value`** - The value to compare against
 
-##### Operators
+#### Operators
 
 | Operator | Description |
 |----------|-------------|
@@ -137,7 +137,7 @@ Each condition in the `conditions` array specifies:
 | `matches` | Glob pattern matching with `*` and `?` wildcards |
 | `not_matches` | Match when value doesn't match glob pattern |
 
-##### `_if_exists` variants
+#### `_if_exists` variants
 
 Each operator has an `_if_exists` variant that matches by default when the tag key is absent, or evaluates the condition normally when the tag exists:
 

--- a/src/oss/python/integrations/providers/microsoft.mdx
+++ b/src/oss/python/integrations/providers/microsoft.mdx
@@ -478,7 +478,7 @@ Below are two available Azure Cosmos DB APIs that can provide vector store funct
 > You can apply your MongoDB experience and continue to use your favorite MongoDB drivers, SDKs, and tools by pointing your application to the API for MongoDB vCore account's connection string.
 > Use vector search in Azure Cosmos DB for MongoDB vCore to seamlessly integrate your AI-based applications with your data that's stored in Azure Cosmos DB.
 
-##### Installation and setup
+#### Installation and setup
 
 See [detailed configuration instructions](/oss/integrations/vectorstores/azure_cosmos_db_mongo_vcore).
 
@@ -494,7 +494,7 @@ We need to install `langchain-azure-ai` and `pymongo` python packages.
     ```
 </CodeGroup>
 
-##### Deploy Azure cosmos DB on Microsoft Azure
+#### Deploy Azure cosmos DB on Microsoft Azure
 
 Azure Cosmos DB for MongoDB vCore provides developers with a fully managed MongoDB-compatible database service for building modern applications with a familiar architecture.
 
@@ -517,7 +517,7 @@ but also high-dimensional vectors as other properties of the documents. This col
 as the vectors are stored in the same logical unit as the data they represent. This simplifies data management, AI application architectures, and the
 efficiency of vector-based operations.
 
-##### Installation and setup
+#### Installation and setup
 
 See [detail configuration instructions](/oss/integrations/vectorstores/azure_cosmos_db_no_sql).
 
@@ -533,7 +533,7 @@ We need to install `langchain-azure-cosmosdb` and `azure-cosmos` python packages
     ```
 </CodeGroup>
 
-##### Deploy Azure cosmos DB on Microsoft Azure
+#### Deploy Azure cosmos DB on Microsoft Azure
 
 Azure Cosmos DB offers a solution for modern apps and intelligent workloads by being very responsive with dynamic and elastic autoscale. It is available
 in every Azure region and can automatically replicate data closer to users. It has SLA guaranteed low-latency and high availability.
@@ -562,7 +562,7 @@ Since Azure Database for PostgreSQL is open-source Postgres, you can use the [La
 
 By leveraging your current SQL Server databases for vector search, you can enhance data capabilities while minimizing expenses and avoiding the challenges of transitioning to new systems.
 
-##### Installation and setup
+#### Installation and setup
 
 See [detail configuration instructions](https://learn.microsoft.com/azure/azure-sql/database/ai-artificial-intelligence-intelligent-applications?view=azuresql).
 
@@ -572,7 +572,7 @@ We need to install the `langchain-sqlserver` python package.
 !pip install langchain-sqlserver==0.1.1
 ```
 
-##### Deploy Azure SQL DB on Microsoft Azure
+#### Deploy Azure SQL DB on Microsoft Azure
 
 [Sign Up](https://learn.microsoft.com/azure/azure-sql/database/free-offer?view=azuresql) for free to get started today.
 


### PR DESCRIPTION
The docs style guide (AGENTS.md) states: "Do not use H5 or H6 headings."

Two recently modified files use ##### headings:

- src/langsmith/abac.mdx: 2 H5 headings ("Operators", "`_if_exists` variants")
- src/oss/python/integrations/providers/microsoft.mdx: 6 H5 headings
  ("Installation and setup", "Deploy Azure cosmos DB on Microsoft Azure" ×2,
   "Deploy Azure SQL DB on Microsoft Azure")

Fix: promote all 8 H5 headings to H4 (##### → ####).
2 files, 8 lines changed, pipeline build passes. Fix ready.