### PR TITLE
docs(aimlapi): add AI/ML API to the Python Popular Providers sidebar

### DIFF
--- a/src/docs.json
+++ b/src/docs.json
@@ -563,6 +563,7 @@
                           "oss/python/integrations/providers/microsoft",
                           "oss/python/integrations/providers/ollama",
                           "oss/python/integrations/providers/groq",
+                          "oss/python/integrations/providers/aimlapi",
                           "oss/python/integrations/providers/fireworks"
                         ]
                       },

--- a/src/oss/python/integrations/providers/aimlapi.mdx
+++ b/src/oss/python/integrations/providers/aimlapi.mdx
@@ -1,5 +1,6 @@
 ---
 title: "AI/ML API integrations"
+sidebarTitle: "AI/ML API"
 description: "Integrate with AI/ML API using LangChain Python."
 ---
 


### PR DESCRIPTION
Hi! I'm Hugo from aimlapi.com — an AI aggregator that gives access to 1000+ models in one API.

First of all, thank you so much for merging #5755! It brought the AI/ML API pages in line with the `langchain-aimlapi` package. This PR is a small follow-up to it: we'd like AI/ML API to be listed among the Popular Providers in the Python docs sidebar. Here's why we think it belongs there:

- 400k+ users on AI/ML API
- Millions of views of our posts on X and LinkedIn
- A lot of feedback from users who came to us through LangChain

## Overview

Today the AI/ML API provider page is reachable only from the long alphabetical `all_providers` list; the Python Popular Providers sidebar group does not include it.

Changes (2 files, +2/-0):

- `src/docs.json`: adds `oss/python/integrations/providers/aimlapi` to the Python **Popular Providers** sidebar group, between Groq and Fireworks. Existing entries and their order are unchanged.
- `src/oss/python/integrations/providers/aimlapi.mdx`: adds `sidebarTitle: "AI/ML API"`, so the sidebar label matches its neighbours ("OpenAI", "Groq", "Fireworks") instead of the full page title "AI/ML API integrations". No other content changes.

Not changed:

- The JavaScript **Popular Providers** group: it nests chat/embeddings/tools pages per provider, and there are no JavaScript AI/ML API pages.
- The "Popular providers" table on the providers overview page.
- No pages are added or removed.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: N/A — follow-up to #5755
- Feature PR: N/A (navigation-only change)

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [ ] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly (N/A: no code examples changed)
- [ ] I have used **root relative** paths for internal links (N/A: no links added)
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

- The position in the group (between Groq and Fireworks) is your call, and we're happy to move the entry.
- Checked: `src/docs.json` parses as JSON; the new entry resolves to the existing `src/oss/python/integrations/providers/aimlapi.mdx` and appears in the navigation exactly once; the branch merges cleanly into current `main`.
- This PR was prepared with AI agent assistance (Claude) and reviewed by the AI/ML API team before submission.
