### PR TITLE
Standardize UI navigation paths on ">" and enforce it with Vale

### DIFF
--- a/.cursor/rules/docs-style.mdc
+++ b/.cursor/rules/docs-style.mdc
@@ -35,6 +35,7 @@ Follow [Google Developer Documentation Style Guide](https://developers.google.co
 - Use `/python/` or `/javascript/` in links (resolved by build pipeline)
 - Use model aliases — use full identifiers (e.g., `claude-sonnet-4-6`)
 - Use `>=` in prose for version minimums — write "v0.153.4 or later"; reserve `>=` for package specifiers in code (`langsmith>=0.3.13`)
+- Use "→" to separate UI navigation steps — write "Go to **Settings** > **API Keys**"
 - Use FontAwesome icon names
 - Use nested double quotes in component attributes — use `default="['a', 'b']"` not `default='["a", "b"]'`
 - Use contractions ("do not" not "don't", "cannot" not "can't", "it is" not "it's")
@@ -79,6 +80,12 @@ Write version minimums as "<version> or later" in prose. Reserve `>=` for packag
 Keep a `v` prefix when the page or the upstream project already uses one. Do not add one to a package specifier. When another requirement follows the version, set it off with a comma so it does not read as part of the constraint ("v0.153.4 or later, with plugin hooks enabled").
 
 This rule covers version numbers only. Leave `>=` as is in numeric parameter constraints ("Must be >= 0") and in comparison-operator reference tables.
+
+### Navigation paths
+
+Separate UI navigation steps with a greater-than sign surrounded by spaces, not an arrow: "Go to **Settings** > **API Keys**". Bold the UI labels, either individually (`**Settings** > **API Keys**`) or as a single span (`**Settings > API Keys**`), and match whichever form the page already uses. Vale enforces this as `LangChain.NavPathArrows`.
+
+The arrow character stays where it does not mark navigation: mermaid diagrams, data flow (`browser or client → data plane`), API renames in migration guides (`create_react_agent` → `create_agent`), state progressions, and UI labels that literally contain an arrow ("Manage app access →").
 
 ### Release stage names
 

--- a/.github/instructions/docs-style.instructions.md
+++ b/.github/instructions/docs-style.instructions.md
@@ -33,6 +33,7 @@ Follow [Google Developer Documentation Style Guide](https://developers.google.co
 - Use `/python/` or `/javascript/` in links (resolved by build pipeline)
 - Use model aliases — use full identifiers (e.g., `claude-sonnet-4-6`)
 - Use `>=` in prose for version minimums — write "v0.153.4 or later"; reserve `>=` for package specifiers in code (`langsmith>=0.3.13`)
+- Use "→" to separate UI navigation steps — write "Go to **Settings** > **API Keys**"
 - Use FontAwesome icon names
 - Use nested double quotes in component attributes — use `default="['a', 'b']"` not `default='["a", "b"]'`
 - Use contractions ("do not" not "don't", "cannot" not "can't", "it is" not "it's")
@@ -77,6 +78,12 @@ Write version minimums as "<version> or later" in prose. Reserve `>=` for packag
 Keep a `v` prefix when the page or the upstream project already uses one. Do not add one to a package specifier. When another requirement follows the version, set it off with a comma so it does not read as part of the constraint ("v0.153.4 or later, with plugin hooks enabled").
 
 This rule covers version numbers only. Leave `>=` as is in numeric parameter constraints ("Must be >= 0") and in comparison-operator reference tables.
+
+### Navigation paths
+
+Separate UI navigation steps with a greater-than sign surrounded by spaces, not an arrow: "Go to **Settings** > **API Keys**". Bold the UI labels, either individually (`**Settings** > **API Keys**`) or as a single span (`**Settings > API Keys**`), and match whichever form the page already uses. Vale enforces this as `LangChain.NavPathArrows`.
+
+The arrow character stays where it does not mark navigation: mermaid diagrams, data flow (`browser or client → data plane`), API renames in migration guides (`create_react_agent` → `create_agent`), state progressions, and UI labels that literally contain an arrow ("Manage app access →").
 
 ### Release stage names
 

--- a/.github/vale/styles/LangChain/NavPathArrows.yml
+++ b/.github/vale/styles/LangChain/NavPathArrows.yml
@@ -1,0 +1,13 @@
+# Navigation paths use the greater-than sign, not an arrow.
+# See the "Navigation paths" section of the style guide in AGENTS.md.
+extends: existence
+message: "Use '>' instead of '→' to separate UI navigation steps ('%s')."
+link: 'https://developers.google.com/style/ui-elements#describing-interactions-with-ui-elements'
+level: error
+scope: raw
+nonword: true
+tokens:
+ # Arrow between two bold UI labels: **Settings** → **API Keys**
+ - '\*\*\s*→\s*\*\*'
+ # Arrow inside one bold UI label path: **Settings → API Keys**
+ - '\*\*[^*\n`(]*\S\s*→\s*[A-Z][^*\n`(]*\*\*'

--- a/.vale.ini
+++ b/.vale.ini
@@ -34,6 +34,7 @@ LangChain.GlobalAudienceMetaphorical = YES
 LangChain.GlobalAudienceNonOppressiveLanguage = YES
 LangChain.Hyphen = YES
 LangChain.Interjections = YES
+LangChain.NavPathArrows = YES
 LangChain.NegativeWords = YES
 LangChain.NoContractions = YES
 LangChain.NoHyphen = YES

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -370,6 +370,7 @@ Follow [Google Developer Documentation Style Guide](https://developers.google.co
 - Use `/python/` or `/javascript/` in links (resolved by build pipeline)
 - Use model aliases — use full identifiers (e.g., `claude-sonnet-4-6`)
 - Use `>=` in prose for version minimums — write "v0.153.4 or later"; reserve `>=` for package specifiers in code (`langsmith>=0.3.13`)
+- Use "→" to separate UI navigation steps — write "Go to **Settings** > **API Keys**"
 - Use FontAwesome icon names
 - Use nested double quotes in component attributes — use `default="['a', 'b']"` not `default='["a", "b"]'`
 - Use contractions ("do not" not "don't", "cannot" not "can't", "it is" not "it's")
@@ -414,6 +415,12 @@ Write version minimums as "<version> or later" in prose. Reserve `>=` for packag
 Keep a `v` prefix when the page or the upstream project already uses one. Do not add one to a package specifier. When another requirement follows the version, set it off with a comma so it does not read as part of the constraint ("v0.153.4 or later, with plugin hooks enabled").
 
 This rule covers version numbers only. Leave `>=` as is in numeric parameter constraints ("Must be >= 0") and in comparison-operator reference tables.
+
+### Navigation paths
+
+Separate UI navigation steps with a greater-than sign surrounded by spaces, not an arrow: "Go to **Settings** > **API Keys**". Bold the UI labels, either individually (`**Settings** > **API Keys**`) or as a single span (`**Settings > API Keys**`), and match whichever form the page already uses. Vale enforces this as `LangChain.NavPathArrows`.
+
+The arrow character stays where it does not mark navigation: mermaid diagrams, data flow (`browser or client → data plane`), API renames in migration guides (`create_react_agent` → `create_agent`), state progressions, and UI labels that literally contain an arrow ("Manage app access →").
 
 ### Release stage names
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -370,6 +370,7 @@ Follow [Google Developer Documentation Style Guide](https://developers.google.co
 - Use `/python/` or `/javascript/` in links (resolved by build pipeline)
 - Use model aliases — use full identifiers (e.g., `claude-sonnet-4-6`)
 - Use `>=` in prose for version minimums — write "v0.153.4 or later"; reserve `>=` for package specifiers in code (`langsmith>=0.3.13`)
+- Use "→" to separate UI navigation steps — write "Go to **Settings** > **API Keys**"
 - Use FontAwesome icon names
 - Use nested double quotes in component attributes — use `default="['a', 'b']"` not `default='["a", "b"]'`
 - Use contractions ("do not" not "don't", "cannot" not "can't", "it is" not "it's")
@@ -414,6 +415,12 @@ Write version minimums as "<version> or later" in prose. Reserve `>=` for packag
 Keep a `v` prefix when the page or the upstream project already uses one. Do not add one to a package specifier. When another requirement follows the version, set it off with a comma so it does not read as part of the constraint ("v0.153.4 or later, with plugin hooks enabled").
 
 This rule covers version numbers only. Leave `>=` as is in numeric parameter constraints ("Must be >= 0") and in comparison-operator reference tables.
+
+### Navigation paths
+
+Separate UI navigation steps with a greater-than sign surrounded by spaces, not an arrow: "Go to **Settings** > **API Keys**". Bold the UI labels, either individually (`**Settings** > **API Keys**`) or as a single span (`**Settings > API Keys**`), and match whichever form the page already uses. Vale enforces this as `LangChain.NavPathArrows`.
+
+The arrow character stays where it does not mark navigation: mermaid diagrams, data flow (`browser or client → data plane`), API renames in migration guides (`create_react_agent` → `create_agent`), state progressions, and UI labels that literally contain an arrow ("Manage app access →").
 
 ### Release stage names
 

--- a/src/langsmith/alerts.mdx
+++ b/src/langsmith/alerts.mdx
@@ -114,7 +114,7 @@ You can preview alert behavior over a historical time window to understand how m
     ### 1. Create a Service in PagerDuty
 
     1. Log in to your PagerDuty account
-    2. Navigate to **Services → Service Directory**
+    2. Navigate to **Services > Service Directory**
     3. Click **+ New Service**
     4. Complete the following fields:
        - **Name**: Provide a descriptive name (e.g., "LangSmith Monitoring")
@@ -347,7 +347,7 @@ You can preview alert behavior over a historical time window to understand how m
       **Step 5: Configure the webhook alert in LangSmith**
 
       1. In LangSmith, navigate to your project.
-      2. Select **Alerts → Create Alert**.
+      2. Select **Alerts > Create Alert**.
       3. Define your alert metrics and conditions.
       4. In the notification section, select **Webhook**.
       5. Configure the webhook with the following settings:
@@ -458,7 +458,7 @@ You can preview alert behavior over a historical time window to understand how m
       **Step 3: Configure the webhook alert in LangSmith**
 
       1. In LangSmith, navigate to your project.
-      2. Select **Alerts → Create Alert**.
+      2. Select **Alerts > Create Alert**.
       3. Define your alert metrics and conditions.
       4. In the notification section, select **Webhook**.
       5. Configure the webhook with the following settings:
@@ -512,20 +512,20 @@ You can preview alert behavior over a historical time window to understand how m
       **Step 1: Create a SendGrid API key**
 
       1. Log in to your [SendGrid dashboard](https://app.sendgrid.com).
-      2. Navigate to **Settings → API Keys**.
+      2. Navigate to **Settings > API Keys**.
       3. Click **Create API Key**.
-      4. Choose **Restricted Access** and enable **Mail Send → Full Access**.
+      4. Choose **Restricted Access** and enable **Mail Send > Full Access**.
       5. Click **Create & View**, copy the key, and store it securely.
 
       **Step 2: Verify your sender email**
 
-      1. In SendGrid, navigate to **Settings → Sender Authentication**.
+      1. In SendGrid, navigate to **Settings > Sender Authentication**.
       2. Complete either **Domain Authentication** (recommended) or **Single Sender Verification** for the address you want to send from.
 
       **Step 3: Configure the webhook alert in LangSmith**
 
       1. In LangSmith, navigate to your project.
-      2. Select **Alerts → Create Alert**.
+      2. Select **Alerts > Create Alert**.
       3. Define your alert metrics and conditions.
       4. In the notification section, select **Webhook**.
       5. Configure the webhook with the following settings:
@@ -613,7 +613,7 @@ You can preview alert behavior over a historical time window to understand how m
 
       **Prerequisites**
 
-      - A Google Chat space with an incoming webhook configured. In Google Chat, open the space → **Apps & integrations** → **Add webhooks**, create a webhook, and copy the URL.
+      - A Google Chat space with an incoming webhook configured. In Google Chat, open the space, then go to **Apps & integrations** > **Add webhooks**, create a webhook, and copy the URL.
       - A Google Cloud project with Cloud Run or Cloud Functions enabled, or equivalent hosting.
 
       **Step 1: Deploy the handler**
@@ -727,7 +727,7 @@ You can preview alert behavior over a historical time window to understand how m
       }
       ```
 
-      Set `GCHAT_WEBHOOK_URL` and `LANGSMITH_SHARED_SECRET` in **Project Settings → Script Properties**.
+      Set `GCHAT_WEBHOOK_URL` and `LANGSMITH_SHARED_SECRET` in **Project Settings > Script Properties**.
 
       <Warning>
       Apps Script web apps cannot read custom HTTP request headers, so the shared secret must be passed as a **query string parameter** (`?secret=...`) rather than a header. Include it in the LangSmith webhook URL rather than the Headers field.

--- a/src/langsmith/annotation-queues.mdx
+++ b/src/langsmith/annotation-queues.mdx
@@ -80,7 +80,7 @@ Set a number of reviewers or the maximum time you want to reserve the item to a 
 - **Use assigned reviewers**: Enable this toggle to use specific workspace members instead of a count-based threshold. When enabled:
 
     - A multi-select user picker appears so you can choose specific workspace members as assigned reviewers.
-    - An item is marked **Completed** only when every assigned reviewer has submitted their review. Queue items progress through three states: **Needs Review** → **Needs Others' Review** → **Completed**.
+    - An item is marked **Completed** only when every assigned reviewer has submitted their review. Queue items progress through three states: **Needs Review**, **Needs Others' Review**, and **Completed**.
     - Non-assigned workspace members can still annotate items, but their submissions do not count toward completion.
     - Any workspace member can edit the assigned reviewers list in the queue settings.
 

--- a/src/langsmith/big-query-bulk-export.mdx
+++ b/src/langsmith/big-query-bulk-export.mdx
@@ -74,7 +74,7 @@ gcloud storage hmac create \
   langsmith-bulk-export@YOUR_PROJECT.iam.gserviceaccount.com
 ```
 
-Save the `accessId` and `secret` from the output. You can also generate HMAC keys in the GCP Console under **Cloud Storage → Settings → Interoperability → Create a key for a service account**.
+Save the `accessId` and `secret` from the output. You can also generate HMAC keys in the GCP Console under **Cloud Storage > Settings > Interoperability > Create a key for a service account**.
 
 ## 4. Create a bulk export destination
 

--- a/src/langsmith/context-hub-webhooks.mdx
+++ b/src/langsmith/context-hub-webhooks.mdx
@@ -16,7 +16,7 @@ Each webhook applies to the entire workspace. Every configured endpoint receives
 
 To add a webhook:
 
-1. In the [LangSmith UI](https://smith.langchain.com), go to **Settings** → **Integrations** → **Context Hub webhooks**.
+1. In the [LangSmith UI](https://smith.langchain.com), go to **Settings** > **Integrations** > **Context Hub webhooks**.
 1. Click **Add webhook**.
 1. Enter a publicly reachable HTTPS URL.
 1. (Optional) Add custom request headers, such as an `Authorization` header.

--- a/src/langsmith/jit-invite-sso.mdx
+++ b/src/langsmith/jit-invite-sso.mdx
@@ -30,9 +30,9 @@ You can update these settings in the LangSmith UI or with the LangSmith API:
 
 In the [LangSmith UI](https://smith.langchain.com):
 
-1. Navigate to **Settings** → **Organization** → **Access and Security** → **General**.
+1. Navigate to **Settings** > **Organization** > **Access and Security** > **General**.
 1. Toggle **Enable JIT provisioning** and **Allow invites** as needed.
-1. [Configure SSO default workspaces and roles](#configure-default-sso-settings) in **Settings** → **Organization** → **SSO Configuration**.
+1. [Configure SSO default workspaces and roles](#configure-default-sso-settings) in **Settings** > **Organization** > **SSO Configuration**.
 
 </Tab>
 <Tab title="API" icon="code">
@@ -187,7 +187,7 @@ When [JIT provisioning](#jit-provisioning) is enabled, configure default setting
 
 1. Default workspaces. Select one or more workspaces that users are automatically added to. Users receive the same role in all selected workspaces. To configure:
 
-    1. Go to **Settings** → **Organization** → **SSO Configuration**.
+    1. Go to **Settings** > **Organization** > **SSO Configuration**.
     1. Set **Default workspace role**.
     1. Select **Default workspaces**.
     1. Save your configuration.

--- a/src/langsmith/llm-gateway-admin-setup.mdx
+++ b/src/langsmith/llm-gateway-admin-setup.mdx
@@ -17,7 +17,7 @@ You need [`organization:manage` permission](/langsmith/organization-workspace-op
 
 The gateway resolves provider API keys from your workspace's Provider Secrets—this is how it proxies calls to upstream providers without individual users needing local copies of provider keys.
 
-Go to **Settings → Integrations → Provider Secrets** and add the keys for the providers you want to proxy through the gateway:
+Go to **Settings > Integrations > Provider Secrets** and add the keys for the providers you want to proxy through the gateway:
 
 | Secret name | Provider |
 | --- | --- |
@@ -41,7 +41,7 @@ The built-in roles `WORKSPACE_USER` and `WORKSPACE_VIEWER` do not include the `g
 
 Requires an RBAC-enabled plan.
 
-1. Go to **Settings → Members/Roles**.
+1. Go to **Settings > Members/Roles**.
 1. Create a new workspace role.
 1. Grant it at minimum `gateway:invoke` and `workspaces:read`.
 1. Assign users who need gateway access to this role.
@@ -60,7 +60,7 @@ Use this if you don't need fine-grained access control, or if you don't have RBA
 
 Gateway policy management requires `organization:manage` permission.
 
-Go to **Settings → Gateway → LLM Gateway** to create governance policies. You can configure:
+Go to **Settings > Gateway > LLM Gateway** to create governance policies. You can configure:
 
 - **Spend limits:** hard caps at the organization, workspace, API key, or user level. Refer to [Spend policies](/langsmith/llm-gateway-spend-policies).
 - **Data protection:** detect and redact PII and secrets before they reach the model. Refer to [Data protection](/langsmith/llm-gateway-data-protection).

--- a/src/langsmith/llm-gateway-custom-providers.mdx
+++ b/src/langsmith/llm-gateway-custom-providers.mdx
@@ -11,7 +11,7 @@ In addition to the [built-in providers](/langsmith/llm-gateway-direct-model-acce
 
 ## How it works
 
-A custom provider is defined by a [model configuration](/langsmith/model-configurations) that you save under **Settings → Model configurations** in the [LangSmith UI](https://smith.langchain.com). The provider you select in that configuration sets the format the gateway speaks to your upstream:
+A custom provider is defined by a [model configuration](/langsmith/model-configurations) that you save under **Settings > Model configurations** in the [LangSmith UI](https://smith.langchain.com). The provider you select in that configuration sets the format the gateway speaks to your upstream:
 
 | Configuration provider | Wire format | Example endpoints |
 | --- | --- | --- |
@@ -39,8 +39,8 @@ Both routes look up the same configuration, resolve the same secret, and proxy t
 
 ## 1. Create a custom provider configuration
 
-1. Add the upstream endpoint's API key as a workspace secret under **Settings → Integrations → Provider Secrets**. Give it a descriptive name (for example, `MY_PROVIDER_API_KEY`).
-1. Go to **Settings → Model configurations** and create a configuration with **OpenAI Compatible Endpoint** or **Anthropic** as the provider.
+1. Add the upstream endpoint's API key as a workspace secret under **Settings > Integrations > Provider Secrets**. Give it a descriptive name (for example, `MY_PROVIDER_API_KEY`).
+1. Go to **Settings > Model configurations** and create a configuration with **OpenAI Compatible Endpoint** or **Anthropic** as the provider.
 1. Set the **Base URL** to your upstream endpoint (for example, `https://my-inference-server.example.com/v1`) and the **Model Name** to a model identifier the endpoint expects.
 1. Set the **API Key Name** to the secret you created.
 1. Save the configuration with a **name**. This name is what you'll use in the gateway route.

--- a/src/langsmith/llm-gateway-data-protection.mdx
+++ b/src/langsmith/llm-gateway-data-protection.mdx
@@ -53,7 +53,7 @@ The gateway detects and redacts API keys, tokens, and credentials across a wide 
 Creating and managing policies requires `organization:manage` permission.
 </Warning>
 
-1. Go to **Settings → Gateway → LLM Gateway**.
+1. Go to **Settings > Gateway > LLM Gateway**.
 1. Click **Create policy**.
 1. Select **PII redaction** or **Secrets redaction** as the policy type.
 1. Configure which categories to detect (or enable all).

--- a/src/langsmith/llm-gateway-fallbacks.mdx
+++ b/src/langsmith/llm-gateway-fallbacks.mdx
@@ -36,7 +36,7 @@ Creating and managing fallback chains requires `organization:manage` permission.
 
 To create a fallback chain:
 
-1. Go to **Settings → Gateway → LLM Gateway** and select the **Model Fallbacks** tab.
+1. Go to **Settings > Gateway > LLM Gateway** and select the **Model Fallbacks** tab.
 1. Click **Create fallback chain**.
 1. Select the **Workspace** where the chain applies.
 1. Select the primary provider and model. Requests to this provider-prefixed model ID use the chain when the primary attempt fails.

--- a/src/langsmith/llm-gateway-header-policies.mdx
+++ b/src/langsmith/llm-gateway-header-policies.mdx
@@ -39,7 +39,7 @@ Default spend bucketing follows these rules:
 
 To separate a default spend limit by header:
 
-1. Go to **Settings → Gateway → LLM Gateway** and select **Cost Controls**.
+1. Go to **Settings > Gateway > LLM Gateway** and select **Cost Controls**.
 1. Click **Create spend limit**.
 1. Select **Workspace**, **User**, or **API Key**, then select the option to apply the limit to every subject of that type by default.
 1. Select **Separate limits by custom header**.
@@ -62,7 +62,7 @@ Explicit header conditions follow these rules:
 - **Every matching policy is enforced**: A request that matches both a plain subject policy and a policy with a header condition counts against both, and either one can block it.
 - **At most 10 conditions**: A policy carries no more than 10 subject conditions in total.
 
-1. Go to **Settings → Gateway → LLM Gateway**.
+1. Go to **Settings > Gateway > LLM Gateway**.
 1. Click **Create policy**.
 1. Select the policy type and subject scope, then set the limits.
 1. Under **Custom header condition (optional)**, enter the **Header name** without its `X-Gateway-` prefix (for example, `Customer-Id`) and the **Header value** to match (for example, `acme`).

--- a/src/langsmith/llm-gateway-model-access-policies.mdx
+++ b/src/langsmith/llm-gateway-model-access-policies.mdx
@@ -43,7 +43,7 @@ When a request matches policies at multiple tiers, only the most specific tier a
 Creating and managing policies requires `organization:manage` permission. For the full permissions breakdown, refer to [Traces, Engine, and access control](/langsmith/llm-gateway-access).
 </Warning>
 
-1. Go to **Settings → Gateway → LLM Gateway** and select **Model Access**.
+1. Go to **Settings > Gateway > LLM Gateway** and select **Model Access**.
 1. Click **Create model access**.
 1. Enter a **Policy name**.
 1. Select the scope under **Applies to** (organization, workspace, user, or API key).

--- a/src/langsmith/llm-gateway-quickstart.mdx
+++ b/src/langsmith/llm-gateway-quickstart.mdx
@@ -235,7 +235,7 @@ If your application also emits its own LangSmith traces, for example, through [L
 
 ## 4. Set a spend policy (optional)
 
-Go to **Settings → Gateway → LLM Gateway** in LangSmith to create a spend policy. For example, you can set a daily $10 cap on your API key. When the cap is reached, the gateway returns a `402` response with the message: `"Request blocked by gateway policies: R&D Spend Cap"`.
+Go to **Settings > Gateway > LLM Gateway** in LangSmith to create a spend policy. For example, you can set a daily $10 cap on your API key. When the cap is reached, the gateway returns a `402` response with the message: `"Request blocked by gateway policies: R&D Spend Cap"`.
 
 See [Spend policies](/langsmith/llm-gateway-spend-policies) for the full guide on policy dimensions, time windows, and conflict resolution.
 

--- a/src/langsmith/llm-gateway-rate-limit-policies.mdx
+++ b/src/langsmith/llm-gateway-rate-limit-policies.mdx
@@ -62,7 +62,7 @@ Rules:
 Creating and managing policies requires `organization:manage` permission. For the full permissions breakdown, refer to [Traces, Engine, and access control](/langsmith/llm-gateway-access).
 </Warning>
 
-1. Go to **Settings → Gateway → LLM Gateway**.
+1. Go to **Settings > Gateway > LLM Gateway**.
 1. Click **Create policy**.
 1. Select **Rate limit** as the policy type.
 1. Select the subject scope (user, workspace, or API key).

--- a/src/langsmith/llm-gateway-spend-policies.mdx
+++ b/src/langsmith/llm-gateway-spend-policies.mdx
@@ -54,7 +54,7 @@ You can apply multiple time windows to the same scope. For example, a workspace 
 Creating and managing policies requires `organization:manage` permission. For the full permissions breakdown, refer to [Traces, Engine, and access control](/langsmith/llm-gateway-access).
 </Warning>
 
-1. Go to **Settings → Gateway → LLM Gateway** and select **Cost Controls**.
+1. Go to **Settings > Gateway > LLM Gateway** and select **Cost Controls**.
 1. Click **Create spend limit**.
 1. Select the scope (organization, workspace, API key, or user).
 1. (Optional) To apply the same default limit independently to every custom header value, apply the limit to every subject of the selected type by default, select **Separate limits by custom header**, and enter the header name.

--- a/src/langsmith/manage-trace.mdx
+++ b/src/langsmith/manage-trace.mdx
@@ -24,7 +24,7 @@ Shared traces are accessible to anyone with the link, even without a LangSmith a
 To unshare a trace, use either of the following methods:
 
 1. Open the shared trace, click **Public** in the toolbar at the top of the Details view, then click **Unshare** in the dialog.
-1. Go to **Settings** → **Shared URLs** to view all publicly shared traces in the selected workspace. Click **Unshare** next to the trace you want to unshare.
+1. Go to **Settings** > **Shared URLs** to view all publicly shared traces in the selected workspace. Click **Unshare** next to the trace you want to unshare.
 
 ## View server logs
 

--- a/src/langsmith/playground-model-providers.mdx
+++ b/src/langsmith/playground-model-providers.mdx
@@ -364,7 +364,7 @@ Gemini Enterprise Agent Platform uses a **service account JSON key** for authent
 
 #### Step 1: Create a service account
 
-1. Go to the [Google Cloud Console → IAM & Admin → Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts).
+1. Go to the [Google Cloud Console > IAM & Admin > Service Accounts](https://console.cloud.google.com/iam-admin/serviceaccounts).
 2. Select your project and click **Create Service Account**.
 3. Give it a name (e.g., `langsmith-vertex-ai`) and click **Create and Continue**.
 4. Assign the role **Vertex AI User** (`roles/aiplatform.user`) and click **Done**.
@@ -372,7 +372,7 @@ Gemini Enterprise Agent Platform uses a **service account JSON key** for authent
 #### Step 2: Download the JSON key
 
 1. Click on the service account you just created.
-2. Go to the **Keys** tab and click **Add Key → Create new key**.
+2. Go to the **Keys** tab and click **Add Key > Create new key**.
 3. Choose **JSON** and click **Create**. A `.json` file will download to your machine.
 
 The downloaded file looks like this:

--- a/src/langsmith/quick-start-studio.mdx
+++ b/src/langsmith/quick-start-studio.mdx
@@ -111,7 +111,7 @@ Then attach your preferred debugger:
     ```
     </Tab>
     <Tab title="PyCharm">
-    1. Go to Run → Edit Configurations
+    1. Go to Run > Edit Configurations
     2. Click + and select "Python Debug Server"
     3. Set IDE host name: `localhost`
     4. Set port: `5678` (or the port number you chose in the previous step)

--- a/src/langsmith/self-host-sso.mdx
+++ b/src/langsmith/self-host-sso.mdx
@@ -131,7 +131,7 @@ You must have administrator-level access to your organization's Google Cloud Pla
 
 2. After you have created the project, open the [Credentials](https://console.developers.google.com/apis/credentials) page in the Google API Console (making sure the project in the top left corner is correct)
 
-3. Create new credentials: `Create Credentials → OAuth client ID`
+3. Create new credentials: `Create Credentials > OAuth client ID`
 
 4. Choose `Web application` as the `Application type` and enter a name for the application e.g. `LangSmith`
 
@@ -346,7 +346,7 @@ Per-provider SSO Groups Sync settings are stored on the SSO provider record and 
 
 <Tabs>
 <Tab title="UI">
-Once your IdP emits the groups claim, configure SSO Groups Sync from the UI in **Settings** → **Members and roles** → **SSO Configuration** → **SSO Groups Sync**. The claim name configured in the **Groups claim field** must match the claim emitted by your IdP.
+Once your IdP emits the groups claim, configure SSO Groups Sync from the UI in **Settings** > **Members and roles** > **SSO Configuration** > **SSO Groups Sync**. The claim name configured in the **Groups claim field** must match the claim emitted by your IdP.
 </Tab>
 <Tab title="API">
 

--- a/src/langsmith/trace-with-cursor.mdx
+++ b/src/langsmith/trace-with-cursor.mdx
@@ -20,7 +20,7 @@ Before setting up tracing, ensure you have:
 
 Install the plugin directly from the GitHub repository in Cursor's settings:
 
-1. Open **Cursor → Settings → Plugins**.
+1. Open **Cursor > Settings > Plugins**.
 2. Paste `https://github.com/langchain-ai/langsmith-cursor-plugins` into the plugin link field.
 3. Confirm to add **LangSmith Tracing for Cursor**.
 

--- a/src/langsmith/user-management.mdx
+++ b/src/langsmith/user-management.mdx
@@ -162,7 +162,7 @@ The attribute name is preserved end-to-end: the IdP attribute name, the SAML Att
 
 #### Configuration
 
-In **Settings** → **Members and roles** → **SSO Configuration**, scroll to the **SAML Attribute Mapping** section and add one row per non-standard attribute you want to forward:
+In **Settings** > **Members and roles** > **SSO Configuration**, scroll to the **SAML Attribute Mapping** section and add one row per non-standard attribute you want to forward:
 
 | Column | Description |
 | --- | --- |
@@ -786,7 +786,7 @@ Choose **SSO Groups Sync** when IdP admin involvement is minimal and reactive (l
 #### Configuration
 
 1. In your IdP: add the user's group memberships to the SSO token claim (default claim name: `groups`). Group names must follow the [SCIM naming convention](#group-naming-convention).
-2. In LangSmith: go to **Settings** → **Members and roles** → **SSO Configuration** → **SSO Groups Sync** and configure the following:
+2. In LangSmith: go to **Settings** > **Members and roles** > **SSO Configuration** > **SSO Groups Sync** and configure the following:
 
    | Setting | Description |
    | --- | --- |
@@ -838,9 +838,9 @@ To make a user's group memberships visible to LangSmith at login, you need to do
 
 In the LangSmith SAML application:
 
-1. **Directory** → **Profile Editor** → select the LangSmith application's user profile.
+1. Go to **Directory** > **Profile Editor**, then select the LangSmith application's user profile.
 2. Add a custom attribute named `groups` with **Type** `string array`.
-3. **Sign On** → edit the SAML settings and add an attribute statement:
+3. On **Sign On**, edit the SAML settings and add an attribute statement:
    - **Name**: `groups`
    - **Name format**: `Unspecified` (or `Basic`)
    - **Filter**: `Matches regex` with `.*` to send all groups, or use a more restrictive regex (e.g., `^LS:.*`) to limit to LangSmith-prefixed groups.
@@ -850,7 +850,7 @@ In the LangSmith SAML application:
 
 In the LangSmith Enterprise Application:
 
-1. **Single sign-on** → **Attributes & Claims** → **Add a group claim**.
+1. **Single sign-on** > **Attributes & Claims** > **Add a group claim**.
 2. Choose which groups to emit (typically **Groups assigned to the application**).
 3. Set **Source attribute** to `Cloud-only group display names` so the group name (which must match the [naming convention](#group-naming-convention)) is sent rather than the object ID.
 4. Set the claim **Name** to `groups` (or your configured **Groups claim field** value), with no namespace.

--- a/src/langsmith/view-usage.mdx
+++ b/src/langsmith/view-usage.mdx
@@ -19,7 +19,7 @@ LangSmith provides several views into your [organization's](/langsmith/administr
 
 The usage graph shows aggregate trace consumption for your [organization](/langsmith/administration-overview#organizations), broken down by [workspace](/langsmith/administration-overview#workspaces). It covers the current billing period and does not show spend—for spend, refer to the invoice.
 
-Navigate to **Settings** → **Billing and Usage** → **Usage Graph**.
+Navigate to **Settings** > **Billing and Usage** > **Usage Graph**.
 
 ### Billable metrics
 
@@ -41,7 +41,7 @@ The usage graph uses the term `tenant_id` interchangeably with workspace ID.
 
 Enterprise customers with prepaid commitments can view how much of their contract has been consumed.
 
-Navigate to **Settings** → **Usage Configuration** → **Contract Usage**.
+Navigate to **Settings** > **Usage Configuration** > **Contract Usage**.
 
 This view shows:
 
@@ -62,13 +62,13 @@ If your contract spans multiple organizations under the same billing entity, the
 
 Invoices are available on **self-serve Cloud plans only**. Enterprise Cloud organizations have a separate usage view for tracking spend.
 
-Navigate to **Settings** → **Billing and Usage** → **Invoices** to see how your usage translates to spend. The first invoice shown is a draft of your current month's invoice, reflecting your running spend to date.
+Navigate to **Settings** > **Billing and Usage** > **Invoices** to see how your usage translates to spend. The first invoice shown is a draft of your current month's invoice, reflecting your running spend to date.
 
 ## Granular usage
 
 Granular usage gives you trace counts broken down by a dimension you choose (workspace, project, user, or API key) over a time range you select. This is useful for internal chargebacks, identifying high-usage teams, or auditing trace activity.
 
-Navigate to **Settings** → **Billing and Usage** → **Granular Usage**, or use the [granular usage API](/langsmith/granular-usage).
+Navigate to **Settings** > **Billing and Usage** > **Granular Usage**, or use the [granular usage API](/langsmith/granular-usage).
 
 ### What "traces" means here
 
@@ -109,7 +109,7 @@ Data collection begins from the moment the feature is enabled. There is no backf
 
 ### Aggregate usage on Self-hosted
 
-The usage graph is available on [Self-hosted](/langsmith/self-hosted) running Helm chart 0.9.5 or later. LangSmith automatically generates and syncs organization usage charts, available under **Settings** → **Usage and billing** → **Usage graph**:
+The usage graph is available on [Self-hosted](/langsmith/self-hosted) running Helm chart 0.9.5 or later. LangSmith automatically generates and syncs organization usage charts, available under **Settings** > **Usage and billing** > **Usage graph**:
 
 - **Usage by Workspace**: trace counts (root runs) per workspace
 - **Organization Usage**: total trace counts across the organization

--- a/src/oss/deepagents/code/quickstart.mdx
+++ b/src/oss/deepagents/code/quickstart.mdx
@@ -147,7 +147,7 @@ The agent uses its built-in tools, skills, and memory to help you with tasks.
             Terminal emulators intercept `Cmd`-modified keys before they reach the running application, so Deep Agents Code never receives them directly. Instead, the terminal translates them into the readline shortcuts above.
 
             - **Ghostty:** Works out of the box. `Cmd+Left`, `Cmd+Right`, and `Cmd+Delete` are translated to `Ctrl+A`, `Ctrl+E`, and `Ctrl+U` by default.
-            - **iTerm2:** Not bound by default. Add the following under **Settings → Profiles → Keys → Key Mappings** as `Send Text with vim special chars`:
+            - **iTerm2:** Not bound by default. Add the following under **Settings > Profiles > Keys > Key Mappings** as `Send Text with vim special chars`:
                 - `Cmd+Left` → `\x01` (Ctrl+A)
                 - `Cmd+Right` → `\x05` (Ctrl+E)
                 - `Cmd+Delete` → `\x15` (Ctrl+U)

--- a/src/oss/langchain/deep-agent-from-scratch.mdx
+++ b/src/oss/langchain/deep-agent-from-scratch.mdx
@@ -72,7 +72,7 @@ npm install deepagents langsmith
 This tutorial uses @[`LangSmithSandbox`], which provisions sandboxes through `SandboxClient`. That client authenticates with LangSmith using `LANGSMITH_API_KEY` from your environment, so an API key is required to run the tutorial. Setting up LangSmith also allows you to see traces of what happens when your agent runs.
 
 1. [Sign up for a free account](https://smith.langchain.com). You can use Google, GitHub, or email.
-2. [Create an API key](/langsmith/create-account-api-key) in **Settings → API Keys**.
+2. [Create an API key](/langsmith/create-account-api-key) in **Settings > API Keys**.
 3. Export the LangSmith API key:
 
 ```bash

--- a/src/snippets/langsmith/account-api-key-quickstart.mdx
+++ b/src/snippets/langsmith/account-api-key-quickstart.mdx
@@ -4,7 +4,7 @@
         You can log in with **Google**, **GitHub**, or **email**.
     </Step>
     <Step title="Create an API key" icon="key">
-        Go to your [Settings page](https://smith.langchain.com/settings) → **API Keys** → **Create API Key**.
+        Go to your [Settings page](https://smith.langchain.com/settings) > **API Keys** > **Create API Key**.
         Copy the key and save it securely.
     </Step>
 </Steps>


### PR DESCRIPTION
## Why

Nav paths are split between two separators with no written rule: `>` in 37 files, `→` in 23. The arrows cluster by area, so LLM Gateway, alerts, and view-usage are all-arrow while the self-hosted and Fleet pages are all-`>`. #5961 prompted this: it edits arrow-style paths, which is correct for that PR, but there was nothing to point at for the separator itself.

Google's style guide, which the docs follow, uses the greater-than sign for UI navigation sequences. This writes that down, enforces it, and converts the stragglers.

## What changed

**The rule** — a `### Navigation paths` subsection in the style guide plus a matching `Don't` bullet next to the version-minimums rule. Per the sync note at the top of `CLAUDE.md`, both are mirrored into `AGENTS.md` and the two path-scoped agent rule files.

**The linter** — `LangChain.NavPathArrows`, registered in `.vale.ini` at error level. It uses `scope: raw` because Vale's parsed text drops the `**` markers the rule needs to tell a nav path from any other arrow. Two tokens: an arrow between bold labels (`**Settings** → **API Keys**`) and an arrow inside one bold path (`**Settings → API Keys**`).

**The sweep** — 70 nav paths across 25 pages.

## Review notes

The interesting part is what the rule deliberately does not flag, since an unscoped arrow rule would invite agents to "fix" prose that is not navigation at all. Verified exclusions:

- Mermaid diagrams and fenced code
- Data flow: `browser or client → data plane`, `STT → LLM → TTS`
- API renames in migration guides: **`create_react_agent` → `create_agent`**
- Function signatures in `deepagents/backends.mdx`: **`ls(path: string) → LsResult`**
- The JIT SSO decision tree in `jit-invite-sso.mdx`
- `engine.mdx`, where **Manage app access →** is a literal button label

Three lines were rewritten rather than converted, because a straight swap would have read wrong. Worth a look:

- `annotation-queues.mdx` — **Needs Review** → **Needs Others' Review** → **Completed** is a state progression, not navigation. Now a comma list.
- `user-management.mdx` — two Okta steps where an arrow joined a nav path to an instruction ("**Sign On** → edit the SAML settings").
- `alerts.mdx` — same shape, in the Google Chat prerequisite.

`self-host-sso.mdx` keeps its nav path inside backticks; only the separator changed. Restyling it as bold is a separate call.

Vale passes on all changed files, and `LangChain.NavPathArrows` reports zero violations across all 2,347 files in `src/`.

## AI disclosure

Drafted with Claude Code. The sweep ran as a script over bold-delimited spans; every match and every remaining arrow in the touched files was reviewed by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
