### PR TITLE
docs(langgraph): fix broken serialization link in Graph API guide

### DIFF
--- a/src/oss/langgraph/graph-api.mdx
+++ b/src/oss/langgraph/graph-api.mdx
@@ -566,7 +566,7 @@ The `MessagesValue` reducer is vital to telling the graph how to update the list
 :::python
 In addition to keeping track of message IDs, the @[`add_messages`] function will also try to deserialize messages into LangChain `Message` objects whenever a state update is received on the `messages` channel.
 
-For more information, see [LangChain serialization/deserialization](https://python.langchain.com/docs/how_to/serialization/). This allows sending graph inputs / state updates in the following format:
+For more information, see [LangChain serialization/deserialization](/oss/langchain/messages#serialization). This allows sending graph inputs / state updates in the following format:
 
 ```python
 # this is supported


### PR DESCRIPTION
## Summary

- Fixes an obsolete documentation link in `src/oss/langgraph/graph-api.mdx`.
- Replaces the legacy external link `https://python.langchain.com/docs/how_to/serialization/` with the canonical internal relative path `/oss/langchain/messages#serialization`.
- Adheres to repository documentation guidelines requiring internal relative links over absolute URLs.

## Issue

Closes #5769

## Motivation & Context

The serialization link inside the LangGraph Graph API guide pointed to an outdated Python documentation path. Updating it to `/oss/langchain/messages#serialization` ensures seamless navigation to the active LangChain message serialization section.

## Validation

- [x] `git diff --check` — Verified clean diff with no trailing whitespace or extra line modifications.
- [x] `make lint_prose` — Passed with 0 errors and 0 warnings across all files.
- [x] `make build` — Build pipeline executed and completed successfully.

## Type of Change

- [x] Documentation fix (non-breaking change which fixes an outdated/broken link)
