### PR TITLE
Correct the LLM Gateway navigation path (DOC-1611)

### DIFF
--- a/src/langsmith/llm-gateway-admin-setup.mdx
+++ b/src/langsmith/llm-gateway-admin-setup.mdx
@@ -60,7 +60,7 @@ Use this if you don't need fine-grained access control, or if you don't have RBA
 
 Gateway policy management requires `organization:manage` permission.
 
-Go to **Settings > Gateway > LLM Gateway** to create governance policies. You can configure:
+Go to **LLM Gateway** to create governance policies. You can configure:
 
 - **Spend limits:** hard caps at the organization, workspace, API key, or user level. Refer to [Spend policies](/langsmith/llm-gateway-spend-policies).
 - **Data protection:** detect and redact PII and secrets before they reach the model. Refer to [Data protection](/langsmith/llm-gateway-data-protection).

--- a/src/langsmith/llm-gateway-data-protection.mdx
+++ b/src/langsmith/llm-gateway-data-protection.mdx
@@ -53,7 +53,7 @@ The gateway detects and redacts API keys, tokens, and credentials across a wide 
 Creating and managing policies requires `organization:manage` permission.
 </Warning>
 
-1. Go to **Settings > Gateway > LLM Gateway**.
+1. Go to **LLM Gateway**.
 1. Click **Create policy**.
 1. Select **PII redaction** or **Secrets redaction** as the policy type.
 1. Configure which categories to detect (or enable all).

--- a/src/langsmith/llm-gateway-fallbacks.mdx
+++ b/src/langsmith/llm-gateway-fallbacks.mdx
@@ -36,7 +36,7 @@ Creating and managing fallback chains requires `organization:manage` permission.
 
 To create a fallback chain:
 
-1. Go to **Settings > Gateway > LLM Gateway** and select the **Model Fallbacks** tab.
+1. Go to **LLM Gateway** and select the **Model Fallbacks** tab.
 1. Click **Create fallback chain**.
 1. Select the **Workspace** where the chain applies.
 1. Select the primary provider and model. Requests to this provider-prefixed model ID use the chain when the primary attempt fails.

--- a/src/langsmith/llm-gateway-header-policies.mdx
+++ b/src/langsmith/llm-gateway-header-policies.mdx
@@ -39,7 +39,7 @@ Default spend bucketing follows these rules:
 
 To separate a default spend limit by header:
 
-1. Go to **Settings > Gateway > LLM Gateway** and select **Cost Controls**.
+1. Go to **LLM Gateway** and select **Cost Controls**.
 1. Click **Create spend limit**.
 1. Select **Workspace**, **User**, or **API Key**, then select the option to apply the limit to every subject of that type by default.
 1. Select **Separate limits by custom header**.
@@ -62,7 +62,7 @@ Explicit header conditions follow these rules:
 - **Every matching policy is enforced**: A request that matches both a plain subject policy and a policy with a header condition counts against both, and either one can block it.
 - **At most 10 conditions**: A policy carries no more than 10 subject conditions in total.
 
-1. Go to **Settings > Gateway > LLM Gateway**.
+1. Go to **LLM Gateway**.
 1. Click **Create policy**.
 1. Select the policy type and subject scope, then set the limits.
 1. Under **Custom header condition (optional)**, enter the **Header name** without its `X-Gateway-` prefix (for example, `Customer-Id`) and the **Header value** to match (for example, `acme`).

--- a/src/langsmith/llm-gateway-model-access-policies.mdx
+++ b/src/langsmith/llm-gateway-model-access-policies.mdx
@@ -43,7 +43,7 @@ When a request matches policies at multiple tiers, only the most specific tier a
 Creating and managing policies requires `organization:manage` permission. For the full permissions breakdown, refer to [Traces, Engine, and access control](/langsmith/llm-gateway-access).
 </Warning>
 
-1. Go to **Settings > Gateway > LLM Gateway** and select **Model Access**.
+1. Go to **LLM Gateway** and select **Model Access**.
 1. Click **Create model access**.
 1. Enter a **Policy name**.
 1. Select the scope under **Applies to** (organization, workspace, user, or API key).

