### PR TITLE
docs(dcode): document Auto classifier defaults

### DIFF
--- a/src/oss/deepagents/code/approval-modes.mdx
+++ b/src/oss/deepagents/code/approval-modes.mdx
@@ -127,9 +127,19 @@ flowchart TD
 
 ### Select a classifier model
 
-By default, the Auto classifier uses the same model as the main agent. You can point it at a different (typically cheaper and faster) model to reduce cost and latency during Auto review.
+When you do not configure an Auto classifier, Deep Agents Code selects a lower-latency default based on the main model's provider:
 
-Set the classifier model through any of these source:
+| Main model provider | Default classifier |
+|---|---|
+| Anthropic | `anthropic:claude-sonnet-5` |
+| Google AI | `google_genai:gemini-3.8-flash` |
+| Google Vertex AI | `google_vertexai:gemini-3.8-flash` |
+| OpenAI | `openai:gpt-5.6-luna` |
+| OpenAI Codex | `openai_codex:gpt-5.6-luna` |
+
+For other providers, the classifier uses the main agent model. You can select a different model to control cost and latency during Auto review.
+
+Set the classifier model through any of these sources:
 
 <Tabs>
     <Tab title="TUI command">
@@ -171,9 +181,10 @@ Set the classifier model through any of these source:
     2. **`--auto-classifier-model` flag**: sets the classifier on launch (interactive TUI sessions only).
     3. **`DEEPAGENTS_CODE_AUTO_CLASSIFIER_MODEL` environment variable**: applies at startup.
     4. **`[models].auto_classifier` in `config.toml`**: your persistent default.
-    5. **Inherit**: uses the main agent model (the default when nothing is configured).
+    5. **Provider default**: uses the lower-latency model listed above when the main model uses a supported provider.
+    6. **Inherit**: uses the main agent model for providers without a built-in default.
 
-    A blank value at any level means "inherit from the next source". For example, an unset env var falls through to `config.toml`.
+    An unset value falls through to the next source. Explicitly clearing the classifier with `/auto model clear` or an empty CLI flag selects the main agent model instead of the provider default.
 </Accordion>
 
 The TUI displays which model is reviewing when Auto turns on and inside `/auto model` output.

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -28,7 +28,7 @@ auto_classifier = "openai:gpt-5.6-luna"  # optional: cheaper model for Auto appr
 
 `[models].default` always takes priority over `[models].recent`. The `/model` command only writes to `[models].recent`, so your configured default is never overwritten by mid-session switches. To remove the default, use `/model --default --clear` or delete the `default` key from the config file.
 
-`[models].auto_classifier` sets the model used by the [Auto approval classifier](/oss/deepagents/code/approval-modes#select-a-classifier-model) to review gated tool calls. When unset, the classifier inherits the main agent model. You can override this at runtime with `--auto-classifier-model` or `/auto model`. See [Select a classifier model](/oss/deepagents/code/approval-modes#select-a-classifier-model) for full precedence and security notes.
+`[models].auto_classifier` sets the model used by the [Auto approval classifier](/oss/deepagents/code/approval-modes#select-a-classifier-model) to review gated tool calls. When unset, Deep Agents Code selects a lower-latency default for supported main-model providers: Claude Sonnet for Anthropic, Gemini Flash for Google, and GPT Luna for OpenAI. Other providers inherit the main agent model. You can override this at runtime with `--auto-classifier-model` or `/auto model`. See [Select a classifier model](/oss/deepagents/code/approval-modes#select-a-classifier-model) for exact model specifications, full precedence, and security notes.
 
 ## Set a summarization model
 


### PR DESCRIPTION
Document the provider-specific Auto classifier defaults introduced by https://github.com/langchain-ai/deepagents/pull/6039.

- List the default classifier model for Anthropic, Google, OpenAI, and their supported provider variants.
- Clarify fallback and explicit inheritance behavior.
- Align the `config.toml` reference with the new resolution order.

Made by [Open SWE](https://openswe.vercel.app/agents/cf4d385d-999c-574a-9fc3-165e9a7d0732)