### PR TITLE
docs: clarify LLM augmentation examples

### DIFF
--- a/src/oss/langgraph/workflows-agents.mdx
+++ b/src/oss/langgraph/workflows-agents.mdx
@@ -93,9 +93,11 @@ from pydantic import BaseModel, Field
 
 
 class SearchQuery(BaseModel):
-    search_query: str = Field(None, description="Query that is optimized web search.")
-    justification: str = Field(
-        None, description="Why this query is relevant to the user's request."
+    search_query: str | None = Field(
+        default=None, description="Query that is optimized web search."
+    )
+    justification: str | None = Field(
+        default=None, description="Why this query is relevant to the user's request."
     )
 
 
@@ -104,6 +106,7 @@ structured_llm = llm.with_structured_output(SearchQuery)
 
 # Invoke the augmented LLM
 output = structured_llm.invoke("How does Calcium CT score relate to high cholesterol?")
+print(output)  # The model returns an instance of SearchQuery.
 
 # Define a tool
 def multiply(a: int, b: int) -> int:
@@ -114,9 +117,7 @@ llm_with_tools = llm.bind_tools([multiply])
 
 # Invoke the LLM with input that triggers the tool call
 msg = llm_with_tools.invoke("What is 2 times 3?")
-
-# Get the tool call
-msg.tool_calls
+print(msg.tool_calls)  # The model returns a request to call the tool.
 ```
 :::
 :::js


### PR DESCRIPTION
## Summary

This PR clarifies the LangGraph "LLMs and augmentations" documentation examples by making the returned values from structured output and tool-calling invocations explicit.

### Changes

* Display the result returned by the structured-output LLM invocation.
* Display `msg.tool_calls` for the tool-calling example.
* Update the `SearchQuery` Pydantic model to use modern `str | None` optional annotations with `default=None`.
* Keep the changes scoped to the existing documentation example without modifying unrelated content.

## Validation

* `make lint_prose FILES=src/oss/langgraph/workflows-agents.mdx` ✅
* Python syntax validation of the updated code block ✅
* Pydantic model validation using the repository environment ✅

The actual LLM invocations were not executed because they require external provider credentials.

Closes #5298
