### PR TITLE
docs: clarify BYOC upgrade cadence

### DIFF
--- a/src/langsmith/byoc-operations.mdx
+++ b/src/langsmith/byoc-operations.mdx
@@ -28,16 +28,12 @@ Data planes are provisioned with default instance sizes for the databases and no
 
 ## LangSmith upgrades
 
-LangChain upgrades the LangSmith version in your data plane once a week. Upgrades are rolling, replica-by-replica, so there is no whole-service downtime.
+LangChain upgrades the LangSmith version in your data plane daily. Upgrades are rolling, replica-by-replica, so there is no whole-service downtime.
 
 Two mechanisms keep upgrades free of downtime:
 
 - **Horizontal pod autoscaling**: LangSmith services run multiple replicas, sized by a horizontal pod autoscaler, so pods are replaced a few at a time while the remaining replicas continue serving traffic.
 - **Pod disruption budgets**: A pod disruption budget caps how many replicas of a service can be unavailable at once, so neither a rolling update nor a node drain takes a service below the capacity it needs to stay available.
-
-<Note>
-Support for release channels is coming soon.
-</Note>
 
 ## Supporting service upgrades
 


### PR DESCRIPTION
## Overview

Update the BYOC operations page to reflect daily LangSmith upgrades and remove the outdated release channels note.

## Type of change

**Type:** Update existing documentation

## Checklist

- [x] I have read the contributing guidelines
- [x] No code examples or links were changed
- [x] Navigation changes are not needed
- [x] `make lint_prose FILES="src/langsmith/byoc-operations.mdx"` passes

Made by [Open SWE](https://openswe.vercel.app/agents/95824ae2-b705-5c94-b601-337cde6ffebc)