### PR TITLE
docs: fix missing InMemorySaver import in handoffs complete example

### DIFF
--- a/src/oss/langchain/multi-agent/handoffs.mdx
+++ b/src/oss/langchain/multi-agent/handoffs.mdx
@@ -184,6 +184,7 @@ from langchain.agents import AgentState, create_agent
 from langchain.agents.middleware import wrap_model_call, ModelRequest, ModelResponse
 from langchain.tools import tool, ToolRuntime
 from langchain.messages import ToolMessage
+from langgraph.checkpoint.memory import InMemorySaver
 from langgraph.types import Command
 from typing import Callable
 


### PR DESCRIPTION
## Overview
The "Complete example: Customer support with middleware" code block
passes checkpointer=InMemorySaver() but never imports InMemorySaver,
so running the example as written raises a NameError. Added
`from langgraph.checkpoint.memory import InMemorySaver`, matching the
import path used consistently elsewhere in the docs.

## Type of change
**Type:** Fix typo/bug/link/formatting

## Related issues/PRs
- GitHub issue:
- Feature PR:

## Checklist
- [x] I have read the contributing guidelines
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
Single-line addition, no other changes.