### PR TITLE
ChatOpenZoo: flip multimodal to true

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -143,7 +143,7 @@ python:
     stream: true
     tool_calling: true
     structured_output: true
-    multimodal: false
+    multimodal: true
   - name: ChatGreenNode
     pypi: langchain-greennode
     docs_url: https://github.com/greennode-ai/langchain-greennode


### PR DESCRIPTION
Follow-up to #5803. The OpenZoo gateway's paid chat lane now verifiably serves OpenAI-style `image_url` content parts end to end: a 2-color PNG sent as a data URL through `ChatOpenZoo`'s endpoint to a vision model (gemini-2.5-flash) is described correctly, and the gateway repo carries an e2e test asserting the image content part reaches the upstream byte-identical. One line: `multimodal: false` → `true` on the ChatOpenZoo row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)