### PR TITLE
Increase Deep Agents demo height

### DIFF
--- a/src/oss/deepagents/overview.mdx
+++ b/src/oss/deepagents/overview.mdx
@@ -29,7 +29,7 @@ See [Core capabilities](#core-capabilities) for a full breakdown of each compone
 
 ## Try it
 
-<PatternEmbed pattern="deep-agents-comparison" />
+<PatternEmbed pattern="deep-agents-comparison" minHeight={700} />
 
 ## Quickstart
 


### PR DESCRIPTION
### Summary

Increase the minimum height of the interactive Deep Agents comparison from 400px to 700px so generated responses have more room and are easier to inspect.

### Testing

- `make lint_prose FILES="src/oss/deepagents/overview.mdx"`
- `git diff --check`

Made by [Open SWE](https://openswe.vercel.app/agents/7026f567-bd4e-5457-97b9-9624c5442c12)