### PR TITLE
docs: add forked vs. isolated context table to Subagents page

### DIFF
--- a/src/oss/langchain/multi-agent/subagents.mdx
+++ b/src/oss/langchain/multi-agent/subagents.mdx
@@ -614,7 +614,7 @@ const callSubagent1 = tool(
 
 `some_logic` controls how much context the subagent receives. Passing only `query` keeps the subagent isolated, giving it just the task description. Passing `runtime.state["messages"]` instead gives the subagent the parent's full conversation history. This is helpful when the subagent needs to continue work the parent already started, like resuming a PR review or picking up a bug fix. [Deep Agents](/oss/deepagents/subagents#forked-subagents) has built-in support for this: setting `mode: "fork"` on a subagent spec gives it the parent's full message history (including tool calls) and system prompt.
 
-There are two context modes to choose between:
+There are two context modes you can pass into `invoke`. [Deep Agents](/oss/deepagents/subagents#forked-subagents) names these patterns `mode: "isolated"` (default) and `mode: "fork"`, and implements forking for you: a forked subagent receives the parent's full message history (including tool calls) and system prompt.
 
 | Mode | Subagent receives | Best for | Tradeoff |
 |------|-------------------|----------|----------|

--- a/src/oss/langchain/multi-agent/subagents.mdx
+++ b/src/oss/langchain/multi-agent/subagents.mdx
@@ -619,7 +619,7 @@ There are two context modes you can pass into `invoke`. [Deep Agents](/oss/deepa
 | Mode | Subagent receives | Best for | Tradeoff |
 |------|-------------------|----------|----------|
 | **Isolated** (default) | Only the task description | Focused work that needs little prior context | Context isolation, but re-derives everything the parent already did |
-| **Forked** | The parent's full conversation history | Continuing a task the parent already started | Seeded with more context but prompt caching is respected |
+| **Forked** | The parent's conversation history (and, in Deep Agents, the system prompt) | Continuing a task the parent already started | Seeded with prior context, at the cost of a larger prompt and less isolation |
 
 ### Subagent outputs
 

--- a/src/oss/langchain/multi-agent/subagents.mdx
+++ b/src/oss/langchain/multi-agent/subagents.mdx
@@ -2,7 +2,9 @@
 title: Subagents
 ---
 
-In the **subagents** architecture, a central main [agent](/oss/langchain/agents) (often referred to as a **supervisor**) coordinates subagents by calling them as [tools](/oss/langchain/tools). The main agent decides which subagent to invoke, what input to provide, and how to combine results. Subagents are stateless—they don't remember past interactions, with all conversation memory maintained by the main agent. This provides [context](/oss/langchain/context-engineering) isolation: each subagent invocation works in a clean context window, preventing context bloat in the main conversation.
+In the **subagents** architecture, a central main [agent](/oss/langchain/agents) (often referred to as a **supervisor**) coordinates subagents by calling them as [tools](/oss/langchain/tools). The main agent decides which subagent to invoke, what input to provide, and how to combine results. By default, subagents are stateless—they don't remember past interactions, with all conversation memory maintained by the main agent. This provides [context](/oss/langchain/context-engineering) isolation: each subagent invocation works in a clean context window, preventing context bloat in the main conversation.
+
+You can opt a subagent into sharing the main agent's context instead. See [Subagent inputs](#subagent-inputs).
 
 For built-in subagent support, see [Deep Agents](/oss/deepagents/subagents).
 
@@ -609,6 +611,15 @@ const callSubagent1 = tool(
 );
 ```
 :::
+
+`some_logic` controls how much context the subagent receives. Passing only `query` keeps the subagent isolated, giving it just the task description. Passing `runtime.state["messages"]` instead gives the subagent the parent's full conversation history. This is helpful when the subagent needs to continue work the parent already started, like resuming a PR review or picking up a bug fix. [Deep Agents](/oss/deepagents/subagents#forked-subagents) has built-in support for this: setting `mode: "fork"` on a subagent spec gives it the parent's full message history (including tool calls) and system prompt.
+
+There are two context modes to choose between:
+
+| Mode | Subagent receives | Best for | Tradeoff |
+|------|-------------------|----------|----------|
+| **Isolated** (default) | Only the task description | Focused work that needs little prior context | Context isolation, but re-derives everything the parent already did |
+| **Forked** | The parent's full conversation history | Continuing a task the parent already started | Seeded with more context but prompt caching is respected |
 
 ### Subagent outputs
 

--- a/src/oss/langchain/multi-agent/subagents.mdx
+++ b/src/oss/langchain/multi-agent/subagents.mdx
@@ -612,7 +612,7 @@ const callSubagent1 = tool(
 ```
 :::
 
-`some_logic` controls how much context the subagent receives. Passing only `query` keeps the subagent isolated, giving it just the task description. Passing `runtime.state["messages"]` instead gives the subagent the parent's full conversation history. This is helpful when the subagent needs to continue work the parent already started, like resuming a PR review or picking up a bug fix. [Deep Agents](/oss/deepagents/subagents#forked-subagents) has built-in support for this: setting `mode: "fork"` on a subagent spec gives it the parent's full message history (including tool calls) and system prompt.
+`some_logic` controls how much context the subagent receives. Passing only the task description (`query`) keeps the subagent isolated. Passing the parent's message history (`runtime.state["messages"]`) instead seeds the subagent with prior work, which helps when it needs to continue something the parent already started, like resuming a PR review or picking up a bug fix.
 
 There are two context modes you can pass into `invoke`. [Deep Agents](/oss/deepagents/subagents#forked-subagents) names these patterns `mode: "isolated"` (default) and `mode: "fork"`, and implements forking for you: a forked subagent receives the parent's full message history (including tool calls) and system prompt.
 

--- a/src/oss/langchain/multi-agent/subagents.mdx
+++ b/src/oss/langchain/multi-agent/subagents.mdx
@@ -4,7 +4,7 @@ title: Subagents
 
 In the **subagents** architecture, a central main [agent](/oss/langchain/agents) (often referred to as a **supervisor**) coordinates subagents by calling them as [tools](/oss/langchain/tools). The main agent decides which subagent to invoke, what input to provide, and how to combine results. By default, subagents are stateless—they don't remember past interactions, with all conversation memory maintained by the main agent. This provides [context](/oss/langchain/context-engineering) isolation: each subagent invocation works in a clean context window, preventing context bloat in the main conversation.
 
-You can opt a subagent into sharing the main agent's context instead. See [Subagent inputs](#subagent-inputs).
+You can also pass the main agent's conversation history into a subagent when it needs that context. See [Subagent inputs](#subagent-inputs).
 
 For built-in subagent support, see [Deep Agents](/oss/deepagents/subagents).
 

--- a/src/oss/langchain/multi-agent/subagents.mdx
+++ b/src/oss/langchain/multi-agent/subagents.mdx
@@ -614,7 +614,7 @@ const callSubagent1 = tool(
 
 `some_logic` controls how much context the subagent receives. Passing only the task description (`query`) keeps the subagent isolated. Passing the parent's message history (`runtime.state["messages"]`) instead seeds the subagent with prior work, which helps when it needs to continue something the parent already started, like resuming a PR review or picking up a bug fix.
 
-There are two context modes you can pass into `invoke`. [Deep Agents](/oss/deepagents/subagents#forked-subagents) names these patterns `mode: "isolated"` (default) and `mode: "fork"`, and implements forking for you: a forked subagent receives the parent's full message history (including tool calls) and system prompt.
+[Deep Agents](/oss/deepagents/subagents#forked-subagents) names these patterns `mode: "isolated"` (default) and `mode: "fork"`, and implements forking for you: a forked subagent receives the parent's full message history (including tool calls) and system prompt.
 
 | Mode | Subagent receives | Best for | Tradeoff |
 |------|-------------------|----------|----------|


### PR DESCRIPTION
## Overview
Adds an explanation and comparison table for **isolated vs. forked** subagent context modes to the "Subagent inputs" section of the LangChain multi-agent Subagents page.

## Type of change
**Type:** Update existing documentation

## Related issues/PRs
- Slack thread: https://langchain.slack.com/archives/C09M16GJNNP/p1788542890757979?thread_ts=1788304841.494769&cid=C09M16GJNNP

## Checklist
- [x] I have read the contributing guidelines, including the language policy
- [x] I have tested my changes locally using `docs dev`
- [x] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes
- No code samples were added or modified