### PR TITLE
Fix OTel URLs/variables (explicitly use "TRACES" suffix)

### DIFF
--- a/src/langsmith/deploy-other-frameworks.mdx
+++ b/src/langsmith/deploy-other-frameworks.mdx
@@ -602,7 +602,7 @@ dependencies = [
 LANGSMITH_API_KEY=your-langsmith-api-key
 LANGSMITH_TRACING=true
 LANGSMITH_PROJECT=my-strands-agent
-OTEL_EXPORTER_OTLP_ENDPOINT=https://api.smith.langchain.com/otel/v1/traces
+OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://api.smith.langchain.com/otel/v1/traces
 OTEL_EXPORTER_OTLP_HEADERS=x-api-key=your-langsmith-api-key,Langsmith-Project=my-strands-agent
 AWS_REGION=your-aws-region
 AWS_PROFILE=your-aws-profile

--- a/src/langsmith/trace-with-microsoft-agent-framework.mdx
+++ b/src/langsmith/trace-with-microsoft-agent-framework.mdx
@@ -30,7 +30,7 @@ Enable OpenTelemetry instrumentation of the agent and set the OpenTelemetry envi
 ```bash
 export ENABLE_INSTRUMENTATION=true
 export OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
-export OTEL_EXPORTER_OTLP_ENDPOINT=https://api.smith.langchain.com/otel/v1/traces
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://api.smith.langchain.com/otel/v1/traces
 export OTEL_EXPORTER_OTLP_HEADERS="x-api-key=<your_langsmith_api_key>,Langsmith-Project=<your_project_name>"
 ```
 

--- a/src/langsmith/trace-with-opentelemetry.mdx
+++ b/src/langsmith/trace-with-opentelemetry.mdx
@@ -708,12 +708,12 @@ For more advanced scenarios, you can use the OpenTelemetry Collector to fan out 
 
    exporters:
      otlphttp/langsmith:
-       endpoint: https://api.smith.langchain.com/otel/v1/traces
+       traces_endpoint: https://api.smith.langchain.com/otel/v1/traces
        headers:
          x-api-key: ${env:LANGSMITH_API_KEY}
          Langsmith-Project: my_project
      otlphttp/other_provider:
-       endpoint: https://otel.your-provider.com/v1/traces
+       traces_endpoint: https://otel.your-provider.com/v1/traces
        headers:
          api-key: ${env:OTHER_PROVIDER_API_KEY}
 

--- a/src/langsmith/trace-with-strands-agents.mdx
+++ b/src/langsmith/trace-with-strands-agents.mdx
@@ -31,7 +31,7 @@ This installs LangSmith, Strands Agents, Strands Agents tools, and the OpenTelem
 Set your [LangSmith API key](/langsmith/create-account-api-key) and project name. If you use Amazon Bedrock as the model provider for Strands Agents, also configure AWS credentials with your preferred AWS authentication method.
 
 ```bash
-export OTEL_EXPORTER_OTLP_ENDPOINT=https://api.smith.langchain.com/otel/v1/traces
+export OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=https://api.smith.langchain.com/otel/v1/traces
 export OTEL_EXPORTER_OTLP_HEADERS="x-api-key=<your_langsmith_api_key>,Langsmith-Project=<your_project_name>"
 
 # Required when using Amazon Bedrock.

--- a/tests/unit_tests/test_otel_endpoints.py
+++ b/tests/unit_tests/test_otel_endpoints.py
@@ -1,0 +1,109 @@
+"""Unit tests for OpenTelemetry endpoint configurations and docs accuracy."""
+
+import os
+import re
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+
+DOCS_DIR = Path(__file__).resolve().parents[2] / "src"
+
+
+def test_docs_no_generic_otlp_endpoint_with_signal_path() -> None:
+    """Verify docs never set generic OTEL_EXPORTER_OTLP_ENDPOINT with a signal path."""
+    bad_pattern = re.compile(
+        r"OTEL_EXPORTER_OTLP_ENDPOINT\s*=\s*['\"]?https?://[^\s'\"]+/v1/(traces|metrics|logs)"
+    )
+    violations = []
+    for mdx_path in DOCS_DIR.glob("**/*.mdx"):
+        content = mdx_path.read_text(encoding="utf-8")
+        for i, line in enumerate(content.splitlines(), start=1):
+            if bad_pattern.search(line):
+                rel_path = mdx_path.relative_to(DOCS_DIR.parent)
+                violations.append(f"{rel_path}:{i} - {line.strip()}")
+
+    assert not violations, (
+        "Found generic OTEL_EXPORTER_OTLP_ENDPOINT with signal suffix:\n"
+        + "\n".join(violations)
+    )
+
+
+def test_docs_collector_configs_use_traces_endpoint() -> None:
+    """Verify collector exporter YAML configs use traces_endpoint for /v1/traces."""
+    bad_pattern = re.compile(r"\bendpoint:\s+https?://[^\s]+/v1/traces")
+    violations = []
+    for mdx_path in DOCS_DIR.glob("**/*.mdx"):
+        content = mdx_path.read_text(encoding="utf-8")
+        if "exporters:" not in content:
+            continue
+        for i, line in enumerate(content.splitlines(), start=1):
+            if bad_pattern.search(line):
+                rel_path = mdx_path.relative_to(DOCS_DIR.parent)
+                violations.append(f"{rel_path}:{i} - {line.strip()}")
+
+    assert not violations, (
+        "Found collector exporter using 'endpoint:' with /v1/traces:\n"
+        + "\n".join(violations)
+    )
+
+
+def test_otlp_traces_endpoint_mocked_export() -> None:
+    """Ensure OTEL_EXPORTER_OTLP_TRACES_ENDPOINT resolves without duplicate suffix."""
+    expected_url = "https://api.smith.langchain.com/otel/v1/traces"
+    test_env = {
+        "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT": expected_url,
+    }
+
+    with patch.dict(os.environ, test_env, clear=True):
+        exporter = OTLPSpanExporter()
+        assert exporter._endpoint == expected_url
+
+        with patch.object(exporter._session, "post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200, text="OK")
+
+            provider = TracerProvider()
+            provider.add_span_processor(SimpleSpanProcessor(exporter))
+            tracer = provider.get_tracer("test")
+
+            with tracer.start_as_current_span("test-span"):
+                pass
+
+            provider.force_flush()
+
+            assert mock_post.called
+            called_url = mock_post.call_args.kwargs["url"]
+            assert called_url == expected_url
+            assert not called_url.endswith("/v1/traces/v1/traces")
+
+
+def test_otlp_base_endpoint_appends_single_suffix() -> None:
+    """Ensure OTEL_EXPORTER_OTLP_ENDPOINT base URL appends /v1/traces exactly once."""
+    base_url = "https://api.smith.langchain.com/otel"
+    expected_url = "https://api.smith.langchain.com/otel/v1/traces"
+    test_env = {
+        "OTEL_EXPORTER_OTLP_ENDPOINT": base_url,
+    }
+
+    with patch.dict(os.environ, test_env, clear=True):
+        exporter = OTLPSpanExporter()
+        assert exporter._endpoint == expected_url
+
+        with patch.object(exporter._session, "post") as mock_post:
+            mock_post.return_value = MagicMock(status_code=200, text="OK")
+
+            provider = TracerProvider()
+            provider.add_span_processor(SimpleSpanProcessor(exporter))
+            tracer = provider.get_tracer("test")
+
+            with tracer.start_as_current_span("test-span"):
+                pass
+
+            provider.force_flush()
+
+            assert mock_post.called
+            called_url = mock_post.call_args.kwargs["url"]
+            assert called_url == expected_url
+            assert not called_url.endswith("/v1/traces/v1/traces")


### PR DESCRIPTION
## Overview

The OTel setup snippets set the generic `OTEL_EXPORTER_OTLP_ENDPOINT` variable to a full signal URL:

```bash
OTEL_EXPORTER_OTLP_ENDPOINT=https://api.smith.langchain.com/otel/v1/traces
```

Per the [OTel spec](https://opentelemetry.io/docs/specs/otel/protocol/exporter/), that variable holds a **base** URL, and HTTP exporters append the signal path themselves. Users who copied the snippet exported to `https://api.smith.langchain.com/otel/v1/traces/v1/traces`, which is wrong.

This PR switches those snippets to the signal-specific `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, which exporters use verbatim with no append:

- `trace-with-strands-agents.mdx`
- `trace-with-microsoft-agent-framework.mdx`
- `deploy-other-frameworks.mdx` (Strands tab `.env`)

The same rule applies to the OTel Collector `otlphttp` exporter, where `endpoint` is a base URL and `traces_endpoint` is a full URL. `trace-with-opentelemetry.mdx` now uses `traces_endpoint` for both exporters in the fan-out example.

`tests/unit_tests/test_otel_endpoints.py` locks the fix in with four checks: two that scan every `.mdx` file for the bad patterns, and two that assert the real `OTLPSpanExporter` resolves both variables to a single `/v1/traces` path.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Related issues/PRs

- GitHub issue:
- Feature PR:

- Linear issue:
- Slack thread:

## Checklist
- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

The two framework pages (Strands and Microsoft Agent Framework) were verified against real installs of `strands-agents` and `agent-framework-core`, not just against the spec. Both end up on `opentelemetry.exporter.otlp`, and both resolve the new variable correctly.