### PR TITLE
Document the "or later" convention for version minimums

### DIFF
--- a/.cursor/rules/docs-style.mdc
+++ b/.cursor/rules/docs-style.mdc
@@ -34,6 +34,7 @@ Follow [Google Developer Documentation Style Guide](https://developers.google.co
 - Use markdown in description fields
 - Use `/python/` or `/javascript/` in links (resolved by build pipeline)
 - Use model aliases — use full identifiers (e.g., `claude-sonnet-4-6`)
+- Use `>=` in prose for version minimums — write "v0.153.4 or later"; reserve `>=` for package specifiers in code (`langsmith>=0.3.13`)
 - Use FontAwesome icon names
 - Use nested double quotes in component attributes — use `default="['a', 'b']"` not `default='["a", "b"]'`
 - Use contractions ("do not" not "don't", "cannot" not "can't", "it is" not "it's")
@@ -59,7 +60,7 @@ Match these patterns, drawn from established pages, when authoring new content:
 - **Open with definition, then benefit, then task** — start a section (and the page) with a one-sentence statement of what the feature is or does, follow with a sentence on what it enables for the reader, then give the procedure or detail. When a page has a sibling variant (for example, a paid or self-hosted version), link it in the opening lines.
 - **Introduce procedures with a colon lead-in** — precede steps with a phrase such as "To add a channel:", then a numbered list (or the `<Steps>` component) of imperative steps. State a step's result as a follow-on line when it matters ("The Add User modal displays."). Flag optional steps inline with "(Optional)". For long, multi-stage tasks, use `### Step N. <verb>` headings.
 - **Use bold-led definition lists for options** — for parameters, permissions, secrets, or enumerated types, write `- **Term**: Explanation.` and end each explanation with a period.
-- **Link on first mention, and point forward at section ends** — link a feature, class, or term on first mention only, not on repeats. Use the pointer phrasing "For more information, see [Page](/path)". Close substantial pages with a `## See also` list of related links.
+- **Link on first mention, and point forward at section ends** — link a feature, class, or term on first mention only, not on repeats. Two pointer forms are established, and neither is canonical, so do not mass-convert one into the other. Use the long form ("For more information, see [Page](/path)") at section ends and for standalone pointers. Use the short form ("See [Page](/path)") where the pointer trails an already-complete thought, such as an FAQ answer or a table cell, and especially in a run where nearly every item ends in a pointer. Close substantial pages with a `## See also` list of related links.
 - **State requirements and constraints up front** — put permission, plan tier, or preview requirements before the steps they govern ("Adding MCP servers requires admin permissions."). Write hard constraints as plain facts ("Once an agent identity is set, it cannot be changed.").
 
 ### Model references
@@ -67,6 +68,17 @@ Match these patterns, drawn from established pages, when authoring new content:
 Always use the latest generally available (GA) models when referencing LLMs in docstrings and illustrative code snippets. Avoid preview or beta identifiers unless the model has no GA equivalent. Outdated model names signal stale code and confuse users.
 
 Before writing or updating model references, verify current model IDs against the provider's official docs. Do not rely on memorized or cached model names — they go stale quickly.
+
+### Version requirements
+
+Write version minimums as "<version> or later" in prose. Reserve `>=` for package specifiers, where it is literal install syntax and belongs in backticks.
+
+- Tools, CLIs, runtimes, servers, and Helm charts: "Codex CLI v0.153.4 or later", "Node.js 22.x or later", "Helm chart version 0.12.33 or later".
+- Package specifiers: `langsmith>=0.3.13`, `langchain>=1.0.0`. Readers paste these into an install command, so keep the operator.
+
+Keep a `v` prefix when the page or the upstream project already uses one. Do not add one to a package specifier. When another requirement follows the version, set it off with a comma so it does not read as part of the constraint ("v0.153.4 or later, with plugin hooks enabled").
+
+This rule covers version numbers only. Leave `>=` as is in numeric parameter constraints ("Must be >= 0") and in comparison-operator reference tables.
 
 ### Release stage names
 

--- a/.github/instructions/docs-style.instructions.md
+++ b/.github/instructions/docs-style.instructions.md
@@ -32,6 +32,7 @@ Follow [Google Developer Documentation Style Guide](https://developers.google.co
 - Use markdown in description fields
 - Use `/python/` or `/javascript/` in links (resolved by build pipeline)
 - Use model aliases — use full identifiers (e.g., `claude-sonnet-4-6`)
+- Use `>=` in prose for version minimums — write "v0.153.4 or later"; reserve `>=` for package specifiers in code (`langsmith>=0.3.13`)
 - Use FontAwesome icon names
 - Use nested double quotes in component attributes — use `default="['a', 'b']"` not `default='["a", "b"]'`
 - Use contractions ("do not" not "don't", "cannot" not "can't", "it is" not "it's")
@@ -57,7 +58,7 @@ Match these patterns, drawn from established pages, when authoring new content:
 - **Open with definition, then benefit, then task** — start a section (and the page) with a one-sentence statement of what the feature is or does, follow with a sentence on what it enables for the reader, then give the procedure or detail. When a page has a sibling variant (for example, a paid or self-hosted version), link it in the opening lines.
 - **Introduce procedures with a colon lead-in** — precede steps with a phrase such as "To add a channel:", then a numbered list (or the `<Steps>` component) of imperative steps. State a step's result as a follow-on line when it matters ("The Add User modal displays."). Flag optional steps inline with "(Optional)". For long, multi-stage tasks, use `### Step N. <verb>` headings.
 - **Use bold-led definition lists for options** — for parameters, permissions, secrets, or enumerated types, write `- **Term**: Explanation.` and end each explanation with a period.
-- **Link on first mention, and point forward at section ends** — link a feature, class, or term on first mention only, not on repeats. Use the pointer phrasing "For more information, see [Page](/path)". Close substantial pages with a `## See also` list of related links.
+- **Link on first mention, and point forward at section ends** — link a feature, class, or term on first mention only, not on repeats. Two pointer forms are established, and neither is canonical, so do not mass-convert one into the other. Use the long form ("For more information, see [Page](/path)") at section ends and for standalone pointers. Use the short form ("See [Page](/path)") where the pointer trails an already-complete thought, such as an FAQ answer or a table cell, and especially in a run where nearly every item ends in a pointer. Close substantial pages with a `## See also` list of related links.
 - **State requirements and constraints up front** — put permission, plan tier, or preview requirements before the steps they govern ("Adding MCP servers requires admin permissions."). Write hard constraints as plain facts ("Once an agent identity is set, it cannot be changed.").
 
 ### Model references
@@ -65,6 +66,17 @@ Match these patterns, drawn from established pages, when authoring new content:
 Always use the latest generally available (GA) models when referencing LLMs in docstrings and illustrative code snippets. Avoid preview or beta identifiers unless the model has no GA equivalent. Outdated model names signal stale code and confuse users.
 
 Before writing or updating model references, verify current model IDs against the provider's official docs. Do not rely on memorized or cached model names — they go stale quickly.
+
+### Version requirements
+
+Write version minimums as "<version> or later" in prose. Reserve `>=` for package specifiers, where it is literal install syntax and belongs in backticks.
+
+- Tools, CLIs, runtimes, servers, and Helm charts: "Codex CLI v0.153.4 or later", "Node.js 22.x or later", "Helm chart version 0.12.33 or later".
+- Package specifiers: `langsmith>=0.3.13`, `langchain>=1.0.0`. Readers paste these into an install command, so keep the operator.
+
+Keep a `v` prefix when the page or the upstream project already uses one. Do not add one to a package specifier. When another requirement follows the version, set it off with a comma so it does not read as part of the constraint ("v0.153.4 or later, with plugin hooks enabled").
+
+This rule covers version numbers only. Leave `>=` as is in numeric parameter constraints ("Must be >= 0") and in comparison-operator reference tables.
 
 ### Release stage names
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -318,7 +318,7 @@ The prompt must cover every API rename, import path change, behavioral differenc
 
 ### Version-added admonitions
 
-When documenting new features, APIs, or behavior that requires a minimum package or CLI version, add a version-added admonition near the first mention of the feature. Use a `<Note>` callout with a concise requirement, for example: `Feature name requires \`package>=x.y.z\`.`
+When documenting new features, APIs, or behavior that requires a minimum package or CLI version, add a version-added admonition near the first mention of the feature. Use a `<Note>` callout with a concise requirement, for example: `Feature name requires \`package>=x.y.z\`.` For a CLI, runtime, or chart version, use the prose form instead ("Feature name requires Codex CLI v0.153.4 or later."). See [Version requirements](#version-requirements).
 
 For language-specific requirements, wrap the note in the relevant `:::python` or `:::js` fence. Include separate notes when Python and TypeScript packages have different minimum versions.
 
@@ -369,6 +369,7 @@ Follow [Google Developer Documentation Style Guide](https://developers.google.co
 - Use markdown in description fields
 - Use `/python/` or `/javascript/` in links (resolved by build pipeline)
 - Use model aliases — use full identifiers (e.g., `claude-sonnet-4-6`)
+- Use `>=` in prose for version minimums — write "v0.153.4 or later"; reserve `>=` for package specifiers in code (`langsmith>=0.3.13`)
 - Use FontAwesome icon names
 - Use nested double quotes in component attributes — use `default="['a', 'b']"` not `default='["a", "b"]'`
 - Use contractions ("do not" not "don't", "cannot" not "can't", "it is" not "it's")
@@ -402,6 +403,17 @@ Match these patterns, drawn from established pages, when authoring new content:
 Always use the latest generally available (GA) models when referencing LLMs in docstrings and illustrative code snippets. Avoid preview or beta identifiers unless the model has no GA equivalent. Outdated model names signal stale code and confuse users.
 
 Before writing or updating model references, verify current model IDs against the provider's official docs. Do not rely on memorized or cached model names — they go stale quickly.
+
+### Version requirements
+
+Write version minimums as "<version> or later" in prose. Reserve `>=` for package specifiers, where it is literal install syntax and belongs in backticks.
+
+- Tools, CLIs, runtimes, servers, and Helm charts: "Codex CLI v0.153.4 or later", "Node.js 22.x or later", "Helm chart version 0.12.33 or later".
+- Package specifiers: `langsmith>=0.3.13`, `langchain>=1.0.0`. Readers paste these into an install command, so keep the operator.
+
+Keep a `v` prefix when the page or the upstream project already uses one. Do not add one to a package specifier. When another requirement follows the version, set it off with a comma so it does not read as part of the constraint ("v0.153.4 or later, with plugin hooks enabled").
+
+This rule covers version numbers only. Leave `>=` as is in numeric parameter constraints ("Must be >= 0") and in comparison-operator reference tables.
 
 ### Release stage names
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,7 +318,7 @@ The prompt must cover every API rename, import path change, behavioral differenc
 
 ### Version-added admonitions
 
-When documenting new features, APIs, or behavior that requires a minimum package or CLI version, add a version-added admonition near the first mention of the feature. Use a `<Note>` callout with a concise requirement, for example: `Feature name requires \`package>=x.y.z\`.`
+When documenting new features, APIs, or behavior that requires a minimum package or CLI version, add a version-added admonition near the first mention of the feature. Use a `<Note>` callout with a concise requirement, for example: `Feature name requires \`package>=x.y.z\`.` For a CLI, runtime, or chart version, use the prose form instead ("Feature name requires Codex CLI v0.153.4 or later."). See [Version requirements](#version-requirements).
 
 For language-specific requirements, wrap the note in the relevant `:::python` or `:::js` fence. Include separate notes when Python and TypeScript packages have different minimum versions.
 
@@ -369,6 +369,7 @@ Follow [Google Developer Documentation Style Guide](https://developers.google.co
 - Use markdown in description fields
 - Use `/python/` or `/javascript/` in links (resolved by build pipeline)
 - Use model aliases — use full identifiers (e.g., `claude-sonnet-4-6`)
+- Use `>=` in prose for version minimums — write "v0.153.4 or later"; reserve `>=` for package specifiers in code (`langsmith>=0.3.13`)
 - Use FontAwesome icon names
 - Use nested double quotes in component attributes — use `default="['a', 'b']"` not `default='["a", "b"]'`
 - Use contractions ("do not" not "don't", "cannot" not "can't", "it is" not "it's")
@@ -402,6 +403,17 @@ Match these patterns, drawn from established pages, when authoring new content:
 Always use the latest generally available (GA) models when referencing LLMs in docstrings and illustrative code snippets. Avoid preview or beta identifiers unless the model has no GA equivalent. Outdated model names signal stale code and confuse users.
 
 Before writing or updating model references, verify current model IDs against the provider's official docs. Do not rely on memorized or cached model names — they go stale quickly.
+
+### Version requirements
+
+Write version minimums as "<version> or later" in prose. Reserve `>=` for package specifiers, where it is literal install syntax and belongs in backticks.
+
+- Tools, CLIs, runtimes, servers, and Helm charts: "Codex CLI v0.153.4 or later", "Node.js 22.x or later", "Helm chart version 0.12.33 or later".
+- Package specifiers: `langsmith>=0.3.13`, `langchain>=1.0.0`. Readers paste these into an install command, so keep the operator.
+
+Keep a `v` prefix when the page or the upstream project already uses one. Do not add one to a package specifier. When another requirement follows the version, set it off with a comma so it does not read as part of the constraint ("v0.153.4 or later, with plugin hooks enabled").
+
+This rule covers version numbers only. Leave `>=` as is in numeric parameter constraints ("Must be >= 0") and in comparison-operator reference tables.
 
 ### Release stage names
 

--- a/src/langsmith/cli.mdx
+++ b/src/langsmith/cli.mdx
@@ -495,7 +495,7 @@ To build and run a valid application, the LangGraph CLI requires a JSON configur
     <Tab title="Python">
     Run LangGraph API server in development mode with hot reloading and debugging capabilities. This lightweight server requires no Docker installation and is suitable for development and testing. State is persisted to a local directory.
 
-        <Note>Currently, the CLI only supports Python >= 3.11.</Note>
+        <Note>Currently, the CLI only supports Python 3.11 or later.</Note>
 
     <Tip>
     If you need more information on when to use `langgraph dev` vs `langgraph up`, refer to the [Local development & testing guide](/langsmith/local-dev-testing) for a detailed comparison.

--- a/src/langsmith/data-export-destinations.mdx
+++ b/src/langsmith/data-export-destinations.mdx
@@ -138,7 +138,7 @@ Use the returned `id` to reference this destination in subsequent bulk export op
 
 ### Credentials configuration
 
-<Note>**Requires LangSmith Helm version >= `0.10.34` (application version >= `0.10.91`)**</Note>
+<Note>**Requires LangSmith Helm version `0.10.34` or later (application version `0.10.91` or later)**</Note>
 
 We support the following additional credentials formats besides static `access_key_id` and `secret_access_key`:
 

--- a/src/langsmith/data-export.mdx
+++ b/src/langsmith/data-export.mdx
@@ -139,7 +139,7 @@ On [LangSmith cloud](/langsmith/cloud), each `all_experiments` export includes a
 ### Schedule recurring exports
 
 <Note>
-Requires LangSmith Helm version >= `0.10.42` (application version >= `0.10.109`)
+Requires LangSmith Helm version `0.10.42` or later (application version `0.10.109` or later)
 </Note>
 
 Scheduled exports collect runs periodically and export to the configured destination. To create a scheduled export, include `interval_hours` and omit `end_time`:
@@ -191,7 +191,7 @@ If a scheduled bulk export is created with `start_time=2025-07-16T00:00:00Z` and
 ### Limit exported fields
 
 <Note>
-Requires LangSmith Helm version >= `0.12.11` (application version >= `0.12.42`). Supported in both one-time and scheduled exports.
+Requires LangSmith Helm version `0.12.11` or later (application version `0.12.42` or later). Supported in both one-time and scheduled exports.
 </Note>
 
 You can improve export speed and reduce file size by limiting which fields are included using the `export_fields` parameter. If you omit `export_fields`, all fields except `feedbacks` are included.

--- a/src/langsmith/distributed-tracing.mdx
+++ b/src/langsmith/distributed-tracing.mdx
@@ -107,7 +107,7 @@ async def fake_route(request: Request):
 ## Distributed tracing in TypeScript
 
 <Note>
-Distributed tracing in TypeScript requires `langsmith` version `>=0.1.31`
+Distributed tracing in TypeScript requires `langsmith>=0.1.31`
 </Note>
 
 First, we obtain the current run tree from the client and convert it to `langsmith-trace` and `baggage` header values, which we can pass to the server:

--- a/src/langsmith/evaluate-pairwise.mdx
+++ b/src/langsmith/evaluate-pairwise.mdx
@@ -12,7 +12,7 @@ LangSmith supports evaluating **existing** experiments in a comparative manner. 
 ## Prerequisites
 
 * If you haven't already created experiments to compare, check out the [quick start](/langsmith/evaluation-quickstart) or the [how-to guide](/langsmith/evaluate-llm-application) to get started with evaluations.
-* This guide requires `langsmith` Python version `>=0.2.0` or JS version `>=0.2.9`.
+* This guide requires `langsmith>=0.2.0` for Python or `langsmith>=0.2.9` for JS.
 
 <Info>
 You can also use [`evaluate_comparative()`](https://docs.smith.langchain.com/reference/python/evaluation/langsmith.evaluation._runner.evaluate_comparative) with more than two existing experiments.

--- a/src/langsmith/evaluate-with-attachments.mdx
+++ b/src/langsmith/evaluate-with-attachments.mdx
@@ -179,7 +179,7 @@ ls_client.create_examples(
 
 #### TypeScript
 
-Requires version >= 0.2.13
+Requires version 0.2.13 or later
 
 You can use the `uploadExamplesMultipart` method to upload examples with attachments.
 

--- a/src/langsmith/log-traces-to-project.mdx
+++ b/src/langsmith/log-traces-to-project.mdx
@@ -23,7 +23,7 @@ export LANGSMITH_PROJECT=my-custom-project
 ```
 
 <Warning>
-The `LANGSMITH_PROJECT` flag is only supported in JS SDK versions >= 0.2.16, use `LANGCHAIN_PROJECT` instead if you are using an older version.
+The `LANGSMITH_PROJECT` flag is only supported in JS SDK 0.2.16 or later, use `LANGCHAIN_PROJECT` instead if you are using an older version.
 </Warning>
 
 If the project specified does not exist, LangSmith will automatically create it when the first trace is ingested.
@@ -836,7 +836,7 @@ if (primaryRunId) {
 </CodeGroup>
 
 <Note>
-The `compute_run_id_for_secondary_replica` / `computeRunIdForSecondaryReplica` helper is available in Python SDK >= 0.10.8 and JS SDK >= 0.8.5. If you are using an earlier SDK version, upgrade to use this feature.
+The `compute_run_id_for_secondary_replica` / `computeRunIdForSecondaryReplica` helper is available in Python SDK 0.10.8 or later and JS SDK 0.8.5 or later. If you are using an earlier SDK version, upgrade to use this feature.
 </Note>
 
 ### Route between LangSmith and OpenTelemetry destinations

--- a/src/langsmith/self-host-dependency-versions.mdx
+++ b/src/langsmith/self-host-dependency-versions.mdx
@@ -17,7 +17,7 @@ If you are using a managed service (such as Amazon RDS, Google Cloud SQL, or Azu
 | [PostgreSQL](/langsmith/self-host-external-postgres) | 14 | Primary relational store for operational data. Required for both LangSmith and standalone Agent Server deployments. Used to install the `btree_gin`, `btree_gist`, `pgcrypto`, `citext`, `ltree`, and `pg_trgm` extensions. |
 | [Redis](/langsmith/self-host-external-redis) | 6.2 | Used for queueing and caching. Standalone and Redis Cluster modes are both supported. As of Agent Server 0.8.0, the Redis-backed run queue requires Redis 6.2 or later: it enqueues runs with the `ZADD ... LT` flag, which was added in 6.2. |
 | [Valkey](/langsmith/self-host-external-redis) | 8 | Officially supported as a drop-in replacement for Redis. Standalone and Cluster modes are both supported. |
-| [ClickHouse](/langsmith/self-host-external-clickhouse) | Version specified in the [LangSmith Helm chart](https://github.com/langchain-ai/helm/releases) or greater | Stores traces and feedback. ClickHouse versions >= 24.2 require LangSmith v0.6 or later. Downgrades are not supported. |
+| [ClickHouse](/langsmith/self-host-external-clickhouse) | Version specified in the [LangSmith Helm chart](https://github.com/langchain-ai/helm/releases) or greater | Stores traces and feedback. ClickHouse 24.2 or later requires LangSmith v0.6 or later. Downgrades are not supported. |
 
 <Warning>
 **Redis < 6.2 and PostgreSQL < 14 are not supported.** A LangSmith installation pointed at an older Redis or PostgreSQL instance may fail to start or behave unpredictably. Upgrade your datastore before installing or upgrading LangSmith.
@@ -41,8 +41,8 @@ If you are using a managed service (such as Amazon RDS, Google Cloud SQL, or Azu
 
 ## Where these versions are enforced
 
-- PostgreSQL `>= 14`: refer to [Connect to an external PostgreSQL database](/langsmith/self-host-external-postgres#requirements).
-- Redis `>= 6.2` and Valkey `8`: refer to [Connect to an external Redis or Valkey database](/langsmith/self-host-external-redis#requirements).
+- PostgreSQL 14 or later: refer to [Connect to an external PostgreSQL database](/langsmith/self-host-external-postgres#requirements).
+- Redis 6.2 or later and Valkey 8: refer to [Connect to an external Redis or Valkey database](/langsmith/self-host-external-redis#requirements).
 - ClickHouse: use the version specified in the [LangSmith Helm chart](https://github.com/langchain-ai/helm/releases) or greater: refer to [Connect to an external ClickHouse database](/langsmith/self-host-external-clickhouse#requirements).
 - Kubernetes cluster prerequisites: refer to [Self-host LangSmith on Kubernetes](/langsmith/kubernetes#prerequisites).
 

--- a/src/langsmith/self-host-external-clickhouse.mdx
+++ b/src/langsmith/self-host-external-clickhouse.mdx
@@ -30,7 +30,7 @@ Additionally, sensitive information can be configured to be not stored in Clickh
 * A provisioned ClickHouse instance that your LangSmith application will have network access to (see above for options).
 * A user with admin access to the ClickHouse database. This user will be used to create the necessary tables, indexes, and views.
 * We support both standalone ClickHouse and externally managed clustered deployments. For clustered deployments, ensure all nodes are running the same version. Note that clustered setups are not supported with bundled ClickHouse installations.
-* We only support ClickHouse versions >= 23.9. Use of ClickHouse versions >= 24.2 requires LangSmith v0.6 or later.
+* We only support ClickHouse 23.9 or later. Use of ClickHouse 24.2 or later requires LangSmith v0.6 or later.
 
 <Warning>
 Downgrading ClickHouse to an earlier version can cause data corruption of system tables and result in significant downtime. If you need assistance with a ClickHouse version change or are experiencing issues after an upgrade, contact support at [support.langchain.com](https://support.langchain.com) before attempting a downgrade.

--- a/src/langsmith/self-host-external-postgres.mdx
+++ b/src/langsmith/self-host-external-postgres.mdx
@@ -22,7 +22,7 @@ For cloud-specific IAM/Workload Identity authentication, refer to the [IAM authe
   * [Google Cloud SQL](https://cloud.google.com/curated-resources/cloud-sql#section-1)
   * [Azure Database for PostgreSQL](https://azure.microsoft.com/en-us/products/postgresql#features)
 
-* Note: We only officially support PostgreSQL versions >= 14.
+* Note: We only officially support PostgreSQL 14 or later.
 
 * We support password and [IAM/Workload Identity](#iam-authentication) authentication.
 

--- a/src/langsmith/self-host-external-redis.mdx
+++ b/src/langsmith/self-host-external-redis.mdx
@@ -28,7 +28,7 @@ For cloud-specific IAM/Workload Identity authentication, refer to the [IAM authe
   * [Google Cloud Memorystore](https://cloud.google.com/memorystore) (Redis or Valkey)
   * [Azure Cache for Redis](https://azure.microsoft.com/en-us/services/cache/)
 
-* **Supported versions:** Redis >= 6.2, or Valkey 8. Valkey is treated as a drop-in replacement for Redis throughout this guide.
+* **Supported versions:** Redis 6.2 or later, or Valkey 8. Valkey is treated as a drop-in replacement for Redis throughout this guide.
 * We support both Standalone and Redis Cluster (including Valkey Cluster). See the appropriate sections for deployment instructions.
 * We support no authentication, password, and [IAM/Workload Identity](#iam-authentication) authentication.
 * By default, we recommend an instance with at least 2 vCPUs and 8GB of memory. However, the actual requirements will depend on your tracing workload. We recommend monitoring your Redis instance and scaling up as needed.

--- a/src/langsmith/self-host-terraform-aws-deploy.mdx
+++ b/src/langsmith/self-host-terraform-aws-deploy.mdx
@@ -423,7 +423,7 @@ You can enable Fleet with `enable_fleet`. On AWS, it requires `enable_deployment
 Terraform creates a dedicated `langsmith_fleet` database on RDS and wires the `langsmith-fleet-postgres` and `langsmith-fleet-redis` secrets to the existing RDS and ElastiCache instances. Fleet reuses `langsmith_agent_builder_encryption_key`, so migrating from `enable_agent_builder` keeps the same key and data.
 
 <Note>
-Fleet requires the LangSmith Helm chart `>=0.15.0` and the Agent Builder or Fleet entitlement in your license.
+Fleet requires the LangSmith Helm chart 0.15.0 or later and the Agent Builder or Fleet entitlement in your license.
 </Note>
 
 Fleet installs the `standalone-fleet-api-server`, `standalone-fleet-tool-server`, `standalone-fleet-trigger-server`, and `standalone-fleet-queue` services.

--- a/src/langsmith/self-host-terraform-gcp-deploy.mdx
+++ b/src/langsmith/self-host-terraform-gcp-deploy.mdx
@@ -478,7 +478,7 @@ Fleet is the current form of the feature formerly called Agent Builder, deployed
 You can enable Fleet with `enable_fleet`. Unlike the deprecated `enable_agent_builder` path, it does not require LangSmith Deployment. Terraform provisions a dedicated `fleet` database on Cloud SQL and wires the `langsmith-fleet-postgres` and `langsmith-fleet-redis` secrets to the existing Cloud SQL and Memorystore instances. Fleet reuses `langsmith_agent_builder_encryption_key`, so migrating from `enable_agent_builder` keeps the same key and data.
 
 <Note>
-Fleet requires the LangSmith Helm chart `>=0.15.0` and the Agent Builder or Fleet entitlement in your license.
+Fleet requires the LangSmith Helm chart 0.15.0 or later and the Agent Builder or Fleet entitlement in your license.
 </Note>
 
 ```hcl

--- a/src/langsmith/smithdb-sdk-migration.mdx
+++ b/src/langsmith/smithdb-sdk-migration.mdx
@@ -36,7 +36,7 @@ The [LangSmith CLI](/langsmith/langsmith-cli) queries the same SmithDB-backed en
 
 ## About self-hosted
 
-- The new methods documented in this guide require `>=0.16` self-hosted version, independent of the data store used.
+- The new methods documented in this guide require self-hosted version 0.16 or later, independent of the data store used.
 - The deprecated methods stop working once ClickHouse is disabled.
 - Where possible, the SDK raises a warning or error identifying the version to upgrade to, instead of failing without explanation.
 

--- a/src/langsmith/trace-with-langchain.mdx
+++ b/src/langsmith/trace-with-langchain.mdx
@@ -168,7 +168,7 @@ export LANGSMITH_PROJECT=my-project
 ```
 
 <Warning>
-The `LANGSMITH_PROJECT` flag is only supported in JS SDK versions >= 0.2.16, use `LANGCHAIN_PROJECT` instead if you are using an older version.
+The `LANGSMITH_PROJECT` flag is only supported in JS SDK 0.2.16 or later, use `LANGCHAIN_PROJECT` instead if you are using an older version.
 </Warning>
 
 ### Dynamically

--- a/src/oss/deepagents/dynamic-subagents.mdx
+++ b/src/oss/deepagents/dynamic-subagents.mdx
@@ -40,7 +40,7 @@ Use this pattern when work spans many independent units, needs multiple perspect
 
 :::python
 <Note>
-    Interpreters require `langchain-quickjs>=0.2.0` and Python `>=3.11`.
+    Interpreters require `langchain-quickjs>=0.2.0` and Python 3.11 or later.
 </Note>
 :::
 

--- a/src/oss/deepagents/interpreters.mdx
+++ b/src/oss/deepagents/interpreters.mdx
@@ -25,7 +25,7 @@ Where [sandboxes](/oss/deepagents/sandboxes) are a code-first way for acting on 
 
 :::python
 <Note>
-    Interpreters require `langchain-quickjs>=0.2.0` and Python `>=3.11`.
+    Interpreters require `langchain-quickjs>=0.2.0` and Python 3.11 or later.
 </Note>
 :::
 

--- a/src/oss/deepagents/streaming.mdx
+++ b/src/oss/deepagents/streaming.mdx
@@ -187,7 +187,7 @@ Monitor when subagents start, run, and complete:
 ## v2 streaming format
 
 <Note>
-Requires LangGraph >= 1.1.
+Requires LangGraph 1.1 or later.
 </Note>
 
 All examples on this page use the v2 streaming format (`version="v2"`), which is the recommended approach. Every chunk is a `StreamPart` dict with `type`, `ns`, and `data` keys — the same shape regardless of stream mode, number of modes, or subgraph settings.

--- a/src/oss/deepagents/subagents.mdx
+++ b/src/oss/deepagents/subagents.mdx
@@ -357,7 +357,7 @@ uv add "deepagents[quickjs]"
 <DynamicSubagentsQuickstartPy />
 
 <Note>
-    Dynamic subagent dispatch is on by default whenever the agent has subagents and the interpreter middleware. Pass `CodeInterpreterMiddleware(subagents=False)` to require dispatch through the normal `task` tool path. Interpreters require `langchain-quickjs>=0.2.0` and Python `>=3.11`.
+    Dynamic subagent dispatch is on by default whenever the agent has subagents and the interpreter middleware. Pass `CodeInterpreterMiddleware(subagents=False)` to require dispatch through the normal `task` tool path. Interpreters require `langchain-quickjs>=0.2.0` and Python 3.11 or later.
 </Note>
 :::
 

--- a/src/oss/javascript/integrations/chat/openai.mdx
+++ b/src/oss/javascript/integrations/chat/openai.mdx
@@ -224,7 +224,7 @@ await fineTunedLlm.invoke("Hi there!");
 If you need additional information like logprobs or token usage, these will be returned directly in the `invoke` response within the `response_metadata` field on the message.
 
 <Info>
-    **Requires `@langchain/core` version >=0.1.48.**
+    **Requires `@langchain/core>=0.1.48`.**
 </Info>
 
 ```typescript

--- a/src/oss/javascript/integrations/tools/falkordb.mdx
+++ b/src/oss/javascript/integrations/tools/falkordb.mdx
@@ -197,9 +197,9 @@ console.log(structuredSchema.relationships);
 
 ## Requirements
 
-- Node.js >= 18
+- Node.js 18 or later
 - FalkorDB server running (Redis-compatible)
-- LangChain >= 0.1.0
+- LangChain 0.1.0 or later
 
 ## Examples
 

--- a/src/oss/langchain/streaming.mdx
+++ b/src/oss/langchain/streaming.mdx
@@ -1095,7 +1095,7 @@ See the [LangGraph streaming guide](/oss/langgraph/streaming#disable-streaming-f
 ## v2 streaming format
 
 <Note>
-Requires LangGraph >= 1.1.
+Requires LangGraph 1.1 or later.
 </Note>
 
 Pass `version="v2"` to `stream()` or `astream()` to get a unified output format. Every chunk is a `StreamPart` dict with `type`, `ns`, and `data` keys — the same shape regardless of stream mode or number of modes:

--- a/src/oss/langgraph/streaming.mdx
+++ b/src/oss/langgraph/streaming.mdx
@@ -100,7 +100,7 @@ Debug streaming events, inspect token-by-token LLM output, and monitor latency w
 ### Stream output format (v2)
 
 <Note>
-Requires LangGraph >= 1.1. All examples on this page use `version="v2"`.
+Requires LangGraph 1.1 or later. All examples on this page use `version="v2"`.
 </Note>
 
 Pass `version="v2"` to `stream()` or `astream()` to get a unified output format. Every chunk is a `StreamPart` dict with a consistent shape — regardless of stream mode, number of modes, or subgraph settings:
@@ -1232,7 +1232,7 @@ To include outputs from [subgraphs](/oss/langgraph/use-subgraphs) in the streame
 The outputs will be streamed as tuples `(namespace, data)`, where `namespace` is a tuple with the path to the node where a subgraph is invoked, e.g. `("parent_node:<task_id>", "child_node:<task_id>")`.
 
 <Tabs>
-    <Tab title="v2 (LangGraph >= 1.1)">
+    <Tab title="v2 (LangGraph 1.1 or later)">
     With `version="v2"`, subgraph events use the same `StreamPart` format. The `ns` field identifies the source:
 
     ```python

--- a/src/oss/python/integrations/vectorstores/google_cloud_sql_mysql.mdx
+++ b/src/oss/python/integrations/vectorstores/google_cloud_sql_mysql.mdx
@@ -21,7 +21,7 @@ To run this notebook, you will need to do the following:
 
 * [Create a Google Cloud Project](https://developers.google.com/workspace/guides/create-project)
 * [Enable the Cloud SQL Admin API.](https://console.cloud.google.com/flows/enableapi?apiid=sqladmin.googleapis.com)
-* [Create a Cloud SQL instance.](https://cloud.google.com/sql/docs/mysql/connect-instance-auth-proxy#create-instance) (version must be >= **8.0.36** with **cloudsql_vector** database flag configured to "On")
+* [Create a Cloud SQL instance.](https://cloud.google.com/sql/docs/mysql/connect-instance-auth-proxy#create-instance) (version must be **8.0.36** or later with **cloudsql_vector** database flag configured to "On")
 * [Create a Cloud SQL database.](https://cloud.google.com/sql/docs/mysql/create-manage-databases)
 * [Add a User to the database.](https://cloud.google.com/sql/docs/mysql/create-manage-users)
 
@@ -81,7 +81,7 @@ PROJECT_ID = "my-project-id"  # @param {type:"string"}
 
 Find your database values, in the [Cloud SQL Instances page](https://console.cloud.google.com/sql?_ga=2.223735448.2062268965.1707700487-2088871159.1707257687).
 
-**Note:** MySQL vector support is only available on MySQL instances with version **>= 8.0.36**.
+**Note:** MySQL vector support is only available on MySQL instances with version **8.0.36** or later.
 
 For existing instances, you may need to perform a [self-service maintenance update](https://cloud.google.com/sql/docs/mysql/self-service-maintenance) to update your maintenance version to **MYSQL_8_0_36.R20240401.03_00** or greater. Once updated, [configure your database flags](https://cloud.google.com/sql/docs/mysql/flags) to have the new **cloudsql_vector** flag to "On".
 


### PR DESCRIPTION
## Why

The docs already have a settled convention for version minimums, but the style guide never wrote it down: prose uses "<version> or later" for tools, CLIs, runtimes, and Helm charts (65 instances), while bare `>=` is reserved for package specifiers written as code (`langsmith>=0.3.13`), where it is literal install syntax. Because the rule was unwritten, new pages kept arriving with `>=` in prose — including #5963, which prompted this.

## What changed

**The rule** — a `### Version requirements` subsection in the style guide, placed beside Model references since both cover how to reference versioned software, plus a matching `Don't` bullet next to the model-alias rule. Per the sync note at the top of `CLAUDE.md`, this is mirrored into `AGENTS.md` and both path-scoped agent rule files.

The rule is deliberately scoped to version numbers. A sweep found 101 `>=` occurrences outside code fences, and most are legitimate: `Must be >= 0` parameter constraints in `middleware/built-in.mdx`, and `Greater than or equal (>=)` operator-reference tables in six vectorstore pages. An unscoped rule would have invited agents to "fix" those into nonsense, so the subsection closes by excluding them.

**The existing violations** — 31 replacements across 24 pages. Package specifiers, pin ranges (`>=0.3.5,<0.4.0`), and version-column tables are left alone. Changelog pages are untouched: `agent-server-changelog.mdx` is updated by `langgraph-api` PRs and `self-hosted-changelog.mdx` is bot-generated, and both are historical records.

Three cases were mixed forms, where a package was named but its version sat stranded outside the backticks (`` `langsmith` version `>=0.1.31` ``). Those collapse into one sanctioned specifier rather than becoming prose.

## Incidental fixes worth a look

Two things surfaced that are not strictly part of this change:

1. **The mirrors had drifted.** #5472 rewrote the "Link on first mention" bullet in `CLAUDE.md`/`AGENTS.md` to stop prescribing a single pointer phrasing, but never updated `.cursor/rules/docs-style.mdc` or `.github/instructions/docs-style.instructions.md`. Both still carried the old wording — so the two files Cursor and Copilot actually load were prescribing the exact thing that PR removed. I regenerated them mechanically from `CLAUDE.md`, which is why their diffs are larger than the version rule alone.

2. **Two self-hosted pages contradicted themselves mid-sentence.** `self-host-dependency-versions.mdx` and `self-host-external-clickhouse.mdx` each used both forms in one sentence ("ClickHouse versions >= 24.2 require LangSmith v0.6 or later").

## Review notes

- The scoping line in the new subsection is the part most worth a second opinion — it decides what future agents will and will not rewrite.
- `<Tab title="v2 (LangGraph >= 1.1)">` in `oss/langgraph/streaming.mdx` became `v2 (LangGraph 1.1 or later)`. It is a UI label, so push back if the longer title crowds the tab strip.
- `evaluate-with-attachments.mdx` said only "Requires version >= 0.2.13" without naming a package. I kept it version-only rather than guessing which SDK.

## Verification

- `make lint_prose` clean on all 24 changed pages.
- All four style guide copies verified byte-identical after regeneration.
- Re-ran the sweep afterward: the only `>=` left outside changelogs are package specifiers, a pin range, and a version-column table.
- No nav or link changes, so `make broken-links` was not run.

Drafted with Claude Code; every rewrite reviewed against the surrounding prose.
