### PR TITLE
fix: undefined 'tools' variable in Python structured-output examples

### DIFF
--- a/src/oss/langchain/structured-output.mdx
+++ b/src/oss/langchain/structured-output.mdx
@@ -179,7 +179,7 @@ LangChain automatically uses `ProviderStrategy` when you pass a schema type dire
 
     agent = create_agent(
         model="gpt-5.5",
-        tools=tools,
+        tools=[],
         response_format=ContactInfo  # Auto-selects ProviderStrategy
     )
 
@@ -204,7 +204,7 @@ LangChain automatically uses `ProviderStrategy` when you pass a schema type dire
 
     agent = create_agent(
         model="gpt-5.5",
-        tools=tools,
+        tools=[],
         response_format=ContactInfo  # Auto-selects ProviderStrategy
     )
 
@@ -235,7 +235,7 @@ LangChain automatically uses `ProviderStrategy` when you pass a schema type dire
 
     agent = create_agent(
         model="gpt-5.5",
-        tools=tools,
+        tools=[],
         response_format=ProviderStrategy(contact_info_schema)
     )
 
@@ -424,7 +424,7 @@ class ToolStrategy(Generic[SchemaT]):
 
     agent = create_agent(
         model="gpt-5.5",
-        tools=tools,
+        tools=[],
         response_format=ToolStrategy(ProductReview)
     )
 
@@ -451,7 +451,7 @@ class ToolStrategy(Generic[SchemaT]):
 
     agent = create_agent(
         model="gpt-5.5",
-        tools=tools,
+        tools=[],
         response_format=ToolStrategy(ProductReview)
     )
 
@@ -477,7 +477,7 @@ class ToolStrategy(Generic[SchemaT]):
 
     agent = create_agent(
         model="gpt-5.5",
-        tools=tools,
+        tools=[],
         response_format=ToolStrategy(ProductReview)
     )
 
@@ -520,7 +520,7 @@ class ToolStrategy(Generic[SchemaT]):
 
     agent = create_agent(
         model="gpt-5.5",
-        tools=tools,
+        tools=[],
         response_format=ToolStrategy(product_review_schema)
     )
 
@@ -552,7 +552,7 @@ class ToolStrategy(Generic[SchemaT]):
 
     agent = create_agent(
         model="gpt-5.5",
-        tools=tools,
+        tools=[],
         response_format=ToolStrategy(Union[ProductReview, CustomerComplaint])
     )
 


### PR DESCRIPTION
## What
Fixes 8 instances of `tools=tools` (undefined variable) in the Python
Structured Output examples, changing them to `tools=[]`.

## Why
`tools` is never defined in these self-contained snippets — copying any
of them as-is raises `NameError: name 'tools' is not defined`. This is
the exact same bug already fixed on the JavaScript side of this same
page in #1359 (`tools: tools` → `tools: []`), which was missed on the
Python side. The sibling "Pydantic" tab already correctly omits the
argument, and four other calls later in the file already use `tools=[]`,
confirming this is the page's established pattern.

## Type of change
- [x] Fix typo/bug/link/formatting

Diff size: 1 file changed, 8 insertions(+), 8 deletions(-)