### PR TITLE
docs: clarify Align Evaluator score limits

### DIFF
--- a/src/langsmith/improve-judge-evaluator-feedback.mdx
+++ b/src/langsmith/improve-judge-evaluator-feedback.mdx
@@ -19,7 +19,7 @@ This guide describes how to align your LLM-as-a-judge evaluator using human feed
 LangSmith's **Align Evaluator** feature has a series of steps that help you align your LLM-as-a-judge evaluator with human expert feedback. You can use this feature to align evaluators that run on a dataset for [offline evaluations](/langsmith/evaluation-concepts#offline-evaluations) or for [online evaluations](/langsmith/evaluation-concepts#online-evaluations).
 
 <Note>
-Align Evaluator currently supports evaluators that return exactly one binary feedback key. Evaluators that return multiple feedback keys or non-binary scores cannot use alignment queues. This restriction is a product limitation, not a recommendation against collecting or correcting non-binary scores.
+Align Evaluator currently supports evaluators that return exactly one binary feedback key. Evaluators that return multiple feedback keys or non-binary scores cannot use alignment queues.
 </Note>
 
 In either case, the steps are similar:

--- a/src/langsmith/improve-judge-evaluator-feedback.mdx
+++ b/src/langsmith/improve-judge-evaluator-feedback.mdx
@@ -16,7 +16,13 @@ This guide describes how to align your LLM-as-a-judge evaluator using human feed
 
 ## How it works
 
-LangSmith's **Align Evaluator** feature has a series of steps that help you align your LLM-as-a-judge evaluator with human expert feedback. You can use this feature to align evaluators that run on a dataset for [offline evaluations](/langsmith/evaluation-concepts#offline-evaluations) or for [online evaluations](/langsmith/evaluation-concepts#online-evaluations). In either case, the steps are similar:
+LangSmith's **Align Evaluator** feature has a series of steps that help you align your LLM-as-a-judge evaluator with human expert feedback. You can use this feature to align evaluators that run on a dataset for [offline evaluations](/langsmith/evaluation-concepts#offline-evaluations) or for [online evaluations](/langsmith/evaluation-concepts#online-evaluations).
+
+<Note>
+Align Evaluator currently supports evaluators that return exactly one binary feedback key. Evaluators that return multiple feedback keys or non-binary scores cannot use alignment queues. This restriction is a product limitation, not a recommendation against collecting or correcting non-binary scores.
+</Note>
+
+In either case, the steps are similar:
 
 1. **Select experiments or runs** that contain outputs from your application.
 2. Add the selected experiments or runs to an **annotation queue** where a human expert can label the data.


### PR DESCRIPTION
## Overview

Clarify that Align Evaluator currently requires exactly one binary feedback key. Explain that multiple feedback keys and non-binary scores cannot use alignment queues because of a known product limitation, not because non-binary scores should not be corrected.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: N/A
- Feature PR: N/A
- Linear issue: N/A
- Slack thread: Internal discussion

## Checklist

- [x] I have read the contributing guidelines

## Additional notes

Validated the changed page with the focused prose linter.

Made by [Open SWE](https://openswe.vercel.app/agents/1b05c0eb-6075-594c-847e-66a97388e52c)