### PR TITLE
docs(byoc): use LangChain-provided external IDs

### DIFF
--- a/src/langsmith/byoc-architecture.mdx
+++ b/src/langsmith/byoc-architecture.mdx
@@ -49,6 +49,8 @@ LangChain needs cross-account IAM permissions to provision and manage resources 
 
 Permissions are granted through a single cross-account IAM role that you create during onboarding by applying the [`langsmith-byoc-role` Terraform module](https://github.com/langchain-ai/terraform/tree/main/modules/byoc/aws/langsmith-byoc-role).
 
+LangChain provides the external ID used in the role's trust policy. Copy it using the button next to the **Data Planes** header in **Settings > Data Planes**, and use it when applying the module. The role's `ExternalId` condition must match this value.
+
 ### How least privilege is enforced
 
 The role is scoped to only what BYOC operations require:

--- a/src/langsmith/byoc-faq.mdx
+++ b/src/langsmith/byoc-faq.mdx
@@ -37,6 +37,10 @@ In the Kubernetes cluster, passive workloads that do not interfere with LangSmit
 LangChain is not responsible for downtime or issues caused by interfering workloads.
 </Accordion>
 
+<Accordion title="What value do I set to the external ID for my role?">
+LangChain provides the external ID. Navigate to **Settings > Data Planes** and use the copy button next to the **Data Planes** header to copy it. Use this value when applying the `langsmith-byoc-role` Terraform module. The role's trust policy must use this value in its `ExternalId` condition.
+</Accordion>
+
 <Accordion title="How long does provisioning take?">
 End-to-end provisioning of a data plane takes around 60 to 90 minutes. Provisioning time can vary, because AWS resource provisioning is inconsistent.
 </Accordion>

--- a/src/langsmith/byoc-onboarding.mdx
+++ b/src/langsmith/byoc-onboarding.mdx
@@ -16,7 +16,9 @@ Send your organization ID to the LangChain team to enable BYOC.
 </Step>
 
 <Step title="Create the IAM role">
-Apply the [`langsmith-byoc-role` Terraform module](https://github.com/langchain-ai/terraform/tree/main/modules/byoc/aws/langsmith-byoc-role) in your AWS account. This creates the cross-account role LangChain assumes to provision and manage the data plane.
+LangChain provides the external ID for the IAM role. Navigate to **Settings > Data Planes** and use the copy button next to the **Data Planes** header to copy it.
+
+Apply the [`langsmith-byoc-role` Terraform module](https://github.com/langchain-ai/terraform/tree/main/modules/byoc/aws/langsmith-byoc-role) in your AWS account using the copied external ID. This creates the cross-account role LangChain assumes to provision and manage the data plane. The role's trust policy must use this value in its `ExternalId` condition.
 
 <Note>
 LangChain recommends a fresh AWS account dedicated to LangSmith BYOC.
@@ -30,7 +32,6 @@ Navigate to **Settings > Data Planes** and create a data plane with the followin
 - **Name**: Lowercase letters, digits, and hyphens, up to 24 characters.
 - **AWS region**: One of the [supported regions](/langsmith/byoc#regions-and-cloud-providers).
 - **AWS IAM role ARN**: The ARN of the role you created in the previous step, which LangSmith assumes in your account.
-- **External ID**: Must match the `ExternalId` condition in the role's trust policy.
 - **VPC CIDR range**: A private RFC 1918 range, from `/16` to `/18`.
 - **Load balancer access**: Private by default, which keeps the ingress load balancer reachable only from your VPC. Set it to **Public** to make the load balancer internet-facing.
 </Step>

--- a/src/langsmith/byoc.mdx
+++ b/src/langsmith/byoc.mdx
@@ -65,4 +65,4 @@ Before LangChain can provision a data plane, you need the following:
 - **A LangSmith organization on AWS**: Create one at [aws.smith.langchain.com](https://aws.smith.langchain.com), then send your organization ID to the LangChain team to enable BYOC.
 - **An AWS account**: LangChain recommends a fresh account dedicated to LangSmith BYOC, but it is not required.
 - **A supported region**: Pick one of the AWS regions listed above.
-- **An IAM role and external ID**: Apply the [`langsmith-byoc-role` Terraform module](https://github.com/langchain-ai/terraform/tree/main/modules/byoc/aws/langsmith-byoc-role) to create the role LangChain assumes to provision and manage your data plane. You must use this module.
+- **An IAM role and external ID**: LangChain provides the external ID. Copy it using the button next to the **Data Planes** header in **Settings > Data Planes**, then apply the [`langsmith-byoc-role` Terraform module](https://github.com/langchain-ai/terraform/tree/main/modules/byoc/aws/langsmith-byoc-role) with this value to create the role LangChain assumes to provision and manage your data plane. You must use this module.


### PR DESCRIPTION
## Overview

BYOC now uses an external ID provided by LangChain. Update the overview, onboarding, FAQ, and architecture docs to explain how to copy it from the button next to the Data Planes header in Settings > Data Planes and use it when applying the IAM role Terraform module. Remove external ID from the data plane creation parameters.

## Type of change

**Type:** Update existing documentation

## Additional notes

AI assistance: Codex assisted with the documentation edits and validation.
