### PR TITLE
docs(langsmith): describe the Context Hub Preview and Edit tabs

### DIFF
--- a/src/langsmith/use-the-context-hub.mdx
+++ b/src/langsmith/use-the-context-hub.mdx
@@ -40,7 +40,7 @@ Click on an agent or skill from the Context Hub to view it.
 
 The middle panel shows the file tree for the current commit and the right panel previews the selected file. Click a file in the middle panel to open it.
 
-Markdown files open in **Preview**, which is a read-only rendering. To change a file, switch to the **Edit** tab in the top right of the right panel: it shows the exact bytes stored in the repo, so saving only changes the lines you edit. Save your changes to create a new commit.
+Markdown files open in **Preview**, which is a read-only rendering. To change a file, switch to the **Edit** tab in the top right of the right panel: it shows the exact text in the file. Save your changes to create a new commit.
 
 Each saved change creates a new **commit** in the **Commit History** panel on
 the left, so you can browse, compare, and revert prior versions without losing

--- a/src/langsmith/use-the-context-hub.mdx
+++ b/src/langsmith/use-the-context-hub.mdx
@@ -38,7 +38,9 @@ Click on an agent or skill from the Context Hub to view it.
 
 ![An Agent context with an AGENTS.md file open, showing the environments panel, commit history, and file tree.](/langsmith/images/context-hub-agent-view.png)
 
-The middle panel shows the file tree for the current commit and the right panel previews the selected file. Click a file in the middle panel to open it, then edit it in the right panel and save your changes to create a new commit.
+The middle panel shows the file tree for the current commit and the right panel previews the selected file. Click a file in the middle panel to open it.
+
+Markdown files open in **Preview**, which is a read-only rendering. To change a file, switch to the **Edit** tab in the top right of the right panel: it shows the exact bytes stored in the repo, so saving only changes the lines you edit. Save your changes to create a new commit.
 
 Each saved change creates a new **commit** in the **Commit History** panel on
 the left, so you can browse, compare, and revert prior versions without losing


### PR DESCRIPTION
## Overview

Context Hub's markdown Preview pane is becoming a read-only viewer: markdown files open in a rendered **Preview**, and editing happens in the **Edit** tab, which shows the exact bytes stored in the repo. The preview editor reserialized the whole document on every keystroke, which could rewrite lines the author never touched.

`use-the-context-hub.mdx` currently tells readers to "edit it in the right panel", which no longer works for markdown. This adds a short paragraph naming the two tabs and saying why Edit is the one that touches stored bytes.

No other page describes this editor. `changelog.mdx` mentions the earlier "Source mode" change, but that is a published historical entry and is intentionally left as-is.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Feature PR: langchain-ai/langchainplus#38486

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev` — not run; this is a three-line prose change to an existing page with no new links, components, or navigation. Vale prose lint passes via the pre-commit hook.
- [x] All code examples have been tested and work correctly — no code examples in this change
- [x] I have used **root relative** paths for internal links — no links added
- [x] I have updated navigation in `src/docs.json` if needed — no navigation change

## Additional notes

Worth timing the merge with langchain-ai/langchainplus#38486, since the wording describes behavior that ships there. The screenshot on that page (`context-hub-agent-view.png`) still shows the old toolbar with a **Source** tab; it will need retaking once the frontend change is deployed, and I have not replaced it here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
