### PR TITLE
docs: document thread resume limits

### DIFF
--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -128,10 +128,6 @@ Run `/line-numbers` in a session to toggle the preference and save it to `config
 
 Limit which saved threads users can resume to prevent old conversations from restoring stale context after a model or policy change.
 
-<Note>
-    Thread resume limits require a Deep Agents Code release newer than `0.1.66`.
-</Note>
-
 Set a rolling maximum age with `threads.max_resume_age`:
 
 ```toml title="~/.deepagents/config.toml"

--- a/src/oss/deepagents/code/config-file.mdx
+++ b/src/oss/deepagents/code/config-file.mdx
@@ -9,6 +9,7 @@ description: Configure model providers, defaults, retries, and gateways in confi
 - **Defaults**: pin a [default model](#default-and-recent-model), [summarization model](#set-a-summarization-model), or [agent](#default-and-recent-agent), or [restrict usable models](#allowed-models) with an allowlist.
 - **Warnings**: [session cost](#session-cost-warning) and [cold prompt-cache](#cold-prompt-cache-warning) thresholds, and [trusted gateway endpoints](#trust-a-gateway-endpoint-for-cache-policies).
 - **Display**: [provider-visible reasoning](#show-provider-visible-reasoning) and diff line numbers.
+- **Threads**: [resume limits](#limit-thread-resume-age) for stale conversations.
 - **Interpreter**: the [`[interpreter]` settings](#js-interpreter) for the built-in QuickJS REPL.
 - **Python extensions**: [discovery and project trust](#python-extensions) for custom tools, middleware, and storage routes.
 - **Tracing**: [client-side secret redaction](#redact-langsmith-trace-secrets) for LangSmith traces.
@@ -122,6 +123,34 @@ show_diff_line_numbers = false
 ```
 
 Run `/line-numbers` in a session to toggle the preference and save it to `config.toml`. The change applies to new diffs; already rendered diffs do not change.
+
+## Limit thread resume age
+
+Limit which saved threads users can resume to prevent old conversations from restoring stale context after a model or policy change.
+
+<Note>
+    Thread resume limits require a Deep Agents Code release newer than `0.1.66`.
+</Note>
+
+Set a rolling maximum age with `threads.max_resume_age`:
+
+```toml title="~/.deepagents/config.toml"
+[threads]
+max_resume_age = "7d"
+```
+
+The value must be a positive integer followed by one of these duration suffixes: `s` for seconds, `m` for minutes, `h` for hours, `d` for days, or `w` for weeks.
+
+For a fixed migration or policy boundary, set `threads.resume_after` to an ISO 8601 date or timezone-aware datetime. A date uses midnight UTC:
+
+```toml title="~/.deepagents/config.toml"
+[threads]
+resume_after = "2025-06-01T00:00:00Z"
+```
+
+When you set both options, Deep Agents Code applies the later, stricter cutoff. The limit applies when you resume at launch, resume or switch threads in a session, select a thread, or switch to a thread owned by another agent. If a saved thread has a missing or invalid last-updated timestamp, Deep Agents Code blocks the resume while either limit is active.
+
+Administrators can enforce either option in `managed_config.toml`. Invalid managed values stop startup instead of falling back to user configuration.
 
 ## Allowed models
 


### PR DESCRIPTION
Documents the new Deep Agents Code thread-resume limits so users and administrators can prevent stale conversations from restoring outdated context.

Made by [Open SWE](https://openswe.vercel.app/agents/7fdf1d25-a596-51cf-b382-7f36900a8136)