### PR TITLE
fix: update Docling links after DS4SD org rename

### DIFF
--- a/src/oss/python/integrations/document_loaders/docling.mdx
+++ b/src/oss/python/integrations/document_loaders/docling.mdx
@@ -6,7 +6,7 @@ integration:
   pypi: langchain-docling
 ---
 
-[Docling](https://github.com/DS4SD/docling) parses PDF, DOCX, PPTX, HTML, and other formats into a rich unified representation including document layout, tables etc., making them ready for generative AI workflows like RAG.
+[Docling](https://github.com/docling-project/docling) parses PDF, DOCX, PPTX, HTML, and other formats into a rich unified representation including document layout, tables etc., making them ready for generative AI workflows like RAG.
 
 This integration provides Docling's capabilities via the `DoclingLoader` document loader.
 
@@ -82,7 +82,7 @@ Token indices sequence length is longer than the specified maximum sequence leng
 ```
 
 > Note: a message saying `"Token indices sequence length is longer than the specified
-maximum sequence length..."` can be ignored in this case — more details in this [docling-core GitHub issue](https://github.com/DS4SD/docling-core/issues/119#issuecomment-2577418826).
+maximum sequence length..."` can be ignored in this case — more details in this [docling-core GitHub issue](https://github.com/docling-project/docling-core/issues/119#issuecomment-2577418826).
 
 Inspecting some sample docs:
 

--- a/src/oss/python/integrations/document_loaders/index.mdx
+++ b/src/oss/python/integrations/document_loaders/index.mdx
@@ -105,7 +105,7 @@ The below document loaders allow you to load data from common data formats.
 |----------------|-----------|
 | [`Unstructured`](/oss/integrations/document_loaders/unstructured_file) | Many file types (see https://docs.unstructured.io/platform/supported-file-types) |
 | [`HwpHwpxLoader`](https://github.com/jaypakdevkr/HWP-Loader) | HWP/HWPX files |
-| [`DoclingLoader`](/oss/integrations/document_loaders/docling) | Various file types (see https://ds4sd.github.io/docling/) |
+| [`DoclingLoader`](/oss/integrations/document_loaders/docling) | Various file types (see https://docling-project.github.io/docling/) |
 | [`PolarisAIDataInsightLoader`](https://datainsight.polarisoffice.com/playground) | Various file types (see https://datainsight.polarisoffice.com/documentation?docType=doc_extract) |
 
 ## All document loaders

--- a/src/oss/python/integrations/providers/docling.mdx
+++ b/src/oss/python/integrations/providers/docling.mdx
@@ -3,7 +3,7 @@ title: "Docling integrations"
 description: "Integrate with Docling using LangChain Python."
 ---
 
-> [Docling](https://github.com/DS4SD/docling) parses PDF, DOCX, PPTX, HTML, and other formats into a rich unified representation including document layout, tables etc., making them ready for generative AI workflows like RAG.
+> [Docling](https://github.com/docling-project/docling) parses PDF, DOCX, PPTX, HTML, and other formats into a rich unified representation including document layout, tables etc., making them ready for generative AI workflows like RAG.
 >
 > This integration provides Docling's capabilities via the `DoclingLoader` document loader.
 
@@ -45,7 +45,7 @@ For end-to-end usage check out
 
 ## Additional resources
 
-- [LangChain Docling integration GitHub](https://github.com/DS4SD/docling-langchain)
+- [LangChain Docling integration GitHub](https://github.com/docling-project/docling-langchain)
 - [LangChain Docling integration PyPI package](https://pypi.org/project/langchain-docling/)
-- [Docling GitHub](https://github.com/DS4SD/docling)
-- [Docling docs](https://ds4sd.github.io/docling/)
+- [Docling GitHub](https://github.com/docling-project/docling)
+- [Docling docs](https://docling-project.github.io/docling/)


### PR DESCRIPTION
## What
Updates all `DS4SD` GitHub org and `ds4sd.github.io` Docling links to the
current `docling-project` org, across the Docling provider page, document
loader page, and the document loaders index table.

## Why
Docling's GitHub org moved from DS4SD to docling-project. The old
github.com/DS4SD/* repo links still redirect, but ds4sd.github.io/docling/
is a stale snapshot that no longer reflects the current docs site.
Closes #574.

## Type of change
- [x] Fix typo/bug/link/formatting

Diff size: 3 files changed, 7 insertions(+), 7 deletions(-)