### PR TITLE
docs: add opsen as a deep agents sandbox backend

### DIFF
--- a/src/oss/python/integrations/providers/opsen.mdx
+++ b/src/oss/python/integrations/providers/opsen.mdx
@@ -1,0 +1,13 @@
+---
+title: "opsen integrations"
+sidebarTitle: "opsen"
+description: "Integrate with opsen using LangChain Python."
+---
+
+[opsen](https://opsen.dev) runs agent sandboxes and proxies their model calls, so machine, model and tool spend land under one task id. See the [opsen docs](https://opsen.dev/docs) for signup, authentication, and platform details.
+
+<Columns cols={2}>
+    <Card title="OpsenSandbox" href="/oss/integrations/sandboxes/opsen" cta="Get started" icon="terminal" arrow>
+        opsen sandbox backend for deepagents.
+    </Card>
+</Columns>

--- a/src/oss/python/integrations/sandboxes/opsen.mdx
+++ b/src/oss/python/integrations/sandboxes/opsen.mdx
@@ -1,0 +1,91 @@
+---
+title: OpsenSandbox integration
+description: Integrate with the OpsenSandbox sandbox backend using LangChain Python.
+integration:
+  name: OpsenSandbox
+  pypi: langchain-opsen
+---
+
+[opsen](https://opsen.dev) runs agent sandboxes and proxies their model calls, so machine, model and tool spend land under one task id. See the [opsen docs](https://opsen.dev/docs) for signup, authentication, and platform details.
+
+## Installation
+
+<CodeGroup>
+```bash pip
+pip install langchain-opsen
+```
+
+```bash uv
+uv add langchain-opsen
+```
+</CodeGroup>
+
+## Create a sandbox backend
+
+Unlike most sandbox backends, there is no provider SDK object to create first: the session starts on the first command, so an agent that is built and never run costs nothing.
+
+```python
+from langchain_opsen import OpsenSandbox
+
+backend = OpsenSandbox(task_id="hello", budget_usd=1.00)
+
+result = backend.execute("echo hello")
+print(result.output)
+```
+
+Set `OPSEN_API_KEY` in the environment, or pass `api_key=`.
+
+## Use with Deep Agents
+
+```python
+from langchain_anthropic import ChatAnthropic
+
+from deepagents import create_deep_agent
+from langchain_opsen import OpsenSandbox
+
+backend = OpsenSandbox(task_id="nightly-report", budget_usd=2.00)
+
+agent = create_deep_agent(
+    model=ChatAnthropic(model="claude-sonnet-4-20250514"),
+    system_prompt="You are a coding assistant with sandbox access.",
+    backend=backend,
+)
+
+result = agent.invoke(
+    {
+        "messages": [
+            {"role": "user", "content": "Create a hello world Python script and run it"}
+        ]
+    }
+)
+```
+
+## Spend under one task id
+
+The agent's model calls are proxied through the same session that owns the sandbox, so both are attributed together:
+
+```python
+backend.cost()
+# {'total_usd': 0.41, 'compute_usd': 0.02, 'tokens_usd': 0.39,
+#  'calls': 34, 'input_tokens': 84120, 'output_tokens': 9310,
+#  'task_id': 'nightly-report'}
+```
+
+`budget_usd` is a ceiling enforced during the run: an agent that would cross it is refused mid-flight rather than discovered afterwards.
+
+## Configuration
+
+| Argument | Default | Description |
+| --- | --- | --- |
+| `api_key` | `$OPSEN_API_KEY` | API key |
+| `task_id` | `"deepagents"` | Groups this agent's spend |
+| `budget_usd` | `None` | Hard ceiling, enforced mid-run |
+| `labels` | `{}` | Arbitrary tags to group spend by |
+| `base_url` | `https://opsen.dev` | For self-hosted deployments |
+| `timeout` | `300` | Default seconds per command |
+
+## Cleanup
+
+Call `backend.close()` when you are done, or use the backend as a context manager. A sandbox left running continues to bill.
+
+See also: [Sandboxes](/oss/deepagents/sandboxes).


### PR DESCRIPTION
Adds sandbox and provider pages for opsen, following the existing Daytona pages.

`langchain-opsen` is published and installable: https://pypi.org/project/langchain-opsen/

**What it is.** opsen runs the sandbox and proxies the agent's model calls through the same session, so machine, model and tool spend are attributed to one task id — `backend.cost()` returns the three together. `budget_usd` is a ceiling enforced during the run, so an agent that would cross it is refused mid-flight rather than found on an invoice.

**Interface.** `OpsenSandbox` subclasses `BaseSandbox` and implements `id`, `execute`, `upload_files` and `download_files`, per the contributing guide. The filesystem tools and async variants are inherited.

**Standard suite: 79/86.** Running `SandboxIntegrationTests` found three real bugs, all now fixed: absolute paths were being made relative on upload; large writes silently failed by exceeding the shell argument limit; and errors were raw shell text rather than the normalised codes (`file_not_found`, `invalid_path`, `is_directory`, `permission_denied`).

The remaining 7 appear to be a disagreement between deepagents 0.7.13 and langchain-tests 1.1.9, and are all in inherited methods, so no provider implementation affects them:

- **6 glob tests.** `_parse_glob_output` calls `_absolutize_glob_path` and its docstring states "GlobResult with absolute paths". The suite asserts `"file1.txt" in paths`.
- **`test_write_existing_file_fails`.** `BaseSandbox.write` documents "creating or overwriting it if it already exists". The suite asserts `result.error is not None` when the file exists.

Flagging rather than working around, since if the intended contract changed then the base class and the suite disagree for every provider. Happy to adjust if I have misread it.

**Two behaviours the page calls out**, because they differ from the other backends:

- There is no provider SDK object to construct first. The session starts on the first command, so an agent built and never run starts no sandbox.
- Port exposure depends on the runtime underneath and raises with a message naming the limitation where unavailable, rather than returning a URL that does not answer.

Happy to adjust to house style — I followed `sandboxes/daytona.mdx` and `providers/daytona.mdx`.