### PR TITLE
docs: add agentic video understanding example

### DIFF
--- a/src/oss/python/integrations/chat/google_generative_ai.mdx
+++ b/src/oss/python/integrations/chat/google_generative_ai.mdx
@@ -703,6 +703,37 @@ Provide video file inputs along with text.
     - Free tier: max 8 hours of YouTube video per day
 </Note>
 
+#### Agentic video understanding
+
+[Agentic video understanding](https://ai.google.dev/gemini-api/docs/video-understanding#agentic-video-understanding) lets the model dynamically explore a video to find content relevant to the prompt.
+
+<Note>
+    Agentic video understanding requires `langchain-google-genai>=4.4.0`.
+</Note>
+
+```python
+from langchain.chat_models import init_chat_model
+
+model = init_chat_model("google_genai:gemini-3.7-flash")
+
+message = {
+    "role": "user",
+    "content": [
+        {
+            "type": "video",
+            "url": "https://www.youtube.com/watch?v=GbzEDgcuGJU",
+            "mime_type": "video/mp4",
+            "media_processing": "AGENTIC",
+        },
+        {"type": "text", "text": "What is deepagents in one sentence?"},
+    ],
+}
+response = model.invoke([message])
+print(response.text)
+```
+
+Inline video data and videos uploaded through the Files API also support agentic processing.
+
 ### Image generation
 
 Certain models can generate text and images inline. See [Gemini API docs](https://ai.google.dev/gemini-api/docs/image-generation) for details.


### PR DESCRIPTION
### Summary

Document agentic video understanding on the `ChatGoogleGenerativeAI` integration page so users can enable the capability added in `langchain-google-genai` 4.4.0.

- Link to Google's feature documentation
- Add the YouTube example from the implementation PR
- Note support for inline video data and Files API uploads

### Testing

- `make lint_prose FILES="src/oss/python/integrations/chat/google_generative_ai.mdx"`
- `make broken-links`
- Compiled the added Python snippet to validate its syntax

Made by [Open SWE](https://openswe.vercel.app/agents/fc2a2036-3a70-5436-bcec-ffdc37727233)