### PR TITLE
docs: fix missing traceable import in Instructor tracing guide

### DIFF
--- a/src/langsmith/trace-with-instructor.mdx
+++ b/src/langsmith/trace-with-instructor.mdx
@@ -66,7 +66,9 @@ Oftentimes, you use `instructor` inside of other functions.
 You can get nested traces by using this wrapped client and decorating those functions with `@traceable`.
 Please see [Custom instrumentation](/langsmith/annotate-code) for more information on how to annotate your code for tracing with the `@traceable` decorator.
 
-```python {highlight={2}}
+```python {highlight={4}}
+from langsmith import traceable
+
 # You can customize the run name with the `name` keyword argument
 @traceable(name="Extract User Details")
 def my_function(text: str) -> UserDetail:


### PR DESCRIPTION
## Overview
The final example in this tutorial uses the `@traceable` decorator but
never imports it, so following the guide step by step raises a
NameError. Added `from langsmith import traceable`, matching the
import pattern used consistently elsewhere in the LangSmith docs.

## Type of change
**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue:
- Feature PR:

## Checklist
- [x] I have read the contributing guidelines
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
Also bumped the code block's `{highlight={2}}` to `{highlight={4}}`
since the import line shifts the `@traceable` line down by two.