### PR TITLE
Unblock local setup on current uv and document the mise toolchain

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,10 @@ packages = ["pipeline"]
 
 
 [tool.uv]
-required-version = "0.9.26"
+# Floor, not an exact pin: a bare version is read as `==`, which breaks every
+# contributor on a newer uv. The exact version for CI lives in
+# .github/actions/uv_setup, and for local development in .mise.toml.
+required-version = ">=0.9.26"
 package = true
 prerelease = "allow"
 override-dependencies = [

--- a/src/oss/contributing/documentation.mdx
+++ b/src/oss/contributing/documentation.mdx
@@ -20,6 +20,12 @@ git clone https://github.com/langchain-ai/docs.git
 cd docs
 ```
 
+Install the pinned toolchain with [mise](https://mise.jdx.dev/getting-started.html), which reads the versions of Python, Node.js, uv, Vale, and the Mintlify CLI from `.mise.toml` and installs the repository's git hooks:
+
+```bash
+mise trust && mise install
+```
+
 ```bash
 make install
 ```
@@ -47,10 +53,12 @@ If you are having issues with you local preview, try running `mint update` to en
 </Tip>
 
 <Accordion title="Prerequisites">
+    **Recommended:** run `mise trust && mise install` to get every pinned version at once. `.mise.toml` is the canonical pin for the toolchain, and its postinstall hook wires up the pre-commit and pre-push hooks.
+
     **Required:**
     - Python 3.13+
-    - [uv](https://docs.astral.sh/uv/) - Python package manager
-    - [Node.js](https://nodejs.org/en) and npm
+    - [uv](https://docs.astral.sh/uv/) 0.9.26 or later - Python package manager
+    - [Node.js](https://nodejs.org/en) 22.x and npm. Mintlify does not support Node 25 or later
     - [Make](https://www.gnu.org/software/make/)
     - [Git](https://git-scm.com/)
 


### PR DESCRIPTION
## Why

`pyproject.toml` carries `required-version = "0.9.26"` under `[tool.uv]`. A bare version is read by uv as `==`, so `make install`, `make build`, and `make broken-links` fail outright unless a contributor's uv is *exactly* 0.9.26. The latest uv is 0.12.12, which means this blocks nearly anyone who installs uv today:

```
error: Required uv version `==0.9.26` does not match the running version `0.12.12`
```

I hit this while working on another PR and could not build locally until I worked around it.

The second half of the problem is discoverability. `.mise.toml` already pins node 22, python 3.13, uv, prek, vale, and `npm:mint`, and its postinstall hook installs the pre-commit and pre-push hooks. Nothing in the setup path mentions it. The contributing page listed unversioned "uv" and "Node.js", so a contributor who follows the published docs installs mismatched versions and lands on the error above.

## What changed

- **`pyproject.toml`**: `required-version` becomes `>=0.9.26`. Reproducibility is unaffected. The exact version still comes from `.github/actions/uv_setup/action.yml` (`UV_VERSION: "0.9.26"`) for CI and from `.mise.toml` for local development, both untouched.
- **`src/oss/contributing/documentation.mdx`**: documents `mise trust && mise install` in the quick start and prerequisites, and supplies the versions that matter where prerequisites are still listed by hand (uv 0.9.26 or later, Node.js 22.x with the Node 25 ceiling that `.mise.toml` already notes).

## Verified

Ran against both ends of the range to confirm the floor still holds and current uv is unblocked:

| uv | `==0.9.26` (before) | `>=0.9.26` (after) |
|---|---|---|
| 0.9.10 | fails | fails, correctly below the floor |
| 0.9.26 | passes | passes |
| 0.12.12 (latest) | **fails** | passes |

`make broken-links` reports no broken links, `make lint_prose` is clean, and all 242 tests in `tests/` pass.

## Review focus

**Is `>=` the constraint you want, or should `required-version` be dropped entirely?** `.mise.toml` and the CI action already pin the exact version, so the `pyproject.toml` entry is arguably redundant rather than merely too strict. I kept a floor because it still catches a genuinely ancient uv, but I do not feel strongly.

Worth knowing how the pin arrived: #5821, a `langsmith-fleet[bot]` PR titled "Update self-hosted bulk export default compression to zstandard." Its entire stated scope was a docs content change, and the `pyproject.toml` line rode along, so it was never reviewed as an infrastructure decision. May be worth a look at whether that bot should be touching build config.

## Agent involvement

Drafted with Claude Code. The diagnosis, the version-matrix verification, and the prose were agent work, reviewed against `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
