### PR TITLE
docs(js): add missing HumanMessage import in OpenAI multi-turn image example

### DIFF
--- a/src/oss/javascript/integrations/tools/openai.mdx
+++ b/src/oss/javascript/integrations/tools/openai.mdx
@@ -326,6 +326,8 @@ const response = await model.invoke("A serene lake at dawn", {
 **Multi-turn editing** - Refine images across conversation turns:
 
 ```typescript
+import { HumanMessage } from "@langchain/core/messages";
+
 // First turn: generate initial image
 const response1 = await model.invoke("Draw a red car", {
   tools: [tools.imageGeneration()],


### PR DESCRIPTION
## What
The "Multi-turn editing" TypeScript example under Image Generation
constructs `new HumanMessage(...)` but the file never imports
HumanMessage, so the snippet fails to compile/run as written.

## Why
`HumanMessage` is used but not imported anywhere in this page.
Added: `import { HumanMessage } from "@langchain/core/messages";`
— the same path already used for this class elsewhere on the site.

## Type of change
- [x] Documentation fix (broken code example)

2-line, docs-only change, no functional impact outside the code sample.