### PR TITLE
docs: fix subject-verb agreement typo in CI/CD pipeline example

### DIFF
--- a/src/langsmith/cicd-pipeline-example.mdx
+++ b/src/langsmith/cicd-pipeline-example.mdx
@@ -315,7 +315,7 @@ See the [LangGraph CLI build documentation](/langsmith/cli#build) for more detai
 
 #### Database & cache configuration
 
-By default, LangSmith Deployment create PostgreSQL and Redis instances for you. To use external services, set the following environment variables in your new deployment or revision:
+By default, LangSmith Deployment creates PostgreSQL and Redis instances for you. To use external services, set the following environment variables in your new deployment or revision:
 
 ```bash
 # Set environment variables for external services


### PR DESCRIPTION
## What
Fixes a small grammar error in `src/langsmith/cicd-pipeline-example.mdx`.

"By default, LangSmith Deployment create PostgreSQL and Redis instances
for you." → "...LangSmith Deployment **creates** PostgreSQL and Redis
instances for you."

## Why
Subject-verb agreement — "LangSmith Deployment" is singular, so the
verb should be "creates", not "create".

## Type of change
- [x] Documentation fix (typo/grammar)

This is a 1-line, docs-only change with no functional impact.