### PR TITLE
Link authoring skills as part of make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,6 +125,7 @@ install:
 	uv sync --all-groups
 	npm install
 	npm install -g mint@latest
+	@$(MAKE) --no-print-directory skills
 	@echo "If the docs command is not available, relaunch your shell so it picks up the docs binary."
 
 clean:
@@ -245,7 +246,7 @@ help:
 	@echo "  make lint_md_fix        - Lint and fix markdown files"
 	@echo "  make lint_prose         - Lint prose with Vale (terminology, style)"
 	@echo "  make test               - Run tests"
-	@echo "  make install            - Install dependencies"
+	@echo "  make install            - Install dependencies and link skills"
 	@echo "  make code-snippets      - Extract code snippets (line-based, Bluehawk-compatible)"
 	@echo "  make test-code-samples  - Run code samples (FILES=\"path ...\" for specific)"
 	@echo "  make skills             - Link .agents/skills into .claude/skills for Claude Code"

--- a/README.md
+++ b/README.md
@@ -105,14 +105,14 @@ API reference is generated and deployed outside this repo. Browse [Python](https
 * `make build` - Build documentation to `./build` directory
 * `make broken-links` - Check for broken links in documentation
 * `make broken-links-with-anchors` - Check for broken links + check links with anchors
-* `make install` - Install all dependencies
+* `make install` - Install all dependencies and link authoring skills
 * `make clean` - Remove build artifacts
 * `make test` - Run the test suite
 * `make lint` - Check code style and formatting
 * `make format` - Auto-format code
 * `make lint_md` - Lint markdown files
 * `make lint_md_fix` - Lint and fix markdown files
-* `make skills` - Link `.agents/skills` into `.claude/skills` for Claude Code (run once per clone)
+* `make skills` - Link `.agents/skills` into `.claude/skills` for Claude Code. Runs as part of `make install`; re-run it after new skills are added
 * `make help` - Show all available commands
 
 **`docs` CLI tool:**

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ API reference is generated and deployed outside this repo. Browse [Python](https
 * `make format` - Auto-format code
 * `make lint_md` - Lint markdown files
 * `make lint_md_fix` - Lint and fix markdown files
+* `make skills` - Link `.agents/skills` into `.claude/skills` for Claude Code (run once per clone)
 * `make help` - Show all available commands
 
 **`docs` CLI tool:**


### PR DESCRIPTION
## Why

`make skills` links `.agents/skills` into `.claude/skills`, which is the only way Claude Code discovers this repository's authoring skills. It was a step you had to know about and run by hand, and `README.md` had **zero** mentions of it.

The common case is someone who already has this repo cloned and uses an agent to open PRs. For them the fix is not more documentation, it is not having to run a separate command at all.

## What changed

- **`Makefile`**: `make install` now links the skills. It is the command people already run to set up the repo, and it did not touch skills before. Implemented as `@$(MAKE) --no-print-directory skills` in the recipe rather than a prerequisite, so it runs *after* the dependencies and the output follows the order the steps actually happen.
- **`README.md`**: adds a `make skills` entry, and notes on `make install` that it links skills.
- **`make help`**: updated the `install` description to match.

## New skills do require a re-run, and the README now says so

The target symlinks per skill, so a name it has not seen is not linked. I verified this rather than assuming: dropping a new directory into `.agents/skills/` leaves it unlinked until `make skills` runs again.

That is a deliberate tradeoff, not an oversight. A whole-directory symlink (`.claude/skills -> .agents/skills`) would auto-pick-up new skills, but it would clobber any personal skills a contributor keeps in `.claude/skills` — which is exactly what the existing "skip if not a symlink" branch protects. Per-skill linking is the right call; the README entry just makes the consequence visible.

## Scope: one Makefile line and two README lines

I audited the other entry points first. Most were already covered by #5970:

| Entry point | State |
|---|---|
| `make install` | **Was missing** — fixed here |
| `README.md` command list | **Was missing** — fixed here |
| `make help` | Already listed `skills`, and `.PHONY` includes it |
| `src/oss/contributing/documentation.mdx` | Already present, line 48, in the "Using an AI coding agent?" tip |
| `.github/CONTRIBUTING.md` | 6-line stub pointing at the published guide. Nothing to add |

## Verified

- Ran `make skills` in a **clean shallow clone**: all six skills link, every symlink resolves to a readable `SKILL.md`, re-running is idempotent, stale links to deleted skills are pruned, and a real directory of the same name is skipped rather than clobbered. `.claude` is gitignored (`.gitignore:203`), so the links never show up as changes to commit.
- Ran the chained step in a second clean clone to confirm it links correctly from the `install` recipe.
- `.github/workflows/create-preview-branch.yml` runs `make install`. The added step only creates gitignored symlinks, so it is a no-op for the preview build.
- `markdownlint README.md` reports the same 20 pre-existing MD004 violations before and after, none on the added lines. Vale is clean.

## Note for a follow-up

The README's Make command list is stale beyond this: `make lint_prose`, `make export`, `make htmltest`, `make check-cross-refs`, `make code-snippets`, and `make test-code-samples` are all in `make help` but absent from the README. Left alone to keep this reviewable.

## Agent involvement

Drafted with Claude Code. The entry-point audit, the clean-clone verification, and the prose were agent work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
