### PR TITLE
docs: fix NameError in Azure Cosmos DB NoSQL vector store example

### DIFF
--- a/src/oss/python/integrations/vectorstores/azure_cosmos_db_no_sql.mdx
+++ b/src/oss/python/integrations/vectorstores/azure_cosmos_db_no_sql.mdx
@@ -134,7 +134,7 @@ container_name = "langchain_python_container"
 partition_key = PartitionKey(path="/id")
 cosmos_container_properties = {"partition_key": partition_key}
 
-openai_embeddings = OpenAIEmbeddings(
+openai_embeddings = AzureOpenAIEmbeddings(
     deployment="smart-agent-embedding-ada",
     model="text-embedding-ada-002",
     chunk_size=1,


### PR DESCRIPTION
## Overview
The example imports `AzureOpenAIEmbeddings` from `langchain_openai` but
instantiates the unimported `OpenAIEmbeddings` class instead, which raises
a `NameError` when run as written. The `deployment=` kwarg used is
Azure-specific, confirming `AzureOpenAIEmbeddings` was the intended class.

## Type of change
**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue:
- Feature PR:

## Checklist
- [x] I have read the contributing guidelines
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
Minimal one-line diff — no other changes in this file.