### PR TITLE
docs: modernize deprecated create_react_agent in AWS provider page

### DIFF
--- a/src/oss/python/integrations/providers/aws.mdx
+++ b/src/oss/python/integrations/providers/aws.mdx
@@ -168,14 +168,14 @@ from langchain_aws import AmazonKnowledgeBasesRetriever
 See a [usage example](/oss/integrations/tools/bedrock_agentcore_browser).
 
 ```python
-from langgraph.prebuilt import create_react_agent
+from langchain.agents import create_agent
 from langchain_aws.tools import create_browser_toolkit
 
 # Create toolkit
 toolkit, browser_tools = create_browser_toolkit(region="us-west-2")
 
 # Use with an agent
-agent = create_react_agent(model=llm, tools=browser_tools)
+agent = create_agent(model=llm, tools=browser_tools)
 result = await agent.ainvoke(
     {"messages": [{"role": "user", "content": "Go to example.com and get the heading"}]},
     config={"configurable": {"thread_id": "session-1"}}
@@ -203,14 +203,14 @@ await toolkit.cleanup()
 See a [usage example](/oss/integrations/tools/bedrock_agentcore_code_interpreter).
 
 ```python
-from langgraph.prebuilt import create_react_agent
+from langchain.agents import create_agent
 from langchain_aws.tools import create_code_interpreter_toolkit
 
 # Create toolkit (async)
 toolkit, code_tools = await create_code_interpreter_toolkit(region="us-west-2")
 
 # Use with an agent
-agent = create_react_agent(model=llm, tools=code_tools)
+agent = create_agent(model=llm, tools=code_tools)
 result = await agent.ainvoke(
     {"messages": [{"role": "user", "content": "Calculate factorial of 10"}]},
     config={"configurable": {"thread_id": "session-1"}}


### PR DESCRIPTION
## What
Updates the AWS provider page's Bedrock AgentCore Browser and Code
Interpreter snippets from `langgraph.prebuilt.create_react_agent` to
`langchain.agents.create_agent`.

## Why
LangGraph v1 deprecates `create_react_agent` in favor of `create_agent`
(per this repo's own migration guide at /oss/migrate/langgraph-v1). The
snippets also link to "usage example" pages for the same two tools that
already use `create_agent`, so this brings the provider page in line
with both the current API and its own linked examples.

## Type of change
- [x] Fix typo/bug/link/formatting

Diff size: 1 file changed, 4 insertions(+), 4 deletions(-)