### PR TITLE
docs: fix outdated 'langchain import hub' to use langchain_classic

### DIFF
--- a/src/oss/python/integrations/retrievers/egnyte.mdx
+++ b/src/oss/python/integrations/retrievers/egnyte.mdx
@@ -161,7 +161,7 @@ results = await retriever.abatch(
 Like other retrievers, EgnyteRetriever can be added to a LangGraph agent as a tool.
 
 ```python
-from langchain import hub
+from langchain_classic import hub
 from langchain.agents import AgentExecutor, create_openai_tools_agent
 from langchain.tools.retriever import create_retriever_tool
 from langchain_openai import ChatOpenAI

--- a/src/oss/python/integrations/tools/ibm_watsonx_sql.mdx
+++ b/src/oss/python/integrations/tools/ibm_watsonx_sql.mdx
@@ -148,7 +148,7 @@ llm = ChatWatsonx(
 from langchain.agents import create_agent
 
 # Use one of the prompt from langchain hub
-from langchain import hub
+from langchain_classic import hub
 
 prompt_template = hub.pull("langchain-ai/sql-agent-system-prompt")
 system_message = prompt_template.format(dialect="PostgreSQL", top_k=5)


### PR DESCRIPTION
## What
Fixes an outdated import in two integration docs that raises
`ImportError: cannot import name 'hub' from 'langchain'` under
LangChain 1.0+.

- src/oss/python/integrations/retrievers/egnyte.mdx
- src/oss/python/integrations/tools/ibm_watsonx_sql.mdx

## Why
Per the LangChain v1 migration guide (src/oss/python/migrate/langchain-v1.mdx),
the `hub` module moved from the `langchain` package to `langchain-classic`
in v1. These two pages still show:

    from langchain import hub

which fails on LangChain 1.0+. Changed to:

    from langchain_classic import hub

This follows the same pattern already applied to retriever imports in
PR #1196 (issue #1195), which fixed the same class of outdated import
for a different module.

## Type of change
- [x] Documentation fix (broken code example)

2-line, docs-only change with no functional impact outside the code samples.