### PR TITLE
fix: correct nonexistent create_react_agent import in AWS Bedrock AgentCore docs

### DIFF
--- a/src/oss/python/integrations/tools/bedrock_agentcore_browser.mdx
+++ b/src/oss/python/integrations/tools/bedrock_agentcore_browser.mdx
@@ -214,7 +214,7 @@ print(text)
 
 ```python
 import asyncio
-from langchain.agents import create_react_agent
+from langchain.agents import create_agent
 from langchain.chat_models import init_chat_model
 from langchain_aws.tools import create_browser_toolkit
 
@@ -229,7 +229,7 @@ async def main():
     )
 
     # Create agent with browser tools
-    agent = create_react_agent(
+    agent = create_agent(
         model=llm,
         tools=browser_tools,
     )

--- a/src/oss/python/integrations/tools/bedrock_agentcore_code_interpreter.mdx
+++ b/src/oss/python/integrations/tools/bedrock_agentcore_code_interpreter.mdx
@@ -105,7 +105,7 @@ print(result)
 
 ```python
 import asyncio
-from langchain.agents import create_react_agent
+from langchain.agents import create_agent
 from langchain.chat_models import init_chat_model
 from langchain_aws.tools import create_code_interpreter_toolkit
 
@@ -120,7 +120,7 @@ async def main():
     )
 
     # Create agent with code interpreter tools
-    agent = create_react_agent(
+    agent = create_agent(
         model=llm,
         tools=code_tools,
     )


### PR DESCRIPTION
## What
Fixes `from langchain.agents import create_react_agent` → `create_agent`
in the AWS Bedrock AgentCore browser toolkit and code interpreter toolkit
usage examples.

## Why
`create_react_agent` does not exist in `langchain.agents` (verified against
installed langchain==1.3.18) — copying either example as shown raises
ImportError. The repo's own LangGraph v1 migration guide confirms
`create_react_agent` → `langchain.agents.create_agent` as the current API.

## Type of change
- [x] Fix typo/bug/link/formatting

Diff size: 2 files changed, 4 insertions(+), 4 deletions(-)