### PR TITLE
Add Diffbot tool descriptions

### DIFF
--- a/src/oss/javascript/integrations/tools/index.mdx
+++ b/src/oss/javascript/integrations/tools/index.mdx
@@ -10,6 +10,19 @@ import IntegrationDownloads from '/snippets/oss/javascript-tools-downloads.mdx';
 
 A [toolkit](/oss/langchain/tools#prebuilt-tools) is a collection of tools meant to be used together.
 
+## Web search
+
+The following table shows tools that execute online searches in some shape or form:
+
+| Tool/Toolkit | Free/Paid | Return Data |
+|-------------|-----------|-------------|
+| [Diffbot](https://github.com/diffbot/langchain-diffbot) | Free | URL, Snippet, Title, Date, Knowledge Graph (Organizations, News, People, Places, Deals) |
+| [Exa Search](/oss/integrations/tools/exa_search) | 1000 free searches/month | URL, Author, Title, Published Date |
+| [Nia Toolkit](/oss/integrations/tools/nia) | Free tier available | Code, Docs, Metadata, Sources |
+| [Perplexity Search](/oss/integrations/tools/perplexity_search) | Paid (with monthly free tier) | URL, Title, Snippet, Date, Last Updated |
+| [TalorData SERP](https://docs.talordata.com/serp-api/integration/sdk-integration/how-to-set-up-talordata-with-langchain) | Paid | Title, URL, snippet, position, knowledge graph, answer box, AI overview |
+| [Tavily Search](/oss/integrations/tools/tavily_search) | 1000 free searches/month | URL, Content, Title, Images, Answer |
+
 ## Integration platforms
 
 The following platforms provide access to multiple tools and services through a unified interface:

--- a/src/oss/python/integrations/document_loaders/index.mdx
+++ b/src/oss/python/integrations/document_loaders/index.mdx
@@ -58,6 +58,8 @@ The below document loaders allow you to load webpages.
 | [Unstructured](/oss/integrations/document_loaders/unstructured_file) | Uses Unstructured to load and parse web pages | Package |
 | [Apify Dataset](https://docs.apify.com/integrations/langchain) | Load documents from Apify datasets | API |
 | [Apify Crawl](https://docs.apify.com/integrations/langchain) | Crawl a website on demand and load each page as a Document | API |
+| [Diffbot Crawl Loader](https://github.com/diffbot/langchain-diffbot) | Crawl a website and load each page as ontologically consistent JSON using the Diffbot Crawl API | API |
+| [Diffbot Extract Loader](https://github.com/diffbot/langchain-diffbot) | Load web pages as ontologically consistent JSON using the Diffbot Extract API | API |
 | [Docling](/oss/integrations/document_loaders/docling) | Uses Docling to load and parse web pages | Package |
 | [DomPruner](https://github.com/dong7812/dompruner-py) | DOM AST pruning: loads web pages as compact Markdown with 97%+ token reduction, no API key | Package |
 | [Firecrawl](https://docs.firecrawl.dev) | Turns websites into clean, LLM-ready data via scrape/crawl/map/extract/search | API |

--- a/src/oss/python/integrations/retrievers/index.mdx
+++ b/src/oss/python/integrations/retrievers/index.mdx
@@ -37,6 +37,8 @@ The below retrievers will search over an external index (e.g., constructed from 
 | Retriever | Source | Package |
 |-----------|---------|---------|
 | [`ApifySearchRetriever`](https://docs.apify.com/integrations/langchain) | Internet search via the [Apify RAG Web Browser](https://apify.com/apify/rag-web-browser) | [`langchain-apify`](https://pypi.org/project/langchain-apify/) |
+| [`DiffbotKnowledgeGraphRetriever`](https://github.com/diffbot/langchain-diffbot) | Entity search over the Diffbot Knowledge Graph | [`langchain-diffbot`](https://pypi.org/project/langchain-diffbot/) |
+| [`DiffbotWebSearchRetriever`](https://github.com/diffbot/langchain-diffbot) | Internet search via the Diffbot Web Search API | [`langchain-diffbot`](https://pypi.org/project/langchain-diffbot/) |
 | [`ParallelSearchRetriever`](/oss/integrations/retrievers/parallel) | Internet search via the [Parallel Search API](https://docs.parallel.ai/search/search-quickstart) | [`langchain-parallel`](https://reference.langchain.com/python/langchain-parallel/retrievers/ParallelSearchRetriever) |
 | [`PerplexitySearchRetriever`](/oss/integrations/retrievers/perplexity_search) | Internet search via the [Perplexity Search API](https://docs.perplexity.ai/docs/search/quickstart) | [`langchain-perplexity`](https://reference.langchain.com/python/langchain-perplexity/retrievers/PerplexitySearchRetriever) |
 | [`YouRetriever`](https://you.com/docs/integrations/langchain) | Internet search | [`langchain-youdotcom`](https://pypi.org/project/langchain-youdotcom/) |

--- a/src/oss/python/integrations/tools/index.mdx
+++ b/src/oss/python/integrations/tools/index.mdx
@@ -21,6 +21,7 @@ The following table shows tools that execute online searches in some shape or fo
 | [ContextSearch](https://docs.context.dev) | Free tier available | URL, Title, Description, Page Content |
 | [Crawleo](https://crawleo.dev/integrations/langchain) | Paid | URL, Snippet, Copilot Answer, Sidebar, Title, Published Date, Site Links, Page Content |
 | [CrustAPI](https://crustapi.com/docs) | 3,000 free credits/month, no card | URL, Title, Snippet, Maps, News, Shopping, Images, Videos, Places, Scholar, Patents, LinkedIn |
+| [Diffbot](https://github.com/diffbot/langchain-diffbot) | Free | URL, Snippet, Title, Date, Knowledge Graph (Organizations, News, People, Places, Deals) |
 | [Exa Search](/oss/integrations/tools/exa_search) | 1000 free searches/month | URL, Author, Title, Published Date |
 | [Google Search](/oss/integrations/tools/google_search) | Paid | URL, Snippet, Title |
 | [iFlow Search](https://platform.iflow.cn/) | Paid | URL, Title, Snippet, Date |


### PR DESCRIPTION
## Overview
Adds Diffbot tool descriptions in appropriate sections (Search, Retrievers, Document Loaders). In a previous PR, they were only added to the directory listing.

Changes:
 - Added Diffbot Web Search to Search section in [Python Tools](https://docs.langchain.com/oss/python/integrations/tools#search)
 - Added a new Search section in [Typescript Tools](https://docs.langchain.com/oss/javascript/integrations/tools), equivalent to its Python counterpart.
 - Added Diffbot Extract and Crawl Loaders to Webpages section in [Python Document Loaders](https://docs.langchain.com/oss/python/integrations/document_loaders#webpages)
 - Added Diffbot Knowledge Graph and Web Search to External Index section in [Python Retrievers](https://docs.langchain.com/oss/python/integrations/retrievers#external-index)

## Type of change

**Type:** Update existing documentation

## Related issues/PRs
- https://github.com/langchain-ai/docs/pull/4376

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
Thanks for the review! All documentation content is written by me. Commits written by Claude.