### PR TITLE
docs(langsmith): use Azure sandbox storage account field

### DIFF
--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -1015,7 +1015,7 @@ sandboxes:
     name: "sandbox-juicefs"
     storage: "wasb"
     bucket: "https://container-name.core.windows.net"
-    accessKey: "<storage-account-name>" # Account name, not a credential.
+    storageAccountName: "<storage-account-name>"
     redis:
       metaURL: "redis://redis-host:6379/1"
   juicefsFormatJob:


### PR DESCRIPTION
## Overview
Update the public Helm example to use `storageAccountName` for Azure Workload Identity. The `juicefs` `--access-key` flag that we map to is confusing.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs

- GitHub issue: None
- Feature PR: None
- Linear issue: None
- Slack thread: None

## Checklist

- [ ] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
An AI agent prepared this change.
Vale and `git diff --check` pass.