### PR TITLE
docs: clarify Azure sandbox chart requirement

### DIFF
--- a/src/langsmith/deploy-self-hosted-full-platform.mdx
+++ b/src/langsmith/deploy-self-hosted-full-platform.mdx
@@ -825,7 +825,7 @@ polly:
 ## Enable Sandboxes
 
 <Note>
-Self-hosted Sandboxes require LangSmith Helm chart v17 (`0.17.x`).
+Self-hosted Sandboxes on Azure require LangSmith Helm chart v17 (`0.17.x`).
 </Note>
 
 Sandboxes are disabled by default. After installation, see [LangSmith Sandboxes](/langsmith/sandboxes) for user workflows in the LangSmith UI and APIs.


### PR DESCRIPTION
## Overview

Clarifies that the LangSmith Helm chart v17 requirement for self-hosted Sandboxes applies only to Azure. This prevents AWS and GCP users from interpreting v17 as a universal prerequisite.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Checklist

- [x] I have read the contributing guidelines
- [x] No code examples were changed
- [x] Navigation changes are not needed
- [x] Focused Vale prose lint passes

## Additional notes

Validation: `make lint_prose FILES="src/langsmith/deploy-self-hosted-full-platform.mdx"` and `git diff --check`.

Made by [Open SWE](https://openswe.vercel.app/agents/f1bcc2f1-874d-5822-b0b5-ea3975f06b0e)