--- a/src/langsmith/llm-gateway-quickstart.mdx
+++ b/src/langsmith/llm-gateway-quickstart.mdx
@@ -235,7 +235,7 @@ If your application also emits its own LangSmith traces, for example, through [L
 
 ## 4. Set a spend policy (optional)
 
-Go to **Settings > Gateway > LLM Gateway** in LangSmith to create a spend policy. For example, you can set a daily $10 cap on your API key. When the cap is reached, the gateway returns a `402` response with the message: `"Request blocked by gateway policies: R&D Spend Cap"`.
+Go to **LLM Gateway** in LangSmith to create a spend policy. For example, you can set a daily $10 cap on your API key. When the cap is reached, the gateway returns a `402` response with the message: `"Request blocked by gateway policies: R&D Spend Cap"`.
 
 See [Spend policies](/langsmith/llm-gateway-spend-policies) for the full guide on policy dimensions, time windows, and conflict resolution.
 

--- a/src/langsmith/llm-gateway-rate-limit-policies.mdx
+++ b/src/langsmith/llm-gateway-rate-limit-policies.mdx
@@ -62,7 +62,7 @@ Rules:
 Creating and managing policies requires `organization:manage` permission. For the full permissions breakdown, refer to [Traces, Engine, and access control](/langsmith/llm-gateway-access).
 </Warning>
 
-1. Go to **Settings > Gateway > LLM Gateway**.
+1. Go to **LLM Gateway**.
 1. Click **Create policy**.
 1. Select **Rate limit** as the policy type.
 1. Select the subject scope (user, workspace, or API key).

--- a/src/langsmith/llm-gateway-spend-policies.mdx
+++ b/src/langsmith/llm-gateway-spend-policies.mdx
@@ -54,7 +54,7 @@ You can apply multiple time windows to the same scope. For example, a workspace 
 Creating and managing policies requires `organization:manage` permission. For the full permissions breakdown, refer to [Traces, Engine, and access control](/langsmith/llm-gateway-access).
 </Warning>
 
-1. Go to **Settings > Gateway > LLM Gateway** and select **Cost Controls**.
+1. Go to **LLM Gateway** and select **Cost Controls**.
 1. Click **Create spend limit**.
 1. Select the scope (organization, workspace, API key, or user).
 1. (Optional) To apply the same default limit independently to every custom header value, apply the limit to every subject of the selected type by default, select **Separate limits by custom header**, and enter the header name.


### PR DESCRIPTION
Fixes DOC-1611. Supersedes #5961.

## Why

Eight LLM Gateway pages send readers to **Settings > Gateway > LLM Gateway**. Neither level exists.

Verified in `smith-frontend`:

- `src/components/NavSidebar/utils/useSideNavLinks.tsx:561` pushes one flat side-nav link, `label: GATEWAY_PAGE_TITLE` (`'LLM Gateway'`), `href: {orgPrefix}/{appGatewayIndexPath}`.
- `src/utils/constants.tsx` defines `appGatewayIndexPath = 'gateway'` and `appSettingsPath = 'settings'` as separate constants, so the page sits at `/o/{tenantId}/gateway`.
- `src/Pages/Gateway/GatewayCrumb.tsx` builds its breadcrumb from the same path.
- `src/Pages/Settings/SettingsNavigation.tsx` has no Gateway group.

Draft PR #5961 (from the Fleet bot) caught the Settings half and proposed **Gateway > LLM Gateway**, but there is no "Gateway" parent above the link, so it traded one wrong path for another. It also conflicts with #5966, which rewrote these same nine lines when it standardized nav separators on `>`.

## What changed

Nine occurrences across eight pages become **Go to LLM Gateway**. The tab names that follow are unchanged and already correct: `GatewayPage.tsx:73` defines Home, Usage, Cost Controls, Rate Limiting, Data Policy, Model Fallbacks, and Model Access.

## What did not change

Provider Secrets and model configurations stay under Settings, as #5961 also assumed. `SettingsNavigation.tsx` routes them through `settings/secrets` and `settings/model-configurations` under an Integrations group, so **Settings > Integrations > Provider Secrets** and **Settings > Model configurations** are still right.

One thing I could not verify from source: the side-nav link is gated behind the `llmGatewayVisible` feature flag and an `organization:read` check, so a reader without gateway access will not see the entry at all. The pages do not mention that today, and I left it alone.

## AI disclosure

Drafted with Claude Code, verified against `langchain-ai/langchainplus` at `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
