### PR TITLE
docs: remove Deep Agents Code sidebar

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -2534,36 +2534,6 @@
               "langsmith/engine-security",
               "langsmith/engine-self-hosted"
             ]
-          },
-          {
-            "item": "Deep Agents Code",
-            "icon": "code",
-            "description": "Code with an agent in your terminal",
-            "pages": [
-              "oss/deepagents/code/overview",
-              "oss/deepagents/code/quickstart",
-              "oss/deepagents/code/cli-reference",
-              "oss/deepagents/code/approval-modes",
-              "oss/deepagents/code/goals-and-rubrics",
-              "oss/deepagents/code/plugins",
-              "oss/deepagents/code/extensions",
-              "oss/deepagents/code/memory-and-skills",
-              "oss/deepagents/code/remote-sandboxes",
-              "oss/deepagents/code/subagents",
-              "oss/deepagents/code/providers",
-              {
-                "group": "Configuration",
-                "root": "oss/deepagents/code/configuration",
-                "expanded": true,
-                "pages": [
-                  "oss/deepagents/code/credentials",
-                  "oss/deepagents/code/config-file",
-                  "oss/deepagents/code/hooks",
-                  "oss/deepagents/code/mcp-tools"
-                ]
-              },
-              "oss/deepagents/code/changelog"
-            ]
           }
         ]
       }


### PR DESCRIPTION
### Summary

Remove Deep Agents Code from the Products and setup sidebar while retaining its high-level links and documentation pages.

### Testing

- `python -m json.tool src/docs.json`
- `git diff --check`

Made by [Open SWE](https://openswe.vercel.app/agents/f1c6a8c6-902a-5046-8d74-4bfe3967866b)