### PR TITLE
docs(deepagents): add SkillsMiddleware override examples to customization page

### DIFF
--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -503,6 +503,87 @@ Declarative subagents defined via `subagents=` do not inherit the main agent's m
 
         See [Restricting filesystem tools](/oss/deepagents/overview#virtual-filesystem-access) for more details.
     </Accordion>
+    <Accordion title="Place routing hints next to the skill catalog" icon="route">
+        Override @[`SkillsMiddleware`] with a custom `system_prompt=` template to put routing
+        hints (priorities, category bias) in the same block as the generated skill catalog.
+        The template must include the `{skills_locations}`, `{skills_list}`, and
+        `{skills_load_warnings}` slots, which the middleware substitutes on every turn — so
+        the catalog stays in sync automatically as skills are added, renamed, or removed.
+
+        ```python
+        from deepagents import create_deep_agent
+        from deepagents.backends.filesystem import FilesystemBackend
+        from deepagents.middleware.skills import SkillsMiddleware
+
+        backend = FilesystemBackend(root_dir="/path/to/skills")
+
+        custom_skills_prompt = """## Skills
+
+        Routing hints:
+        - For research topics → prefer arxiv-search first
+        - For general questions → use web-research
+        - For LangGraph documentation → langgraph-docs
+
+        {skills_locations}
+
+        {skills_list}
+
+        {skills_load_warnings}
+        """
+
+        agent = create_deep_agent(
+            model="anthropic:claude-sonnet-4-6",
+            middleware=[
+                SkillsMiddleware(
+                    backend=backend,
+                    sources=["/path/to/skills"],
+                    system_prompt=custom_skills_prompt,
+                ),
+            ],
+        )
+        ```
+
+        Do not also pass `skills=` to `create_deep_agent` in this case: the override instance
+        already owns `backend` and `sources`. Any missing slot (`{skills_locations}`,
+        `{skills_list}`, `{skills_load_warnings}`) raises `ValueError` at construction time.
+    </Accordion>
+    <Accordion title="Suppress the auto-generated skill catalog" icon="eye-off">
+        Override @[`SkillsMiddleware`] with `system_prompt=None` to load skills without
+        appending a skills section to the system prompt. Skills remain in
+        `state["skills_metadata"]` and skill files stay reachable through the filesystem
+        tools, so callers who prefer a hand-written, compact routing summary in
+        `create_deep_agent(system_prompt=...)` can add exactly the guidance they need without
+        the built-in description block.
+
+        ```python
+        from deepagents import create_deep_agent
+        from deepagents.backends.filesystem import FilesystemBackend
+        from deepagents.middleware.skills import SkillsMiddleware
+
+        backend = FilesystemBackend(root_dir="/path/to/skills")
+
+        agent = create_deep_agent(
+            model="anthropic:claude-sonnet-4-6",
+            system_prompt="""You are a research assistant.
+
+        Skills (read the SKILL.md file when relevant):
+        - /path/to/skills/arxiv-search/SKILL.md — papers
+        - /path/to/skills/web-research/SKILL.md — general web lookups
+        - /path/to/skills/langgraph-docs/SKILL.md — LangGraph documentation
+        """,
+            middleware=[
+                SkillsMiddleware(
+                    backend=backend,
+                    sources=["/path/to/skills"],
+                    system_prompt=None,
+                ),
+            ],
+        )
+        ```
+
+        Skill names, paths, and any hand-written hints in `create_deep_agent`'s `system_prompt`
+        are the caller's responsibility to keep in sync when skills change.
+    </Accordion>
 </AccordionGroup>
 :::
 

--- a/src/oss/deepagents/customization.mdx
+++ b/src/oss/deepagents/customization.mdx
@@ -503,12 +503,16 @@ Declarative subagents defined via `subagents=` do not inherit the main agent's m
 
         See [Restricting filesystem tools](/oss/deepagents/overview#virtual-filesystem-access) for more details.
     </Accordion>
-    <Accordion title="Place routing hints next to the skill catalog" icon="route">
-        Override @[`SkillsMiddleware`] with a custom `system_prompt=` template to put routing
-        hints (priorities, category bias) in the same block as the generated skill catalog.
-        The template must include the `{skills_locations}`, `{skills_list}`, and
-        `{skills_load_warnings}` slots, which the middleware substitutes on every turn — so
-        the catalog stays in sync automatically as skills are added, renamed, or removed.
+    <Accordion title="Customize how the skill catalog appears in the system prompt" icon="template">
+        Override @[`SkillsMiddleware`] with a custom `system_prompt=` template to control how
+        the auto-generated skill catalog is framed — for example, to add surrounding context,
+        reorder sections, or place routing hints (priorities, category bias) in the same
+        block as the catalog. The template must include the `{skills_locations}`,
+        `{skills_list}`, and `{skills_load_warnings}` slots, which the middleware substitutes
+        on every turn — so the catalog stays in sync automatically as skills are added,
+        renamed, or removed.
+
+        The example below places routing hints alongside the catalog:
 
         ```python
         from deepagents import create_deep_agent
@@ -549,11 +553,11 @@ Declarative subagents defined via `subagents=` do not inherit the main agent's m
     </Accordion>
     <Accordion title="Suppress the auto-generated skill catalog" icon="eye-off">
         Override @[`SkillsMiddleware`] with `system_prompt=None` to load skills without
-        appending a skills section to the system prompt. Skills remain in
+        appending a skills section to the system prompt at all. Skills remain in
         `state["skills_metadata"]` and skill files stay reachable through the filesystem
-        tools, so callers who prefer a hand-written, compact routing summary in
-        `create_deep_agent(system_prompt=...)` can add exactly the guidance they need without
-        the built-in description block.
+        tools, so callers who prefer to write their own description block (for example, a
+        compact hand-written routing summary) in `create_deep_agent(system_prompt=...)` can
+        add exactly the guidance they need without the built-in one.
 
         ```python
         from deepagents import create_deep_agent


### PR DESCRIPTION
## Overview

Add two accordion entries to the _Override a default middleware instance_ section of the Deep Agents customization page. The section already covers `SummarizationMiddleware`, `AnthropicPromptCachingMiddleware`, and `FilesystemMiddleware` but has no examples for `SkillsMiddleware`.

Both `SkillsMiddleware` knobs shown here are already supported by the current API but not documented on the docs site — `system_prompt=` and the three template slots (`{skills_locations}`, `{skills_list}`, `{skills_load_warnings}`) are not mentioned outside the source code, and `system_prompt=None` is not either. Related discussion: langchain-ai/deepagents#6082.

## What changed

Two new accordions inside the existing `<AccordionGroup>` under _Override a default middleware instance → Examples_, placed after the existing "Restrict the enabled filesystem tools" entry:

1. **Customize how the skill catalog appears in the system prompt** — shows how to pass a custom `system_prompt=` template to `SkillsMiddleware` so that the auto-generated catalog can be framed with surrounding context, reordered, or annotated. The template must include `{skills_locations}`, `{skills_list}`, and `{skills_load_warnings}`; the middleware substitutes them on every turn, so the catalog stays in sync automatically. Routing hints alongside the catalog are shown as the concrete example.

2. **Suppress the auto-generated skill catalog** — shows how to pass `system_prompt=None` to load skills into state without appending any skills section, so callers can write their own description block (for example, a compact hand-written routing summary) in `create_deep_agent(system_prompt=...)`.

## Type of change

**Type:** Update existing documentation

## Related issues/PRs

- GitHub issue: langchain-ai/deepagents#6082

## Checklist

- [x] I have read the [contributing guidelines](README.md), including the [language policy](https://docs.langchain.com/oss/python/contributing/overview#language-policy)
- [x] All code examples have been tested and work correctly (verified against `deepagents` from source with a local MRE)
- [x] I have used **root relative** paths for internal links
- [x] I have updated navigation in `src/docs.json` if needed (not needed — adding accordions to an existing page)