### PR TITLE
Remove LangSmith doc comments saying that thread backfills are not supported, since these are supported now. [LSO-4060]

### DIFF
--- a/src/langsmith/rules.mdx
+++ b/src/langsmith/rules.mdx
@@ -48,7 +48,6 @@ Selecting **Threads** changes three parts of the rule form:
 
 - **Thread Filters**: The filter builder adds **Trace Count** and **Thread ID** to the available fields. Filter on **Trace Count** to scope a rule to conversations of a given length. The other fields evaluate each trace in the thread rather than the thread as a whole, so a thread matches when any of its traces match. For example, a filter on **Status** selects every thread that contains an errored trace, not only threads whose last trace errored.
 - **Action**: The form offers **Add to Annotation Queue**, **Add to Dataset**, or **Trigger Webhooks**.
-- **Apply to Past Runs**: Backfill is not currently offered for thread rules.
 
 The three thread actions behave as follows:
 
@@ -84,7 +83,7 @@ In the [UI](https://smith.langchain.com), navigate to **Tracing** in the sidebar
 1. Select an **Item Type**, either **Runs** or **Threads**. The item type determines which filter fields and actions are available, so set it before configuring either. For more information, refer to [Set the item type to runs or threads](#set-the-item-type-to-runs-or-threads).
 1. Create a filter. Automation rule filters work the same way as filters applied to traces in the project. For more information on filters, you can refer to [Filter traces](/langsmith/filter-traces-in-application).
 1. Configure a **Sampling Rate** to control what percentage of the filtered items trigger the automation action. The form accepts a percentage from 0 to 100. For example, a sampling rate of 50% sends half of the items that pass the filter to the action. The equivalent API field, `sampling_rate`, takes a decimal from 0 to 1.
-1. (Optional) Apply rule to past runs by toggling the **Apply to Past Runs** and entering a **Backfill From** date. This is only possible upon rule creation, and is not offered for rules whose item type is **Threads**.
+1. (Optional) Apply rule to past runs by toggling the **Apply to Past Runs** and entering a **Backfill From** date. This is only possible upon rule creation.
 
     <Note>
     The backfill is processed as a background job, so you will not see the results immediately. In order to track progress of the backfill, you can [view logs for your automations](#view-logs-for-your-automations).


### PR DESCRIPTION

## Overview
This PR removes LangSmith documentation comments saying that thread backfills are not supported, since these are supported now. 


## Type of change

**Type:** [Update existing documentation]

## Related issues/PRs
Linear issue: https://linear.app/langchain/issue/LSO-4060/update-thread-backfill-documentation

Slack thread: https://langchain.slack.com/archives/C0BNNN2AJH2/p1788280609818899

https://github.com/langchain-ai/langchainplus/pull/34246
https://github.com/langchain-ai/langchainplus/pull/33915
https://github.com/langchain-ai/langchainplus/pull/35285

## Checklist 
- [X]  I have read the [contributing guidelines](https://github.com/langchain-ai/docs/pull/README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [X]  I have tested my changes locally using docs dev
- [X] No code examples were changed
- [X]  Prose lint passes
- [X]  No internal links or navigation changes were needed

## Screenshot
<img width="1695" height="936" alt="docUpdate1" src="https://github.com/user-attachments/assets/c059356a-e0be-45db-ae4e-5d10f5dcea81" />

<img width="1711" height="948" alt="docUpdate2" src="https://github.com/user-attachments/assets/fd32841e-c06f-4eea-bf01-b06366c1dd71" />
