### PR TITLE
Add WebzNewsSearch to the Search tools table.

### DIFF
--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -38,6 +38,7 @@ The following table shows tools that execute online searches in some shape or fo
 | [SERPdive](https://serpdive.com/docs) | 1000 free credits/month | URL, Title, Date, Page Content, Answer |
 | [TalorData SERP](https://docs.talordata.com/serp-api/integration/sdk-integration/how-to-set-up-talordata-with-langchain) | Paid | Title, URL, snippet, position, knowledge graph, answer box, AI overview |
 | [Tavily Search](/oss/integrations/tools/tavily_search) | 1000 free searches/month | URL, Content, Title, Images, Answer |
+| [Webz News Search](https://docs.webz.io/docs/webz/news-search-api-mcp) | Paid | Title, URL, Published Date, Excerpt, Score |
 | [Apify](https://docs.apify.com/integrations/langchain) | Free tier, pay-per-use (varies by Actor) | Actor output (varies by Actor) |
 | [Xpoz](https://www.xpoz.ai/docs) | Free tier available | Posts, user profiles, comments, engagement metrics (Twitter/X, Instagram, Reddit, TikTok) |
 | [You.com Search](https://you.com/docs/integrations/langchain) | $100 in credits on sign up | URL, Title, Page Content |


### PR DESCRIPTION
## Overview
Add `WebzNewsSearch` (`langchain-webz`) to the curated **Search** table on the Python tools index.

The package is already listed under **All tools and toolkits** via https://github.com/langchain-ai/docs/pull/5771 (YAML listing). This PR does not remove that row. Search is a separate hand-maintained table in `src/oss/python/integrations/tools/index.mdx`.

Webz is a global news search tool (natural language + filters), same category as Tavily / Exa / Perplexity.

- Package: https://pypi.org/project/langchain-webz/
- Docs: https://docs.webz.io/docs/webz/news-search-api-mcp

Row added: Webz News Search | Paid | Title, URL, Published Date, Excerpt, Score

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- Related listing PR: https://github.com/langchain-ai/docs/pull/5771

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
No new MDX page, no `docs.json` change, no code examples. Single table row.

@lnhsingh