### PR TITLE
[langsmith]: gerund headings in 4 pages violate style guide (should start with active verb)

### DIFF
--- a/src/langsmith/administration-overview.mdx
+++ b/src/langsmith/administration-overview.mdx
@@ -379,7 +379,7 @@ This is thrown by our application and varies by organization based on their conf
 
 The [`POST /runs/query`](/langsmith/smith-api/run/query-runs) endpoint has additional per-tenant rate limits based on query parameters. See [Query traces using the SDK](/langsmith/export-traces#rate-limits) for details.
 
-#### Handling 429s responses in your application
+#### Handle 429s responses in your application
 
 Since some 429 responses are temporary and may succeed on a successive call, if you are directly calling the LangSmith API in your application we recommend implementing retry logic with exponential backoff and jitter.
 
@@ -418,7 +418,7 @@ The extended data retention traces limit has side effects. If the limit is alrea
 
 Each of these features may cause an auto upgrade, so we shut them off when the limit is reached.
 
-#### Updating usage limits
+#### Update usage limits
 
 Usage limits can be updated from the `Settings` page under `Usage and Billing`. Limit values are cached, so it may take a minute or two before the new limits apply.
 

--- a/src/langsmith/rbac.mdx
+++ b/src/langsmith/rbac.mdx
@@ -189,7 +189,7 @@ For step-by-step instructions on assigning workspace roles to users, refer to th
 
 [Organization Admins](#organization-admin) can create custom roles with specific combinations of permissions tailored to their organization's needs.
 
-### Creating custom roles
+### Create custom roles
 
 Custom roles are created at the [organization](/langsmith/administration-overview#organizations) level and can be assigned to users in any [workspace](/langsmith/administration-overview#workspaces) within that organization.
 

--- a/src/langsmith/server-a2a.mdx
+++ b/src/langsmith/server-a2a.mdx
@@ -234,7 +234,7 @@ in `0.15.0`. That version is not published as a stable release yet — check
 Your graph's state must include a `messages` key to accept A2A text and file parts. An assistant
 whose input schema has no `messages` field is rejected with an explanatory error.
 
-## Creating an A2A-compatible agent
+## Create an A2A-compatible agent
 
 This example creates an A2A-compatible agent that processes incoming messages using OpenAI's API and maintains conversational state. The agent defines a message-based state structure and handles the A2A protocol's message format.
 

--- a/src/langsmith/usage-and-billing.mdx
+++ b/src/langsmith/usage-and-billing.mdx
@@ -184,7 +184,7 @@ The [`POST /runs/query`](/langsmith/smith-api/run/query-runs) endpoint has addit
 
 Workspace invite batch requests are rate limited per workspace to reduce bulk invitation abuse.
 
-### Handling 429s responses in your application
+### Handle 429s responses in your application
 
 Since some 429 responses are temporary and may succeed on a successive call, if you are directly calling the LangSmith API in your application we recommend implementing retry logic with exponential backoff and jitter.
 
@@ -220,7 +220,7 @@ The extended data retention traces limit has side effects. If the limit is alrea
 
 Actions that do not change trace retention are not counted against the extended-retention trace limit. You can still submit feedback in the LangSmith UI, add runs or threads to annotation queues, and run automation rules or evaluators with retention extension disabled when the limit is reached.
 
-### Updating usage limits
+### Update usage limits
 
 Usage limits can be updated from the `Settings` page under `Usage and Billing`. Limit values are cached, so it may take a minute or two before the new limits apply.
 


### PR DESCRIPTION
The docs style guide (AGENTS.md) states: "Sentence-case headings starting
with active verb, not gerund." Four recently modified pages use gerund
headings:

- usage-and-billing.mdx: "Handling 429s..." → "Handle 429s...",
  "Updating usage limits" → "Update usage limits"
- administration-overview.mdx: same two headings (mirrored content)
- rbac.mdx: "Creating custom roles" → "Create custom roles"
- server-a2a.mdx: "Creating an A2A-compatible agent" → "Create an A2A-compatible agent"

4 files, 6 heading lines changed, pipeline build passes. Fix ready.