### PR TITLE
docs(langsmith): document org-admin PAT administration and revocation

### DIFF
--- a/src/langsmith/administration-overview.mdx
+++ b/src/langsmith/administration-overview.mdx
@@ -112,6 +112,10 @@ Personal Access Tokens (PATs) are used to authenticate requests to the LangSmith
 
 PATs are prefixed with `lsv2_pt_`
 
+Members can revoke or delete their own PATs. [Organization Admins](#organization-roles) can also list, revoke, and delete any member's PAT: on the [**Settings** page](https://smith.langchain.com/settings) **API Keys** section, open the **Personal** tab and switch the scope from **My keys** to **All members**.
+
+Revoking a token stops it from authenticating but keeps its record listed with a **Revoked** badge, so the token, its owner, and its last use remain visible. Deleting removes the record entirely. Because authentication results are cached, a revoked token stops working within a minute rather than instantly, the same delay that applies to a deleted token. Service keys can only be deleted, not revoked.
+
 #### Service keys
 
 Service keys are similar to PATs, but are used to authenticate requests to the LangSmith API on behalf of a service account. Only admins can create service keys. We recommend using these for applications / services that need to interact with the LangSmith API, such as LangGraph agents or other integrations. Service keys may be scoped to a single workspace, multiple workspaces, or the entire organization, and can be used to authenticate requests to the LangSmith API for whichever workspace(s) it has access to.
@@ -159,6 +163,8 @@ The following table provides an overview of organization level permissions:
 | View data retention settings                | ✅                   | ✅                 | ✅                  |
 | View usage limits                           | ✅                   | ✅                 | ✅                  |
 | Create personal access tokens (PATs)        | ❌                   | ✅                 | ✅                  |
+| View every member's personal access tokens  | ❌                   | ❌                 | ✅                  |
+| Revoke or delete a member's personal access token | ❌             | ❌                 | ✅                  |
 | Admin access to all workspaces              | ❌                   | ❌                 | ✅                  |
 | Manage billing settings                     | ❌                   | ❌                 | ✅                  |
 | Create workspaces                           | ❌                   | ❌                 | ✅                  |

--- a/src/langsmith/administration-overview.mdx
+++ b/src/langsmith/administration-overview.mdx
@@ -112,9 +112,9 @@ Personal Access Tokens (PATs) are used to authenticate requests to the LangSmith
 
 PATs are prefixed with `lsv2_pt_`
 
-Members can revoke or delete their own PATs. [Organization Admins](#organization-roles) can also list, revoke, and delete any member's PAT: on the [**Settings** page](https://smith.langchain.com/settings) **API Keys** section, open the **Personal** tab and switch the scope from **My keys** to **All members**.
+Members can revoke or delete their own PATs. [Organization Admins](/langsmith/rbac#organization-admin) and [Organization Operators](/langsmith/rbac#organization-operator) can also list, revoke, and delete any member's PAT. For the steps, refer to [Create an account and API key](/langsmith/create-account-api-key).
 
-Revoking a token stops it from authenticating but keeps its record listed with a **Revoked** badge, so the token, its owner, and its last use remain visible. Deleting removes the record entirely. Because authentication results are cached, a revoked token stops working within a minute rather than instantly, the same delay that applies to a deleted token. Service keys can only be deleted, not revoked.
+Revoking a token stops it from authenticating but keeps its record, listed with a **Revoked** badge, so the token, its owner, and its last use stay visible. Deleting removes the record entirely. Because authentication results are cached, a revoked or deleted token stops working within a minute rather than instantly. Service keys can only be deleted, not revoked.
 
 #### Service keys
 
@@ -163,8 +163,7 @@ The following table provides an overview of organization level permissions:
 | View data retention settings                | ✅                   | ✅                 | ✅                  |
 | View usage limits                           | ✅                   | ✅                 | ✅                  |
 | Create personal access tokens (PATs)        | ❌                   | ✅                 | ✅                  |
-| View every member's personal access tokens  | ❌                   | ❌                 | ✅                  |
-| Revoke or delete a member's personal access token | ❌             | ❌                 | ✅                  |
+| View, revoke, and delete any member's PATs  | ❌                   | ❌                 | ✅                  |
 | Admin access to all workspaces              | ❌                   | ❌                 | ✅                  |
 | Manage billing settings                     | ❌                   | ❌                 | ✅                  |
 | Create workspaces                           | ❌                   | ❌                 | ✅                  |

--- a/src/langsmith/audit-logs.mdx
+++ b/src/langsmith/audit-logs.mdx
@@ -102,7 +102,7 @@ Audit log events are returned in [OCSF v1.7.0 API Activity (Class UID 6003)](htt
 | `resources` | List of UUIDs for the resources affected by the operation (e.g., the role that was updated, the workspace that was created). |
 | `metadata.uid` | Unique identifier for this audit log event. |
 | `unmapped.original_audit_log` | The full LangSmith-native audit log record, including `organization_id` and `workspace_id`. |
-| `unmapped.original_audit_log.enrichments.resource_owner_ls_user_id` | UUID of the member who owns the resource the operation acted on, for the operations that record it, such as revoking or deleting a personal access token. A value that differs from `actor.user.uid` identifies an administrator acting on another member's resource. |
+| `unmapped.original_audit_log.enrichments.resource_owner_ls_user_id` | UUID of the member who owns the resource the operation acted on, for the operations that record it, such as revoking or deleting a personal access token. A value different from `actor.user.uid` means an administrator acted on another member's resource. |
 
 ## Forwarding to external systems
 

--- a/src/langsmith/audit-logs.mdx
+++ b/src/langsmith/audit-logs.mdx
@@ -102,6 +102,7 @@ Audit log events are returned in [OCSF v1.7.0 API Activity (Class UID 6003)](htt
 | `resources` | List of UUIDs for the resources affected by the operation (e.g., the role that was updated, the workspace that was created). |
 | `metadata.uid` | Unique identifier for this audit log event. |
 | `unmapped.original_audit_log` | The full LangSmith-native audit log record, including `organization_id` and `workspace_id`. |
+| `unmapped.original_audit_log.enrichments.resource_owner_ls_user_id` | UUID of the member who owns the resource the operation acted on, for the operations that record it, such as revoking or deleting a personal access token. A value that differs from `actor.user.uid` identifies an administrator acting on another member's resource. |
 
 ## Forwarding to external systems
 
@@ -111,7 +112,7 @@ To forward audit log events to an external SIEM or logging platform, you can run
 
 | Category | Operations (`api.operation`) |
 |----------|-----------|
-| **API keys & credentials** | `create_api_key`, `delete_api_key`, `create_personal_access_token`, `delete_personal_access_token`, `create_service_key`, `delete_service_key`, `update_service_key`, `create_service_account`, `delete_service_account`, `list_org_personal_access_tokens`, `list_org_service_keys` |
+| **API keys & credentials** | `create_api_key`, `delete_api_key`, `create_personal_access_token`, `delete_personal_access_token`, `create_service_key`, `delete_service_key`, `update_service_key`, `create_service_account`, `delete_service_account`, `revoke_personal_access_token`, `list_org_personal_access_tokens`, `list_all_org_personal_access_tokens`, `list_org_service_keys` |
 | **Roles** | `create_role`, `update_role`, `delete_role` |
 | **Organizations** | `create_organization`, `create_provisioned_saas_org`, `create_tenant`, `invite_provisioned_org_member`, `claim_pending_organization_invite`, `delete_pending_organization_invite` |
 | **Organization members** | `invite_user_to_org`, `invite_users_to_org_batch`, `update_org_member`, `delete_org_member`, `delete_org_pending_member`, `add_basic_auth_users_to_org`, `update_basic_auth_user` |

--- a/src/langsmith/create-account-api-key.mdx
+++ b/src/langsmith/create-account-api-key.mdx
@@ -35,7 +35,11 @@ To log [traces](/langsmith/observability-concepts#traces) and run [evaluations](
 </Steps>
 
 <Tip>
-  To delete an API key, navigate to the [**Settings** page](https://smith.langchain.com/settings), find the key in the **API Keys** section, and select the trash icon <Icon icon="trash" iconType="solid"/> in the **Actions** column.
+  To revoke or delete a key, navigate to the [**Settings** page](https://smith.langchain.com/settings), find the key in the **API Keys** section, and select the trash icon <Icon icon="trash" iconType="solid"/> in the **Actions** column. For a personal access token, select **Revoke** to stop the token working while keeping its record, or type the key's name and select **Delete** to remove the record entirely. Service keys can only be deleted.
+</Tip>
+
+<Tip>
+  Organization Admins can view and manage every member's personal access tokens. In the **API Keys** section of the [**Settings** page](https://smith.langchain.com/settings), open the **Personal** tab and switch the scope from **My keys** to **All members**. For the permissions behind this view, refer to [Organization admin](/langsmith/rbac#organization-admin).
 </Tip>
 
 <Tip>

--- a/src/langsmith/create-account-api-key.mdx
+++ b/src/langsmith/create-account-api-key.mdx
@@ -35,11 +35,11 @@ To log [traces](/langsmith/observability-concepts#traces) and run [evaluations](
 </Steps>
 
 <Tip>
-  To revoke or delete a key, navigate to the [**Settings** page](https://smith.langchain.com/settings), find the key in the **API Keys** section, and select the trash icon <Icon icon="trash" iconType="solid"/> in the **Actions** column. For a personal access token, select **Revoke** to stop the token working while keeping its record, or type the key's name and select **Delete** to remove the record entirely. Service keys can only be deleted.
+  To revoke or delete a key, navigate to the [**Settings** page](https://smith.langchain.com/settings), find the key in the **API Keys** section, and select the trash icon <Icon icon="trash" iconType="solid"/> in the **Actions** column. For a personal access token, type the key's name, then select **Revoke** to stop the token from authenticating while keeping its record, or **Delete** to remove the record entirely. Neither action can be undone. Service keys can only be deleted.
 </Tip>
 
 <Tip>
-  Organization Admins can view and manage every member's personal access tokens. In the **API Keys** section of the [**Settings** page](https://smith.langchain.com/settings), open the **Personal** tab and switch the scope from **My keys** to **All members**. For the permissions behind this view, refer to [Organization admin](/langsmith/rbac#organization-admin).
+  [Organization Admins](/langsmith/rbac#organization-admin) and [Organization Operators](/langsmith/rbac#organization-operator) can view, revoke, and delete every member's personal access tokens. In the **API Keys** section of the [**Settings** page](https://smith.langchain.com/settings), open the **Personal** tab and switch the scope from **My keys** to **All members**.
 </Tip>
 
 <Tip>

--- a/src/langsmith/organization-workspace-operations.mdx
+++ b/src/langsmith/organization-workspace-operations.mdx
@@ -141,7 +141,7 @@ Attribute-based access control (ABAC) policies for fine-grained permissions.
 | Create org-scoped service key (workspace-scoped)* | ✓ | ✓ | ⚠ | ✗ | `organization:pats:create` + `workspaces:manage-keys` |
 | Create org-scoped service key (org-wide)* | ✓ | ✗ | ✗ | ✗ | `organization:pats:create` + `organization:manage` |
 | Delete org-scoped service key (workspace-scoped)* | ✓ | ✓ | ⚠ | ✗ | `organization:read` + `workspaces:manage-keys` |
-| Update service key role | ✓ | ✗ | ✗ | ✗ | `organization:manage` |
+| Update service key role | ✓ | ✓ | ✗ | ✗ | `organization:manage` |
 | List personal access tokens (PATs) | ✓ | ✓ | ✓ | ✗ | `organization:read` |
 | List every member's personal access tokens (PATs) | ✓ | ✓ | ✗ | ✗ | `organization:pats:read` |
 | Create personal access token (PAT) | ✓ | ✓ | ✓ | ✗ | `organization:pats:create` |

--- a/src/langsmith/organization-workspace-operations.mdx
+++ b/src/langsmith/organization-workspace-operations.mdx
@@ -143,8 +143,11 @@ Attribute-based access control (ABAC) policies for fine-grained permissions.
 | Delete org-scoped service key (workspace-scoped)* | ✓ | ✓ | ⚠ | ✗ | `organization:read` + `workspaces:manage-keys` |
 | Update service key role | ✓ | ✗ | ✗ | ✗ | `organization:manage` |
 | List personal access tokens (PATs) | ✓ | ✓ | ✓ | ✗ | `organization:read` |
+| List every member's personal access tokens (PATs) | ✓ | ✓ | ✗ | ✗ | `organization:pats:read` |
 | Create personal access token (PAT) | ✓ | ✓ | ✓ | ✗ | `organization:pats:create` |
-| Delete personal access token (PAT) | ✓ | ✓ | ✓ | ✗ | `organization:read` |
+| Revoke own personal access token (PAT) | ✓ | ✓ | ✓ | ✗ | `organization:read` |
+| Delete own personal access token (PAT) | ✓ | ✓ | ✓ | ✗ | `organization:read` |
+| Revoke or delete another member's personal access token (PAT) | ✓ | ✓ | ✗ | ✗ | `organization:pats:manage` |
 
 <Note>
 \* Organization Operators and Organization Users can create or delete workspace-scoped service keys only in workspaces where their role grants `workspaces:manage-keys`, such as the Workspace Admin role. Creating an org-wide service key requires the Organization Admin role.

--- a/src/langsmith/organization-workspace-operations.mdx
+++ b/src/langsmith/organization-workspace-operations.mdx
@@ -142,11 +142,10 @@ Attribute-based access control (ABAC) policies for fine-grained permissions.
 | Create org-scoped service key (org-wide)* | ✓ | ✗ | ✗ | ✗ | `organization:pats:create` + `organization:manage` |
 | Delete org-scoped service key (workspace-scoped)* | ✓ | ✓ | ⚠ | ✗ | `organization:read` + `workspaces:manage-keys` |
 | Update service key role | ✓ | ✓ | ✗ | ✗ | `organization:manage` |
-| List personal access tokens (PATs) | ✓ | ✓ | ✓ | ✗ | `organization:read` |
+| List own personal access tokens (PATs) | ✓ | ✓ | ✓ | ✗ | `organization:read` |
 | List every member's personal access tokens (PATs) | ✓ | ✓ | ✗ | ✗ | `organization:pats:read` |
 | Create personal access token (PAT) | ✓ | ✓ | ✓ | ✗ | `organization:pats:create` |
-| Revoke own personal access token (PAT) | ✓ | ✓ | ✓ | ✗ | `organization:read` |
-| Delete own personal access token (PAT) | ✓ | ✓ | ✓ | ✗ | `organization:read` |
+| Revoke or delete own personal access token (PAT) | ✓ | ✓ | ✓ | ✗ | `organization:read` |
 | Revoke or delete another member's personal access token (PAT) | ✓ | ✓ | ✗ | ✗ | `organization:pats:manage` |
 
 <Note>

--- a/src/langsmith/rbac.mdx
+++ b/src/langsmith/rbac.mdx
@@ -48,6 +48,8 @@ Organization roles are **distinct from the workspace RBAC feature** and are used
 - `organization:manage` - Full control over organization settings, SSO, security, billing
 - `organization:read` - Read access to all organization information
 - `organization:pats:create` - Create organization-level [personal access tokens](/langsmith/administration-overview#personal-access-tokens-pats)
+- `organization:pats:read` - View every organization member's personal access tokens
+- `organization:pats:manage` - Revoke or delete any organization member's personal access token
 
 <PermissionReference/>
 
@@ -57,6 +59,7 @@ Organization roles are **distinct from the workspace RBAC feature** and are used
 - Manage [billing](/langsmith/billing) and subscription plans
 - Create and delete [workspaces](/langsmith/set-up-hierarchy)
 - Invite and remove organization members
+- View, revoke, and delete any member's [personal access tokens](/langsmith/administration-overview#personal-access-tokens-pats)
 - Assign organization and workspace roles to members
 - Create and manage [custom roles](#custom-roles)
 - Configure RBAC and ABAC (Attribute-Based Access Control) policies
@@ -73,6 +76,8 @@ Management access for day-to-day operations including workspace and user managem
 - `organization:manage` - Control over organization settings, workspaces, and non-admin users
 - `organization:read` - Read access to all organization information
 - `organization:pats:create` - Create personal access tokens
+- `organization:pats:read` - View every organization member's personal access tokens
+- `organization:pats:manage` - Revoke or delete any organization member's personal access token
 
 <PermissionReference/>
 
@@ -80,6 +85,7 @@ Management access for day-to-day operations including workspace and user managem
 - Create and manage [workspaces](/langsmith/set-up-hierarchy#set-up-a-workspace)
 - Invite organization members (all roles except Organization Admin)
 - Manage non-admin organization members (modify and remove Organization Users, Viewers, and Operators)
+- View, revoke, and delete any member's [personal access tokens](/langsmith/administration-overview#personal-access-tokens-pats)
 - Assign workspace roles to members
 - Create workspace-scoped service keys and service accounts
 - View organization [usage](/langsmith/usage-and-billing#usage-limits) and analytics


### PR DESCRIPTION
Docs for the ENT-296 PAT administration work: https://linear.app/langchain/issue/ENT-1626

Backend merged in langchain-ai/langchainplus#37695 (admin listing), #37731 (admin delete), and #37757 (revocation). The UI is still open in #37768 and #37787, so **this is a draft until those land** — the pages describe the Revoke action and the My keys / All members scope switcher.



## Testing

`vale` clean on all five files. No new pages, so `docs.json` is unchanged.

