### PR TITLE
fix: correct invalid createAgent() call signature in Composio docs

### DIFF
--- a/src/oss/javascript/integrations/tools/composio.mdx
+++ b/src/oss/javascript/integrations/tools/composio.mdx
@@ -277,10 +277,10 @@ const toolsUser2 = await composio.tools.get('user_2', 'GITHUB');
 
 // Tools will use the respective user's credentials
 // User 1's agent will act on User 1's GitHub account
-const agent1 = createAgent(model, toolsUser1);
+const agent1 = createAgent({ model, tools: toolsUser1 });
 
 // User 2's agent will act on User 2's GitHub account
-const agent2 = createAgent(model, toolsUser2);
+const agent2 = createAgent({ model, tools: toolsUser2 });
 ```
 
 ## Event-driven workflows


### PR DESCRIPTION
## What
Fixes two `createAgent(model, tools)` calls (positional arguments) in
the Composio "Multi-user scenarios" example to the correct
`createAgent({ model, tools })` signature.

## Why
`createAgent` takes a single options object everywhere else in this
codebase and per the official reference
(reference.langchain.com/javascript/langchain/index/createAgent).
As written, this snippet would throw at runtime if copied and run.

## Type of change
- [x] Fix typo/bug/link/formatting

Diff size: 1 file changed, 2 insertions(+), 2 deletions(-)