### PR TITLE
docs(google-gmail): replace deprecated get_gmail_credentials with get_google_credentials

### DIFF
--- a/src/oss/python/integrations/tools/google_gmail.mdx
+++ b/src/oss/python/integrations/tools/google_gmail.mdx
@@ -45,12 +45,12 @@ you can manually build a `googleapi` resource for more auth control.
 ```python
 from langchain_google_community.gmail.utils import (
     build_resource_service,
-    get_gmail_credentials,
+    get_google_credentials,
 )
 
 # Can review scopes here https://developers.google.com/gmail/api/auth/scopes
 # For instance, readonly scope is 'https://www.googleapis.com/auth/gmail.readonly'
-credentials = get_gmail_credentials(
+credentials = get_google_credentials(
     token_file="token.json",
     scopes=["https://mail.google.com/"],
     client_secrets_file="credentials.json",


### PR DESCRIPTION
## Why

The Gmail toolkit integration page still shows the deprecated
`get_gmail_credentials`, which emits:

    DeprecationWarning: get_gmail_credentials is deprecated and will be
    removed in a future version. Use get_google_credentials instead.

The Google Calendar page already demonstrates the replacement
(`get_google_credentials`), and `langchain_google_community.gmail.utils`
re-exports it, so the docs example can switch to the new helper without
changing behavior.

## What changed

- `src/oss/python/integrations/tools/google_gmail.mdx`: replace
  `get_gmail_credentials` with `get_google_credentials` (import and call).

## Verification

- Confirmed `get_google_credentials` is exported from
  `langchain_google_community.gmail.utils` (from the installed wheel, and
  the same import shape used in `google_calendar.mdx`).
- No structural or navigation change, so no `docs.json` update and no
  broken-links risk.

Resolves #5695

_Disclosure: generated with AI assistance (Kimi Code CLI), reviewed before submission._