### PR TITLE
docs: align retention UI dropdown list with 180-day SaaS maximum (follow-up to #5859)

### DIFF
--- a/src/langsmith/data-purging-compliance.mdx
+++ b/src/langsmith/data-purging-compliance.mdx
@@ -38,7 +38,7 @@ Organization Admins and Operators (`organization:manage`) can configure retentio
     1. Select **Usage configuration** from the left-hand menu.
     1. Find the workspace in the list that you would like to configure.
     1. Click on the value under the **Data retention policy** column for that workspace.
-    1. On the **workspace usage configurations** modal, customize the extended policy using the dropdown for **Extended - All traces are retained for** option. Available durations are: 30d, 60d, 90d, 120d, 150d, 180d, 240d, 300d, 365d, and 400d.
+    1. On the **workspace usage configurations** modal, customize the extended policy using the dropdown for **Extended - All traces are retained for** option. Available durations for SaaS customers are: 30d, 60d, 90d, 120d, 150d, and 180d (maximum as of September 14, 2026). Self-hosted deployments are not subject to this cap.
     1. Select **Save**.
   </Tab>
   <Tab title="API">


### PR DESCRIPTION
Follow-up to #5859 for DOC-1591.

## Summary

- #5859 updated the SaaS trace retention maximum to 180 days (as of September 14, 2026) but missed the **UI** tab in `src/langsmith/data-purging-compliance.mdx`. Step 5 of the UI tab still listed dropdown durations through 400d.
- This PR updates that one sentence so the UI dropdown list matches the API tab: durations for SaaS customers are now 30d, 60d, 90d, 120d, 150d, and 180d, with a note that self-hosted deployments are not subject to this cap.
- No other changes.

## Links

- Linear: https://linear.app/langchain/issue/DOC-1591/update-trace-retention-docs-400-day-max-changing-to-180-day-as-of-914
- Parent PR: #5859

🤖 Generated with [Claude Code](https://claude.com/claude-code)