### PR TITLE
Expand Webz News Search pricing and return data in Search table

### DIFF
--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -38,7 +38,7 @@ The following table shows tools that execute online searches in some shape or fo
 | [SERPdive](https://serpdive.com/docs) | 1000 free credits/month | URL, Title, Date, Page Content, Answer |
 | [TalorData SERP](https://docs.talordata.com/serp-api/integration/sdk-integration/how-to-set-up-talordata-with-langchain) | Paid | Title, URL, snippet, position, knowledge graph, answer box, AI overview |
 | [Tavily Search](/oss/integrations/tools/tavily_search) | 1000 free searches/month | URL, Content, Title, Images, Answer |
-| [Webz News Search](https://docs.webz.io/docs/webz/news-search-api-mcp) | Free $5/month, then pay-as-you-go | Title, URL, Published Date, Excerpt, Score |
+| [Webz News Search](https://docs.webz.io/docs/webz/news-search-api-mcp) | $5 free/month (~1,400 searches), then pay-as-you-go | Title, URL, Main image, Published Date, Content excerpt, Score, Sentiment, Topic, Person, Organization, Location, Ticker, Political bias, Domain rank |
 | [Apify](https://docs.apify.com/integrations/langchain) | Free tier, pay-per-use (varies by Actor) | Actor output (varies by Actor) |
 | [Xpoz](https://www.xpoz.ai/docs) | Free tier available | Posts, user profiles, comments, engagement metrics (Twitter/X, Instagram, Reddit, TikTok) |
 | [You.com Search](https://you.com/docs/integrations/langchain) | $100 in credits on sign up | URL, Title, Page Content |


### PR DESCRIPTION
## Overview
Updates the Webz News Search row in the Search tools table (#5805, pricing fix in #5824).

**Pricing:** `Free $5/month, then pay-as-you-go` → `$5 free/month (~1,400 searches), then pay-as-you-go`
(~$0.0035/search at avg. 5 results: $0.001/call + $0.0005/result)

**Return data:** expand to reflect actual MCP response fields per https://docs.webz.io/docs/webz/news-search-api-mcp — content excerpt, score, sentiment, and entity metadata (topic, person, organization, location, ticker, political bias, domain rank).

## Type of change
**Type:** Update existing documentation

## Related issues/PRs
- https://github.com/langchain-ai/docs/pull/5805
- https://github.com/langchain-ai/docs/pull/5824