### PR TITLE
docs(livekit): document SDK requirement for agents 1.7+

### DIFF
--- a/src/langsmith/trace-with-livekit.mdx
+++ b/src/langsmith/trace-with-livekit.mdx
@@ -11,7 +11,7 @@ This integration is in beta, so its API may change.
 Use the LangSmith LiveKit integration to trace your [LiveKit Agents](https://docs.livekit.io/agents/) voice agents, including their transcripts and audio recordings. For high-level conventions, see [Voice tracing fundamentals](/langsmith/trace-voice-fundamentals).
 
 <Note>
-This setup requires `langsmith[livekit]>=0.11.2` and `livekit-agents>=1.6`.
+This setup requires `langsmith[livekit]>=0.11.2` and `livekit-agents>=1.6`. LiveKit Agents 1.7 and later require `langsmith[livekit]>=0.12.4`.
 </Note>
 
 Each conversation appears as one LangSmith trace with its pipeline events, latency, and token metrics.


### PR DESCRIPTION
## Summary

Document that LiveKit Agents 1.7 and later require `langsmith[livekit]>=0.12.4` so transcript and message content is captured with LiveKit's newer telemetry attributes.

## Validation

- `make lint_prose FILES="src/langsmith/trace-with-livekit.mdx"`
- `git diff --check`

## AI involvement

This PR was prepared with Codex. The documentation change and validation results were reviewed before submission.
