### PR TITLE
docs: update self-hosted diagnostics support guidance

### DIFF
--- a/src/langsmith/diagnostics-self-hosted.mdx
+++ b/src/langsmith/diagnostics-self-hosted.mdx
@@ -172,7 +172,7 @@ For more troubleshooting information, refer to:
 
 If you have followed these diagnostic steps and still need assistance, gather the following information before contacting support:
 
-- Output from the [diagnostic steps](#step-1-understand-your-deployment).
+- [Capture diagnostic information](https://support.langchain.com/articles/2087799075-how-to-share-diags?threadId=c47f421f-8f21-448c-9dfb-0e95988b6303).
 - Your Helm chart configuration.
 - Relevant error messages and logs.
 - Description of what you were trying to do when the issue occurred.

--- a/src/langsmith/diagnostics-self-hosted.mdx
+++ b/src/langsmith/diagnostics-self-hosted.mdx
@@ -170,11 +170,9 @@ For more troubleshooting information, refer to:
 
 ## Support
 
-If you have followed these diagnostic steps and still need assistance, gather the following information before contacting support:
+If you have followed these diagnostic steps and still need assistance, gather the following information and contact [Technical Support](https://support.langchain.com/):
 
-- [Capture diagnostic information](https://support.langchain.com/articles/2087799075-how-to-share-diags?threadId=c47f421f-8f21-448c-9dfb-0e95988b6303).
-- Your Helm chart configuration.
-- Relevant error messages and logs.
+- Capture the [diagnostic bundle](https://support.langchain.com/articles/2087799075-how-to-share-diags).
 - Description of what you were trying to do when the issue occurred.
 
-Having this information ready will help the [support](https://support.langchain.com) team diagnose and resolve your issue more quickly.
+Having this information in the ticket will help the [support](https://support.langchain.com/) team diagnose and resolve your issue more quickly.


### PR DESCRIPTION
## Overview

Replace the self-hosted diagnostics Support section with concise guidance for contacting Technical Support, capturing the diagnostic bundle, and describing the issue context. This helps the support team diagnose and resolve self-hosted deployment issues more quickly.

## Type of change

**Type:** Update existing documentation

## Checklist

- [x] I have read the contributing guidelines
- [x] No code examples were changed
- [x] No internal links or navigation changes were needed
- [x] Prose lint passes

## Additional notes

The Technical Support and diagnostic bundle links both returned HTTP 200. `make broken-links` completed the documentation build, but could not run Mintlify’s link checker because the global `mint` CLI is not installed in the sandbox.

Made by [Open SWE](https://openswe.vercel.app/agents/cd89bb91-9725-53f6-82a4-8194b7019623)