### PR TITLE
docs(sandbox): document AWS IAM roles for proxy auth and S3 mounts

### DIFF
--- a/src/langsmith/sandbox-auth-proxy.mdx
+++ b/src/langsmith/sandbox-auth-proxy.mdx
@@ -257,8 +257,43 @@ await client.createSandbox({
 After the sandbox is ready, use AWS SDKs or CLIs normally inside the sandbox. The SDK or CLI can discover the placeholder AWS environment variables, and the proxy applies the real SigV4 signature to outbound AWS requests.
 
 <Note>
-AWS auth proxy rules currently support access key ID and secret access key credentials. They do not include a session token or assume-role configuration.
+Static AWS auth accepts an access key ID and secret access key, but not a caller-supplied session token. Deployments with AWS proxy role authentication enabled also support an IAM role as described below.
 </Note>
+
+### Authenticate with an IAM role
+
+An AWS proxy role lets LangSmith assume a customer IAM role and sign supported AWS HTTPS requests with renewable temporary credentials. It works with or without [S3 mounts](/langsmith/sandbox-mounts#authenticate-with-an-iam-role), without exposing real credentials to sandbox code.
+
+This option requires deployment support for AWS proxy role authentication. ECR registry role authentication is a separate feature. In **Create sandbox > Network**, enable AWS authentication and select **AWS IAM role**. The form shows the exact LangSmith principal and workspace External ID that the customer role must trust. Follow the linked setup instructions to configure the trust and permissions policies, then enter the customer role in **AWS role ARN**.
+
+For the HTTP API, supply `aws.role_arn` instead of static credential fields:
+
+```bash
+curl -X POST "$LANGSMITH_ENDPOINT/v2/sandboxes/boxes" \
+  -H "x-api-key: $LANGSMITH_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "aws-role-sandbox",
+    "proxy_config": {
+      "rules": [
+        {
+          "name": "aws",
+          "type": "aws",
+          "enabled": true,
+          "aws": {
+            "role_arn": "arn:aws:iam::123456789012:role/LangSmithSandbox"
+          }
+        }
+      ]
+    }
+  }'
+```
+
+Replace the example ARN with your configured customer role. The single-rule limit still applies. Role authentication is configured at creation: an update can preserve the existing role, but cannot add, remove, change, or disable it. Create a new sandbox to change role authentication.
+
+The role's effective AWS permissions apply to all supported requests. LangSmith does not add a mount-derived session policy to this rule. A read-only S3 mount blocks filesystem writes, not direct S3 API writes that IAM allows. Restrict the customer role to the services, resources, and actions the sandbox needs.
+
+LangSmith renews temporary credentials on demand and reacquires them after stop/start. If renewal is temporarily unavailable, cached credentials remain usable only until expiration. Authorization denial or expiration fails closed, without falling back to static keys.
 
 ## Authenticate GCP requests
 

--- a/src/langsmith/sandbox-mounts.mdx
+++ b/src/langsmith/sandbox-mounts.mdx
@@ -125,26 +125,26 @@ try {
 
 ### Authenticate with an IAM role
 
-IAM role authentication lets LangSmith assume a role in your AWS account for S3 mounts. LangSmith obtains and renews temporary AWS credentials, so you do not need to store or rotate access keys in workspace secrets.
+IAM role authentication lets the [AWS auth proxy](/langsmith/sandbox-auth-proxy#authenticate-with-an-iam-role) assume a role in your AWS account. S3 mounts use the same authentication as other supported AWS requests from the sandbox. LangSmith obtains and renews temporary AWS credentials, so you do not need to store or rotate access keys in workspace secrets.
 
 <Note>
-This option requires your LangSmith deployment to enable IAM role authentication for S3 mounts. Enabling IAM roles for ECR registries does not enable them for mounts. If the S3 mount authentication selector is absent, use static access keys or contact your LangSmith administrator. The setup below uses the UI; the SDK examples on this page use static access keys.
+This option requires your LangSmith deployment to enable AWS proxy role authentication. Enabling IAM roles for ECR registries does not enable them for the auth proxy. If **AWS IAM role** is absent from the AWS authentication options, use static access keys or contact your LangSmith administrator. The setup below uses the UI; the SDK examples on this page use static access keys.
 </Note>
 
-You need permission to configure the customer IAM role's trust and S3 access policies. One role applies to all S3 mounts in the sandbox. You cannot combine role authentication with static AWS mount credentials or a separate AWS auth proxy rule. Create a new sandbox to change mount authentication.
+You need permission to configure the customer IAM role's trust and access policies. One AWS auth rule applies to the sandbox's AWS requests, including all S3 mounts. Choose either static access keys or an IAM role; do not configure both. Role authentication is configured at creation. Create a new sandbox to add, remove, disable, or change its role.
 
 The LangSmith principal also needs permission to assume the customer role. For self-hosted deployments, your administrator configures that permission and any required role tags. Cross-account S3 buckets may also require a bucket policy that permits the customer role.
 
 To configure the role and create the sandbox:
 
 1. Open **Sandboxes > Create sandbox**, add an **S3 bucket** in the **Mounts** section, and configure its bucket, region, prefix, mount path, and read-only setting.
-2. Select **AWS IAM role** under **S3 mount authentication**.
-3. Expand **AWS role setup**. The form displays two values to use in your IAM role's trust policy:
-   - **Principal**: The exact AWS role ARN that this LangSmith deployment uses to assume customer roles. Use the displayed mount principal, not an ARN copied from another environment or from an ECR registry.
+2. Go to the **Network** section, enable AWS authentication, and select **AWS IAM role**. To use the role without mounts, skip the mount configuration in step 1.
+3. Use the two values displayed below **AWS role ARN** in your IAM role's trust policy:
+   - **Principal**: The exact AWS role ARN that this LangSmith deployment uses to assume customer roles. Use the displayed principal, not an ARN copied from another environment or from an ECR registry.
    - **External ID**: Your current LangSmith workspace UUID. LangSmith supplies this value when assuming the role; you do not choose a separate external ID.
-4. Select **Copy trust policy** and apply that policy to the customer role in AWS IAM. It permits `sts:AssumeRole` only for the displayed principal with the matching `sts:ExternalId`.
-5. Select **Copy S3 permissions** and attach that permissions policy to the same role. The form generates it from the configured mounts. Update the policy if you change the mount settings before creating the sandbox.
-6. Enter the customer role's ARN in **S3 AWS role ARN**. This is the role you configured in your account, not the LangSmith principal shown in the setup instructions.
+4. Expand **AWS role setup**, select **Copy trust policy**, and apply that policy to the customer role in AWS IAM. It permits `sts:AssumeRole` only for the displayed principal with the matching `sts:ExternalId`.
+5. Attach a least-privilege permissions policy for the AWS services and resources the sandbox needs. For configured S3 mounts, **Copy S3 permissions** supplies a starting policy. Review it before attaching it; LangSmith does not apply it automatically.
+6. Enter the customer role's ARN in **AWS role ARN**. This is the role you configured in your account, not the LangSmith principal shown in the setup instructions.
 7. Select **Create Sandbox**, then verify that sandbox code can read the mounted path and, for writable mounts, write to it.
 
 The generated trust policy has this structure. Replace the placeholders with the principal and external ID displayed in the form, or copy the completed policy from the form:
@@ -156,7 +156,7 @@ The generated trust policy has this structure. Replace the placeholders with the
     {
       "Effect": "Allow",
       "Principal": {
-        "AWS": "<LANGSMITH_MOUNT_PRINCIPAL_ARN>"
+        "AWS": "<LANGSMITH_AWS_PROXY_PRINCIPAL_ARN>"
       },
       "Action": "sts:AssumeRole",
       "Condition": {
@@ -173,19 +173,25 @@ Do not replace the principal with `*` or remove the external ID condition. Enter
 
 #### Limit S3 access
 
-The generated S3 permissions policy grants access based on the mount settings:
+The optional S3 permissions example grants access based on the mount settings:
 
 - **All S3 mounts**: Bucket-location access, prefix-scoped listing, and object reads.
 - **Writable mounts**: Additional object-write, delete, and multipart-upload permissions.
 - **Empty prefix**: Object access throughout the bucket. Use a prefix to restrict access to a subtree.
 
-LangSmith further restricts each temporary session to the configured buckets, prefixes, and read-only settings. A broader policy on the customer role does not widen the sandbox's mount access. LangSmith rejects conflicting read-only and writable mounts with overlapping scopes.
+The role's effective AWS permissions control all supported AWS proxy requests. LangSmith does not restrict a general AWS role session to the configured mounts. Limit the role's IAM policy to the required buckets, prefixes, operations, and other AWS resources.
 
-Role authentication supports standard S3 buckets on commercial AWS HTTPS endpoints. It does not support customer-managed KMS keys, S3 Access Points, S3 Express directory buckets, or non-commercial AWS partitions such as AWS GovCloud and China. Large mount configurations can exceed AWS's session-policy size limit; reduce the scope configuration if validation rejects it.
+<Warning>
+A read-only mount rejects filesystem writes, but does not block direct S3 API writes that the role permits. Use the role's IAM policy to enforce read-only AWS access.
+</Warning>
+
+Use a commercial AWS role and supported AWS HTTPS endpoints. The S3 permissions example does not include KMS permissions; review the permissions required by your bucket's encryption settings.
+
+The legacy `mount_config.auth.aws_role` API remains mount-scoped and cannot be combined with an AWS proxy rule. It is separate from the shared role setup described here.
 
 #### Renew credentials
 
-LangSmith renews temporary credentials as the mount needs them, including after a sandbox stops and resumes. You do not supply a saved STS token or renew it manually. Keep the role's trust and S3 permissions in place for continued access.
+LangSmith renews temporary credentials as AWS requests need them, including after a sandbox stops and resumes. You do not supply a saved STS token or renew it manually. Keep the role's trust and access permissions in place for continued access.
 
 If renewal is temporarily unavailable, the mount can use cached credentials only until they expire. An authorization denial or expired credentials causes authenticated S3 requests to fail; the mount does not fall back to static keys.
 

--- a/src/langsmith/sandbox-mounts.mdx
+++ b/src/langsmith/sandbox-mounts.mdx
@@ -13,7 +13,7 @@ Sandbox mounts require `langsmith[sandbox]>=0.8.16` for Python or `langsmith>=0.
 </Note>
 
 <Warning>
-Store cloud credentials as LangSmith workspace secrets before creating a sandbox that mounts S3 or GCS. Do not pass real cloud credentials as sandbox environment variables, command arguments, or files.
+When using static AWS keys or a GCP service account, store cloud credentials as LangSmith workspace secrets before creating the sandbox. S3 mounts authenticated with an IAM role do not require stored AWS access keys. Do not pass real cloud credentials as sandbox environment variables, command arguments, or files.
 </Warning>
 
 ## Configure mount paths
@@ -33,7 +33,11 @@ Mount IDs can contain ASCII letters, digits, underscores, and hyphens. Do not re
 
 ## Mount an S3 bucket
 
-S3 mounts require AWS auth. The SDK creates an AWS auth proxy rule from `aws_auth` / `awsAuth`, so the sandbox can access the bucket without seeing the real access keys.
+S3 mounts require AWS authentication. Use static access keys with the SDK examples below, or use an IAM role in the LangSmith UI when your deployment supports role authentication. Both methods keep real AWS credentials outside the sandbox.
+
+### Authenticate with static access keys
+
+The SDK creates an AWS auth proxy rule from `aws_auth` / `awsAuth`, so the sandbox can access the bucket without seeing the real access keys.
 
 <CodeGroup>
 
@@ -118,6 +122,72 @@ try {
 ```
 
 </CodeGroup>
+
+### Authenticate with an IAM role
+
+IAM role authentication lets LangSmith assume a role in your AWS account for S3 mounts. LangSmith obtains and renews temporary AWS credentials, so you do not need to store or rotate access keys in workspace secrets.
+
+<Note>
+This option requires your LangSmith deployment to enable IAM role authentication for S3 mounts. Enabling IAM roles for ECR registries does not enable them for mounts. If the S3 mount authentication selector is absent, use static access keys or contact your LangSmith administrator. The setup below uses the UI; the SDK examples on this page use static access keys.
+</Note>
+
+You need permission to configure the customer IAM role's trust and S3 access policies. One role applies to all S3 mounts in the sandbox. You cannot combine role authentication with static AWS mount credentials or a separate AWS auth proxy rule. Create a new sandbox to change mount authentication.
+
+The LangSmith principal also needs permission to assume the customer role. For self-hosted deployments, your administrator configures that permission and any required role tags. Cross-account S3 buckets may also require a bucket policy that permits the customer role.
+
+To configure the role and create the sandbox:
+
+1. Open **Sandboxes > Create sandbox**, add an **S3 bucket** in the **Mounts** section, and configure its bucket, region, prefix, mount path, and read-only setting.
+2. Select **AWS IAM role** under **S3 mount authentication**.
+3. Expand **AWS role setup**. The form displays two values to use in your IAM role's trust policy:
+   - **Principal**: The exact AWS role ARN that this LangSmith deployment uses to assume customer roles. Use the displayed mount principal, not an ARN copied from another environment or from an ECR registry.
+   - **External ID**: Your current LangSmith workspace UUID. LangSmith supplies this value when assuming the role; you do not choose a separate external ID.
+4. Select **Copy trust policy** and apply that policy to the customer role in AWS IAM. It permits `sts:AssumeRole` only for the displayed principal with the matching `sts:ExternalId`.
+5. Select **Copy S3 permissions** and attach that permissions policy to the same role. The form generates it from the configured mounts. Update the policy if you change the mount settings before creating the sandbox.
+6. Enter the customer role's ARN in **S3 AWS role ARN**. This is the role you configured in your account, not the LangSmith principal shown in the setup instructions.
+7. Select **Create Sandbox**, then verify that sandbox code can read the mounted path and, for writable mounts, write to it.
+
+The generated trust policy has this structure. Replace the placeholders with the principal and external ID displayed in the form, or copy the completed policy from the form:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "<LANGSMITH_MOUNT_PRINCIPAL_ARN>"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "<LANGSMITH_WORKSPACE_ID>"
+        }
+      }
+    }
+  ]
+}
+```
+
+Do not replace the principal with `*` or remove the external ID condition. Entering the customer role ARN in LangSmith does not create the role or update its AWS policies.
+
+#### Limit S3 access
+
+The generated S3 permissions policy grants access based on the mount settings:
+
+- **All S3 mounts**: Bucket-location access, prefix-scoped listing, and object reads.
+- **Writable mounts**: Additional object-write, delete, and multipart-upload permissions.
+- **Empty prefix**: Object access throughout the bucket. Use a prefix to restrict access to a subtree.
+
+LangSmith further restricts each temporary session to the configured buckets, prefixes, and read-only settings. A broader policy on the customer role does not widen the sandbox's mount access. LangSmith rejects conflicting read-only and writable mounts with overlapping scopes.
+
+Role authentication supports standard S3 buckets on commercial AWS HTTPS endpoints. It does not support customer-managed KMS keys, S3 Access Points, S3 Express directory buckets, or non-commercial AWS partitions such as AWS GovCloud and China. Large mount configurations can exceed AWS's session-policy size limit; reduce the scope configuration if validation rejects it.
+
+#### Renew credentials
+
+LangSmith renews temporary credentials as the mount needs them, including after a sandbox stops and resumes. You do not supply a saved STS token or renew it manually. Keep the role's trust and S3 permissions in place for continued access.
+
+If renewal is temporarily unavailable, the mount can use cached credentials only until they expire. An authorization denial or expired credentials causes authenticated S3 requests to fail; the mount does not fall back to static keys.
 
 ## Mount a GCS bucket
 


### PR DESCRIPTION
## Overview

Document AWS IAM role authentication for the Sandbox auth proxy, with or without S3 mounts, so customers can configure trust and permissions without storing static AWS keys.

- Describe the Network > AWS authentication UI, the deployment-specific LangSmith principal, and the workspace-scoped `sts:ExternalId` trust requirement.
- Add Python and TypeScript examples for standalone proxy roles, shared proxy roles with S3 mounts, and mount-scoped roles under `mount_config.auth.aws.role_arn`.
- Distinguish general proxy-role IAM permissions from the additional S3 session policy applied to mount-scoped roles. A read-only mount does not block direct API writes that a general role permits.
- Explain automatic credential renewal, immutable role configuration, and separate ECR activation. Preserve the existing static-key examples.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- Role-auth implementation (merged): https://github.com/langchain-ai/langchainplus/pull/38911
- Shared-service transport alignment (merged): https://github.com/langchain-ai/langchainplus/pull/38912
- Python/TypeScript helper support: https://github.com/langchain-ai/langsmith-sdk/pull/3536
- Linear issue: https://linear.app/langchain/issue/INF-2856

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] I have tested my changes locally using `docs dev`
- [ ] All code examples have been tested and work correctly
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed

## Additional notes

**Before publishing these instructions, verify the SDK helper releases and the intended role-enabled backend/host rollout. Add exact minimum Python and TypeScript versions when those releases exist.** The implementation and transport PRs have merged, but merge status alone does not establish deployed availability. No release version is invented here.

Review focus:

- Use the principal and workspace External ID displayed in the AWS authentication form. These values are visible before expanding **AWS role setup**; policy copy controls are inside it. Customers must configure the trust and least-privilege permissions in AWS themselves.
- Shared AWS proxy authentication supports S3 mounts, not GCS mounts. GCS still requires explicit mount authentication.
- Role grants and renewal use the existing authenticated service transport. There is no new customer-facing TLS option or transport-specific Helm setting. This documentation does not deploy, activate, or change infrastructure.

Validation for this update:

- Prose lint on both changed pages: zero errors, warnings, or suggestions; `docs build` and `git diff --check` passed.
- `docs dev --skip-build`: both updated pages rendered successfully, including the new role examples and permission-scope sections.
- All six new SDK examples (three Python, three TypeScript) executed against the SDK PR using mocked create requests. Assertions verified standalone/shared/mount-scoped wire payloads, absence of duplicate AWS auth, and the read-only mount prefix. TypeScript examples also passed type checking.
- After the SDK type cleanup in langchain-ai/langsmith-sdk@707889a, all six AWS TypeScript examples across the two pages, including existing static-auth examples, passed type checking against the built SDK declarations with `exactOptionalPropertyTypes` both disabled and enabled. The docs use existing helpers and do not reference the removed public type exports, so no docs source changes were needed. This follow-up did not change or rerun the Python examples.
- The retained trust policy was previously compared with the frontend generator; it is unchanged in this update.
- These checks are not live AWS tests. The latest static TypeScript example checks were compile-time only; static examples were not re-executed. The all-examples checkbox remains unchecked. Run the SDK examples against an enabled backend before release.
- No pages or existing anchors were renamed, and no navigation updates were needed.

Prepared with Codex assistance; content checked against the implementation and rendered locally.
