### PR TITLE
docs(middleware): point NeuralTrust listing to partner docs

### DIFF
--- a/scripts/data/integration_external_docs.yaml
+++ b/scripts/data/integration_external_docs.yaml
@@ -962,7 +962,7 @@ python:
     source: "[`cisco-ai-defense/ai-defense-langchain-middleware`](https://github.com/cisco-ai-defense/ai-defense-langchain-middleware)"
   - name: NeuralTrust TrustGuard
     pypi: langchain-neuraltrust
-    docs_url: https://github.com/NeuralTrust/langchain-neuraltrust
+    docs_url: https://docs.neuraltrust.ai/integrations/langchain
     available: TrustGuard evaluate middleware. Allow, block, report, or transform agent input, model output, and optional tool traffic.
     source: "[`NeuralTrust/langchain-neuraltrust`](https://github.com/NeuralTrust/langchain-neuraltrust)"
   - name: DeepKeep middleware

--- a/src/oss/python/integrations/providers/all_providers.mdx
+++ b/src/oss/python/integrations/providers/all_providers.mdx
@@ -1915,7 +1915,7 @@ Browse the complete collection of integrations available for Python. LangChain P
 
     <Card
         title="NeuralTrust"
-        href="https://github.com/NeuralTrust/langchain-neuraltrust"
+        href="https://docs.neuraltrust.ai/integrations/langchain"
         icon="link"
     >
         TrustGuard middleware that allows, blocks, reports, or transforms agent input, model output, and tool traffic.


### PR DESCRIPTION
## Overview

Updates the `langchain-neuraltrust` middleware listing to link to the [NeuralTrust LangChain guide](https://docs.neuraltrust.ai/integrations/langchain).

The listing added in #5610 linked to the GitHub README because a separate partner guide was not yet available. The guide is now published, matching the [documented preference for partner docs](https://docs.langchain.com/oss/python/contributing/publish-langchain#list-in-the-download-table-default). The Source column continues to link to the package repository.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: n/a (metadata-only follow-up to the approved listing in #5610, per the integration publishing guide)
- Feature PR: #5610

## Checklist

- [x] I have read the contributing guidelines, including the language policy
- [x] I have tested my changes locally using `docs dev` (n/a: one external URL in listing metadata; validation below)
- [x] All code examples have been tested and work correctly (n/a: no code examples changed)
- [x] I have used **root relative** paths for internal links (n/a: external HTTPS URL only)
- [x] I have updated navigation in `src/docs.json` if needed (not needed)

## Additional notes

AI assistance was used to prepare and verify this update.

Validation:

- `uv run --frozen python scripts/refresh_integration_downloads.py --check-docs-urls` passes.
- The new guide returns HTTP 200 with no redirects and declares the same canonical URL.
- Checked the row with the existing generator and cached download count: only the Provider link changes; the GitHub Source link is preserved.
- `git diff --check` passes. `make lint_prose FILES=scripts/data/integration_external_docs.yaml` reports no applicable files.

The PR changes only `docs_url`. Generated snippets are updated by the refresh job after merge.
