### PR TITLE
docs(langchain): list AACP integration

### DIFF
--- a/packages.yml
+++ b/packages.yml
@@ -1488,3 +1488,7 @@ packages:
   name_title: Context.dev
   repo: context-dot-dev/langchain-context
   js: "n/a"
+- name: aacp-langchain
+  name_title: AACP
+  repo: MackayAndrew/aacp-langchain
+  js: "n/a"

--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -18,6 +18,14 @@ Browse the complete collection of integrations available for Python. LangChain P
     </Card>
 
     <Card
+        title="AACP"
+        href="https://github.com/MackayAndrew/aacp-langchain"
+        icon="link"
+    >
+        Typed, validated coordination packets for LangChain multi-agent workflows.
+    </Card>
+
+    <Card
         title="Abso"
         href="https://github.com/lunary-ai/langchain-abso"
         icon="link"


### PR DESCRIPTION
### Summary

- Add `aacp-langchain` to the package registry.
- List AACP in the Python integrations provider directory.
- Link to the integration repository instead of adding a hosted guide because the package is below the 50,000 monthly-download eligibility threshold.

AACP is a coordination layer rather than an existing generated-table component, so this change does not force it into an unrelated chat, tool, retriever, callback, or middleware table.

Closes #4640

### Testing

- `make lint_prose FILES="src/oss/python/integrations/providers/all_providers.mdx"`
- `uv run python scripts/refresh_integration_downloads.py --check-docs-urls`
- YAML parsing for `packages.yml` and `scripts/data/integration_external_docs.yaml`
- `make broken-links`

Made by [Open SWE](https://openswe.vercel.app/agents/98e93871-cf16-5197-830f-cac574c0b66b)