### PR TITLE
fix: undefined 'tools' variable in Models dynamic-model-selection example

### DIFF
--- a/src/oss/langchain/models.mdx
+++ b/src/oss/langchain/models.mdx
@@ -2127,7 +2127,7 @@ def dynamic_model_selection(request: ModelRequest, handler) -> ModelResponse:
 
 agent = create_agent(
     model=basic_model,  # Default model
-    tools=tools,
+    tools=[],
     middleware=[dynamic_model_selection]
 )
 ```
@@ -2163,7 +2163,7 @@ const dynamicModelSelection = createMiddleware({
 
 const agent = createAgent({
   model: "gpt-5.4-mini", // Base model (used when messageCount ≤ 10)
-  tools,
+  tools: [],
   middleware: [dynamicModelSelection],
 });
 ```


### PR DESCRIPTION
## What
Fixes an undefined `tools` variable passed to `create_agent`/`createAgent`
in the "Dynamic model selection" example on the Models page, in both
the Python and JavaScript versions.

## Why
Neither snippet defines `tools` anywhere — only the models and middleware
are defined. Copying either block as-is raises NameError (Python) or
ReferenceError (JS). Same bug class as already fixed in
structured-output.mdx, itself following precedent PR #1359. Uses the
same established `tools=[]` / `tools: []` convention for consistency.

## Type of change
- [x] Fix typo/bug/link/formatting

Diff size: 1 file changed, 2 insertions(+), 2 deletions(-)