### PR TITLE
docs: add missing imports in Box and Cohere reranker retriever examples

### DIFF
--- a/src/oss/python/integrations/retrievers/box.mdx
+++ b/src/oss/python/integrations/retrievers/box.mdx
@@ -173,6 +173,7 @@ pip install -U langsmith
 from langchain_classic import hub
 from langchain.agents import AgentExecutor, create_openai_tools_agent
 from langchain.tools.retriever import create_retriever_tool
+from langchain_openai import ChatOpenAI
 ```
 
 ```python

--- a/src/oss/python/integrations/retrievers/cohere-reranker.mdx
+++ b/src/oss/python/integrations/retrievers/cohere-reranker.mdx
@@ -306,6 +306,9 @@ You can of course use this retriever within a QA pipeline
 
 
 ```python
+from langchain_core.output_parsers import StrOutputParser
+from langchain_core.runnables import RunnablePassthrough
+
 client = Client()
 prompt = client.pull_prompt("rlm/rag-prompt", include_model=True)
 


### PR DESCRIPTION
## What
Two retriever integration examples call classes that are never
imported in the snippet, so copying them as-is raises NameError.

- src/oss/python/integrations/retrievers/box.mdx
  The LangGraph agent example calls `ChatOpenAI(...)` without
  importing it. Added: `from langchain_openai import ChatOpenAI`

- src/oss/python/integrations/retrievers/cohere-reranker.mdx
  The QA pipeline example builds a chain with `RunnablePassthrough()`
  and `StrOutputParser()`, neither of which is imported. Added:
  `from langchain_core.output_parsers import StrOutputParser`
  `from langchain_core.runnables import RunnablePassthrough`

## Why
Both symbols are used but never defined/imported anywhere else on
the page, so running the snippet as written fails immediately.
Same bug class as #1619 ("add missing import").

## Type of change
- [x] Documentation fix (broken code example)

4-line, docs-only change, no functional impact outside the code samples.