### PR TITLE
docs(langgraph): document which checkpoints exist before the first node runs per durability mode

### DIFF
--- a/src/oss/langgraph/checkpointers.mdx
+++ b/src/oss/langgraph/checkpointers.mdx
@@ -602,6 +602,26 @@ The durability modes, from least to most durable, are as follows:
 * `"async"`: LangGraph persists changes asynchronously while the next step executes. This provides good performance and durability, but there is a small risk that LangGraph does not write checkpoints if the process crashes during execution.
 * `"sync"`: LangGraph persists changes synchronously before the next step starts. This ensures that LangGraph writes every checkpoint before continuing execution, providing high durability at the cost of some performance overhead.
 
+### What exists before the first node runs
+
+The durability mode also determines which checkpoints are committed before the first node executes:
+
+* `"exit"`: No checkpoint exists until the run ends. A crash during the run leaves no record of the thread.
+* `"async"`: LangGraph starts writing the input checkpoint before the first node executes, but does not wait for the write to finish. The first node can run before any checkpoint is committed.
+* `"sync"`: LangGraph commits the input checkpoint (step `-1`) and the step `0` checkpoint before the first node executes.
+
+In every mode, a crash during the first checkpoint write leaves the thread indistinguishable from a thread that was never invoked:
+
+:::python
+`get_tuple()` returns `None` in both cases, and `invoke(None, config)` raises `EmptyInputError`.
+:::
+
+:::js
+`getTuple()` returns `undefined` in both cases, and `invoke(null, config)` raises `EmptyInputError`.
+:::
+
+If you need to distinguish "never accepted" from "accepted but lost", record admission outside the checkpointer, for example by committing an outbox row to your own store before you call `invoke`.
+
 ## Optimize checkpoint storage
 
 :::python

--- a/src/oss/langgraph/checkpointers.mdx
+++ b/src/oss/langgraph/checkpointers.mdx
@@ -604,13 +604,13 @@ The durability modes, from least to most durable, are as follows:
 
 ### What exists before the first node runs
 
-The durability mode also determines which checkpoints are committed before the first node executes:
+For a new thread, the durability mode also determines which checkpoints are committed before the first node executes:
 
 * `"exit"`: No checkpoint exists until the run ends. A crash during the run leaves no record of the thread.
 * `"async"`: LangGraph starts writing the input checkpoint before the first node executes, but does not wait for the write to finish. The first node can run before any checkpoint is committed.
 * `"sync"`: LangGraph commits the input checkpoint (step `-1`) and the step `0` checkpoint before the first node executes.
 
-In every mode, a crash during the first checkpoint write leaves the thread indistinguishable from a thread that was never invoked:
+In every mode, a crash before the first checkpoint becomes durable leaves the thread indistinguishable from a thread that was never invoked:
 
 :::python
 `get_tuple()` returns `None` in both cases, and `invoke(None, config)` raises `EmptyInputError`.


### PR DESCRIPTION
## Overview

Adds a short subsection, **What exists before the first node runs**, under *Durability modes* in `src/oss/langgraph/checkpointers.mdx`. It states which checkpoints are committed before the first node executes in each mode, that a crash during the first checkpoint write leaves the thread indistinguishable from one that was never invoked, and that callers who need to tell those apart must record admission outside the checkpointer.

Verified against `langgraph==1.2.11` / `langgraph-checkpoint-sqlite==3.1.1` by recording `SqliteSaver.put()` calls and counting `checkpoints` rows from inside the first node:

| durability | committed before first node runs |
|---|---|
| `"sync"` | input (step -1) and step 0, deterministically (200/200 runs) |
| `"async"` | not guaranteed: 0 rows in 90/200 runs, input only in 48, input + step 0 in 13, remainder mid-commit |
| `"exit"` | none (200/200 runs) |

The `"async"` row is the one that is easy to get wrong; the write is submitted before the node runs but nothing waits on it (`Pregel.stream` only calls `loop._put_checkpoint_fut.result()` when `durability == "sync"`).

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: See langchain-ai/langgraph#8764 for context (reporter agreed on the narrowed scope of "document the pre-first-node checkpoint guarantee and the admission limitation")
- Feature PR: none; no runtime change proposed

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev` (prose linted with the pinned Vale 3.17.1: 0 errors)
- [x] All code examples have been tested and work correctly (no new code examples; the Python/JS names `get_tuple`/`getTuple`, `EmptyInputError` were checked against both repos)
- [x] I have used **root relative** paths for internal links (no new links)
- [ ] I have updated navigation in `src/docs.json` if needed (not needed; subsection only)

## Additional notes

The Python and JS variants differ only in `None`/`undefined` and `invoke(None, …)`/`invoke(null, …)`, so they are split with `:::python` / `:::js` fences.
