### PR TITLE
fix: replace dict[str, Any] tool param that breaks OpenAI strict mode

### DIFF
--- a/src/oss/langchain/tools.mdx
+++ b/src/oss/langchain/tools.mdx
@@ -328,7 +328,6 @@ Access the store through `runtime.store`. The store uses a namespace/key pattern
 </Tip>
 
 ```python expandable
-from typing import Any
 from langgraph.store.memory import InMemoryStore
 from langchain.agents import create_agent
 from langchain.tools import tool, ToolRuntime
@@ -344,10 +343,10 @@ def get_user_info(user_id: str, runtime: ToolRuntime) -> str:
 
 # Update memory
 @tool
-def save_user_info(user_id: str, user_info: dict[str, Any], runtime: ToolRuntime) -> str:
+def save_user_info(user_id: str, name: str, age: int, email: str, runtime: ToolRuntime) -> str:
     """Save user info."""
     store = runtime.store
-    store.put(("users",), user_id, user_info)
+    store.put(("users",), user_id, {"name": name, "age": age, "email": email})
     return "Successfully saved user info."
 
 model = ChatOpenAI(model="gpt-5.5")


### PR DESCRIPTION
## What
Replaces the `user_info: dict[str, Any]` parameter in the `save_user_info`
tool example on the Tools page with explicit `name`, `age`, `email` fields.

## Why
`dict[str, Any]` generates a JSON schema with `additionalProperties: true`
on that field (verified directly against installed langchain), which
OpenAI's strict function-calling mode rejects with:
`BadRequestError: Invalid JSON schema - the "additionalProperties"...`

This is the exact error reported in #3161 (Long-Term-Memory code block
throwing BadRequestError). That page was already fixed via a TypedDict
approach, but the same anti-pattern remained here. The fix matches the
JS version of this same example, which already uses a flat Zod schema.

Closes #3161

## Type of change
- [x] Fix typo/bug/link/formatting

Diff size: 1 file changed, 2 insertions(+), 3 deletions(-)