### PR TITLE
docs(langsmith): fix Engine spend-limit default and note GHES is unsupported

### DIFF
--- a/src/langsmith/engine-github.mdx
+++ b/src/langsmith/engine-github.mdx
@@ -21,6 +21,10 @@ For the access and retention model of the managed app, see [Engine security](/la
 
 ## Self-hosted
 
+<Note>
+Engine connects to `github.com` only. GitHub Enterprise Server is not supported: Engine's sandboxes reach `github.com` and `api.github.com`, and the sandbox auth proxy injects repository credentials for those hosts alone. A GitHub App created on a GitHub Enterprise Server instance cannot be used.
+</Note>
+
 To create and configure a GitHub App for a self-hosted deployment:
 
 ### Create a GitHub App

--- a/src/langsmith/engine.mdx
+++ b/src/langsmith/engine.mdx
@@ -96,7 +96,12 @@ Organization Admins can set spend limits at two levels:
 
 You can enter limits in LCU or USD (1 LCU = $1.50). When a limit is reached, LangSmith pauses new Engine runs until the limit is raised or the next monthly billing period begins.
 
-Leave the limit blank to allow unlimited Engine spend. To stop Engine entirely, use the **Enable Engine** toggle in **Settings > Engine enablement**.
+The two levels default differently:
+
+- **Org-wide limit**: Choose **Default**, **No limit**, or a custom cap. Until an admin chooses, the default applies (500 LCU per month, about $750), so Engine spend is capped even though no one has set a limit. The **Engine enablement** page names the enforced limit and its source.
+- **Per-project limit**: Leave the field blank for no limit. Use **Remove limit** to clear a cap you set earlier.
+
+To stop Engine entirely, use the **Enable Engine** toggle in **Settings > Engine enablement**.
 
 To monitor usage, you can view your organization's monthly LCU spend on the **Engine enablement** page in **Settings**, or view per-project spend in the [**Engine Settings**](#configure-engine) panel for each tracing project.
 


### PR DESCRIPTION
## What

Two independent correctness fixes to the Engine docs, both verified against `langchainplus`. Neither touches page structure, so this is independent of #5836.

### 1. The org-wide spend limit is not unlimited when blank

`engine.mdx` said "Leave the limit blank to allow unlimited Engine spend." That is true of the **per-project** limit, but not the **org-wide** one.

When `organizations.engine_lcu_spend_limit_monthly` is NULL, `ResolveMonthlyLCUSpendLimit` substitutes `DefaultOrgMonthlyLCUSpendLimitLCU` = 500 LCU (`smith-go/engine/usage/spend_limit.go:27`), and a reached limit pauses new Engine runs. An admin who follows the old wording leaves the field alone, expects no cap, and sees Engine stop around 500 LCU (about $750) with no obvious cause.

The product UI is already correct: the **Engine enablement** page offers **Default · 500 LCU**, **No limit**, and a custom cap, and names the enforced limit and its source. Only the docs disagreed. The replacement describes the two levels separately and matches those controls.

The per-project layer genuinely is unlimited when unset (`EvaluateSessionMonthlyLCUSpendLimit` returns early on a nil or negative limit), so that half of the old sentence is preserved.

### 2. GitHub Enterprise Server is not supported

`engine-github.mdx` documents a nine-step self-hosted GitHub App setup with no mention of GHES. Engine's sandbox allow list is `github.com` / `api.github.com`, and the proxy's credential-injection match hosts are `github.com` only (`smith-issues-agent/smith_issues_agent/_sandbox.py:84,109`). The allow list is default-deny and not configurable, so an App created against a GHES instance cannot work.

Today a self-hosted operator on GHES can create the App, generate two secrets, build a Kubernetes Secret, and wire seven env vars before discovering that. The note states the limitation before the steps begin.

## Test plan

- `make lint_prose FILES="src/langsmith/engine.mdx src/langsmith/engine-github.mdx"` — 0 errors, 0 warnings, 0 suggestions.
- No structural, navigation, or anchor changes; no new pages, so `docs.json` is untouched.

Written by Claude Code on behalf of @bagatur.