### PR TITLE
docs(langsmith): document the sandbox run config

### DIFF
--- a/src/langsmith/sandbox-sdk.mdx
+++ b/src/langsmith/sandbox-sdk.mdx
@@ -109,10 +109,9 @@ try {
   console.log(result.stderr);     // ""
   console.log(result.exit_code);  // 0
 
-  // Pass environment variables and working directory
+  // Pass environment variables and a working directory
   const envResult = await sandbox.run("echo $MY_VAR", {
-    env: { MY_VAR: "test-value" },
-    cwd: "/tmp",
+    runConfig: { env_vars: { MY_VAR: "test-value" }, work_dir: "/tmp" },
   });
 } finally {
   await sandbox.delete();
@@ -120,6 +119,62 @@ try {
 ```
 
 </CodeGroup>
+
+## Run as a different user, directory, or environment
+
+`run_config` sets the account commands run as, their working directory, and their environment. It mirrors `docker run -u/-w/-e`: `user` and `work_dir` replace the value from the layer below, and `env_vars` merge over it key by key.
+
+It applies at three points, each layered over the one before:
+
+| Where | Effect |
+| --- | --- |
+| Snapshot | What every sandbox built from it boots with. See [snapshots](/langsmith/sandbox-snapshots#user-working-directory-and-environment). |
+| Sandbox | On create, overrides the snapshot's. On update, changes what subsequent commands run with. |
+| Command | Applies to that one command only. |
+
+<CodeGroup>
+
+```python Python
+# Override the snapshot's run config for this sandbox
+with client.sandbox(run_config={"user": "app", "work_dir": "/srv"}) as sb:
+    print(sb.run("id -un").stdout)  # "app"
+
+    # Change it for subsequent commands
+    client.update_sandbox(sb.name, run_config={"env_vars": {"STAGE": "beta"}})
+    print(sb.run("echo $STAGE").stdout)  # "beta"
+
+    # Or for one command only
+    result = sb.run(
+        "whoami",
+        run_config={"user": "root", "env_vars": {"STAGE": "debug"}},
+    )
+    print(result.stdout)  # "root"
+```
+
+```ts TypeScript
+// Override the snapshot's run config for this sandbox
+const sandbox = await client.createSandbox(snapshot.id, {
+  runConfig: { user: "app", work_dir: "/srv" },
+});
+
+// Change it for subsequent commands
+await client.updateSandbox(sandbox.name, {
+  runConfig: { env_vars: { STAGE: "beta" } },
+});
+
+// Or for one command only
+const result = await sandbox.run("whoami", {
+  runConfig: { user: "root", env_vars: { STAGE: "debug" } },
+});
+```
+
+</CodeGroup>
+
+An update takes effect for commands started after it; commands already running keep what they started with, and a stopped sandbox picks the change up on its next start. A snapshot captured from a sandbox carries the sandbox's run config, so the next sandbox built from it starts the same way.
+
+<Warning>
+The per-command `cwd` and `env` arguments are deprecated in favor of `run_config["work_dir"]` and `run_config["env_vars"]`. They still work on their own, but a command that sets them together with `run_config` is rejected.
+</Warning>
 
 ## Stream output
 

--- a/src/langsmith/sandbox-snapshots.mdx
+++ b/src/langsmith/sandbox-snapshots.mdx
@@ -114,6 +114,54 @@ console.log(snapshot.id);
 
 </CodeGroup>
 
+### User, working directory, and environment
+
+A snapshot built from a container image records that image's `USER`, `WORKDIR`, and `ENV`, and every sandbox created from it runs commands that way — the same values `docker run` would use.
+
+Pass `run_config` to override them. `user` and `work_dir` replace the image's; `env_vars` merge over the image's `ENV` key by key, so a key set here wins and the rest of the image's environment stays.
+
+<CodeGroup>
+
+```python Python
+snapshot = client.create_snapshot(
+    "python",
+    docker_image="python:3.12-slim",
+    fs_capacity_bytes=1 * 1024**3,
+    run_config={
+        "user": "app",
+        "work_dir": "/srv",
+        "env_vars": {"PYTHONUNBUFFERED": "1"},
+    },
+)
+
+print(snapshot.run_config)
+```
+
+```ts TypeScript
+const snapshot = await client.createSnapshot(
+  "python",
+  "python:3.12-slim",
+  1_073_741_824,
+  {
+    runConfig: {
+      user: "app",
+      work_dir: "/srv",
+      env_vars: { PYTHONUNBUFFERED: "1" },
+    },
+  },
+);
+
+console.log(snapshot.run_config);
+```
+
+</CodeGroup>
+
+`user` accepts the same forms as `docker run -u`: `name`, `uid`, `name:group`, or `uid:gid`. `work_dir` must be absolute, and is created if it does not exist. Every snapshot response reports the `run_config` it resolved, so you can see what a snapshot will boot as before you use it.
+
+<Note>
+Snapshots built before LangSmith recorded run configs carry no `run_config` and keep their previous behavior: commands run as root with only the sandbox's own environment. Rebuilding such a snapshot picks up the image's `USER` and `ENV`. To keep running as root on a rebuilt snapshot, pass `run_config={"user": "0"}`.
+</Note>
+
 ### Verify a snapshot built from a container image
 
 LangSmith builds a custom snapshot from the filesystem in the container image you provide. To independently verify those contents:


### PR DESCRIPTION
## Overview

Documents the sandbox run config — the user, working directory, and environment that sandbox commands run with — for the server feature landed in langchain-ai/langchainplus#35583 and the SDK support in langchain-ai/langsmith-sdk#3528.

- `sandbox-snapshots.mdx`: a snapshot built from a container image now records that image's `USER`, `WORKDIR`, and `ENV`, and sandboxes created from it run that way; `run_config` overrides it. Includes the back-compat note for snapshots built before this and how to keep running as root on a rebuild.
- `sandbox-sdk.mdx`: how the three override points layer (snapshot, sandbox create/update, single command), with Python and TypeScript examples, plus the deprecation of the per-command `cwd` and `env` arguments.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- langchain-ai/langsmith-sdk#3528

## Test Plan

- [x] `vale src/langsmith/sandbox-sdk.mdx src/langsmith/sandbox-snapshots.mdx` — 0 errors, 0 warnings, 0 suggestions
- [x] No new pages, so `src/docs.json` is unchanged
