### PR TITLE
fix: correct actor_type and ls_user_id in the JWT claims reference

### DIFF
--- a/src/langsmith/llm-auth-proxy-self-hosted.mdx
+++ b/src/langsmith/llm-auth-proxy-self-hosted.mdx
@@ -773,13 +773,17 @@ LangSmith signs JWTs using **Ed25519 (EdDSA)**. Public keys are served at `/.wel
 | `iss` | Issuer. `langsmith` for SaaS; set via `LLM_AUTH_PROXY_ISSUER` for self-hosted |
 | `aud` | Audience. Matches the JWT audience in LangSmith organization settings |
 | `sub` | Actor identifier (user ID, evaluator ID, assistant ID, or API key ID) |
-| `actor_type` | One of: `user`, `evaluator`, `agent-builder`, `api_key` |
+| `actor_type` | One of: `user`, `evaluator`, `agent-builder`, `insights`, `polly`, `api_key:pat` (personal access token), or `api_key:service` (service account key) |
 | `workspace_id` | Workspace ID |
 | `workspace_name` | Workspace Name |
 | `organization_id` | Organization ID |
 | `organization_name` | Organization Name |
 | `request_id` | Request correlation ID |
-| `ls_user_id` | LangSmith user ID (present only when `actor_type` is `user`) |
+| `ls_user_id` | LangSmith user ID (present whenever the request has an associated user) |
+
+<Warning>
+Use `ls_user_id` to identify the end user. On agent runs, `sub` is the assistant's ID and `actor_type` is `agent-builder`, so neither identifies the person.
+</Warning>
 
 The JWT is passed to your `ext_authz` or transformer service in the `x-langsmith-llm-auth` request header.
 


### PR DESCRIPTION
## Overview
Corrects LLM auth proxy handling and behavior

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs

- Linear issue: ENT-1573

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

