### PR TITLE
Add conversation_id to valid thread metadata keys

### DIFF
--- a/src/langsmith/threads.mdx
+++ b/src/langsmith/threads.mdx
@@ -17,7 +17,10 @@ Many LLM applications have a chatbot-like interface in which the user and the LL
 To associate traces together into a thread, you need to pass in a special `metadata` key where the value is the unique identifier for that thread. The key name should be one of:
 
 - `session_id`
+- `conversation_id`
 - `thread_id`
+
+The ingest pipeline checks these keys in the order listed and uses the first one present.
 
 The value can be any string you want, but we recommend using **UUID v7** thread IDs.
 
@@ -29,7 +32,7 @@ The [LangSmith SDK](/langsmith/reference) exports a `uuid7` helper (Python v0.4.
 For instructions, refer to [Add metadata and tags to traces](/langsmith/add-metadata-tags).
 
 <Warning>
-**Important:** To ensure filtering and token counting work correctly across your entire thread, you must set the thread metadata (`session_id` or `thread_id`) on **all runs**, including child runs within a trace.
+**Important:** To ensure filtering and token counting work correctly across your entire thread, you must set the thread metadata (`session_id`, `conversation_id`, or `thread_id`) on **all runs**, including child runs within a trace.
 
 If child runs don't have the thread_id metadata, they won't be included when:
 


### PR DESCRIPTION
## Why

The tracer's ingest pipeline accepts three metadata keys as aliases for thread grouping, but the docs listed only two. As a result, users following the docs might not know that `conversation_id` is a valid alias, and users who already use `conversation_id` (a natural name for chat frameworks) might assume their threads are misconfigured when in fact they are grouping correctly.

## Source of truth

`smith-go/queue/ingest/prepare_run_payload.go:145`:

\`\`\`go
for _, k := range []string{\"session_id\", \"conversation_id\", \"thread_id\"} {
\`\`\`

The ingest layer checks the three keys in this order and uses the first one present.

## Change

`src/langsmith/threads.mdx`:
- Added `conversation_id` to the bulleted list of valid keys.
- Added a one-sentence note on the check order.
- Updated the Warning callout to include `conversation_id` alongside `session_id` and `thread_id`.

## Other pages that mention this list

Several other pages still list only `session_id` and `thread_id`. Left them out of this PR to keep the change focused, but flagging for follow-up:

- \`src/langsmith/export-traces.mdx\`
- \`src/langsmith/annotation-queues.mdx\`
- \`src/langsmith/cost-tracking.mdx\`
- \`src/langsmith/query-threads.mdx\`
- \`src/langsmith/trace-query-syntax.mdx\`

Some of these may be intentionally two-key (query/filter side vs ingest side) — worth someone with more context looking.

## AI involvement

Drafted with Claude Code. Change and PR description reviewed by human.