### PR TITLE
docs: document per-thread coding-agent trace controls

### DIFF
--- a/src/langsmith/trace-claude-code.mdx
+++ b/src/langsmith/trace-claude-code.mdx
@@ -5,7 +5,7 @@ sidebarTitle: Claude Code
 
 This guide shows you how to send conversations automatically from the [Claude Code CLI](https://code.claude.com/docs/en/overview) to LangSmith.
 
-Once configured, each Claude Code project can opt in to sending traces to LangSmith. Each trace includes user messages, tool calls, compaction, subagent runs, and assistant responses. System prompts are not included, because Claude Code does not return them in conversation transcripts.
+Once configured in full mode, each Claude Code project can send traces to LangSmith. Each trace includes user messages, tool calls, compaction, subagent runs, and assistant responses. System prompts are not included because Claude Code does not return them in conversation transcripts.
 
 ## Prerequisites
 
@@ -34,41 +34,82 @@ To update the plugin, run:
 
 <Note> If you are migrating from the previously recommended version of tracing Claude Code with manually created stop hooks, refer to [Migrating from the manual stop hook](#migrating-from-the-manual-stop-hook). </Note>
 
-### Setting environment variables
+### Configure tracing
 
-**Option 1: Project-level configuration (recommended)**
+The plugin requires an API key and an enabled master switch. The master switch uses the first source that defines it:
 
-The plugin requires the following environment variables:
+| Priority | Source | Enabled value |
+| --- | --- | --- |
+| 1 | `TRACE_TO_LANGSMITH` environment variable | `"true"` |
+| 2 | Project `.claude/langsmith.json` | `{"enabled": true}` |
+| 3 | User `~/.claude/langsmith.json` | `{"enabled": true}` |
+| 4 | Default | Disabled |
 
-- `TRACE_TO_LANGSMITH: "true"`: Enables tracing for this project. Remove or set to `false` to disable tracing.
-- `CC_LANGSMITH_API_KEY`: Your LangSmith API key.
-- `CC_LANGSMITH_PROJECT`: The LangSmith project name to which your traces will send.
-- (optional) `CC_LANGSMITH_METADATA`: JSON object of custom metadata to attach to all runs (e.g., PR URL, author).
-- (optional) `CC_LANGSMITH_DEBUG: "true"`: Enables detailed debug logging. Remove or set to `false` to disable debug logging.
+A higher-precedence `false` overrides lower-precedence `true`. A malformed higher-precedence config disables tracing instead of falling back to a lower-precedence source.
 
-To get set up, create or edit [Claude Code's project settings file](https://code.claude.com/docs/en/settings#:~:text=Project%20settings%20are%20saved%20in%20your%20project%20directory%3A). Create a `.claude/settings.local.json` in your project directory and populate it as follows:
+Create `.claude/langsmith.json` in the project, or `~/.claude/langsmith.json` for all projects:
+
+```json
+{
+  "enabled": true
+}
+```
+
+Configure credentials and the destination in `.claude/settings.local.json`:
 
 ```json
 {
   "env": {
-    "TRACE_TO_LANGSMITH": "true",
     "CC_LANGSMITH_API_KEY": "<LangSmith API key>",
     "CC_LANGSMITH_PROJECT": "my-project"
   }
 }
 ```
 
-<Note> Alternatively, to enable tracing to LangSmith for all Claude Code sessions, you can add the previous JSON to your [global Claude Code settings.json](https://code.claude.com/docs/en/settings#:~:text=User%20settings%20are%20defined%20in%20~/.claude/settings.json%20and%20apply%20to%20all%20projects.) file. </Note>
-
-**Option 2: Shell environment variables**
-
-Run the following commands in your shell or add them to your shell configuration file (`~/.zshrc`, `~/.bashrc`, or `~/.bash_profile`):
+Alternatively, set all values in the shell environment:
 
 ```bash
 export TRACE_TO_LANGSMITH="true"
 export CC_LANGSMITH_API_KEY="<LangSmith API key>"
 export CC_LANGSMITH_PROJECT="my-project"
 ```
+
+Optional environment variables include `CC_LANGSMITH_METADATA` for a JSON object of custom metadata and `CC_LANGSMITH_DEBUG="true"` for detailed logs.
+
+## Control tracing per thread
+
+<Note>
+Per-thread trace controls require version 0.3.0 or later of the `langsmith-tracing` marketplace plugin.
+</Note>
+
+Use these exact lowercase prompts in a Claude Code session:
+
+| Command | Stored thread mode | Effective behavior when the master switch is enabled |
+| --- | --- | --- |
+| `/trace on` | Full | Uploads trace content and metadata. |
+| `/trace off` | Metadata only | Uploads only the safe metadata listed below, with trace topology and timing. |
+| `/trace status` | Unchanged | Reports the effective master-disabled condition when the master switch is off; otherwise reports the stored mode. |
+
+The master switch remains dominant. While it is disabled, `/trace on` and `/trace off` can update the stored per-thread preference, but no command can cause an upload. Control prompts are intercepted and are not traced.
+
+The plugin snapshots the mode for the current turn when you submit its prompt. Mode transitions apply only to later turns and do not backfill or alter earlier turns. Subagents inherit the mode of the turn that launches them.
+
+The preference persists in `~/.claude/state/langsmith_state.json`, or the path set by `STATE_FILE`. If this state is corrupt, tracing fails closed to metadata-only mode until a trace control command safely recovers the state.
+
+### Metadata-only allowlist
+
+Metadata-only mode retains run topology and timing, sets every run's inputs and outputs to `{}`, and permits only these operational metadata keys:
+
+| Scope | Allowed keys |
+| --- | --- |
+| Trace and turn identity | `thread_id`, `turn_id`, `turn_number`, `status`, `ls_tracing_mode` |
+| Integration identity | `ls_agent_purpose`, `ls_agent_type`, `ls_agent_runtime`, `ls_agent_runtime_version`, `ls_integration`, `ls_integration_version`, `ls_trace_schema_version` |
+| Model and tool operations | `ls_model_name`, `ls_tool_name`, `usage_metadata` |
+| Subagents | `ls_subagent_id`, `ls_subagent_type` |
+
+It does not upload prompts, responses, thoughts, tool inputs or outputs, attachments, system prompts, subagent tasks, descriptions, or results, raw errors, custom metadata, or tags. Replica routing overrides are preserved, but their `updates` are ignored in metadata-only mode.
+
+In full mode, the plugin uploads conversation content, including prompts, responses, and tool inputs and outputs. When the master switch is off, the plugin uploads nothing.
 
 ## Verify setup
 
@@ -110,7 +151,7 @@ export CC_LANGSMITH_METADATA='{"author":"jane","environment":"development"}'
 
 </Tabs>
 
-The metadata keys and values will appear on all runs in LangSmith, which you can use to filter and search traces.
+In full mode, the metadata keys and values appear on all runs in LangSmith, where you can use them to filter and search traces. Metadata-only mode excludes custom metadata.
 
 ## Usage with GitHub Actions
 
@@ -232,7 +273,7 @@ Each replica object supports the following fields:
 | `apiUrl` | Yes | LangSmith API URL (typically `https://api.smith.langchain.com`) |
 | `apiKey` | Yes | API key for the destination [workspace](/langsmith/administration-overview#workspaces) |
 | `projectName` | Yes | Project name in the destination workspace |
-| `updates` | No | Optional metadata/fields to override on the replicated runs |
+| `updates` | No | Optional metadata or fields to override on replicated runs. Ignored in metadata-only mode. |
 
 There are two ways to set the `CC_LANGSMITH_RUNS_ENDPOINTS` environment variable:
 
@@ -285,8 +326,8 @@ export CC_LANGSMITH_RUNS_ENDPOINTS='[{"apiUrl":"https://api.smith.langchain.com"
    ```
    You should see log entries after each Claude response.
 
-2. **Verify environment variables**:
-   - Check that `TRACE_TO_LANGSMITH="true"` in your project's `.claude/settings.local.json`.
+2. **Verify configuration**:
+   - Check the effective master switch using the precedence table above.
    - Verify your Personal Access Token (PAT) is correct (starts with `lsv2_pt_`).
    - Ensure the project name exists in LangSmith.
 

--- a/src/langsmith/trace-with-codex.mdx
+++ b/src/langsmith/trace-with-codex.mdx
@@ -35,6 +35,17 @@ enabled = true
 
 Tracing is disabled until either `TRACE_TO_LANGSMITH` is `"true"` or `enabled` is `true` in a config file. Configure credentials with environment variables, a JSON config file, or both.
 
+The master switch uses the first source that defines it:
+
+| Priority | Source | Enabled value |
+| --- | --- | --- |
+| 1 | `TRACE_TO_LANGSMITH` environment variable | `"true"` |
+| 2 | Project `.codex/langsmith.json` | `{"enabled": true}` |
+| 3 | User `~/.codex/langsmith.json` | `{"enabled": true}` |
+| 4 | Default | Disabled |
+
+A higher-precedence `false` overrides lower-precedence `true`. Any malformed configured source disables tracing.
+
 ### Environment variables
 
 The plugin reads Codex-specific variables first, then falls back to the generic LangSmith SDK variables.
@@ -144,11 +155,44 @@ Each replica object supports the following fields:
 | `apiUrl` | Yes | LangSmith API URL (typically `https://api.smith.langchain.com`). |
 | `apiKey` | Yes | API key for the destination workspace. |
 | `projectName` | Yes | Project name in the destination workspace. |
-| `updates` | No | Optional run fields to override on replicated runs, such as extra metadata. |
+| `updates` | No | Optional run fields to override on replicated runs, such as extra metadata. Ignored in metadata-only mode. |
+
+## Control tracing per thread
+
+<Note>
+Per-thread trace controls require version 0.0.8 or later of the `tracing` marketplace plugin.
+</Note>
+
+Use these exact lowercase prompts in a Codex session:
+
+| Command | Stored thread mode | Effective behavior when the master switch is enabled |
+| --- | --- | --- |
+| `/trace on` | Full | Uploads trace content and metadata. |
+| `/trace off` | Metadata only | Uploads only the safe metadata listed below, with trace topology and timing. |
+| `/trace status` | Unchanged | Reports the effective master-disabled condition when the master switch is off; otherwise reports the stored mode. |
+
+The master switch remains dominant. While it is disabled, `/trace on` and `/trace off` can update the stored per-thread preference, but no command can cause an upload. Control prompts are intercepted and are not traced.
+
+The plugin snapshots the mode for the current turn when you submit its prompt. Mode transitions apply only to later turns and do not backfill or alter earlier turns. Subagents inherit the mode of the turn that launches them.
+
+The preference persists in `~/.codex/langsmith-state.json`. If this state is corrupt, tracing fails closed to metadata-only mode until `/trace on` or `/trace off` safely recovers the state.
+
+### Metadata-only allowlist
+
+Metadata-only mode retains run topology and timing, sets every run's inputs and outputs to `{}`, and permits only these operational metadata keys:
+
+| Scope | Allowed keys |
+| --- | --- |
+| Trace and turn identity | `thread_id`, `turn_id`, `turn_number`, `status`, `ls_tracing_mode` |
+| Integration identity | `ls_agent_purpose`, `ls_agent_type`, `ls_agent_runtime`, `ls_agent_runtime_version`, `ls_integration`, `ls_integration_version`, `ls_trace_schema_version` |
+| Model and tool operations | `ls_model_name`, `ls_tool_name`, `usage_metadata`, `ls_raw_aggregated_usage` |
+| Subagents | `ls_subagent_id`, `ls_subagent_type` |
+
+It does not upload prompts, responses, thoughts, tool inputs or outputs, attachments, system prompts, subagent tasks, descriptions, or results, raw errors, custom metadata, or tags. Replica routing overrides are preserved, but their `updates` are ignored in metadata-only mode.
 
 ## What gets traced
 
-Each LLM run includes:
+In full mode, each LLM run includes:
 
 - **Inputs**: accumulated conversation messages.
 - **Outputs**: assistant response content.
@@ -160,10 +204,10 @@ Interrupted turns where the user cancels mid-response are still uploaded once th
 
 ## View traces in LangSmith
 
-Open the configured LangSmith project and complete a Codex turn. By default traces appear in the `codex` project. The plugin uploads completed Codex transcript data, including messages, tool call inputs and outputs, model metadata, token usage, and subagent thread structure.
+Open the configured LangSmith project and complete a Codex turn. By default, traces appear in the `codex` project. In full mode, the plugin uploads completed Codex transcript data, including messages, tool call inputs and outputs, model metadata, token usage, and subagent thread structure.
 
 <Warning>
-The plugin uploads full Codex transcript data to LangSmith. Do not enable tracing for sessions that contain data you do not want stored in LangSmith.
+In full mode, the plugin uploads full Codex transcript data to LangSmith. Metadata-only mode uploads only the allowlisted operational metadata above. When the master switch is off, the plugin uploads nothing.
 </Warning>
 
 ## Troubleshooting

--- a/src/langsmith/trace-with-cursor.mdx
+++ b/src/langsmith/trace-with-cursor.mdx
@@ -58,6 +58,17 @@ Restart Cursor after installing so it reloads `hooks.json`.
 
 Tracing is disabled until both `enabled` (or `TRACE_TO_LANGSMITH=true`) and an API key are set. Configure credentials with [environment variables](#environment-variables), a [JSON config file](#config-file), or both.
 
+The master switch uses the first source that defines it:
+
+| Priority | Source | Enabled value |
+| --- | --- | --- |
+| 1 | `TRACE_TO_LANGSMITH` environment variable | `"true"` |
+| 2 | Project `.cursor/langsmith.json` | `{"enabled": true}` |
+| 3 | User `~/.cursor/langsmith.json` | `{"enabled": true}` |
+| 4 | Default | Disabled |
+
+A higher-precedence `false` overrides lower-precedence `true`. A malformed higher-precedence config disables tracing instead of falling back to a lower-precedence source.
+
 ### Environment variables
 
 Every `LANGSMITH_CURSOR_*` variable also accepts the shorter `LANGSMITH_*` form. When both are set, `LANGSMITH_CURSOR_*` takes precedence.
@@ -116,9 +127,41 @@ Use `~/.cursor/langsmith.json` for global defaults or `./.cursor/langsmith.json`
 
 Keep config files that include API keys out of version control.
 
+## Control tracing per thread
+
+<Note>
+Per-thread trace controls require version 0.4.0 or later of the `langsmith-tracing` marketplace plugin.
+</Note>
+
+Use these exact lowercase prompts in a Cursor conversation:
+
+| Command | Stored thread mode | Effective behavior when the master switch is enabled |
+| --- | --- | --- |
+| `/trace on` | Full | Uploads trace content and metadata. |
+| `/trace off` | Metadata only | Uploads only the safe metadata listed below, with trace topology and timing. |
+| `/trace status` | Unchanged | Reports the effective master-disabled condition when the master switch is off; otherwise reports the stored mode. |
+
+The master switch remains dominant. While it is disabled, `/trace on` and `/trace off` can update the stored per-thread preference, but no command can cause an upload. Control prompts are intercepted and are not traced.
+
+The plugin snapshots the mode for the current turn when you submit its prompt. Mode transitions apply only to later turns and do not backfill or alter earlier turns. Subagents inherit the mode of the turn that launches them.
+
+The preference persists in `~/.cursor/langsmith-state.json`, or the path set by `LANGSMITH_CURSOR_STATE_FILE`. If this state is corrupt, tracing fails closed to metadata-only mode until `/trace on` or `/trace off` safely recovers the state.
+
+### Metadata-only allowlist
+
+Metadata-only mode retains run topology and timing, sets every run's inputs and outputs to `{}`, and permits only these operational metadata keys:
+
+| Scope | Allowed keys |
+| --- | --- |
+| Every run | `thread_id`, `turn_number`, `status`, `ls_agent_purpose`, `ls_agent_type`, `ls_agent_runtime`, `ls_tracing_mode` |
+| Model runs | `ls_model_name`, `usage_metadata` |
+| Tool runs | `ls_tool_name` |
+
+It does not upload prompts, responses, thoughts, tool inputs or outputs, attachments, system prompts, subagent tasks, descriptions, or results, raw errors, custom metadata, or tags. Replica routing overrides are preserved, but their `updates` are ignored in metadata-only mode.
+
 ## What gets traced
 
-The plugin listens to Cursor hooks and assembles one trace per agent turn:
+In full mode, the plugin listens to Cursor hooks and assembles one trace per agent turn:
 
 - **Turns**: each turn becomes its own trace, grouped into a thread using `thread_id` = Cursor's `conversation_id`. The trace nests the model run and any tool or subagent runs underneath the turn.
 - **Token usage**: per-turn `usage_metadata` on the model run.
@@ -132,7 +175,7 @@ The plugin does not compute cost locally. Because `ls_model_name` is normalized 
 </Note>
 
 <Warning>
-The plugin uploads Cursor conversation data, including prompts, model responses, tool inputs and outputs, and recovered attachments. Do not enable tracing for sessions that contain data you do not want stored in LangSmith.
+In full mode, the plugin uploads Cursor conversation data, including prompts, model responses, tool inputs and outputs, and recovered attachments. Metadata-only mode uploads only the allowlisted operational metadata above. When the master switch is off, the plugin uploads nothing.
 </Warning>
 
 ### Trace metadata


### PR DESCRIPTION
## Overview

Document sticky per-thread trace controls for the Cursor, Claude Code, and OpenAI Codex plugins. The updates define master-switch precedence, forward-only mode snapshots, metadata-only privacy guarantees, replica behavior, subagent inheritance, state recovery, and minimum plugin versions.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Feature PRs: companion plugin PRs in the Cursor, Claude Code, and Codex repositories

## Checklist

- [x] I have read the contributing guidelines, including the language policy
- [ ] I have tested my changes locally using `docs dev`
- [x] All code examples have been checked against the plugin implementations
- [x] I have used root relative paths for internal links
- [x] Navigation does not need an update because no pages were added or moved

## Additional notes

- Focused Vale prose lint passed with 0 errors, warnings, or suggestions.
- The documented allowlists and state paths were verified against the companion implementations.
- AI agent involvement: implementation and verification were assisted by Open SWE.

Made by [Open SWE](https://openswe.vercel.app/agents/ead9ba92-aefb-5aca-88eb-712865f67ae9)