### PR TITLE
Add langchain-ictfax to external tools integrations

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1370,3 +1370,7 @@ packages:
   name_title: PIIGhost
   repo: Athroniaeth/piighost
   js: "n/a"
+- name: langchain-ictfax
+  name_title: ICTFax
+  repo: ictinnovations/langchain-ictfax
+  js: "n/a"

--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -269,6 +269,9 @@ python:
     pypi: langchain-runpod
     docs_url: https://docs.runpod.io/overview
   tools:
+  - name: ICTFaxToolkit
+    pypi: langchain-ictfax
+    docs_url: https://www.ictinnovations.com/
   - name: MemgraphToolkit
     pypi: langchain-memgraph
     docs_url: https://github.com/memgraph/langchain-memgraph

--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -1280,6 +1280,14 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
+        title="ICTFax"
+        href="https://www.ictinnovations.com/"
+        icon="link"
+    >
+        LangChain tools to send and track faxes through an ICTFax or ICTCore server.
+    </Card>
+
+    <Card
         title="iLoveVideoEditor"
         href="https://ilovevideoeditor.com/docs/api-guide"
         icon="link"

--- a/src/snippets/oss/python-tools-downloads.mdx
+++ b/src/snippets/oss/python-tools-downloads.mdx
@@ -247,6 +247,7 @@
 | [`Browserless`](https://browserless.io) | <span data-sort-value="-1">N/A</span> |
 | [`HuangtingFlux`](https://huangtingflux.com/integrations/langchain) | <span data-sort-value="-1">N/A</span> |
 | [`GandrText2SpeechTool`](https://gandr.ai/docs) | <span data-sort-value="-1"><a href="https://pypi.org/project/gandr-langchain/" target="_blank"><img src="https://static.pepy.tech/badge/gandr-langchain/month" alt="Downloads per month" noZoom class="rounded not-prose" /></a></span> |
+| [`ICTFaxToolkit`](https://www.ictinnovations.com/) | <span data-sort-value="-1">N/A</span> |
 | [`WebzNewsSearch`](https://docs.webz.io/docs/webz/news-search-api-mcp) | <span data-sort-value="-1"><a href="https://pypi.org/project/langchain-webz/" target="_blank"><img src="https://static.pepy.tech/badge/langchain-webz/month" alt="Downloads per month" noZoom class="rounded not-prose" /></a></span> |
 | [`Stagehand`](/oss/integrations/tools/stagehand) | <span data-sort-value="-1">N/A</span> |
 


### PR DESCRIPTION
Adds a row to `scripts/data/integration_external_docs.yaml` (python → tools) for **`langchain-ictfax`**, now on PyPI: https://pypi.org/project/langchain-ictfax/

`ICTFaxToolkit` provides tools to send and track faxes through an [ICTFax](https://ictfax.org) / ICTCore server (`send_fax`, `get_fax_status`, `list_faxes`, `upload_fax_document`). Under 50k monthly downloads, so this is the external-docs row rather than a hosted guide, per the contributing guide. `docs_url` points at the partner site (ICT Innovations), following the doc-link priority (partner docs > GitHub > PyPI).
