### PR TITLE
Fix Webz News Search pricing in Search tools table

### DIFF
--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -38,7 +38,7 @@ The following table shows tools that execute online searches in some shape or fo
 | [SERPdive](https://serpdive.com/docs) | 1000 free credits/month | URL, Title, Date, Page Content, Answer |
 | [TalorData SERP](https://docs.talordata.com/serp-api/integration/sdk-integration/how-to-set-up-talordata-with-langchain) | Paid | Title, URL, snippet, position, knowledge graph, answer box, AI overview |
 | [Tavily Search](/oss/integrations/tools/tavily_search) | 1000 free searches/month | URL, Content, Title, Images, Answer |
-| [Webz News Search](https://docs.webz.io/docs/webz/news-search-api-mcp) | Paid | Title, URL, Published Date, Excerpt, Score |
+| [Webz News Search](https://docs.webz.io/docs/webz/news-search-api-mcp) | Free $5/month, then pay-as-you-go | Title, URL, Published Date, Excerpt, Score |
 | [Apify](https://docs.apify.com/integrations/langchain) | Free tier, pay-per-use (varies by Actor) | Actor output (varies by Actor) |
 | [Xpoz](https://www.xpoz.ai/docs) | Free tier available | Posts, user profiles, comments, engagement metrics (Twitter/X, Instagram, Reddit, TikTok) |
 | [You.com Search](https://you.com/docs/integrations/langchain) | $100 in credits on sign up | URL, Title, Page Content |


### PR DESCRIPTION
## Overview
Corrects the Free/Paid column for Webz News Search in the Search table (added in #5805).

Change: `Paid` → `Free $5/month, then pay-as-you-go`

Webz offers $5 free credits per user per month, with pay-as-you-go after that.

## Type of change
**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- https://github.com/langchain-ai/docs/pull/5805