### PR TITLE
docs: add AI Power Grid Chat Completions compatibility

### DIFF
--- a/src/oss/python/integrations/chat/index.mdx
+++ b/src/oss/python/integrations/chat/index.mdx
@@ -51,7 +51,7 @@ Certain model providers offer endpoints that are compatible with OpenAI's [Chat 
 
 [Apertis](https://docs.apertis.ai) provides an OpenAI-compatible Chat Completions API. Use `ChatOpenAI` with `base_url` `https://api.apertis.ai/v1` and a model ID available to your account.
 
-[AI Power Grid](https://aipowergrid.io/) routes OpenAI-compatible Chat Completions to remote community-operated model workers. Use `ChatOpenAI` with `base_url="https://api.aipowergrid.io/v1"` and an account-scoped API key; see the [tested AI Power Grid LangChain cookbook](https://github.com/AIPowerGrid/grid-provider-integrations/tree/main/langchain-aipg) for model discovery, streaming, tool calling, credit errors, and the plaintext-worker privacy boundary.
+[AI Power Grid](https://aipowergrid.io/) routes OpenAI-compatible Chat Completions to community-operated model workers. Use `ChatOpenAI` with `base_url` `https://api.aipowergrid.io/v1` and an account-scoped API key.
 
 ## All chat models
 

--- a/src/oss/python/integrations/chat/index.mdx
+++ b/src/oss/python/integrations/chat/index.mdx
@@ -51,6 +51,7 @@ Certain model providers offer endpoints that are compatible with OpenAI's [Chat 
 
 [Apertis](https://docs.apertis.ai) provides an OpenAI-compatible Chat Completions API. Use `ChatOpenAI` with `base_url` `https://api.apertis.ai/v1` and a model ID available to your account.
 
+[AI Power Grid](https://aipowergrid.io/) routes OpenAI-compatible Chat Completions to remote community-operated model workers. Use `ChatOpenAI` with `base_url="https://api.aipowergrid.io/v1"` and an account-scoped API key; see the [tested AI Power Grid LangChain cookbook](https://github.com/AIPowerGrid/grid-provider-integrations/tree/main/langchain-aipg) for model discovery, streaming, tool calling, credit errors, and the plaintext-worker privacy boundary.
 
 ## All chat models
 


### PR DESCRIPTION
## Summary

Adds AI Power Grid to the existing Chat Completions API compatibility section. The entry documents the standard `ChatOpenAI` configuration and links to a tested first-party cookbook covering model discovery, streaming, tool calling, credit errors, and the plaintext remote-worker privacy boundary.

This is deliberately not a new LangChain provider package or hosted integration page. AI Power Grid uses the existing OpenAI-compatible `ChatOpenAI` path.

## Testing

- `npx --yes markdownlint-cli@0.45.0 src/oss/python/integrations/chat/index.mdx`
- `git diff --check`
- Confirmed all three referenced URLs return HTTP 200.
- The linked cookbook's bounded production test passed model discovery, `ChatOpenAI.invoke`, completed streaming, and a forced tool call through the live Grid endpoint. The disposable scoped key was revoked after the run.

## Scope

One paragraph in `src/oss/python/integrations/chat/index.mdx`; no navigation, runtime, package, or generated-file changes.
