### PR TITLE
docs: capitalize Managed Deep Agent instance

### DIFF
--- a/src/langsmith/managed-deep-agents-connections.mdx
+++ b/src/langsmith/managed-deep-agents-connections.mdx
@@ -7,7 +7,7 @@ description: Store API keys and OAuth grants so Managed Deep Agents can authenti
 import ManagedDeepAgentsPublicBetaNote from '/snippets/langsmith/managed-deep-agents-public-beta-note.mdx';
 import MdaOauthCatalog from '/snippets/langsmith/mda-oauth-catalog.mdx';
 
-A connection links a managed deep agent to an external service such as GitHub, Notion, or Tavily. The credential lives in your LangSmith workspace. Use `connections.get(...)` in an authored tool or MCP server definition to resolve it at runtime.
+A connection links a Managed Deep Agent to an external service such as GitHub, Notion, or Tavily. The credential lives in your LangSmith workspace. Use `connections.get(...)` in an authored tool or MCP server definition to resolve it at runtime.
 
 Connections let you:
 


### PR DESCRIPTION
## Overview

Updates the connections guide to use the title-cased product name “Managed Deep Agent” when referring to an instance.

## Type of change

**Type:** Fix typo/bug/link/formatting

## Checklist

- [x] I have read the contributing guidelines
- [x] No code examples or links changed
- [x] Navigation changes are not needed
- [x] `make lint_prose FILES="src/langsmith/managed-deep-agents-connections.mdx"` passes

Made by [Open SWE](https://openswe.vercel.app/agents/dcc3b1e4-e1ec-53fb-90f3-d8d4d9d95be6)